### PR TITLE
Change actiondata type to individual enums and variants

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 #
 
 cmake_minimum_required(VERSION 3.10)
-set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12 CACHE STRING "Build for 10.12")
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14 CACHE STRING "Build for 10.14")  # this way we can use C++17 for real
 project(ShortCircuit VERSION 3.0.0.0 LANGUAGES C CXX ASM)
 
 # Share some information about the  build

--- a/src/interaction_parameters.h
+++ b/src/interaction_parameters.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include "sampler_state.h"
+#include <iostream>
 
 enum
 {
@@ -172,16 +173,7 @@ enum
 
 };
 
-struct interactiondata
-{
-    int vtype;
-    int ptr_offset;
-    int n_subid;
-    int subid_ptr_offset;
-    std::string label;
-};
-
-enum
+enum IPType
 {
     ipvt_int = 0,
     ipvt_char,
@@ -190,6 +182,45 @@ enum
     ipvt_bdata, // binary data for fx preset save/load (size from subid_ptr_offset)
     ipvt_other
 };
+
+struct interactiondata
+{
+    IPType vtype;
+    int ptr_offset;
+    int n_subid;
+    int subid_ptr_offset;
+    std::string label;
+};
+
+inline std::ostream &operator<<(std::ostream &os, const interactiondata &d)
+{
+    os << "interaction[" << d.label << " ";
+    switch(d.vtype)
+    {
+    case ipvt_int:
+        os << "int";
+        break;
+    case ipvt_char:
+        os << "char";
+        break;
+    case ipvt_float:
+        os << "float";
+        break;
+    case ipvt_string:
+        os << "string";
+        break;
+    case ipvt_bdata:
+        os << "bdata";
+        break;
+    case ipvt_other:
+        os << "other";
+        break;
+    }
+
+    os << " ptroff=" << d.ptr_offset << " n_subid=" << d.n_subid << " subpo=" << d.subid_ptr_offset << "]";
+    return os;
+}
+
 
 const interactiondata ip_data[n_ip_entries] = {
     ipvt_int,

--- a/wrappers/juce/SC3Editor.cpp
+++ b/wrappers/juce/SC3Editor.cpp
@@ -164,6 +164,15 @@ void SC3AudioProcessorEditor::idle()
     {
         mcount++;
         auto handled = false;
+        if (std::holds_alternative<VAction>(ad.actiontype))
+        {
+            auto id = ad.id;
+            if (id > 0)
+            {
+                auto inter = ip_data[id];
+                std::cout << ad << " " << inter << std::endl;
+            }
+        }
         for (auto &p : uiStateProxies)
         {
             handled |= p->processActionData(ad);
@@ -176,7 +185,10 @@ void SC3AudioProcessorEditor::idle()
             int aid = ad.id;
             if (collapseSubtypes)
                 aid = -1;
-            unhandled[ad.actiontype][aid]++;
+            if (std::holds_alternative<VAction>(ad.actiontype))
+                unhandled[std::get<VAction>(ad.actiontype)][aid]++;
+            else
+                jassert(false);
         }
 #endif
     }

--- a/wrappers/juce/components/WaveDisplay.cpp
+++ b/wrappers/juce/components/WaveDisplay.cpp
@@ -115,7 +115,11 @@ void WaveDisplay::paint(Graphics &g)
 // this is called when the sampler is sending out a broadcast
 bool WaveDisplay::processActionData(const actiondata &ad) {
     bool res = false;
-    if(ad.actiontype == vga_wavedisp_sample)
+    if (!std::holds_alternative<VAction>(ad.actiontype))
+        return false;
+
+    auto at = std::get<VAction>(ad.actiontype);
+    if(at == vga_wavedisp_sample)
     {
         auto e = (const ActionWaveDisplaySample &)(ad);
         bool same_sample = (mSamplePtr == e.samplePtr()) && (dispmode == 0);
@@ -149,7 +153,7 @@ bool WaveDisplay::processActionData(const actiondata &ad) {
         }
         queue_draw_wave(false,false);
     }
-    if(ad.actiontype == vga_wavedisp_editpoint)
+    if(at == vga_wavedisp_editpoint)
     {
         auto e = (const ActionWaveDisplayEditPoint &)(ad);
         markerpos[e.dragId()] = e.samplePos();
@@ -157,7 +161,7 @@ bool WaveDisplay::processActionData(const actiondata &ad) {
         // todo do we really need a full redraw here?
         queue_draw_wave(false,false);
     }
-    else if(ad.actiontype == vga_wavedisp_multiselect)
+    else if(at == vga_wavedisp_multiselect)
     {
         dispmode = 1;
         repaint();

--- a/wrappers/juce/proxies/ZoneStateProxy.cpp
+++ b/wrappers/juce/proxies/ZoneStateProxy.cpp
@@ -27,7 +27,9 @@ bool ZoneStateProxy::processActionData(const actiondata &ad)
     {
     case ip_kgv_or_list:
     {
-        switch (ad.actiontype)
+        if (!std::holds_alternative<VAction>(ad.actiontype))
+            break;
+        switch (std::get<VAction>(ad.actiontype))
         {
         case vga_zonelist_clear:
         {


### PR DESCRIPTION
Rather than a big enum and ints everywhere, start using type
safety in our messages. Still laods to do of course