### PR TITLE
Fix Mono Bus bug

### DIFF
--- a/wrappers/juce/CMakeLists.txt
+++ b/wrappers/juce/CMakeLists.txt
@@ -13,6 +13,8 @@ juce_add_plugin(ShortcircuitXT
         ICON_BIG "${CMAKE_SOURCE_DIR}/resources/images/SCAppIcon.png"
 
         FORMATS AU VST3 Standalone
+
+        COPY_PLUGIN_AFTER_BUILD TRUE
         )
 
 # images used in the ui

--- a/wrappers/juce/SCXTProcessor.cpp
+++ b/wrappers/juce/SCXTProcessor.cpp
@@ -93,15 +93,9 @@ void SCXTProcessor::releaseResources()
 #ifndef JucePlugin_PreferredChannelConfigurations
 bool SCXTProcessor::isBusesLayoutSupported(const BusesLayout &layouts) const
 {
-    // This is the place where you check if the layout is supported.
-    // In this template code we only support mono or stereo.
-    if (layouts.getMainOutputChannelSet() != juce::AudioChannelSet::mono() &&
-        layouts.getMainOutputChannelSet() != juce::AudioChannelSet::stereo())
+    // There are obviously other options here
+    if (layouts.getMainOutputChannelSet() != juce::AudioChannelSet::stereo())
         return false;
-
-    // FIXME - we can go mono -> stereo in the future
-    // if (layouts.getMainOutputChannelSet() != layouts.getMainInputChannelSet())
-    // return false;
 
     return true;
 }

--- a/wrappers/juce/SCXTProcessor.h
+++ b/wrappers/juce/SCXTProcessor.h
@@ -43,9 +43,7 @@ class SCXTProcessor : public juce::AudioProcessor, public scxt::log::LoggingCall
         }
     }
 
-#ifndef JucePlugin_PreferredChannelConfigurations
     bool isBusesLayoutSupported(const BusesLayout &layouts) const override;
-#endif
 
     void processBlock(juce::AudioBuffer<float> &, juce::MidiBuffer &) override;
 


### PR DESCRIPTION
JUCE advertised a mono output as a possibility. Logic took
us up on that offer at validation time. And we didn't mean it.
So Logic didn't like is.

For now configure as stereo out only. Fix that later obvs.

Closes #206