### PR TITLE
SavePatch and SaveMulti working

### DIFF
--- a/src/sampler_wrapper_interaction.cpp
+++ b/src/sampler_wrapper_interaction.cpp
@@ -214,21 +214,13 @@ void sampler::processWrapperEvents()
         case vga_save_patch:
         {
             // save_part_as_xml(editorpart,editor->savepart_fname.c_str());
-#if 0
-            SaveAllAsRIFF(0, editor->savepart_fname.c_str(), editorpart);
-#else
-            LOGERROR(mLogger) << "Unable to vga_save_patch" << std::endl;
-#endif
+            SaveAllAsRIFF(0, editorProxy.savepart_path.get(), editorpart);
         }
         break;
         case vga_save_multi:
         {
             // save_all_as_xml(0,editor->savepart_fname.c_str());
-#if 0
-            SaveAllAsRIFF(0, editor->savepart_fname.c_str());
-#else
-            LOGERROR(mLogger) << "Unable to vga_save_patch" << std::flush;
-#endif
+            SaveAllAsRIFF(0, editorProxy.savepart_path.get());
         }
         break;
         case vga_browser_preview_start:


### PR DESCRIPTION
The SavePatch/SaveMulti messages assumed an editor reference so
didn't work. Make a locking editor proxy I can write to in a thread
safe way and follow it with a message. Thereby implement savepatch
and savemulti

Addresses #165
Addresses #191