### PR TITLE
Clear on load; multi with sc2m extension

### DIFF
--- a/src/browser/ContentBrowser.cpp
+++ b/src/browser/ContentBrowser.cpp
@@ -52,7 +52,7 @@ void ContentBrowser::Content::recursivelyPopulate()
 
     const static auto samplesuffixes =
         std::unordered_set<std::string>({".wav", ".riff", ".sf2", ".sfz"});
-    const static auto patchsuffixes = std::unordered_set<std::string>({".sc2p"});
+    const static auto patchsuffixes = std::unordered_set<std::string>({".sc2p", ".sc2m"});
     for (const auto &d : fs::directory_iterator(fullPath))
     {
         auto dp = d.path();

--- a/src/sampler_wrapper_interaction.cpp
+++ b/src/sampler_wrapper_interaction.cpp
@@ -146,7 +146,7 @@ void sampler::processWrapperEvents()
             {
                 if (is_multisample_file(f.p))
                 {
-                    if (!load_file(f.p, nullptr, &nz))
+                    if (!load_file(f.p, nullptr, &nz, nullptr, 0, 0, true))
                     {
                         LOGDEBUG(mLogger) << "Did a loadFile for multi. What to do here?";
                     }

--- a/wrappers/juce/SCXTProcessor.cpp
+++ b/wrappers/juce/SCXTProcessor.cpp
@@ -28,6 +28,7 @@ SCXTProcessor::SCXTProcessor()
     configFile.append(SCXT_CONFIG_DIRECTORY);
     configFile.append("config.xml");
     mConfigFileName = configFile;
+    std::cout << "CONFIG LOCATION IS " << configLoc << std::endl;
 
     sc3 = std::make_unique<sampler>(nullptr, 2, nullptr, this);
     if (!sc3->loadUserConfiguration(mConfigFileName))

--- a/wrappers/juce/pages/PartPage.cpp
+++ b/wrappers/juce/pages/PartPage.cpp
@@ -64,7 +64,10 @@ struct Main : public ContentBase
                     return;
 
                 auto p = fs::path{result[0].getFullPathName().toStdString()};
-                p = p.replace_extension(fs::path{".sc2p"});
+                if (isMulti)
+                    p.replace_extension(fs::path{".sc2m"});
+                else
+                    p = p.replace_extension(fs::path{".sc2p"});
                 this->parentPage.editor->audioProcessor.sc3->editorProxy.savepart_path.set(p);
                 actiondata ad;
                 ad.id = ip_none;


### PR DESCRIPTION
When we do a drop of a multifile, set the zone drop in
replace mode not add zone mode. Addresses #155

Save SC2 multifiles as .sc2m extension not .sc2p