### PR TITLE
Add tempo and ppqpos information

### DIFF
--- a/src/sampler.h
+++ b/src/sampler.h
@@ -310,6 +310,9 @@ class sampler
     int polyphony;
     int mNumOutputs;
     timedata time_data;
+    // surge needed this so presume SC3 will too one day. For now make it a noop
+    void resetStateFromTimeData() {}
+
     int VUrate, VUidx, lastSentPolyphony{-1};
     float automation[n_automation_parameters];
 

--- a/src/sampler_state.h
+++ b/src/sampler_state.h
@@ -16,6 +16,7 @@ struct timedata
     double tempo;
     double ppqPos;
     float pos_in_beat, pos_in_2beats, pos_in_bar, pos_in_2bars, pos_in_4bars;
+    int timeSigNumerator{4}, timeSigDenominator{4};
 };
 
 #pragma pack(push, 1)


### PR DESCRIPTION
The plugin now supports tempo and ppqpos from the playhead
as well as the time signature (although we don't use that
yet).

Closes #241