### PR TITLE
Fix AIF File loading

### DIFF
--- a/src/loaders/load_aiff.cpp
+++ b/src/loaders/load_aiff.cpp
@@ -98,6 +98,7 @@ bool sample::parse_aiff(void *data, size_t filesize)
 {
     int datasize;
     scxt::Memfile::RIFFMemFile mf(data, filesize);
+    mf.useWaveEndian = false;
     if (!mf.iff_descend_FORM('AIFF', &datasize))
         return false;
     off_t wr = mf.TellI();


### PR DESCRIPTION
AIF uses an opposite endian from wave for chunk and chunk tag.

CLoses #212