### PR TITLE
Add CLAP to windows installer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,16 +21,12 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 project(ShortCircuit VERSION 0.5.0.0 LANGUAGES C CXX ASM)
 
 # Calculate bitness
-math(EXPR SCXT_BITNESS "${CMAKE_SIZEOF_VOID_P} * 8" OUTPUT_FORMAT DECIMAL)
+math(EXPR BITS "8*${CMAKE_SIZEOF_VOID_P}")
+message(STATUS "Targeting ${BITS}-bit configuration")
 
 # Share some information about the  build
 message(STATUS "ShortCircuit ${CMAKE_PROJECT_VERSION}")
 message(STATUS "Compiler Version is ${CMAKE_CXX_COMPILER_VERSION}")
-if (${CMAKE_SIZEOF_VOID_P} EQUAL 4)
-    message(STATUS "Building in 32 bit configuration")
-else ()
-    message(STATUS "Building in 64 bit configuration")
-endif ()
 
 
 # Optional variables

--- a/cmake/basic-installer.cmake
+++ b/cmake/basic-installer.cmake
@@ -74,7 +74,6 @@ endif ()
 
 string(TIMESTAMP SCXT_DATE "%Y-%m-%d")
 if (WIN32)
-    math(EXPR BITS "8*${CMAKE_SIZEOF_VOID_P}")
     set(SCXT_ZIP ShortcircuitXT-${SCXT_DATE}-${VERSION_CHUNK}-${CMAKE_SYSTEM_NAME}-${BITS}bit.zip)
 else ()
     set(SCXT_ZIP ShortcircuitXT-${SCXT_DATE}-${VERSION_CHUNK}-${CMAKE_SYSTEM_NAME}.zip)
@@ -101,15 +100,15 @@ elseif (WIN32)
             COMMAND ${CMAKE_COMMAND} -E echo "ZIP Installer in: installer/${SCXT_ZIP}")
     find_program(SHORTCIRCUIT_NUGET_EXE nuget.exe PATHS ENV "PATH")
     if(SHORTCIRCUIT_NUGET_EXE)
-        message(STATUS "NuGet found at ${SHORTCIRCUIT_NUGET_EXE}, creating InnoSetup installer")
+        message(STATUS "NuGet found at ${SHORTCIRCUIT_NUGET_EXE}")
         add_custom_command(
             TARGET shortcircuit-installer
             POST_BUILD
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
             COMMAND ${SHORTCIRCUIT_NUGET_EXE} install Tools.InnoSetup -version 6.2.0
-            COMMAND Tools.InnoSetup.6.2.0/tools/iscc.exe /O"installer" /DSCXT_SRC="${CMAKE_SOURCE_DIR}" /DSCXT_BIN="${CMAKE_BINARY_DIR}" /DSCXT_VERSION="${SCXT_DATE}-${VERSION_CHUNK}" "${CMAKE_SOURCE_DIR}/resources/installer_win/scxt${SCXT_BITNESS}.iss")
+            COMMAND Tools.InnoSetup.6.2.0/tools/iscc.exe /O"installer" /DSCXT_SRC="${CMAKE_SOURCE_DIR}" /DSCXT_BIN="${CMAKE_BINARY_DIR}" /DSCXT_VERSION="${SCXT_DATE}-${VERSION_CHUNK}" "${CMAKE_SOURCE_DIR}/resources/installer_win/scxt${BITS}.iss")
     else()
-        message(STATUS "NuGet not found, not creating InnoSetup installer")
+        message(STATUS "NuGet not found")
     endif()
 else ()
     message(STATUS "Basic Installer: Target is installer/${SCXT_ZIP}")

--- a/resources/installer_win/scxt32.iss
+++ b/resources/installer_win/scxt32.iss
@@ -1,7 +1,7 @@
 #define MyAppPublisher "Surge Synth Team"
 #define MyAppURL "https://www.surge-synth-team.org/"
 #define MyAppName "Shortcircuit XT"
-#define MyAppNameCondensed "SCXT"
+#define MyAppNameCondensed "ShortcircuitXT"
 #define MyID "8BDBC849-F102-44A0-9BFA-B28556BDE40C"
 
 ;uncomment these two lines if building the installer locally!
@@ -11,8 +11,8 @@
 [Setup]
 AppId={#MyID}
 AppName={#MyAppName}
+AppVerName={#MyAppName}
 AppVersion={#SCXT_VERSION}
-AppVerName={#MyAppName} {#SCXT_VERSION}
 AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
@@ -23,7 +23,7 @@ DisableDirPage=yes
 DisableProgramGroupPage=yes
 AlwaysShowDirOnReadyPage=yes
 LicenseFile={#SCXT_SRC}\LICENSE
-OutputBaseFilename={#MyAppName}-win32-{#SCXT_VERSION}-setup
+OutputBaseFilename={#MyAppNameCondensed}-{#SCXT_VERSION}-Windows-32bit-setup
 SetupIconFile={#SCXT_SRC}\resources\installer_win\scxt.ico
 UninstallDisplayIcon={uninstallexe}
 UsePreviousAppDir=yes
@@ -42,17 +42,20 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Types]
 Name: "full"; Description: "Full installation"
-Name: "plugin"; Description: "VST3 installation"
+Name: "vst3"; Description: "VST3 installation"
+Name: "clap"; Description: "CLAP installation"
 Name: "standalone"; Description: "Standalone installation"
 Name: "custom"; Description: "Custom"; Flags: iscustom
 
 [Components]
-Name: "vst3"; Description: "{#MyAppNameCondensed} VST3 (32-bit)"; Types: full plugin custom
-Name: "exe"; Description: "{#MyAppNameCondensed} Standalone (32-bit)"; Types: full standalone custom
+Name: "VST3"; Description: "{#MyAppName} VST3 (32-bit)"; Types: full vst3 custom
+Name: "CLAP"; Description: "{#MyAppName} CLAP (32-bit)"; Types: full clap custom
+Name: "SA"; Description: "{#MyAppName} Standalone (32-bit)"; Types: full standalone custom
 
 [Files]
-Source: "{#SCXT_BIN}\shortcircuit-products\{#MyAppName}.exe"; DestDir: "{app}"; Components: exe; Flags: ignoreversion
-Source: "{#SCXT_BIN}\shortcircuit-products\{#MyAppName}.vst3\*"; DestDir: "{autocf}\VST3\{#MyAppName}.vst3\"; Components: vst3; Flags: ignoreversion recursesubdirs
+Source: "{#SCXT_BIN}\shortcircuit-products\{#MyAppName}.vst3\*"; DestDir: "{autocf}\VST3\{#MyAppPublisher}\{#MyAppName}.vst3\"; Components: VST3; Flags: ignoreversion recursesubdirs
+Source: "{#SCXT_BIN}\shortcircuit-products\{#MyAppName}.clap"; DestDir: "{autocf}\Clap\{#MyAppPublisher}\"; Components: CLAP; Flags: ignoreversion
+Source: "{#SCXT_BIN}\shortcircuit-products\{#MyAppName}.exe"; DestDir: "{app}"; Components: SA; Flags: ignoreversion
 
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppName}.exe"; Flags: createonlyiffileexists

--- a/resources/installer_win/scxt64.iss
+++ b/resources/installer_win/scxt64.iss
@@ -1,7 +1,7 @@
 #define MyAppPublisher "Surge Synth Team"
 #define MyAppURL "https://www.surge-synth-team.org/"
 #define MyAppName "Shortcircuit XT"
-#define MyAppNameCondensed "SCXT"
+#define MyAppNameCondensed "ShortcircuitXT"
 #define MyID "8BDBC849-F102-44A0-9BFA-B28556BDE40B"
 
 ;uncomment these two lines if building the installer locally!
@@ -13,8 +13,8 @@ ArchitecturesInstallIn64BitMode=x64
 ArchitecturesAllowed=x64
 AppId={#MyID}
 AppName={#MyAppName}
+AppVerName={#MyAppName}
 AppVersion={#SCXT_VERSION}
-AppVerName={#MyAppName} {#SCXT_VERSION}
 AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
@@ -25,7 +25,7 @@ DisableDirPage=yes
 DisableProgramGroupPage=yes
 AlwaysShowDirOnReadyPage=yes
 LicenseFile={#SCXT_SRC}\LICENSE
-OutputBaseFilename={#MyAppName}-win64-{#SCXT_VERSION}-setup
+OutputBaseFilename={#MyAppNameCondensed}-{#SCXT_VERSION}-Windows-64bit-setup
 SetupIconFile={#SCXT_SRC}\resources\installer_win\scxt.ico
 UninstallDisplayIcon={uninstallexe}
 UsePreviousAppDir=yes
@@ -44,17 +44,20 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Types]
 Name: "full"; Description: "Full installation"
-Name: "plugin"; Description: "VST3 installation"
+Name: "vst3"; Description: "VST3 installation"
+Name: "clap"; Description: "CLAP installation"
 Name: "standalone"; Description: "Standalone installation"
 Name: "custom"; Description: "Custom"; Flags: iscustom
 
 [Components]
-Name: "vst3"; Description: "{#MyAppNameCondensed} VST3 (64-bit)"; Types: full plugin custom
-Name: "exe"; Description: "{#MyAppNameCondensed} Standalone (64-bit)"; Types: full standalone custom
+Name: "VST3"; Description: "{#MyAppName} VST3 (64-bit)"; Types: full vst3 custom
+Name: "CLAP"; Description: "{#MyAppName} CLAP (64-bit)"; Types: full clap custom
+Name: "SA"; Description: "{#MyAppName} Standalone (64-bit)"; Types: full standalone custom
 
 [Files]
-Source: "{#SCXT_BIN}\shortcircuit-products\{#MyAppName}.exe"; DestDir: "{app}"; Components: exe; Flags: ignoreversion
-Source: "{#SCXT_BIN}\shortcircuit-products\{#MyAppName}.vst3\*"; DestDir: "{autocf}\VST3\{#MyAppName}.vst3\"; Components: vst3; Flags: ignoreversion recursesubdirs
+Source: "{#SCXT_BIN}\shortcircuit-products\{#MyAppName}.vst3\*"; DestDir: "{autocf}\VST3\{#MyAppPublisher}\{#MyAppName}.vst3\"; Components: VST3; Flags: ignoreversion recursesubdirs
+Source: "{#SCXT_BIN}\shortcircuit-products\{#MyAppName}.clap"; DestDir: "{autocf}\Clap\{#MyAppPublisher}\"; Components: CLAP; Flags: ignoreversion
+Source: "{#SCXT_BIN}\shortcircuit-products\{#MyAppName}.exe"; DestDir: "{app}"; Components: SA; Flags: ignoreversion
 
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppName}.exe"; Flags: createonlyiffileexists


### PR DESCRIPTION
- Clear up language for NUGET search
(we don't actually create installer at this stage)
- Remove redundant bitness check
- Fix installer exe name to match zip installer
- Fix AppVerName to match Surge installer
- Better uninstaller location
- Make sure we install in publisher folders with Surge