### PR TITLE
Fix sc3-test for gcc > 10

### DIFF
--- a/libs/catch2/include/catch2/catch2.hpp
+++ b/libs/catch2/include/catch2/catch2.hpp
@@ -1,9 +1,9 @@
 /*
- *  Catch v2.9.2
- *  Generated: 2019-08-08 13:35:12.279703
+ *  Catch v2.13.9
+ *  Generated: 2022-04-12 22:37:23.260201
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
- *  Copyright (c) 2019 Two Blue Cubes Ltd. All rights reserved.
+ *  Copyright (c) 2022 Two Blue Cubes Ltd. All rights reserved.
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -13,8 +13,8 @@
 // start catch.hpp
 
 #define CATCH_VERSION_MAJOR 2
-#define CATCH_VERSION_MINOR 9
-#define CATCH_VERSION_PATCH 2
+#define CATCH_VERSION_MINOR 13
+#define CATCH_VERSION_PATCH 9
 
 #ifdef __clang__
 #pragma clang system_header
@@ -65,15 +65,17 @@
 #if !defined(CATCH_CONFIG_IMPL_ONLY)
 // start catch_platform.h
 
+// See e.g.:
+// https://opensource.apple.com/source/CarbonHeaders/CarbonHeaders-18.1/TargetConditionals.h.auto.html
 #ifdef __APPLE__
 #include <TargetConditionals.h>
-#if TARGET_OS_OSX == 1
+#if (defined(TARGET_OS_OSX) && TARGET_OS_OSX == 1) || (defined(TARGET_OS_MAC) && TARGET_OS_MAC == 1)
 #define CATCH_PLATFORM_MAC
-#elif TARGET_OS_IPHONE == 1
+#elif (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE == 1)
 #define CATCH_PLATFORM_IPHONE
 #endif
 
-#elif defined(linux) || defined(__linux) || defined(__linux__) || defined(__FreeBSD__)
+#elif defined(linux) || defined(__linux) || defined(__linux__)
 #define CATCH_PLATFORM_LINUX
 
 #elif defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER) ||              \
@@ -133,30 +135,54 @@ unsigned int rngSeed();
 
 #endif
 
-#if defined(CATCH_CPP17_OR_GREATER)
-#define CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS
+// Only GCC compiler should be used in this block, so other compilers trying to
+// mask themselves as GCC should be ignored.
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__ICC) && !defined(__CUDACC__) &&         \
+    !defined(__LCC__)
+#define CATCH_INTERNAL_START_WARNINGS_SUPPRESSION _Pragma("GCC diagnostic push")
+#define CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION _Pragma("GCC diagnostic pop")
+
+#define CATCH_INTERNAL_IGNORE_BUT_WARN(...) (void)__builtin_constant_p(__VA_ARGS__)
+
 #endif
 
-#ifdef __clang__
+#if defined(__clang__)
+
+#define CATCH_INTERNAL_START_WARNINGS_SUPPRESSION _Pragma("clang diagnostic push")
+#define CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION _Pragma("clang diagnostic pop")
+
+// As of this writing, IBM XL's implementation of __builtin_constant_p has a bug
+// which results in calls to destructors being emitted for each temporary,
+// without a matching initialization. In practice, this can result in something
+// like `std::string::~string` being called on an uninitialized value.
+//
+// For example, this code will likely segfault under IBM XL:
+// ```
+// REQUIRE(std::string("12") + "34" == "1234")
+// ```
+//
+// Therefore, `CATCH_INTERNAL_IGNORE_BUT_WARN` is not implemented.
+#if !defined(__ibmxl__) && !defined(__CUDACC__)
+#define CATCH_INTERNAL_IGNORE_BUT_WARN(...)                                                        \
+    (void)__builtin_constant_p(                                                                    \
+        __VA_ARGS__) /* NOLINT(cppcoreguidelines-pro-type-vararg, hicpp-vararg) */
+#endif
 
 #define CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS                                                   \
-    _Pragma("clang diagnostic push")                                                               \
-        _Pragma("clang diagnostic ignored \"-Wexit-time-destructors\"")                            \
-            _Pragma("clang diagnostic ignored \"-Wglobal-constructors\"")
-#define CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS _Pragma("clang diagnostic pop")
+    _Pragma("clang diagnostic ignored \"-Wexit-time-destructors\"")                                \
+        _Pragma("clang diagnostic ignored \"-Wglobal-constructors\"")
 
 #define CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS                                               \
-    _Pragma("clang diagnostic push") _Pragma("clang diagnostic ignored \"-Wparentheses\"")
-#define CATCH_INTERNAL_UNSUPPRESS_PARENTHESES_WARNINGS _Pragma("clang diagnostic pop")
+    _Pragma("clang diagnostic ignored \"-Wparentheses\"")
 
 #define CATCH_INTERNAL_SUPPRESS_UNUSED_WARNINGS                                                    \
-    _Pragma("clang diagnostic push") _Pragma("clang diagnostic ignored \"-Wunused-variable\"")
-#define CATCH_INTERNAL_UNSUPPRESS_UNUSED_WARNINGS _Pragma("clang diagnostic pop")
+    _Pragma("clang diagnostic ignored \"-Wunused-variable\"")
 
 #define CATCH_INTERNAL_SUPPRESS_ZERO_VARIADIC_WARNINGS                                             \
-    _Pragma("clang diagnostic push")                                                               \
-        _Pragma("clang diagnostic ignored \"-Wgnu-zero-variadic-macro-arguments\"")
-#define CATCH_INTERNAL_UNSUPPRESS_ZERO_VARIADIC_WARNINGS _Pragma("clang diagnostic pop")
+    _Pragma("clang diagnostic ignored \"-Wgnu-zero-variadic-macro-arguments\"")
+
+#define CATCH_INTERNAL_SUPPRESS_UNUSED_TEMPLATE_WARNINGS                                           \
+    _Pragma("clang diagnostic ignored \"-Wunused-template\"")
 
 #endif // __clang__
 
@@ -181,6 +207,7 @@ unsigned int rngSeed();
 // Android somehow still does not support std::to_string
 #if defined(__ANDROID__)
 #define CATCH_INTERNAL_CONFIG_NO_CPP11_TO_STRING
+#define CATCH_INTERNAL_CONFIG_ANDROID_LOGWRITE
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -214,11 +241,7 @@ unsigned int rngSeed();
 
 ////////////////////////////////////////////////////////////////////////////////
 // Visual C++
-#ifdef _MSC_VER
-
-#if _MSC_VER >= 1900 // Visual Studio 2015 or newer
-#define CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS
-#endif
+#if defined(_MSC_VER)
 
 // Universal Windows platform does not support SEH
 // Or console colours (or console at all...)
@@ -228,12 +251,20 @@ unsigned int rngSeed();
 #define CATCH_INTERNAL_CONFIG_WINDOWS_SEH
 #endif
 
+#if !defined(__clang__) // Handle Clang masquerading for msvc
+
 // MSVC traditional preprocessor needs some workaround for __VA_ARGS__
 // _MSVC_TRADITIONAL == 0 means new conformant preprocessor
 // _MSVC_TRADITIONAL == 1 means old traditional non-conformant preprocessor
 #if !defined(_MSVC_TRADITIONAL) || (defined(_MSVC_TRADITIONAL) && _MSVC_TRADITIONAL)
 #define CATCH_INTERNAL_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
-#endif
+#endif // MSVC_TRADITIONAL
+
+// Only do this if we're not using clang on Windows, which uses `diagnostic push` & `diagnostic pop`
+#define CATCH_INTERNAL_START_WARNINGS_SUPPRESSION __pragma(warning(push))
+#define CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION __pragma(warning(pop))
+#endif // __clang__
+
 #endif // _MSC_VER
 
 #if defined(_REENTRANT) || defined(_MSC_VER)
@@ -281,34 +312,31 @@ unsigned int rngSeed();
 #define CATCH_CONFIG_COLOUR_NONE
 #endif
 
-////////////////////////////////////////////////////////////////////////////////
-// Check if string_view is available and usable
-// The check is split apart to work around v140 (VS2015) preprocessor issue...
+#if !defined(_GLIBCXX_USE_C99_MATH_TR1)
+#define CATCH_INTERNAL_CONFIG_GLOBAL_NEXTAFTER
+#endif
+
+// Various stdlib support checks that require __has_include
 #if defined(__has_include)
+// Check if string_view is available and usable
 #if __has_include(<string_view>) && defined(CATCH_CPP17_OR_GREATER)
 #define CATCH_INTERNAL_CONFIG_CPP17_STRING_VIEW
 #endif
-#endif
 
-////////////////////////////////////////////////////////////////////////////////
 // Check if optional is available and usable
-#if defined(__has_include)
 #if __has_include(<optional>) && defined(CATCH_CPP17_OR_GREATER)
 #define CATCH_INTERNAL_CONFIG_CPP17_OPTIONAL
 #endif // __has_include(<optional>) && defined(CATCH_CPP17_OR_GREATER)
-#endif // __has_include
 
-////////////////////////////////////////////////////////////////////////////////
 // Check if byte is available and usable
-#if defined(__has_include)
 #if __has_include(<cstddef>) && defined(CATCH_CPP17_OR_GREATER)
+#include <cstddef>
+#if defined(__cpp_lib_byte) && (__cpp_lib_byte > 0)
 #define CATCH_INTERNAL_CONFIG_CPP17_BYTE
+#endif
 #endif // __has_include(<cstddef>) && defined(CATCH_CPP17_OR_GREATER)
-#endif // __has_include
 
-////////////////////////////////////////////////////////////////////////////////
 // Check if variant is available and usable
-#if defined(__has_include)
 #if __has_include(<variant>) && defined(CATCH_CPP17_OR_GREATER)
 #if defined(__clang__) && (__clang_major__ < 8)
 // work around clang bug with libstdc++ https://bugs.llvm.org/show_bug.cgi?id=31852
@@ -323,7 +351,7 @@ unsigned int rngSeed();
 #define CATCH_INTERNAL_CONFIG_CPP17_VARIANT
 #endif // defined(__clang__) && (__clang_major__ < 8)
 #endif // __has_include(<variant>) && defined(CATCH_CPP17_OR_GREATER)
-#endif // __has_include
+#endif // defined(__has_include)
 
 #if defined(CATCH_INTERNAL_CONFIG_COUNTER) && !defined(CATCH_CONFIG_NO_COUNTER) &&                 \
     !defined(CATCH_CONFIG_COUNTER)
@@ -355,12 +383,6 @@ unsigned int rngSeed();
 #if defined(CATCH_INTERNAL_CONFIG_CPP17_OPTIONAL) && !defined(CATCH_CONFIG_NO_CPP17_OPTIONAL) &&   \
     !defined(CATCH_CONFIG_CPP17_OPTIONAL)
 #define CATCH_CONFIG_CPP17_OPTIONAL
-#endif
-
-#if defined(CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS) &&                                    \
-    !defined(CATCH_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS) &&                                         \
-    !defined(CATCH_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS)
-#define CATCH_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS
 #endif
 
 #if defined(CATCH_INTERNAL_CONFIG_CPP17_STRING_VIEW) &&                                            \
@@ -402,21 +424,51 @@ unsigned int rngSeed();
 #define CATCH_CONFIG_USE_ASYNC
 #endif
 
+#if defined(CATCH_INTERNAL_CONFIG_ANDROID_LOGWRITE) &&                                             \
+    !defined(CATCH_CONFIG_NO_ANDROID_LOGWRITE) && !defined(CATCH_CONFIG_ANDROID_LOGWRITE)
+#define CATCH_CONFIG_ANDROID_LOGWRITE
+#endif
+
+#if defined(CATCH_INTERNAL_CONFIG_GLOBAL_NEXTAFTER) &&                                             \
+    !defined(CATCH_CONFIG_NO_GLOBAL_NEXTAFTER) && !defined(CATCH_CONFIG_GLOBAL_NEXTAFTER)
+#define CATCH_CONFIG_GLOBAL_NEXTAFTER
+#endif
+
+// Even if we do not think the compiler has that warning, we still have
+// to provide a macro that can be used by the code.
+#if !defined(CATCH_INTERNAL_START_WARNINGS_SUPPRESSION)
+#define CATCH_INTERNAL_START_WARNINGS_SUPPRESSION
+#endif
+#if !defined(CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION)
+#define CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
+#endif
 #if !defined(CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS)
 #define CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS
-#define CATCH_INTERNAL_UNSUPPRESS_PARENTHESES_WARNINGS
 #endif
 #if !defined(CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS)
 #define CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS
-#define CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS
 #endif
 #if !defined(CATCH_INTERNAL_SUPPRESS_UNUSED_WARNINGS)
 #define CATCH_INTERNAL_SUPPRESS_UNUSED_WARNINGS
-#define CATCH_INTERNAL_UNSUPPRESS_UNUSED_WARNINGS
 #endif
 #if !defined(CATCH_INTERNAL_SUPPRESS_ZERO_VARIADIC_WARNINGS)
 #define CATCH_INTERNAL_SUPPRESS_ZERO_VARIADIC_WARNINGS
-#define CATCH_INTERNAL_UNSUPPRESS_ZERO_VARIADIC_WARNINGS
+#endif
+
+// The goal of this macro is to avoid evaluation of the arguments, but
+// still have the compiler warn on problems inside...
+#if !defined(CATCH_INTERNAL_IGNORE_BUT_WARN)
+#define CATCH_INTERNAL_IGNORE_BUT_WARN(...)
+#endif
+
+#if defined(__APPLE__) && defined(__apple_build_version__) && (__clang_major__ < 10)
+#undef CATCH_INTERNAL_SUPPRESS_UNUSED_TEMPLATE_WARNINGS
+#elif defined(__clang__) && (__clang_major__ < 5)
+#undef CATCH_INTERNAL_SUPPRESS_UNUSED_TEMPLATE_WARNINGS
+#endif
+
+#if !defined(CATCH_INTERNAL_SUPPRESS_UNUSED_TEMPLATE_WARNINGS)
+#define CATCH_INTERNAL_SUPPRESS_UNUSED_TEMPLATE_WARNINGS
 #endif
 
 #if defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
@@ -489,7 +541,7 @@ struct SourceLineInfo
     SourceLineInfo(SourceLineInfo &&) noexcept = default;
     SourceLineInfo &operator=(SourceLineInfo &&) noexcept = default;
 
-    bool empty() const noexcept;
+    bool empty() const noexcept { return file[0] == '\0'; }
     bool operator==(SourceLineInfo const &other) const noexcept;
     bool operator<(SourceLineInfo const &other) const noexcept;
 
@@ -530,13 +582,14 @@ struct RegistrarForTagAliases
 } // end namespace Catch
 
 #define CATCH_REGISTER_TAG_ALIAS(alias, spec)                                                      \
+    CATCH_INTERNAL_START_WARNINGS_SUPPRESSION                                                      \
     CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS                                                       \
     namespace                                                                                      \
     {                                                                                              \
     Catch::RegistrarForTagAliases                                                                  \
         INTERNAL_CATCH_UNIQUE_NAME(AutoRegisterTagAlias)(alias, spec, CATCH_INTERNAL_LINEINFO);    \
     }                                                                                              \
-    CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS
+    CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 
 // end catch_tag_alias_autoregistrar.h
 // start catch_test_registry.h
@@ -580,145 +633,93 @@ std::vector<TestCase> const &getAllTestCasesSorted(IConfig const &config);
 #include <cstddef>
 #include <string>
 #include <iosfwd>
+#include <cassert>
 
 namespace Catch
 {
 
 /// A non-owning string class (similar to the forthcoming std::string_view)
 /// Note that, because a StringRef may be a substring of another string,
-/// it may not be null terminated. c_str() must return a null terminated
-/// string, however, and so the StringRef will internally take ownership
-/// (taking a copy), if necessary. In theory this ownership is not externally
-/// visible - but it does mean (substring) StringRefs should not be shared between
-/// threads.
+/// it may not be null terminated.
 class StringRef
 {
   public:
     using size_type = std::size_t;
+    using const_iterator = const char *;
 
   private:
-    friend struct StringRefTestAccess;
-
-    char const *m_start;
-    size_type m_size;
-
-    char *m_data = nullptr;
-
-    void takeOwnership();
-
     static constexpr char const *const s_empty = "";
 
-  public: // construction/ assignment
-    StringRef() noexcept : StringRef(s_empty, 0) {}
+    char const *m_start = s_empty;
+    size_type m_size = 0;
 
-    StringRef(StringRef const &other) noexcept : m_start(other.m_start), m_size(other.m_size) {}
-
-    StringRef(StringRef &&other) noexcept
-        : m_start(other.m_start), m_size(other.m_size), m_data(other.m_data)
-    {
-        other.m_data = nullptr;
-    }
+  public: // construction
+    constexpr StringRef() noexcept = default;
 
     StringRef(char const *rawChars) noexcept;
 
-    StringRef(char const *rawChars, size_type size) noexcept : m_start(rawChars), m_size(size) {}
+    constexpr StringRef(char const *rawChars, size_type size) noexcept
+        : m_start(rawChars), m_size(size)
+    {
+    }
 
     StringRef(std::string const &stdString) noexcept
         : m_start(stdString.c_str()), m_size(stdString.size())
     {
     }
 
-    ~StringRef() noexcept { delete[] m_data; }
-
-    auto operator=(StringRef const &other) noexcept -> StringRef &
-    {
-        delete[] m_data;
-        m_data = nullptr;
-        m_start = other.m_start;
-        m_size = other.m_size;
-        return *this;
-    }
-
-    operator std::string() const;
-
-    void swap(StringRef &other) noexcept;
+    explicit operator std::string() const { return std::string(m_start, m_size); }
 
   public: // operators
     auto operator==(StringRef const &other) const noexcept -> bool;
-    auto operator!=(StringRef const &other) const noexcept -> bool;
+    auto operator!=(StringRef const &other) const noexcept -> bool { return !(*this == other); }
 
-    auto operator[](size_type index) const noexcept -> char;
+    auto operator[](size_type index) const noexcept -> char
+    {
+        assert(index < m_size);
+        return m_start[index];
+    }
 
   public: // named queries
-    auto empty() const noexcept -> bool { return m_size == 0; }
-    auto size() const noexcept -> size_type { return m_size; }
+    constexpr auto empty() const noexcept -> bool { return m_size == 0; }
+    constexpr auto size() const noexcept -> size_type { return m_size; }
 
-    auto numberOfCharacters() const noexcept -> size_type;
+    // Returns the current start pointer. If the StringRef is not
+    // null-terminated, throws std::domain_exception
     auto c_str() const -> char const *;
 
   public: // substrings and searches
-    auto substr(size_type start, size_type size) const noexcept -> StringRef;
+    // Returns a substring of [start, start + length).
+    // If start + length > size(), then the substring is [start, size()).
+    // If start > size(), then the substring is empty.
+    auto substr(size_type start, size_type length) const noexcept -> StringRef;
 
-    // Returns the current start pointer.
-    // Note that the pointer can change when if the StringRef is a substring
-    auto currentData() const noexcept -> char const *;
+    // Returns the current start pointer. May not be null-terminated.
+    auto data() const noexcept -> char const *;
 
-  private: // ownership queries - may not be consistent between calls
-    auto isOwned() const noexcept -> bool;
-    auto isSubstring() const noexcept -> bool;
+    constexpr auto isNullTerminated() const noexcept -> bool { return m_start[m_size] == '\0'; }
+
+  public: // iterators
+    constexpr const_iterator begin() const { return m_start; }
+    constexpr const_iterator end() const { return m_start + m_size; }
 };
-
-auto operator+(StringRef const &lhs, StringRef const &rhs) -> std::string;
-auto operator+(StringRef const &lhs, char const *rhs) -> std::string;
-auto operator+(char const *lhs, StringRef const &rhs) -> std::string;
 
 auto operator+=(std::string &lhs, StringRef const &sr) -> std::string &;
 auto operator<<(std::ostream &os, StringRef const &sr) -> std::ostream &;
 
-inline auto operator"" _sr(char const *rawChars, std::size_t size) noexcept -> StringRef
+constexpr auto operator"" _sr(char const *rawChars, std::size_t size) noexcept -> StringRef
 {
     return StringRef(rawChars, size);
 }
-
 } // namespace Catch
 
-inline auto operator"" _catch_sr(char const *rawChars, std::size_t size) noexcept
+constexpr auto operator"" _catch_sr(char const *rawChars, std::size_t size) noexcept
     -> Catch::StringRef
 {
     return Catch::StringRef(rawChars, size);
 }
 
 // end catch_stringref.h
-// start catch_type_traits.hpp
-
-#include <type_traits>
-
-namespace Catch
-{
-
-#ifdef CATCH_CPP17_OR_GREATER
-template <typename...> inline constexpr auto is_unique = std::true_type{};
-
-template <typename T, typename... Rest>
-inline constexpr auto is_unique<T, Rest...> =
-    std::bool_constant<(!std::is_same_v<T, Rest> && ...) && is_unique<Rest...>>{};
-#else
-
-template <typename...> struct is_unique : std::true_type
-{
-};
-
-template <typename T0, typename T1, typename... Rest>
-struct is_unique<T0, T1, Rest...>
-    : std::integral_constant<bool, !std::is_same<T0, T1>::value && is_unique<T0, Rest...>::value &&
-                                       is_unique<T1, Rest...>::value>
-{
-};
-
-#endif
-} // namespace Catch
-
-// end catch_type_traits.hpp
 // start catch_preprocessor.hpp
 
 #define CATCH_RECURSION_LEVEL0(...) __VA_ARGS__
@@ -834,7 +835,7 @@ struct is_unique<T0, T1, Rest...>
 #define INTERNAL_CATCH_REMOVE_PARENS_6_ARG(_0, _1, _2, _3, _4, _5)                                 \
     INTERNAL_CATCH_REMOVE_PARENS(_0), INTERNAL_CATCH_REMOVE_PARENS_5_ARG(_1, _2, _3, _4, _5)
 #define INTERNAL_CATCH_REMOVE_PARENS_7_ARG(_0, _1, _2, _3, _4, _5, _6)                             \
-    INTERNAL_CATCH_REMOVE_PARENS(_0), INTERNAL_CATCH_REMOVE_PARENS_6_ARG(_1, _2, _4, _5, _6)
+    INTERNAL_CATCH_REMOVE_PARENS(_0), INTERNAL_CATCH_REMOVE_PARENS_6_ARG(_1, _2, _3, _4, _5, _6)
 #define INTERNAL_CATCH_REMOVE_PARENS_8_ARG(_0, _1, _2, _3, _4, _5, _6, _7)                         \
     INTERNAL_CATCH_REMOVE_PARENS(_0), INTERNAL_CATCH_REMOVE_PARENS_7_ARG(_1, _2, _3, _4, _5, _6, _7)
 #define INTERNAL_CATCH_REMOVE_PARENS_9_ARG(_0, _1, _2, _3, _4, _5, _6, _7, _8)                     \
@@ -857,53 +858,63 @@ struct is_unique<T0, T1, Rest...>
     {                                                                                              \
         return {};                                                                                 \
     }                                                                                              \
-                                                                                                   \
-    template <template <typename...> class L1, typename... E1, template <typename...> class L2,    \
-              typename... E2>                                                                      \
-    constexpr auto append(L1<E1...>, L2<E2...>) noexcept->L1<E1..., E2...>                         \
+    template <template <typename...> class...> struct TemplateTypeList                             \
+    {                                                                                              \
+    };                                                                                             \
+    template <template <typename...> class... Cs>                                                  \
+    constexpr auto get_wrapper() noexcept->TemplateTypeList<Cs...>                                 \
     {                                                                                              \
         return {};                                                                                 \
     }                                                                                              \
+    template <typename...> struct append;                                                          \
+    template <typename...> struct rewrap;                                                          \
+    template <template <typename...> class, typename...> struct create;                            \
+    template <template <typename...> class, typename> struct convert;                              \
+                                                                                                   \
+    template <typename T> struct append<T>                                                         \
+    {                                                                                              \
+        using type = T;                                                                            \
+    };                                                                                             \
     template <template <typename...> class L1, typename... E1, template <typename...> class L2,    \
               typename... E2, typename... Rest>                                                    \
-    constexpr auto append(L1<E1...>, L2<E2...>,                                                    \
-                          Rest...) noexcept->decltype(append(L1<E1..., E2...>{}, Rest{}...))       \
+    struct append<L1<E1...>, L2<E2...>, Rest...>                                                   \
     {                                                                                              \
-        return {};                                                                                 \
-    }                                                                                              \
+        using type = typename append<L1<E1..., E2...>, Rest...>::type;                             \
+    };                                                                                             \
     template <template <typename...> class L1, typename... E1, typename... Rest>                   \
-    constexpr auto append(L1<E1...>, TypeList<mpl_::na>, Rest...) noexcept->L1<E1...>              \
+    struct append<L1<E1...>, TypeList<mpl_::na>, Rest...>                                          \
     {                                                                                              \
-        return {};                                                                                 \
-    }                                                                                              \
+        using type = L1<E1...>;                                                                    \
+    };                                                                                             \
                                                                                                    \
     template <template <typename...> class Container, template <typename...> class List,           \
               typename... elems>                                                                   \
-    constexpr auto rewrap(List<elems...>) noexcept->TypeList<Container<elems...>>                  \
+    struct rewrap<TemplateTypeList<Container>, List<elems...>>                                     \
     {                                                                                              \
-        return {};                                                                                 \
-    }                                                                                              \
+        using type = TypeList<Container<elems...>>;                                                \
+    };                                                                                             \
     template <template <typename...> class Container, template <typename...> class List,           \
               class... Elems, typename... Elements>                                                \
-    constexpr auto rewrap(List<Elems...>, Elements...) noexcept->decltype(                         \
-        append(TypeList<Container<Elems...>>{}, rewrap<Container>(Elements{}...)))                 \
+    struct rewrap<TemplateTypeList<Container>, List<Elems...>, Elements...>                        \
     {                                                                                              \
-        return {};                                                                                 \
-    }                                                                                              \
+        using type = typename append<                                                              \
+            TypeList<Container<Elems...>>,                                                         \
+            typename rewrap<TemplateTypeList<Container>, Elements...>::type>::type;                \
+    };                                                                                             \
                                                                                                    \
     template <template <typename...> class Final, template <typename...> class... Containers,      \
               typename... Types>                                                                   \
-    constexpr auto create(TypeList<Types...>) noexcept->decltype(                                  \
-        append(Final<>{}, rewrap<Containers>(Types{}...)...))                                      \
+    struct create<Final, TemplateTypeList<Containers...>, TypeList<Types...>>                      \
     {                                                                                              \
-        return {};                                                                                 \
-    }                                                                                              \
+        using type = typename append<                                                              \
+            Final<>, typename rewrap<TemplateTypeList<Containers>, Types...>::type...>::type;      \
+    };                                                                                             \
     template <template <typename...> class Final, template <typename...> class List,               \
               typename... Ts>                                                                      \
-    constexpr auto convert(List<Ts...>) noexcept->decltype(append(Final<>{}, TypeList<Ts>{}...))   \
+    struct convert<Final, List<Ts...>>                                                             \
     {                                                                                              \
-        return {};                                                                                 \
-    }
+        using type = typename append<Final<>, TypeList<Ts>...>::type;                              \
+    };
 
 #define INTERNAL_CATCH_NTTP_1(signature, ...)                                                      \
     template <INTERNAL_CATCH_REMOVE_PARENS(signature)> struct Nttp                                 \
@@ -914,30 +925,40 @@ struct is_unique<T0, T1, Rest...>
     {                                                                                              \
         return {};                                                                                 \
     }                                                                                              \
+    template <template <INTERNAL_CATCH_REMOVE_PARENS(signature)> class...>                         \
+    struct NttpTemplateTypeList                                                                    \
+    {                                                                                              \
+    };                                                                                             \
+    template <template <INTERNAL_CATCH_REMOVE_PARENS(signature)> class... Cs>                      \
+    constexpr auto get_wrapper() noexcept->NttpTemplateTypeList<Cs...>                             \
+    {                                                                                              \
+        return {};                                                                                 \
+    }                                                                                              \
                                                                                                    \
     template <template <INTERNAL_CATCH_REMOVE_PARENS(signature)> class Container,                  \
               template <INTERNAL_CATCH_REMOVE_PARENS(signature)> class List,                       \
               INTERNAL_CATCH_REMOVE_PARENS(signature)>                                             \
-    constexpr auto rewrap(List<__VA_ARGS__>) noexcept->TypeList<Container<__VA_ARGS__>>            \
+    struct rewrap<NttpTemplateTypeList<Container>, List<__VA_ARGS__>>                              \
     {                                                                                              \
-        return {};                                                                                 \
-    }                                                                                              \
+        using type = TypeList<Container<__VA_ARGS__>>;                                             \
+    };                                                                                             \
     template <template <INTERNAL_CATCH_REMOVE_PARENS(signature)> class Container,                  \
               template <INTERNAL_CATCH_REMOVE_PARENS(signature)> class List,                       \
               INTERNAL_CATCH_REMOVE_PARENS(signature), typename... Elements>                       \
-    constexpr auto rewrap(List<__VA_ARGS__>, Elements... elems) noexcept->decltype(                \
-        append(TypeList<Container<__VA_ARGS__>>{}, rewrap<Container>(elems...)))                   \
+    struct rewrap<NttpTemplateTypeList<Container>, List<__VA_ARGS__>, Elements...>                 \
     {                                                                                              \
-        return {};                                                                                 \
-    }                                                                                              \
+        using type = typename append<                                                              \
+            TypeList<Container<__VA_ARGS__>>,                                                      \
+            typename rewrap<NttpTemplateTypeList<Container>, Elements...>::type>::type;            \
+    };                                                                                             \
     template <template <typename...> class Final,                                                  \
               template <INTERNAL_CATCH_REMOVE_PARENS(signature)> class... Containers,              \
               typename... Types>                                                                   \
-    constexpr auto create(TypeList<Types...>) noexcept->decltype(                                  \
-        append(Final<>{}, rewrap<Containers>(Types{}...)...))                                      \
+    struct create<Final, NttpTemplateTypeList<Containers...>, TypeList<Types...>>                  \
     {                                                                                              \
-        return {};                                                                                 \
-    }
+        using type = typename append<                                                              \
+            Final<>, typename rewrap<NttpTemplateTypeList<Containers>, Types...>::type...>::type;  \
+    };
 
 #define INTERNAL_CATCH_DECLARE_SIG_TEST0(TestName)
 #define INTERNAL_CATCH_DECLARE_SIG_TEST1(TestName, signature)                                      \
@@ -1174,6 +1195,19 @@ struct is_callable<Fun(Args...)> : decltype(is_callable_tester::test<Fun, Args..
 {
 };
 
+#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703
+// std::result_of is deprecated in C++17 and removed in C++20. Hence, it is
+// replaced with std::invoke_result here.
+template <typename Func, typename... U>
+using FunctionReturnType =
+    std::remove_reference_t<std::remove_cv_t<std::invoke_result_t<Func, U...>>>;
+#else
+// Keep ::type here because we still support C++11
+template <typename Func, typename... U>
+using FunctionReturnType = typename std::remove_reference<
+    typename std::remove_cv<typename std::result_of<Func(U...)>::type>::type>::type;
+#endif
+
 } // namespace Catch
 
 namespace mpl_
@@ -1252,65 +1286,66 @@ struct AutoReg : NonCopyable
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
 #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION(Name, Tags, ...)                         \
     INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2(                                           \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____),               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____),    \
-        Name, Tags, typename TestType, __VA_ARGS__)
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_),                            \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_), Name, Tags,        \
+        typename TestType, __VA_ARGS__)
 #else
 #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION(Name, Tags, ...)                         \
     INTERNAL_CATCH_EXPAND_VARGS(INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2(               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____),               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____),    \
-        Name, Tags, typename TestType, __VA_ARGS__))
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_),                            \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_), Name, Tags,        \
+        typename TestType, __VA_ARGS__))
 #endif
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
 #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_SIG_NO_REGISTRATION(Name, Tags, Signature, ...)          \
     INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2(                                           \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____),               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____),    \
-        Name, Tags, Signature, __VA_ARGS__)
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_),                            \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_), Name, Tags,        \
+        Signature, __VA_ARGS__)
 #else
 #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_SIG_NO_REGISTRATION(Name, Tags, Signature, ...)          \
     INTERNAL_CATCH_EXPAND_VARGS(INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2(               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____),               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____),    \
-        Name, Tags, Signature, __VA_ARGS__))
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_),                            \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_), Name, Tags,        \
+        Signature, __VA_ARGS__))
 #endif
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
 #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION(ClassName, Name, Tags, ...)       \
     INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2(                                    \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____),  \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____), ClassName,    \
-        Name, Tags, typename T, __VA_ARGS__)
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_),                  \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_), ClassName, Name, Tags,     \
+        typename T, __VA_ARGS__)
 #else
 #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION(ClassName, Name, Tags, ...)       \
     INTERNAL_CATCH_EXPAND_VARGS(INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2(        \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____),  \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____), ClassName,    \
-        Name, Tags, typename T, __VA_ARGS__))
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_),                  \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_), ClassName, Name, Tags,     \
+        typename T, __VA_ARGS__))
 #endif
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
 #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_SIG_NO_REGISTRATION(ClassName, Name, Tags,        \
                                                                      Signature, ...)               \
     INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2(                                    \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____),  \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____), ClassName,    \
-        Name, Tags, Signature, __VA_ARGS__)
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_),                  \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_), ClassName, Name, Tags,     \
+        Signature, __VA_ARGS__)
 #else
 #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_SIG_NO_REGISTRATION(ClassName, Name, Tags,        \
                                                                      Signature, ...)               \
     INTERNAL_CATCH_EXPAND_VARGS(INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2(        \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____),  \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____), ClassName,    \
-        Name, Tags, Signature, __VA_ARGS__))
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_),                  \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_), ClassName, Name, Tags,     \
+        Signature, __VA_ARGS__))
 #endif
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CATCH_TESTCASE2(TestName, ...)                                                    \
     static void TestName();                                                                        \
+    CATCH_INTERNAL_START_WARNINGS_SUPPRESSION                                                      \
     CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS                                                       \
     namespace                                                                                      \
     {                                                                                              \
@@ -1319,13 +1354,14 @@ struct AutoReg : NonCopyable
                                                              Catch::StringRef(),                   \
                                                              Catch::NameAndTags{__VA_ARGS__});     \
     } /* NOLINT */                                                                                 \
-    CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS                                                     \
+    CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION                                                       \
     static void TestName()
 #define INTERNAL_CATCH_TESTCASE(...)                                                               \
-    INTERNAL_CATCH_TESTCASE2(INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_S_T____), __VA_ARGS__)
+    INTERNAL_CATCH_TESTCASE2(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_S_T_), __VA_ARGS__)
 
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CATCH_METHOD_AS_TEST_CASE(QualifiedMethod, ...)                                   \
+    CATCH_INTERNAL_START_WARNINGS_SUPPRESSION                                                      \
     CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS                                                       \
     namespace                                                                                      \
     {                                                                                              \
@@ -1334,10 +1370,11 @@ struct AutoReg : NonCopyable
                                                   CATCH_INTERNAL_LINEINFO, "&" #QualifiedMethod,   \
                                                   Catch::NameAndTags{__VA_ARGS__});                \
     } /* NOLINT */                                                                                 \
-    CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS
+    CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CATCH_TEST_CASE_METHOD2(TestName, ClassName, ...)                                 \
+    CATCH_INTERNAL_START_WARNINGS_SUPPRESSION                                                      \
     CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS                                                       \
     namespace                                                                                      \
     {                                                                                              \
@@ -1350,24 +1387,27 @@ struct AutoReg : NonCopyable
                                                   CATCH_INTERNAL_LINEINFO, #ClassName,             \
                                                   Catch::NameAndTags{__VA_ARGS__}); /* NOLINT */   \
     }                                                                                              \
-    CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS                                                     \
+    CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION                                                       \
     void TestName::test()
 #define INTERNAL_CATCH_TEST_CASE_METHOD(ClassName, ...)                                            \
-    INTERNAL_CATCH_TEST_CASE_METHOD2(INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_S_T____),     \
-                                     ClassName, __VA_ARGS__)
+    INTERNAL_CATCH_TEST_CASE_METHOD2(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_S_T_), ClassName,    \
+                                     __VA_ARGS__)
 
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CATCH_REGISTER_TESTCASE(Function, ...)                                            \
+    CATCH_INTERNAL_START_WARNINGS_SUPPRESSION                                                      \
     CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS                                                       \
     Catch::AutoReg INTERNAL_CATCH_UNIQUE_NAME(autoRegistrar)(                                      \
         Catch::makeTestInvoker(Function), CATCH_INTERNAL_LINEINFO, Catch::StringRef(),             \
         Catch::NameAndTags{__VA_ARGS__}); /* NOLINT */                                             \
-    CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS
+    CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_2(TestName, TestFunc, Name, Tags, Signature, ...)        \
+    CATCH_INTERNAL_START_WARNINGS_SUPPRESSION                                                      \
     CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS                                                       \
     CATCH_INTERNAL_SUPPRESS_ZERO_VARIADIC_WARNINGS                                                 \
+    CATCH_INTERNAL_SUPPRESS_UNUSED_TEMPLATE_WARNINGS                                               \
     INTERNAL_CATCH_DECLARE_SIG_TEST(TestFunc, INTERNAL_CATCH_REMOVE_PARENS(Signature));            \
     namespace                                                                                      \
     {                                                                                              \
@@ -1387,7 +1427,7 @@ struct AutoReg : NonCopyable
                 (void)expander{(reg_test(Types{},                                                  \
                                          Catch::NameAndTags{                                       \
                                              Name " - " + std::string(tmpl_types[index]), Tags}),  \
-                                index++, 0)...}; /* NOLINT */                                      \
+                                index++)...}; /* NOLINT */                                         \
             }                                                                                      \
         };                                                                                         \
         static int INTERNAL_CATCH_UNIQUE_NAME(globalRegistrar) = []() {                            \
@@ -1396,42 +1436,43 @@ struct AutoReg : NonCopyable
         }();                                                                                       \
     }                                                                                              \
     }                                                                                              \
-    CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS                                                     \
-    CATCH_INTERNAL_UNSUPPRESS_ZERO_VARIADIC_WARNINGS                                               \
+    CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION                                                       \
     INTERNAL_CATCH_DEFINE_SIG_TEST(TestFunc, INTERNAL_CATCH_REMOVE_PARENS(Signature))
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
 #define INTERNAL_CATCH_TEMPLATE_TEST_CASE(Name, Tags, ...)                                         \
     INTERNAL_CATCH_TEMPLATE_TEST_CASE_2(                                                           \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____),               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____),    \
-        Name, Tags, typename TestType, __VA_ARGS__)
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_),                            \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_), Name, Tags,        \
+        typename TestType, __VA_ARGS__)
 #else
 #define INTERNAL_CATCH_TEMPLATE_TEST_CASE(Name, Tags, ...)                                         \
     INTERNAL_CATCH_EXPAND_VARGS(INTERNAL_CATCH_TEMPLATE_TEST_CASE_2(                               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____),               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____),    \
-        Name, Tags, typename TestType, __VA_ARGS__))
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_),                            \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_), Name, Tags,        \
+        typename TestType, __VA_ARGS__))
 #endif
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
 #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_SIG(Name, Tags, Signature, ...)                          \
     INTERNAL_CATCH_TEMPLATE_TEST_CASE_2(                                                           \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____),               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____),    \
-        Name, Tags, Signature, __VA_ARGS__)
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_),                            \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_), Name, Tags,        \
+        Signature, __VA_ARGS__)
 #else
 #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_SIG(Name, Tags, Signature, ...)                          \
     INTERNAL_CATCH_EXPAND_VARGS(INTERNAL_CATCH_TEMPLATE_TEST_CASE_2(                               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____),               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____),    \
-        Name, Tags, Signature, __VA_ARGS__))
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_),                            \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_), Name, Tags,        \
+        Signature, __VA_ARGS__))
 #endif
 
 #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2(TestName, TestFuncName, Name, Tags, Signature,  \
                                                    TmplTypes, TypesList)                           \
+    CATCH_INTERNAL_START_WARNINGS_SUPPRESSION                                                      \
     CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS                                                       \
     CATCH_INTERNAL_SUPPRESS_ZERO_VARIADIC_WARNINGS                                                 \
+    CATCH_INTERNAL_SUPPRESS_UNUSED_TEMPLATE_WARNINGS                                               \
     template <typename TestType> static void TestFuncName();                                       \
     namespace                                                                                      \
     {                                                                                              \
@@ -1459,53 +1500,56 @@ struct AutoReg : NonCopyable
                                        Name " - " + std::string(tmpl_types[index / num_types]) +   \
                                            "<" + std::string(types_list[index % num_types]) + ">", \
                                        Tags}),                                                     \
-                    index++, 0)...}; /* NOLINT */                                                  \
+                    index++)...}; /* NOLINT */                                                     \
             }                                                                                      \
         };                                                                                         \
         static int INTERNAL_CATCH_UNIQUE_NAME(globalRegistrar) = []() {                            \
-            using TestInit = decltype(create<TestName, INTERNAL_CATCH_REMOVE_PARENS(TmplTypes)>(   \
-                TypeList<INTERNAL_CATCH_MAKE_TYPE_LISTS_FROM_TYPES(                                \
-                    INTERNAL_CATCH_REMOVE_PARENS(TypesList))>{}));                                 \
+            using TestInit =                                                                       \
+                typename create<TestName,                                                          \
+                                decltype(get_wrapper<INTERNAL_CATCH_REMOVE_PARENS(TmplTypes)>()),  \
+                                TypeList<INTERNAL_CATCH_MAKE_TYPE_LISTS_FROM_TYPES(                \
+                                    INTERNAL_CATCH_REMOVE_PARENS(TypesList))>>::type;              \
             TestInit t;                                                                            \
             t.reg_tests();                                                                         \
             return 0;                                                                              \
         }();                                                                                       \
     }                                                                                              \
     }                                                                                              \
-    CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS                                                     \
-    CATCH_INTERNAL_UNSUPPRESS_ZERO_VARIADIC_WARNINGS                                               \
+    CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION                                                       \
     template <typename TestType> static void TestFuncName()
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
 #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE(Name, Tags, ...)                                 \
     INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2(                                                    \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____),               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____),    \
-        Name, Tags, typename T, __VA_ARGS__)
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_),                            \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_), Name, Tags,        \
+        typename T, __VA_ARGS__)
 #else
 #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE(Name, Tags, ...)                                 \
     INTERNAL_CATCH_EXPAND_VARGS(INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2(                        \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____),               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____),    \
-        Name, Tags, typename T, __VA_ARGS__))
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_),                            \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_), Name, Tags,        \
+        typename T, __VA_ARGS__))
 #endif
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
 #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_SIG(Name, Tags, Signature, ...)                  \
     INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2(                                                    \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____),               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____),    \
-        Name, Tags, Signature, __VA_ARGS__)
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_),                            \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_), Name, Tags,        \
+        Signature, __VA_ARGS__)
 #else
 #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_SIG(Name, Tags, Signature, ...)                  \
     INTERNAL_CATCH_EXPAND_VARGS(INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2(                        \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____),               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____),    \
-        Name, Tags, Signature, __VA_ARGS__))
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_),                            \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_), Name, Tags,        \
+        Signature, __VA_ARGS__))
 #endif
 
 #define INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE_2(TestName, TestFunc, Name, Tags, TmplList)         \
+    CATCH_INTERNAL_START_WARNINGS_SUPPRESSION                                                      \
     CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS                                                       \
+    CATCH_INTERNAL_SUPPRESS_UNUSED_TEMPLATE_WARNINGS                                               \
     template <typename TestType> static void TestFunc();                                           \
     namespace                                                                                      \
     {                                                                                              \
@@ -1526,30 +1570,32 @@ struct AutoReg : NonCopyable
                                                 std::string(INTERNAL_CATCH_STRINGIZE(TmplList)) +  \
                                                 " - " + std::to_string(index),                     \
                                             Tags}),                                                \
-                     index++, 0)...}; /* NOLINT */                                                 \
+                     index++)...}; /* NOLINT */                                                    \
             }                                                                                      \
         };                                                                                         \
         static int INTERNAL_CATCH_UNIQUE_NAME(globalRegistrar) = []() {                            \
-            using TestInit = decltype(convert<TestName>(std::declval<TmplList>()));                \
+            using TestInit = typename convert<TestName, TmplList>::type;                           \
             TestInit t;                                                                            \
             t.reg_tests();                                                                         \
             return 0;                                                                              \
         }();                                                                                       \
     }                                                                                              \
     }                                                                                              \
-    CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS                                                     \
+    CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION                                                       \
     template <typename TestType> static void TestFunc()
 
 #define INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE(Name, Tags, TmplList)                               \
     INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE_2(                                                      \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____),               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____),    \
-        Name, Tags, TmplList)
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_),                            \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_), Name, Tags,        \
+        TmplList)
 
 #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2(TestNameClass, TestName, ClassName, Name, Tags, \
                                                    Signature, ...)                                 \
+    CATCH_INTERNAL_START_WARNINGS_SUPPRESSION                                                      \
     CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS                                                       \
     CATCH_INTERNAL_SUPPRESS_ZERO_VARIADIC_WARNINGS                                                 \
+    CATCH_INTERNAL_SUPPRESS_UNUSED_TEMPLATE_WARNINGS                                               \
     namespace                                                                                      \
     {                                                                                              \
     namespace INTERNAL_CATCH_MAKE_NAMESPACE(TestName)                                              \
@@ -1570,7 +1616,7 @@ struct AutoReg : NonCopyable
                 (void)expander{(reg_test(Types{}, #ClassName,                                      \
                                          Catch::NameAndTags{                                       \
                                              Name " - " + std::string(tmpl_types[index]), Tags}),  \
-                                index++, 0)...}; /* NOLINT */                                      \
+                                index++)...}; /* NOLINT */                                         \
             }                                                                                      \
         };                                                                                         \
         static int INTERNAL_CATCH_UNIQUE_NAME(globalRegistrar) = []() {                            \
@@ -1579,42 +1625,43 @@ struct AutoReg : NonCopyable
         }();                                                                                       \
     }                                                                                              \
     }                                                                                              \
-    CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS                                                     \
-    CATCH_INTERNAL_UNSUPPRESS_ZERO_VARIADIC_WARNINGS                                               \
+    CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION                                                       \
     INTERNAL_CATCH_DEFINE_SIG_TEST_METHOD(TestName, INTERNAL_CATCH_REMOVE_PARENS(Signature))
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
 #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD(ClassName, Name, Tags, ...)                       \
     INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2(                                                    \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____),  \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____), ClassName,    \
-        Name, Tags, typename T, __VA_ARGS__)
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_),                  \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_), ClassName, Name, Tags,     \
+        typename T, __VA_ARGS__)
 #else
 #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD(ClassName, Name, Tags, ...)                       \
     INTERNAL_CATCH_EXPAND_VARGS(INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2(                        \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____),  \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____), ClassName,    \
-        Name, Tags, typename T, __VA_ARGS__))
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_),                  \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_), ClassName, Name, Tags,     \
+        typename T, __VA_ARGS__))
 #endif
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
 #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_SIG(ClassName, Name, Tags, Signature, ...)        \
     INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2(                                                    \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____),  \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____), ClassName,    \
-        Name, Tags, Signature, __VA_ARGS__)
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_),                  \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_), ClassName, Name, Tags,     \
+        Signature, __VA_ARGS__)
 #else
 #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_SIG(ClassName, Name, Tags, Signature, ...)        \
     INTERNAL_CATCH_EXPAND_VARGS(INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2(                        \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____),  \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____), ClassName,    \
-        Name, Tags, Signature, __VA_ARGS__))
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_),                  \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_), ClassName, Name, Tags,     \
+        Signature, __VA_ARGS__))
 #endif
 
 #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2(                                        \
     TestNameClass, TestName, ClassName, Name, Tags, Signature, TmplTypes, TypesList)               \
+    CATCH_INTERNAL_START_WARNINGS_SUPPRESSION                                                      \
     CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS                                                       \
     CATCH_INTERNAL_SUPPRESS_ZERO_VARIADIC_WARNINGS                                                 \
+    CATCH_INTERNAL_SUPPRESS_UNUSED_TEMPLATE_WARNINGS                                               \
     template <typename TestType>                                                                   \
     struct TestName : INTERNAL_CATCH_REMOVE_PARENS(ClassName<TestType>)                            \
     {                                                                                              \
@@ -1646,57 +1693,59 @@ struct AutoReg : NonCopyable
                                        Name " - " + std::string(tmpl_types[index / num_types]) +   \
                                            "<" + std::string(types_list[index % num_types]) + ">", \
                                        Tags}),                                                     \
-                    index++, 0)...}; /* NOLINT */                                                  \
+                    index++)...}; /* NOLINT */                                                     \
             }                                                                                      \
         };                                                                                         \
         static int INTERNAL_CATCH_UNIQUE_NAME(globalRegistrar) = []() {                            \
             using TestInit =                                                                       \
-                decltype(create<TestNameClass, INTERNAL_CATCH_REMOVE_PARENS(TmplTypes)>(           \
-                    TypeList<INTERNAL_CATCH_MAKE_TYPE_LISTS_FROM_TYPES(                            \
-                        INTERNAL_CATCH_REMOVE_PARENS(TypesList))>{}));                             \
+                typename create<TestNameClass,                                                     \
+                                decltype(get_wrapper<INTERNAL_CATCH_REMOVE_PARENS(TmplTypes)>()),  \
+                                TypeList<INTERNAL_CATCH_MAKE_TYPE_LISTS_FROM_TYPES(                \
+                                    INTERNAL_CATCH_REMOVE_PARENS(TypesList))>>::type;              \
             TestInit t;                                                                            \
             t.reg_tests();                                                                         \
             return 0;                                                                              \
         }();                                                                                       \
     }                                                                                              \
     }                                                                                              \
-    CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS                                                     \
-    CATCH_INTERNAL_UNSUPPRESS_ZERO_VARIADIC_WARNINGS                                               \
+    CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION                                                       \
     template <typename TestType> void TestName<TestType>::test()
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
 #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD(ClassName, Name, Tags, ...)               \
     INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2(                                            \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____),               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____),    \
-        ClassName, Name, Tags, typename T, __VA_ARGS__)
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_),                            \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_), ClassName, Name,   \
+        Tags, typename T, __VA_ARGS__)
 #else
 #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD(ClassName, Name, Tags, ...)               \
     INTERNAL_CATCH_EXPAND_VARGS(INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2(                \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____),               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____),    \
-        ClassName, Name, Tags, typename T, __VA_ARGS__))
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_),                            \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_), ClassName, Name,   \
+        Tags, typename T, __VA_ARGS__))
 #endif
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
 #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG(ClassName, Name, Tags, Signature,     \
                                                              ...)                                  \
     INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2(                                            \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____),               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____),    \
-        ClassName, Name, Tags, Signature, __VA_ARGS__)
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_),                            \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_), ClassName, Name,   \
+        Tags, Signature, __VA_ARGS__)
 #else
 #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG(ClassName, Name, Tags, Signature,     \
                                                              ...)                                  \
     INTERNAL_CATCH_EXPAND_VARGS(INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2(                \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____),               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____),    \
-        ClassName, Name, Tags, Signature, __VA_ARGS__))
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_),                            \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_), ClassName, Name,   \
+        Tags, Signature, __VA_ARGS__))
 #endif
 
 #define INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE_METHOD_2(TestNameClass, TestName, ClassName, Name,  \
                                                         Tags, TmplList)                            \
+    CATCH_INTERNAL_START_WARNINGS_SUPPRESSION                                                      \
     CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS                                                       \
+    CATCH_INTERNAL_SUPPRESS_UNUSED_TEMPLATE_WARNINGS                                               \
     template <typename TestType>                                                                   \
     struct TestName : INTERNAL_CATCH_REMOVE_PARENS(ClassName<TestType>)                            \
     {                                                                                              \
@@ -1721,25 +1770,25 @@ struct AutoReg : NonCopyable
                                                 std::string(INTERNAL_CATCH_STRINGIZE(TmplList)) +  \
                                                 " - " + std::to_string(index),                     \
                                             Tags}),                                                \
-                     index++, 0)...}; /* NOLINT */                                                 \
+                     index++)...}; /* NOLINT */                                                    \
             }                                                                                      \
         };                                                                                         \
         static int INTERNAL_CATCH_UNIQUE_NAME(globalRegistrar) = []() {                            \
-            using TestInit = decltype(convert<TestNameClass>(std::declval<TmplList>()));           \
+            using TestInit = typename convert<TestNameClass, TmplList>::type;                      \
             TestInit t;                                                                            \
             t.reg_tests();                                                                         \
             return 0;                                                                              \
         }();                                                                                       \
     }                                                                                              \
     }                                                                                              \
-    CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS                                                     \
+    CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION                                                       \
     template <typename TestType> void TestName<TestType>::test()
 
 #define INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE_METHOD(ClassName, Name, Tags, TmplList)             \
     INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE_METHOD_2(                                               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____),               \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____),    \
-        ClassName, Name, Tags, TmplList)
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_),                            \
+        INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_), ClassName, Name,   \
+        Tags, TmplList)
 
 // end catch_test_registry.h
 // start catch_capture.hpp
@@ -1852,7 +1901,7 @@ struct IStream
 
 auto makeStream(StringRef const &filename) -> IStream const *;
 
-class ReusableStringStream
+class ReusableStringStream : NonCopyable
 {
     std::size_t m_index;
     std::ostream *m_oss;
@@ -1885,7 +1934,7 @@ namespace Detail
 struct EnumInfo
 {
     StringRef m_name;
-    std::vector<std::pair<int, std::string>> m_values;
+    std::vector<std::pair<int, StringRef>> m_values;
 
     ~EnumInfo();
 
@@ -1904,6 +1953,7 @@ struct IMutableEnumValuesRegistry
     Detail::EnumInfo const &registerEnum(StringRef enumName, StringRef allEnums,
                                          std::initializer_list<E> values)
     {
+        static_assert(sizeof(int) >= sizeof(E), "Cannot serialize enum to int");
         std::vector<int> intValues;
         intValues.reserve(values.size());
         for (auto enumValue : values)
@@ -1988,8 +2038,9 @@ template <typename T> std::string rawMemoryToString(const T &object)
 
 template <typename T> class IsStreamInsertable
 {
-    template <typename SS, typename TT>
-    static auto test(int) -> decltype(std::declval<SS &>() << std::declval<TT>(), std::true_type());
+    template <typename Stream, typename U>
+    static auto test(int)
+        -> decltype(std::declval<Stream &>() << std::declval<U>(), std::true_type());
 
     template <typename, typename> static auto test(...) -> std::false_type;
 
@@ -2260,7 +2311,8 @@ template <typename T> struct StringMaker<T ^>
 
 namespace Detail
 {
-template <typename InputIterator> std::string rangeToString(InputIterator first, InputIterator last)
+template <typename InputIterator, typename Sentinel = InputIterator>
+std::string rangeToString(InputIterator first, Sentinel last)
 {
     ReusableStringStream rss;
     rss << "{ ";
@@ -2424,23 +2476,30 @@ template <typename... Elements> struct StringMaker<std::variant<Elements...>>
 
 namespace Catch
 {
-struct not_this_one
-{
-}; // Tag type for detecting which begin/ end are being selected
-
-// Import begin/ end from std here so they are considered alongside the fallback (...) overloads in
-// this namespace
+// Import begin/ end from std here
 using std::begin;
 using std::end;
 
-not_this_one begin(...);
-not_this_one end(...);
-
-template <typename T> struct is_range
+namespace detail
 {
-    static const bool value =
-        !std::is_same<decltype(begin(std::declval<T>())), not_this_one>::value &&
-        !std::is_same<decltype(end(std::declval<T>())), not_this_one>::value;
+template <typename...> struct void_type
+{
+    using type = void;
+};
+
+template <typename T, typename = void> struct is_range_impl : std::false_type
+{
+};
+
+template <typename T>
+struct is_range_impl<T, typename void_type<decltype(begin(std::declval<T>()))>::type>
+    : std::true_type
+{
+};
+} // namespace detail
+
+template <typename T> struct is_range : detail::is_range_impl<T>
+{
 };
 
 #if defined(_MANAGED) // Managed types are never ranges
@@ -2623,7 +2682,7 @@ struct StringMaker<std::chrono::time_point<std::chrono::system_clock, Duration>>
             static const auto &enumInfo =                                                          \
                 ::Catch::getMutableRegistryHub().getMutableEnumValuesRegistry().registerEnum(      \
                     #enumName, #__VA_ARGS__, {__VA_ARGS__});                                       \
-            return enumInfo.lookup(static_cast<int>(value));                                       \
+            return static_cast<std::string>(enumInfo.lookup(static_cast<int>(value)));             \
         }                                                                                          \
     };                                                                                             \
     }
@@ -2851,6 +2910,18 @@ template <typename LhsT> class ExprLhs
     {
         return {static_cast<bool>(m_lhs <= rhs), m_lhs, "<=", rhs};
     }
+    template <typename RhsT> auto operator|(RhsT const &rhs) -> BinaryExpr<LhsT, RhsT const &> const
+    {
+        return {static_cast<bool>(m_lhs | rhs), m_lhs, "|", rhs};
+    }
+    template <typename RhsT> auto operator&(RhsT const &rhs) -> BinaryExpr<LhsT, RhsT const &> const
+    {
+        return {static_cast<bool>(m_lhs & rhs), m_lhs, "&", rhs};
+    }
+    template <typename RhsT> auto operator^(RhsT const &rhs) -> BinaryExpr<LhsT, RhsT const &> const
+    {
+        return {static_cast<bool>(m_lhs ^ rhs), m_lhs, "^", rhs};
+    }
 
     template <typename RhsT> auto operator&&(RhsT const &) -> BinaryExpr<LhsT, RhsT const &> const
     {
@@ -2928,7 +2999,8 @@ struct IResultCapture
     virtual void sectionEnded(SectionEndInfo const &endInfo) = 0;
     virtual void sectionEndedEarly(SectionEndInfo const &endInfo) = 0;
 
-    virtual auto acquireGeneratorTracker(SourceLineInfo const &lineInfo) -> IGeneratorTracker & = 0;
+    virtual auto acquireGeneratorTracker(StringRef generatorName, SourceLineInfo const &lineInfo)
+        -> IGeneratorTracker & = 0;
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
     virtual void benchmarkPreparing(std::string const &name) = 0;
@@ -3173,23 +3245,20 @@ class Capturer
 #define INTERNAL_CATCH_TEST(macroName, resultDisposition, ...)                                     \
     do                                                                                             \
     {                                                                                              \
+        CATCH_INTERNAL_IGNORE_BUT_WARN(__VA_ARGS__);                                               \
         Catch::AssertionHandler catchAssertionHandler(                                             \
             macroName##_catch_sr, CATCH_INTERNAL_LINEINFO, CATCH_INTERNAL_STRINGIFY(__VA_ARGS__),  \
             resultDisposition);                                                                    \
         INTERNAL_CATCH_TRY                                                                         \
         {                                                                                          \
+            CATCH_INTERNAL_START_WARNINGS_SUPPRESSION                                              \
             CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS                                           \
             catchAssertionHandler.handleExpr(Catch::Decomposer() <= __VA_ARGS__);                  \
-            CATCH_INTERNAL_UNSUPPRESS_PARENTHESES_WARNINGS                                         \
+            CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION                                               \
         }                                                                                          \
         INTERNAL_CATCH_CATCH(catchAssertionHandler)                                                \
         INTERNAL_CATCH_REACT(catchAssertionHandler)                                                \
-    } while ((void)0,                                                                              \
-             (false) && static_cast<bool>(                                                         \
-                            !!(__VA_ARGS__))) // the expression here is never evaluated at runtime
-                                              // but it forces the compiler to give it a look
-  // The double negation silences MSVC's C4800 warning, the static_cast forces short-circuit
-  // evaluation if the type has overloaded &&.
+    } while ((void)0, (false) && static_cast<bool>(!!(__VA_ARGS__)))
 
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CATCH_IF(macroName, resultDisposition, ...)                                       \
@@ -3450,17 +3519,19 @@ class Section : NonCopyable
 } // end namespace Catch
 
 #define INTERNAL_CATCH_SECTION(...)                                                                \
+    CATCH_INTERNAL_START_WARNINGS_SUPPRESSION                                                      \
     CATCH_INTERNAL_SUPPRESS_UNUSED_WARNINGS                                                        \
     if (Catch::Section const &INTERNAL_CATCH_UNIQUE_NAME(catch_internal_Section) =                 \
             Catch::SectionInfo(CATCH_INTERNAL_LINEINFO, __VA_ARGS__))                              \
-    CATCH_INTERNAL_UNSUPPRESS_UNUSED_WARNINGS
+    CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 
 #define INTERNAL_CATCH_DYNAMIC_SECTION(...)                                                        \
+    CATCH_INTERNAL_START_WARNINGS_SUPPRESSION                                                      \
     CATCH_INTERNAL_SUPPRESS_UNUSED_WARNINGS                                                        \
     if (Catch::Section const &INTERNAL_CATCH_UNIQUE_NAME(catch_internal_Section) =                 \
             Catch::SectionInfo(CATCH_INTERNAL_LINEINFO,                                            \
                                (Catch::ReusableStringStream() << __VA_ARGS__).str()))              \
-    CATCH_INTERNAL_UNSUPPRESS_UNUSED_WARNINGS
+    CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 
 // end catch_section.h
 // start catch_interfaces_exception.h
@@ -3562,6 +3633,9 @@ class ExceptionTranslatorRegistrar
         std::string translate(ExceptionTranslators::const_iterator it,
                               ExceptionTranslators::const_iterator itEnd) const override
         {
+#if defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
+            return "";
+#else
             try
             {
                 if (it == itEnd)
@@ -3573,6 +3647,7 @@ class ExceptionTranslatorRegistrar
             {
                 return m_translateFunction(ex);
             }
+#endif
         }
 
       protected:
@@ -3590,13 +3665,14 @@ class ExceptionTranslatorRegistrar
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CATCH_TRANSLATE_EXCEPTION2(translatorName, signature)                             \
     static std::string translatorName(signature);                                                  \
+    CATCH_INTERNAL_START_WARNINGS_SUPPRESSION                                                      \
     CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS                                                       \
     namespace                                                                                      \
     {                                                                                              \
     Catch::ExceptionTranslatorRegistrar                                                            \
         INTERNAL_CATCH_UNIQUE_NAME(catch_internal_ExceptionRegistrar)(&translatorName);            \
     }                                                                                              \
-    CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS                                                     \
+    CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION                                                       \
     static std::string translatorName(signature)
 
 #define INTERNAL_CATCH_TRANSLATE_EXCEPTION(signature)                                              \
@@ -3633,7 +3709,7 @@ class Approx
 
     template <typename T,
               typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-    Approx operator()(T const &value)
+    Approx operator()(T const &value) const
     {
         Approx approx(static_cast<double>(value));
         approx.m_epsilon = m_epsilon;
@@ -3771,7 +3847,10 @@ bool endsWith(std::string const &s, char suffix);
 bool contains(std::string const &s, std::string const &infix);
 void toLowerInPlace(std::string &s);
 std::string toLower(std::string const &s);
+//! Returns a new string without whitespace at the start/end
 std::string trim(std::string const &str);
+//! Returns a substring of the original ref without whitespace. Beware lifetimes!
+StringRef trim(StringRef ref);
 
 // !!! Be aware, returns refs into original string - make sure original string outlives them
 std::vector<StringRef> splitStringRef(StringRef str, char delimiter);
@@ -3883,10 +3962,11 @@ template <typename ArgT> struct MatchAllOf : MatcherBase<ArgT>
         return description;
     }
 
-    MatchAllOf<ArgT> &operator&&(MatcherBase<ArgT> const &other)
+    MatchAllOf<ArgT> operator&&(MatcherBase<ArgT> const &other)
     {
-        m_matchers.push_back(&other);
-        return *this;
+        auto copy(*this);
+        copy.m_matchers.push_back(&other);
+        return copy;
     }
 
     std::vector<MatcherBase<ArgT> const *> m_matchers;
@@ -3921,10 +4001,11 @@ template <typename ArgT> struct MatchAnyOf : MatcherBase<ArgT>
         return description;
     }
 
-    MatchAnyOf<ArgT> &operator||(MatcherBase<ArgT> const &other)
+    MatchAnyOf<ArgT> operator||(MatcherBase<ArgT> const &other)
     {
-        m_matchers.push_back(&other);
-        return *this;
+        auto copy(*this);
+        copy.m_matchers.push_back(&other);
+        return copy;
     }
 
     std::vector<MatcherBase<ArgT> const *> m_matchers;
@@ -3966,10 +4047,36 @@ using Matchers::Impl::MatcherBase;
 } // namespace Catch
 
 // end catch_matchers.h
-// start catch_matchers_floating.h
+// start catch_matchers_exception.hpp
 
-#include <type_traits>
-#include <cmath>
+namespace Catch
+{
+namespace Matchers
+{
+namespace Exception
+{
+
+class ExceptionMessageMatcher : public MatcherBase<std::exception>
+{
+    std::string m_message;
+
+  public:
+    ExceptionMessageMatcher(std::string const &message) : m_message(message) {}
+
+    bool match(std::exception const &ex) const override;
+
+    std::string describe() const override;
+};
+
+} // namespace Exception
+
+Exception::ExceptionMessageMatcher Message(std::string const &message);
+
+} // namespace Matchers
+} // namespace Catch
+
+// end catch_matchers_exception.hpp
+// start catch_matchers_floating.h
 
 namespace Catch
 {
@@ -3994,23 +4101,46 @@ struct WithinAbsMatcher : MatcherBase<double>
 
 struct WithinUlpsMatcher : MatcherBase<double>
 {
-    WithinUlpsMatcher(double target, int ulps, FloatingPointKind baseType);
+    WithinUlpsMatcher(double target, uint64_t ulps, FloatingPointKind baseType);
     bool match(double const &matchee) const override;
     std::string describe() const override;
 
   private:
     double m_target;
-    int m_ulps;
+    uint64_t m_ulps;
     FloatingPointKind m_type;
+};
+
+// Given IEEE-754 format for floats and doubles, we can assume
+// that float -> double promotion is lossless. Given this, we can
+// assume that if we do the standard relative comparison of
+// |lhs - rhs| <= epsilon * max(fabs(lhs), fabs(rhs)), then we get
+// the same result if we do this for floats, as if we do this for
+// doubles that were promoted from floats.
+struct WithinRelMatcher : MatcherBase<double>
+{
+    WithinRelMatcher(double target, double epsilon);
+    bool match(double const &matchee) const override;
+    std::string describe() const override;
+
+  private:
+    double m_target;
+    double m_epsilon;
 };
 
 } // namespace Floating
 
 // The following functions create the actual matcher objects.
 // This allows the types to be inferred
-Floating::WithinUlpsMatcher WithinULP(double target, int maxUlpDiff);
-Floating::WithinUlpsMatcher WithinULP(float target, int maxUlpDiff);
+Floating::WithinUlpsMatcher WithinULP(double target, uint64_t maxUlpDiff);
+Floating::WithinUlpsMatcher WithinULP(float target, uint64_t maxUlpDiff);
 Floating::WithinAbsMatcher WithinAbs(double target, double margin);
+Floating::WithinRelMatcher WithinRel(double target, double eps);
+// defaults epsilon to 100*numeric_limits<double>::epsilon()
+Floating::WithinRelMatcher WithinRel(double target);
+Floating::WithinRelMatcher WithinRel(float target, float eps);
+// defaults epsilon to 100*numeric_limits<float>::epsilon()
+Floating::WithinRelMatcher WithinRel(float target);
 
 } // namespace Matchers
 } // namespace Catch
@@ -4160,12 +4290,13 @@ namespace Matchers
 
 namespace Vector
 {
-template <typename T> struct ContainsElementMatcher : MatcherBase<std::vector<T>>
+template <typename T, typename Alloc>
+struct ContainsElementMatcher : MatcherBase<std::vector<T, Alloc>>
 {
 
     ContainsElementMatcher(T const &comparator) : m_comparator(comparator) {}
 
-    bool match(std::vector<T> const &v) const override
+    bool match(std::vector<T, Alloc> const &v) const override
     {
         for (auto const &el : v)
         {
@@ -4185,12 +4316,13 @@ template <typename T> struct ContainsElementMatcher : MatcherBase<std::vector<T>
     T const &m_comparator;
 };
 
-template <typename T> struct ContainsMatcher : MatcherBase<std::vector<T>>
+template <typename T, typename AllocComp, typename AllocMatch>
+struct ContainsMatcher : MatcherBase<std::vector<T, AllocMatch>>
 {
 
-    ContainsMatcher(std::vector<T> const &comparator) : m_comparator(comparator) {}
+    ContainsMatcher(std::vector<T, AllocComp> const &comparator) : m_comparator(comparator) {}
 
-    bool match(std::vector<T> const &v) const override
+    bool match(std::vector<T, AllocMatch> const &v) const override
     {
         // !TBD: see note in EqualsMatcher
         if (m_comparator.size() > v.size())
@@ -4218,19 +4350,20 @@ template <typename T> struct ContainsMatcher : MatcherBase<std::vector<T>>
         return "Contains: " + ::Catch::Detail::stringify(m_comparator);
     }
 
-    std::vector<T> const &m_comparator;
+    std::vector<T, AllocComp> const &m_comparator;
 };
 
-template <typename T> struct EqualsMatcher : MatcherBase<std::vector<T>>
+template <typename T, typename AllocComp, typename AllocMatch>
+struct EqualsMatcher : MatcherBase<std::vector<T, AllocMatch>>
 {
 
-    EqualsMatcher(std::vector<T> const &comparator) : m_comparator(comparator) {}
+    EqualsMatcher(std::vector<T, AllocComp> const &comparator) : m_comparator(comparator) {}
 
-    bool match(std::vector<T> const &v) const override
+    bool match(std::vector<T, AllocMatch> const &v) const override
     {
         // !TBD: This currently works if all elements can be compared using !=
         // - a more general approach would be via a compare template that defaults
-        // to using !=. but could be specialised for, e.g. std::vector<T> etc
+        // to using !=. but could be specialised for, e.g. std::vector<T, Alloc> etc
         // - then just call that directly
         if (m_comparator.size() != v.size())
             return false;
@@ -4243,15 +4376,16 @@ template <typename T> struct EqualsMatcher : MatcherBase<std::vector<T>>
     {
         return "Equals: " + ::Catch::Detail::stringify(m_comparator);
     }
-    std::vector<T> const &m_comparator;
+    std::vector<T, AllocComp> const &m_comparator;
 };
 
-template <typename T> struct ApproxMatcher : MatcherBase<std::vector<T>>
+template <typename T, typename AllocComp, typename AllocMatch>
+struct ApproxMatcher : MatcherBase<std::vector<T, AllocMatch>>
 {
 
-    ApproxMatcher(std::vector<T> const &comparator) : m_comparator(comparator) {}
+    ApproxMatcher(std::vector<T, AllocComp> const &comparator) : m_comparator(comparator) {}
 
-    bool match(std::vector<T> const &v) const override
+    bool match(std::vector<T, AllocMatch> const &v) const override
     {
         if (m_comparator.size() != v.size())
             return false;
@@ -4283,17 +4417,16 @@ template <typename T> struct ApproxMatcher : MatcherBase<std::vector<T>>
         return *this;
     }
 
-    std::vector<T> const &m_comparator;
+    std::vector<T, AllocComp> const &m_comparator;
     mutable Catch::Detail::Approx approx = Catch::Detail::Approx::custom();
 };
 
-template <typename T> struct UnorderedEqualsMatcher : MatcherBase<std::vector<T>>
+template <typename T, typename AllocComp, typename AllocMatch>
+struct UnorderedEqualsMatcher : MatcherBase<std::vector<T, AllocMatch>>
 {
-    UnorderedEqualsMatcher(std::vector<T> const &target) : m_target(target) {}
-    bool match(std::vector<T> const &vec) const override
+    UnorderedEqualsMatcher(std::vector<T, AllocComp> const &target) : m_target(target) {}
+    bool match(std::vector<T, AllocMatch> const &vec) const override
     {
-        // Note: This is a reimplementation of std::is_permutation,
-        //       because I don't want to include <algorithm> inside the common path
         if (m_target.size() != vec.size())
         {
             return false;
@@ -4307,7 +4440,7 @@ template <typename T> struct UnorderedEqualsMatcher : MatcherBase<std::vector<T>
     }
 
   private:
-    std::vector<T> const &m_target;
+    std::vector<T, AllocComp> const &m_target;
 };
 
 } // namespace Vector
@@ -4315,30 +4448,36 @@ template <typename T> struct UnorderedEqualsMatcher : MatcherBase<std::vector<T>
 // The following functions create the actual matcher objects.
 // This allows the types to be inferred
 
-template <typename T> Vector::ContainsMatcher<T> Contains(std::vector<T> const &comparator)
+template <typename T, typename AllocComp = std::allocator<T>, typename AllocMatch = AllocComp>
+Vector::ContainsMatcher<T, AllocComp, AllocMatch>
+Contains(std::vector<T, AllocComp> const &comparator)
 {
-    return Vector::ContainsMatcher<T>(comparator);
+    return Vector::ContainsMatcher<T, AllocComp, AllocMatch>(comparator);
 }
 
-template <typename T> Vector::ContainsElementMatcher<T> VectorContains(T const &comparator)
+template <typename T, typename Alloc = std::allocator<T>>
+Vector::ContainsElementMatcher<T, Alloc> VectorContains(T const &comparator)
 {
-    return Vector::ContainsElementMatcher<T>(comparator);
+    return Vector::ContainsElementMatcher<T, Alloc>(comparator);
 }
 
-template <typename T> Vector::EqualsMatcher<T> Equals(std::vector<T> const &comparator)
+template <typename T, typename AllocComp = std::allocator<T>, typename AllocMatch = AllocComp>
+Vector::EqualsMatcher<T, AllocComp, AllocMatch> Equals(std::vector<T, AllocComp> const &comparator)
 {
-    return Vector::EqualsMatcher<T>(comparator);
+    return Vector::EqualsMatcher<T, AllocComp, AllocMatch>(comparator);
 }
 
-template <typename T> Vector::ApproxMatcher<T> Approx(std::vector<T> const &comparator)
+template <typename T, typename AllocComp = std::allocator<T>, typename AllocMatch = AllocComp>
+Vector::ApproxMatcher<T, AllocComp, AllocMatch> Approx(std::vector<T, AllocComp> const &comparator)
 {
-    return Vector::ApproxMatcher<T>(comparator);
+    return Vector::ApproxMatcher<T, AllocComp, AllocMatch>(comparator);
 }
 
-template <typename T>
-Vector::UnorderedEqualsMatcher<T> UnorderedEquals(std::vector<T> const &target)
+template <typename T, typename AllocComp = std::allocator<T>, typename AllocMatch = AllocComp>
+Vector::UnorderedEqualsMatcher<T, AllocComp, AllocMatch>
+UnorderedEquals(std::vector<T, AllocComp> const &target)
 {
-    return Vector::UnorderedEqualsMatcher<T>(target);
+    return Vector::UnorderedEqualsMatcher<T, AllocComp, AllocMatch>(target);
 }
 
 } // namespace Matchers
@@ -4493,11 +4632,11 @@ template <typename Ex> [[noreturn]] void throw_exception(Ex const &e) { throw e;
 
 #define CATCH_INTERNAL_ERROR(...)                                                                  \
     Catch::throw_logic_error(                                                                      \
-        CATCH_MAKE_MSG(CATCH_INTERNAL_LINEINFO << ": Internal Catch2 error: " << __VA_ARGS__));
+        CATCH_MAKE_MSG(CATCH_INTERNAL_LINEINFO << ": Internal Catch2 error: " << __VA_ARGS__))
 
-#define CATCH_ERROR(...) Catch::throw_domain_error(CATCH_MAKE_MSG(__VA_ARGS__));
+#define CATCH_ERROR(...) Catch::throw_domain_error(CATCH_MAKE_MSG(__VA_ARGS__))
 
-#define CATCH_RUNTIME_ERROR(...) Catch::throw_runtime_error(CATCH_MAKE_MSG(__VA_ARGS__));
+#define CATCH_RUNTIME_ERROR(...) Catch::throw_runtime_error(CATCH_MAKE_MSG(__VA_ARGS__))
 
 #define CATCH_ENFORCE(condition, ...)                                                              \
     do                                                                                             \
@@ -4556,7 +4695,6 @@ template <typename T> class SingleValueGenerator final : public IGenerator<T>
     T m_value;
 
   public:
-    SingleValueGenerator(T const &value) : m_value(value) {}
     SingleValueGenerator(T &&value) : m_value(std::move(value)) {}
 
     T const &get() const override { return m_value; }
@@ -4566,7 +4704,7 @@ template <typename T> class SingleValueGenerator final : public IGenerator<T>
 template <typename T> class FixedValuesGenerator final : public IGenerator<T>
 {
     static_assert(!std::is_same<T, bool>::value,
-                  "ValuesGenerator does not support bools because of std::vector<bool>"
+                  "FixedValuesGenerator does not support bools because of std::vector<bool>"
                   "specialization, use SingleValue Generator instead.");
     std::vector<T> m_values;
     size_t m_idx = 0;
@@ -4612,16 +4750,17 @@ template <typename T> class Generators : public IGenerator<T>
     {
         m_generators.emplace_back(std::move(generator));
     }
-    void populate(T &&val) { m_generators.emplace_back(value(std::move(val))); }
-    template <typename U> void populate(U &&val) { populate(T(std::move(val))); }
-    template <typename U, typename... Gs> void populate(U &&valueOrGenerator, Gs... moreGenerators)
+    void populate(T &&val) { m_generators.emplace_back(value(std::forward<T>(val))); }
+    template <typename U> void populate(U &&val) { populate(T(std::forward<U>(val))); }
+    template <typename U, typename... Gs>
+    void populate(U &&valueOrGenerator, Gs &&...moreGenerators)
     {
         populate(std::forward<U>(valueOrGenerator));
         populate(std::forward<Gs>(moreGenerators)...);
     }
 
   public:
-    template <typename... Gs> Generators(Gs... moreGenerators)
+    template <typename... Gs> Generators(Gs &&...moreGenerators)
     {
         m_generators.reserve(sizeof...(Gs));
         populate(std::forward<Gs>(moreGenerators)...);
@@ -4657,7 +4796,7 @@ template <typename T> struct as
 };
 
 template <typename T, typename... Gs>
-auto makeGenerators(GeneratorWrapper<T> &&generator, Gs... moreGenerators) -> Generators<T>
+auto makeGenerators(GeneratorWrapper<T> &&generator, Gs &&...moreGenerators) -> Generators<T>
 {
     return Generators<T>(std::move(generator), std::forward<Gs>(moreGenerators)...);
 }
@@ -4666,28 +4805,29 @@ template <typename T> auto makeGenerators(GeneratorWrapper<T> &&generator) -> Ge
     return Generators<T>(std::move(generator));
 }
 template <typename T, typename... Gs>
-auto makeGenerators(T &&val, Gs... moreGenerators) -> Generators<T>
+auto makeGenerators(T &&val, Gs &&...moreGenerators) -> Generators<T>
 {
     return makeGenerators(value(std::forward<T>(val)), std::forward<Gs>(moreGenerators)...);
 }
 template <typename T, typename U, typename... Gs>
-auto makeGenerators(as<T>, U &&val, Gs... moreGenerators) -> Generators<T>
+auto makeGenerators(as<T>, U &&val, Gs &&...moreGenerators) -> Generators<T>
 {
     return makeGenerators(value(T(std::forward<U>(val))), std::forward<Gs>(moreGenerators)...);
 }
 
-auto acquireGeneratorTracker(SourceLineInfo const &lineInfo) -> IGeneratorTracker &;
+auto acquireGeneratorTracker(StringRef generatorName, SourceLineInfo const &lineInfo)
+    -> IGeneratorTracker &;
 
 template <typename L>
 // Note: The type after -> is weird, because VS2015 cannot parse
 //       the expression used in the typedef inside, when it is in
 //       return type. Yeah.
-auto generate(SourceLineInfo const &lineInfo, L const &generatorExpression)
+auto generate(StringRef generatorName, SourceLineInfo const &lineInfo, L const &generatorExpression)
     -> decltype(std::declval<decltype(generatorExpression())>().get())
 {
     using UnderlyingType = typename decltype(generatorExpression())::type;
 
-    IGeneratorTracker &tracker = acquireGeneratorTracker(lineInfo);
+    IGeneratorTracker &tracker = acquireGeneratorTracker(generatorName, lineInfo);
     if (!tracker.hasGenerator())
     {
         tracker.setGenerator(pf::make_unique<Generators<UnderlyingType>>(generatorExpression()));
@@ -4702,20 +4842,23 @@ auto generate(SourceLineInfo const &lineInfo, L const &generatorExpression)
 } // namespace Catch
 
 #define GENERATE(...)                                                                              \
-    Catch::Generators::generate(CATCH_INTERNAL_LINEINFO, [] {                                      \
-        using namespace Catch::Generators;                                                         \
-        return makeGenerators(__VA_ARGS__);                                                        \
-    })
+    Catch::Generators::generate(INTERNAL_CATCH_STRINGIZE(INTERNAL_CATCH_UNIQUE_NAME(generator)),   \
+                                CATCH_INTERNAL_LINEINFO, [] {                                      \
+                                    using namespace Catch::Generators;                             \
+                                    return makeGenerators(__VA_ARGS__);                            \
+                                }) // NOLINT(google-build-using-namespace)
 #define GENERATE_COPY(...)                                                                         \
-    Catch::Generators::generate(CATCH_INTERNAL_LINEINFO, [=] {                                     \
-        using namespace Catch::Generators;                                                         \
-        return makeGenerators(__VA_ARGS__);                                                        \
-    })
+    Catch::Generators::generate(INTERNAL_CATCH_STRINGIZE(INTERNAL_CATCH_UNIQUE_NAME(generator)),   \
+                                CATCH_INTERNAL_LINEINFO, [=] {                                     \
+                                    using namespace Catch::Generators;                             \
+                                    return makeGenerators(__VA_ARGS__);                            \
+                                }) // NOLINT(google-build-using-namespace)
 #define GENERATE_REF(...)                                                                          \
-    Catch::Generators::generate(CATCH_INTERNAL_LINEINFO, [&] {                                     \
-        using namespace Catch::Generators;                                                         \
-        return makeGenerators(__VA_ARGS__);                                                        \
-    })
+    Catch::Generators::generate(INTERNAL_CATCH_STRINGIZE(INTERNAL_CATCH_UNIQUE_NAME(generator)),   \
+                                CATCH_INTERNAL_LINEINFO, [&] {                                     \
+                                    using namespace Catch::Generators;                             \
+                                    return makeGenerators(__VA_ARGS__);                            \
+                                }) // NOLINT(google-build-using-namespace)
 
 // end catch_generators.hpp
 // start catch_generators_generic.hpp
@@ -4776,7 +4919,7 @@ template <typename T, typename Predicate> class FilterGenerator : public IGenera
         {
             // It might happen that there are no values that pass the
             // filter. In that case we throw an exception.
-            auto has_initial_value = next();
+            auto has_initial_value = nextImpl();
             if (!has_initial_value)
             {
                 Catch::throw_exception(
@@ -4787,7 +4930,10 @@ template <typename T, typename Predicate> class FilterGenerator : public IGenera
 
     T const &get() const override { return m_generator.get(); }
 
-    bool next() override
+    bool next() override { return nextImpl(); }
+
+  private:
+    bool nextImpl()
     {
         bool success = m_generator.next();
         if (!success)
@@ -4899,20 +5045,7 @@ template <typename T, typename U, typename Func> class MapGenerator : public IGe
     }
 };
 
-#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703
-// std::result_of is deprecated in C++17 and removed in C++20. Hence, it is
-// replaced with std::invoke_result here. Also *_t format is preferred over
-// typename *::type format.
-template <typename Func, typename U>
-using MapFunctionReturnType =
-    std::remove_reference_t<std::remove_cv_t<std::invoke_result_t<Func, U>>>;
-#else
-template <typename Func, typename U>
-using MapFunctionReturnType = typename std::remove_reference<
-    typename std::remove_cv<typename std::result_of<Func(U)>::type>::type>::type;
-#endif
-
-template <typename Func, typename U, typename T = MapFunctionReturnType<Func, U>>
+template <typename Func, typename U, typename T = FunctionReturnType<Func, U>>
 GeneratorWrapper<T> map(Func &&function, GeneratorWrapper<U> &&generator)
 {
     return GeneratorWrapper<T>(pf::make_unique<MapGenerator<T, U, Func>>(
@@ -5022,12 +5155,16 @@ inline IMutableContext &getCurrentMutableContext()
 {
     if (!IMutableContext::currentContext)
         IMutableContext::createContext();
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
     return *IMutableContext::currentContext;
 }
 
 inline IContext &getCurrentContext() { return getCurrentMutableContext(); }
 
 void cleanUpContext();
+
+class SimplePcg32;
+SimplePcg32 &rng();
 } // namespace Catch
 
 // end catch_context.h
@@ -5093,6 +5230,7 @@ template <typename T> class Option
 } // end namespace Catch
 
 // end catch_option.hpp
+#include <chrono>
 #include <iosfwd>
 #include <string>
 #include <vector>
@@ -5173,6 +5311,7 @@ struct IConfig : NonCopyable
     virtual int abortAfter() const = 0;
     virtual bool showInvisibles() const = 0;
     virtual ShowDurations::OrNot showDurations() const = 0;
+    virtual double minDuration() const = 0;
     virtual TestSpec const &testSpec() const = 0;
     virtual bool hasTestFilters() const = 0;
     virtual std::vector<std::string> const &getTestsOrTags() const = 0;
@@ -5186,12 +5325,62 @@ struct IConfig : NonCopyable
     virtual int benchmarkSamples() const = 0;
     virtual double benchmarkConfidenceInterval() const = 0;
     virtual unsigned int benchmarkResamples() const = 0;
+    virtual std::chrono::milliseconds benchmarkWarmupTime() const = 0;
 };
 
 using IConfigPtr = std::shared_ptr<IConfig const>;
 } // namespace Catch
 
 // end catch_interfaces_config.h
+// start catch_random_number_generator.h
+
+#include <cstdint>
+
+namespace Catch
+{
+
+// This is a simple implementation of C++11 Uniform Random Number
+// Generator. It does not provide all operators, because Catch2
+// does not use it, but it should behave as expected inside stdlib's
+// distributions.
+// The implementation is based on the PCG family (http://pcg-random.org)
+class SimplePcg32
+{
+    using state_type = std::uint64_t;
+
+  public:
+    using result_type = std::uint32_t;
+    static constexpr result_type(min)() { return 0; }
+    static constexpr result_type(max)() { return static_cast<result_type>(-1); }
+
+    // Provide some default initial state for the default constructor
+    SimplePcg32() : SimplePcg32(0xed743cc4U) {}
+
+    explicit SimplePcg32(result_type seed_);
+
+    void seed(result_type seed_);
+    void discard(uint64_t skip);
+
+    result_type operator()();
+
+  private:
+    friend bool operator==(SimplePcg32 const &lhs, SimplePcg32 const &rhs);
+    friend bool operator!=(SimplePcg32 const &lhs, SimplePcg32 const &rhs);
+
+    // In theory we also need operator<< and operator>>
+    // In practice we do not use them, so we will skip them for now
+
+    std::uint64_t m_state;
+    // This part of the state determines which "stream" of the numbers
+    // is chosen -- we take it as a constant for Catch2, so we only
+    // need to deal with seeding the main state.
+    // Picked by reading 8 bytes from `/dev/random` :-)
+    static const std::uint64_t s_inc = (0x13ed0cc53f939476ULL << 1ULL) | 1ULL;
+};
+
+} // end namespace Catch
+
+// end catch_random_number_generator.h
 #include <random>
 
 namespace Catch
@@ -5201,14 +5390,12 @@ namespace Generators
 
 template <typename Float> class RandomFloatingGenerator final : public IGenerator<Float>
 {
-    // FIXME: What is the right seed?
-    std::minstd_rand m_rand;
+    Catch::SimplePcg32 &m_rng;
     std::uniform_real_distribution<Float> m_dist;
     Float m_current_number;
 
   public:
-    RandomFloatingGenerator(Float a, Float b)
-        : m_rand(getCurrentContext().getConfig()->rngSeed()), m_dist(a, b)
+    RandomFloatingGenerator(Float a, Float b) : m_rng(rng()), m_dist(a, b)
     {
         static_cast<void>(next());
     }
@@ -5216,20 +5403,19 @@ template <typename Float> class RandomFloatingGenerator final : public IGenerato
     Float const &get() const override { return m_current_number; }
     bool next() override
     {
-        m_current_number = m_dist(m_rand);
+        m_current_number = m_dist(m_rng);
         return true;
     }
 };
 
 template <typename Integer> class RandomIntegerGenerator final : public IGenerator<Integer>
 {
-    std::minstd_rand m_rand;
+    Catch::SimplePcg32 &m_rng;
     std::uniform_int_distribution<Integer> m_dist;
     Integer m_current_number;
 
   public:
-    RandomIntegerGenerator(Integer a, Integer b)
-        : m_rand(getCurrentContext().getConfig()->rngSeed()), m_dist(a, b)
+    RandomIntegerGenerator(Integer a, Integer b) : m_rng(rng()), m_dist(a, b)
     {
         static_cast<void>(next());
     }
@@ -5237,7 +5423,7 @@ template <typename Integer> class RandomIntegerGenerator final : public IGenerat
     Integer const &get() const override { return m_current_number; }
     bool next() override
     {
-        m_current_number = m_dist(m_rand);
+        m_current_number = m_dist(m_rng);
         return true;
     }
 };
@@ -5292,8 +5478,8 @@ template <typename T> class RangeGenerator final : public IGenerator<T>
 
 template <typename T> GeneratorWrapper<T> range(T const &start, T const &end, T const &step)
 {
-    static_assert(std::is_integral<T>::value && !std::is_same<T, bool>::value,
-                  "Type must be an integer");
+    static_assert(std::is_arithmetic<T>::value && !std::is_same<T, bool>::value,
+                  "Type must be numeric");
     return GeneratorWrapper<T>(pf::make_unique<RangeGenerator<T>>(start, end, step));
 }
 
@@ -5302,6 +5488,49 @@ template <typename T> GeneratorWrapper<T> range(T const &start, T const &end)
     static_assert(std::is_integral<T>::value && !std::is_same<T, bool>::value,
                   "Type must be an integer");
     return GeneratorWrapper<T>(pf::make_unique<RangeGenerator<T>>(start, end));
+}
+
+template <typename T> class IteratorGenerator final : public IGenerator<T>
+{
+    static_assert(!std::is_same<T, bool>::value,
+                  "IteratorGenerator currently does not support bools"
+                  "because of std::vector<bool> specialization");
+
+    std::vector<T> m_elems;
+    size_t m_current = 0;
+
+  public:
+    template <typename InputIterator, typename InputSentinel>
+    IteratorGenerator(InputIterator first, InputSentinel last) : m_elems(first, last)
+    {
+        if (m_elems.empty())
+        {
+            Catch::throw_exception(
+                GeneratorException("IteratorGenerator received no valid values"));
+        }
+    }
+
+    T const &get() const override { return m_elems[m_current]; }
+
+    bool next() override
+    {
+        ++m_current;
+        return m_current != m_elems.size();
+    }
+};
+
+template <typename InputIterator, typename InputSentinel,
+          typename ResultType = typename std::iterator_traits<InputIterator>::value_type>
+GeneratorWrapper<ResultType> from_range(InputIterator from, InputSentinel to)
+{
+    return GeneratorWrapper<ResultType>(pf::make_unique<IteratorGenerator<ResultType>>(from, to));
+}
+
+template <typename Container, typename ResultType = typename Container::value_type>
+GeneratorWrapper<ResultType> from_range(Container const &cnt)
+{
+    return GeneratorWrapper<ResultType>(
+        pf::make_unique<IteratorGenerator<ResultType>>(cnt.begin(), cnt.end()));
 }
 
 } // namespace Generators
@@ -5675,7 +5904,7 @@ class WildcardPattern
     virtual bool matches(std::string const &str) const;
 
   private:
-    std::string adjustCase(std::string const &str) const;
+    std::string normaliseString(std::string const &str) const;
     CaseSensitive::Choice m_caseSensitivity;
     WildcardPosition m_wildcard = NoWildcard;
     std::string m_pattern;
@@ -5752,14 +5981,16 @@ class TestSpec
         std::vector<TestCase const *> tests;
     };
     using Matches = std::vector<FilterMatch>;
+    using vectorStrings = std::vector<std::string>;
 
     bool hasFilters() const;
     bool matches(TestCaseInfo const &testCase) const;
     Matches matchesByFilter(std::vector<TestCase> const &testCases, IConfig const &config) const;
+    const vectorStrings &getInvalidArgs() const;
 
   private:
     std::vector<Filter> m_filters;
-
+    std::vector<std::string> m_invalidArgs;
     friend class TestSpecParser;
 };
 } // namespace Catch
@@ -5805,8 +6036,10 @@ class TestSpecParser
         EscapedName
     };
     Mode m_mode = None;
+    Mode lastMode = None;
     bool m_exclusion = false;
     std::size_t m_pos = 0;
+    std::size_t m_realPatternPos = 0;
     std::string m_arg;
     std::string m_substring;
     std::string m_patternName;
@@ -5822,7 +6055,7 @@ class TestSpecParser
     TestSpec testSpec();
 
   private:
-    void visitChar(char c);
+    bool visitChar(char c);
     void startNewMode(Mode mode);
     bool processNoneChar(char c);
     void processNameChar(char c);
@@ -5830,32 +6063,24 @@ class TestSpecParser
     void endMode();
     void escape();
     bool isControlChar(char c) const;
-
-    template <typename T> void addPattern()
-    {
-        std::string token = m_patternName;
-        for (std::size_t i = 0; i < m_escapeChars.size(); ++i)
-            token = token.substr(0, m_escapeChars[i] - i) + token.substr(m_escapeChars[i] - i + 1);
-        m_escapeChars.clear();
-        if (startsWith(token, "exclude:"))
-        {
-            m_exclusion = true;
-            token = token.substr(8);
-        }
-        if (!token.empty())
-        {
-            TestSpec::PatternPtr pattern = std::make_shared<T>(token, m_substring);
-            if (m_exclusion)
-                pattern = std::make_shared<TestSpec::ExcludedPattern>(pattern);
-            m_currentFilter.m_patterns.push_back(pattern);
-        }
-        m_substring.clear();
-        m_patternName.clear();
-        m_exclusion = false;
-        m_mode = None;
-    }
-
+    void saveLastMode();
+    void revertBackToLastMode();
     void addFilter();
+    bool separate();
+
+    // Handles common preprocessing of the pattern for name/tag patterns
+    std::string preprocessPattern();
+    // Adds the current pattern as a test name
+    void addNamePattern();
+    // Adds the current pattern as a tag
+    void addTagPattern();
+
+    inline void addCharToPattern(char c)
+    {
+        m_substring += c;
+        m_patternName += c;
+        m_realPatternPos++;
+    }
 };
 TestSpec parseTestSpec(std::string const &arg);
 
@@ -5903,10 +6128,12 @@ struct ConfigData
     unsigned int benchmarkSamples = 100;
     double benchmarkConfidenceInterval = 0.95;
     unsigned int benchmarkResamples = 100000;
+    std::chrono::milliseconds::rep benchmarkWarmupTime = 100;
 
     Verbosity verbosity = Verbosity::Normal;
     WarnAbout::What warnings = WarnAbout::Nothing;
     ShowDurations::OrNot showDurations = ShowDurations::DefaultForReporter;
+    double minDuration = -1;
     RunTests::InWhatOrder runOrder = RunTests::InDeclarationOrder;
     UseColour::YesOrNo useColour = UseColour::Auto;
     WaitForKeypress::When waitForKeypress = WaitForKeypress::Never;
@@ -5957,6 +6184,7 @@ class Config : public IConfig
     bool warnAboutMissingAssertions() const override;
     bool warnAboutNoTests() const override;
     ShowDurations::OrNot showDurations() const override;
+    double minDuration() const override;
     RunTests::InWhatOrder runOrder() const override;
     unsigned int rngSeed() const override;
     UseColour::YesOrNo useColour() const override;
@@ -5968,6 +6196,7 @@ class Config : public IConfig
     int benchmarkSamples() const override;
     double benchmarkConfidenceInterval() const override;
     unsigned int benchmarkResamples() const override;
+    std::chrono::milliseconds benchmarkWarmupTime() const override;
 
   private:
     IStream const *openStream();
@@ -6076,6 +6305,8 @@ struct OutlierClassification
 } // namespace Catch
 
 // end catch_outlier_classification.hpp
+
+#include <iterator>
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
 #include <string>
@@ -6266,6 +6497,8 @@ struct IStreamingReporter
 
     virtual void noMatchingTestCases(std::string const &spec) = 0;
 
+    virtual void reportInvalidArguments(std::string const &) {}
+
     virtual void testRunStarting(TestRunInfo const &testRunInfo) = 0;
     virtual void testGroupStarting(GroupInfo const &groupInfo) = 0;
 
@@ -6336,6 +6569,9 @@ void prepareExpandedExpression(AssertionResult &result);
 // Returns double formatted as %.3f (format expected on output)
 std::string getFormattedDuration(double duration);
 
+//! Should the reporter show
+bool shouldShowDuration(IConfig const &config, double duration);
+
 std::string serializeFilters(std::vector<std::string> const &container);
 
 template <typename DerivedT> struct StreamingReporterBase : IStreamingReporter
@@ -6356,6 +6592,8 @@ template <typename DerivedT> struct StreamingReporterBase : IStreamingReporter
     ~StreamingReporterBase() override = default;
 
     void noMatchingTestCases(std::string const &) override {}
+
+    void reportInvalidArguments(std::string const &) override {}
 
     void testRunStarting(TestRunInfo const &_testRunInfo) override
     {
@@ -6709,20 +6947,22 @@ template <typename T> class ListenerRegistrar
 #if !defined(CATCH_CONFIG_DISABLE)
 
 #define CATCH_REGISTER_REPORTER(name, reporterType)                                                \
+    CATCH_INTERNAL_START_WARNINGS_SUPPRESSION                                                      \
     CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS                                                       \
     namespace                                                                                      \
     {                                                                                              \
     Catch::ReporterRegistrar<reporterType> catch_internal_RegistrarFor##reporterType(name);        \
     }                                                                                              \
-    CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS
+    CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 
 #define CATCH_REGISTER_LISTENER(listenerType)                                                      \
+    CATCH_INTERNAL_START_WARNINGS_SUPPRESSION                                                      \
     CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS                                                       \
     namespace                                                                                      \
     {                                                                                              \
     Catch::ListenerRegistrar<listenerType> catch_internal_RegistrarFor##listenerType;              \
     }                                                                                              \
-    CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS
+    CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 #else // CATCH_CONFIG_DISABLE
 
 #define CATCH_REGISTER_REPORTER(name, reporterType)
@@ -6745,8 +6985,6 @@ struct CompactReporter : StreamingReporterBase<CompactReporter>
     ~CompactReporter() override;
 
     static std::string getDescription();
-
-    ReporterPreferences getPreferences() const override;
 
     void noMatchingTestCases(std::string const &spec) override;
 
@@ -6786,6 +7024,8 @@ struct ConsoleReporter : StreamingReporterBase<ConsoleReporter>
     static std::string getDescription();
 
     void noMatchingTestCases(std::string const &spec) override;
+
+    void reportInvalidArguments(std::string const &arg) override;
 
     void assertionStarting(AssertionInfo const &) override;
 
@@ -6848,6 +7088,15 @@ struct ConsoleReporter : StreamingReporterBase<ConsoleReporter>
 
 namespace Catch
 {
+enum class XmlFormatting
+{
+    None = 0x00,
+    Indent = 0x01,
+    Newline = 0x02,
+};
+
+XmlFormatting operator|(XmlFormatting lhs, XmlFormatting rhs);
+XmlFormatting operator&(XmlFormatting lhs, XmlFormatting rhs);
 
 class XmlEncode
 {
@@ -6875,14 +7124,16 @@ class XmlWriter
     class ScopedElement
     {
       public:
-        ScopedElement(XmlWriter *writer);
+        ScopedElement(XmlWriter *writer, XmlFormatting fmt);
 
         ScopedElement(ScopedElement &&other) noexcept;
         ScopedElement &operator=(ScopedElement &&other) noexcept;
 
         ~ScopedElement();
 
-        ScopedElement &writeText(std::string const &text, bool indent = true);
+        ScopedElement &writeText(std::string const &text,
+                                 XmlFormatting fmt = XmlFormatting::Newline |
+                                                     XmlFormatting::Indent);
 
         template <typename T>
         ScopedElement &writeAttribute(std::string const &name, T const &attribute)
@@ -6893,6 +7144,7 @@ class XmlWriter
 
       private:
         mutable XmlWriter *m_writer = nullptr;
+        XmlFormatting m_fmt;
     };
 
     XmlWriter(std::ostream &os = Catch::cout());
@@ -6901,11 +7153,13 @@ class XmlWriter
     XmlWriter(XmlWriter const &) = delete;
     XmlWriter &operator=(XmlWriter const &) = delete;
 
-    XmlWriter &startElement(std::string const &name);
+    XmlWriter &startElement(std::string const &name,
+                            XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
 
-    ScopedElement scopedElement(std::string const &name);
+    ScopedElement scopedElement(std::string const &name,
+                                XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
 
-    XmlWriter &endElement();
+    XmlWriter &endElement(XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
 
     XmlWriter &writeAttribute(std::string const &name, std::string const &attribute);
 
@@ -6918,9 +7172,11 @@ class XmlWriter
         return writeAttribute(name, rss.str());
     }
 
-    XmlWriter &writeText(std::string const &text, bool indent = true);
+    XmlWriter &writeText(std::string const &text,
+                         XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
 
-    XmlWriter &writeComment(std::string const &text);
+    XmlWriter &writeComment(std::string const &text,
+                            XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
 
     void writeStylesheetRef(std::string const &url);
 
@@ -6929,6 +7185,8 @@ class XmlWriter
     void ensureTagClosed();
 
   private:
+    void applyFormatting(XmlFormatting fmt);
+
     void writeDeclaration();
 
     void newlineIfNecessary();
@@ -6975,7 +7233,7 @@ class JunitReporter : public CumulativeReporterBase<JunitReporter>
     void writeTestCase(TestCaseNode const &testCaseNode);
 
     void writeSection(std::string const &className, std::string const &rootName,
-                      SectionNode const &sectionNode);
+                      SectionNode const &sectionNode, bool testOkToFail);
 
     void writeAssertions(SectionNode const &sectionNode);
     void writeAssertion(AssertionStats const &stats);
@@ -7052,6 +7310,12 @@ class XmlReporter : public StreamingReporterBase<XmlReporter>
 #endif
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
+// start catch_benchmarking_all.hpp
+
+// A proxy header that includes all of the benchmarking headers to allow
+// concise include of the benchmarking features. You should prefer the
+// individual includes in standard use.
+
 // start catch_benchmark.hpp
 
 // Benchmark
@@ -7188,20 +7452,19 @@ template <> struct CompleteInvoker<void>
         return {};
     }
 };
-template <typename Sig> using ResultOf_t = typename std::result_of<Sig>::type;
 
 // invoke and not return void :(
 template <typename Fun, typename... Args>
-CompleteType_t<ResultOf_t<Fun(Args...)>> complete_invoke(Fun &&fun, Args &&...args)
+CompleteType_t<FunctionReturnType<Fun, Args...>> complete_invoke(Fun &&fun, Args &&...args)
 {
-    return CompleteInvoker<ResultOf_t<Fun(Args...)>>::invoke(std::forward<Fun>(fun),
-                                                             std::forward<Args>(args)...);
+    return CompleteInvoker<FunctionReturnType<Fun, Args...>>::invoke(std::forward<Fun>(fun),
+                                                                     std::forward<Args>(args)...);
 }
 
 const std::string benchmarkErrorMsg = "a benchmark failed to run successfully";
 } // namespace Detail
 
-template <typename Fun> Detail::CompleteType_t<Detail::ResultOf_t<Fun()>> user_code(Fun &&fun)
+template <typename Fun> Detail::CompleteType_t<FunctionReturnType<Fun>> user_code(Fun &&fun)
 {
     CATCH_TRY { return Detail::complete_invoke(std::forward<Fun>(fun)); }
     CATCH_CATCH_ALL
@@ -7459,8 +7722,9 @@ template <typename Duration, typename Result> struct Timing
     Result result;
     int iterations;
 };
-template <typename Clock, typename Sig>
-using TimingOf = Timing<ClockDuration<Clock>, Detail::CompleteType_t<Detail::ResultOf_t<Sig>>>;
+template <typename Clock, typename Func, typename... Args>
+using TimingOf =
+    Timing<ClockDuration<Clock>, Detail::CompleteType_t<FunctionReturnType<Func, Args...>>>;
 } // namespace Benchmark
 } // namespace Catch
 
@@ -7474,7 +7738,7 @@ namespace Benchmark
 namespace Detail
 {
 template <typename Clock, typename Fun, typename... Args>
-TimingOf<Clock, Fun(Args...)> measure(Fun &&fun, Args &&...args)
+TimingOf<Clock, Fun, Args...> measure(Fun &&fun, Args &&...args)
 {
     auto start = Clock::now();
     auto &&r = Detail::complete_invoke(fun, std::forward<Args>(args)...);
@@ -7497,12 +7761,12 @@ namespace Benchmark
 namespace Detail
 {
 template <typename Clock, typename Fun>
-TimingOf<Clock, Fun(int)> measure_one(Fun &&fun, int iters, std::false_type)
+TimingOf<Clock, Fun, int> measure_one(Fun &&fun, int iters, std::false_type)
 {
     return Detail::measure<Clock>(fun, iters);
 }
 template <typename Clock, typename Fun>
-TimingOf<Clock, Fun(Chronometer)> measure_one(Fun &&fun, int iters, std::true_type)
+TimingOf<Clock, Fun, Chronometer> measure_one(Fun &&fun, int iters, std::true_type)
 {
     Detail::ChronometerModel<Clock> meter;
     auto &&result = Detail::complete_invoke(fun, Chronometer(meter, iters));
@@ -7523,7 +7787,7 @@ struct optimized_away_error : std::exception
 };
 
 template <typename Clock, typename Fun>
-TimingOf<Clock, Fun(run_for_at_least_argument_t<Clock, Fun>)>
+TimingOf<Clock, Fun, run_for_at_least_argument_t<Clock, Fun>>
 run_for_at_least(ClockDuration<Clock> how_long, int seed, Fun &&fun)
 {
     auto iters = seed;
@@ -7537,7 +7801,7 @@ run_for_at_least(ClockDuration<Clock> how_long, int seed, Fun &&fun)
         }
         iters *= 2;
     }
-    throw optimized_away_error{};
+    Catch::throw_exception(optimized_away_error{});
 }
 } // namespace Detail
 } // namespace Benchmark
@@ -7545,6 +7809,7 @@ run_for_at_least(ClockDuration<Clock> how_long, int seed, Fun &&fun)
 
 // end catch_run_for_at_least.hpp
 #include <algorithm>
+#include <iterator>
 
 namespace Catch
 {
@@ -7601,11 +7866,13 @@ template <typename Duration> struct ExecutionPlan
 #include <algorithm>
 #include <functional>
 #include <vector>
+#include <iterator>
 #include <numeric>
 #include <tuple>
 #include <cmath>
 #include <utility>
 #include <cstddef>
+#include <random>
 
 namespace Catch
 {
@@ -7737,8 +8004,8 @@ Estimate<double> bootstrap(double confidence_level, Iterator first, Iterator las
     double b2 = bias - z1;
     double a1 = a(b1);
     double a2 = a(b2);
-    auto lo = std::max(cumn(a1), 0);
-    auto hi = std::min(cumn(a2), n - 1);
+    auto lo = (std::max)(cumn(a1), 0);
+    auto hi = (std::min)(cumn(a2), n - 1);
 
     return {point, resample[lo], resample[hi], confidence_level};
 }
@@ -7819,8 +8086,8 @@ EnvironmentEstimate<FloatDuration<Clock>> estimate_clock_resolution(int iteratio
 template <typename Clock>
 EnvironmentEstimate<FloatDuration<Clock>> estimate_clock_cost(FloatDuration<Clock> resolution)
 {
-    auto time_limit = std::min(resolution * clock_cost_estimation_tick_limit,
-                               FloatDuration<Clock>(clock_cost_estimation_time_limit));
+    auto time_limit = (std::min)(resolution * clock_cost_estimation_tick_limit,
+                                 FloatDuration<Clock>(clock_cost_estimation_time_limit));
     auto time_clock = [](int k) {
         return Detail::measure<Clock>([k] {
                    for (int i = 0; i < k; ++i)
@@ -8002,13 +8269,13 @@ struct Benchmark
                                                 Environment<FloatDuration<Clock>> env) const
     {
         auto min_time = env.clock_resolution.mean * Detail::minimum_ticks;
-        auto run_time =
-            std::max(min_time, std::chrono::duration_cast<decltype(min_time)>(Detail::warmup_time));
+        auto run_time = std::max(
+            min_time, std::chrono::duration_cast<decltype(min_time)>(cfg.benchmarkWarmupTime()));
         auto &&test = Detail::run_for_at_least<Clock>(
             std::chrono::duration_cast<ClockDuration<Clock>>(run_time), 1, fun);
         int new_iters = static_cast<int>(std::ceil(min_time * test.iterations / test.elapsed));
         return {new_iters, test.elapsed / test.iterations * new_iters * cfg.benchmarkSamples(), fun,
-                std::chrono::duration_cast<FloatDuration<Clock>>(Detail::warmup_time),
+                std::chrono::duration_cast<FloatDuration<Clock>>(cfg.benchmarkWarmupTime()),
                 Detail::warmup_iterations};
     }
 
@@ -8036,13 +8303,12 @@ struct Benchmark
             auto samples = user_code([&] { return plan.template run<Clock>(*cfg, env); });
 
             auto analysis = Detail::analyse(*cfg, env, samples.begin(), samples.end());
-            BenchmarkStats<std::chrono::duration<double, std::nano>> stats{
-                info,
-                analysis.samples,
-                analysis.mean,
-                analysis.standard_deviation,
-                analysis.outliers,
-                analysis.outlier_variance};
+            BenchmarkStats<FloatDuration<Clock>> stats{info,
+                                                       analysis.samples,
+                                                       analysis.mean,
+                                                       analysis.standard_deviation,
+                                                       analysis.outliers,
+                                                       analysis.outlier_variance};
             getResultCapture().benchmarkEnded(stats);
         }
         CATCH_CATCH_ALL
@@ -8085,6 +8351,68 @@ struct Benchmark
     BenchmarkName = [&]
 
 // end catch_benchmark.hpp
+// start catch_constructor.hpp
+
+// Constructor and destructor helpers
+
+#include <type_traits>
+
+namespace Catch
+{
+namespace Benchmark
+{
+namespace Detail
+{
+template <typename T, bool Destruct> struct ObjectStorage
+{
+    using TStorage = typename std::aligned_storage<sizeof(T), std::alignment_of<T>::value>::type;
+
+    ObjectStorage() : data() {}
+
+    ObjectStorage(const ObjectStorage &other) { new (&data) T(other.stored_object()); }
+
+    ObjectStorage(ObjectStorage &&other) { new (&data) T(std::move(other.stored_object())); }
+
+    ~ObjectStorage() { destruct_on_exit<T>(); }
+
+    template <typename... Args> void construct(Args &&...args)
+    {
+        new (&data) T(std::forward<Args>(args)...);
+    }
+
+    template <bool AllowManualDestruction = !Destruct>
+    typename std::enable_if<AllowManualDestruction>::type destruct()
+    {
+        stored_object().~T();
+    }
+
+  private:
+    // If this is a constructor benchmark, destruct the underlying object
+    template <typename U> void destruct_on_exit(typename std::enable_if<Destruct, U>::type * = 0)
+    {
+        destruct<true>();
+    }
+    // Otherwise, don't
+    template <typename U> void destruct_on_exit(typename std::enable_if<!Destruct, U>::type * = 0)
+    {
+    }
+
+    T &stored_object() { return *static_cast<T *>(static_cast<void *>(&data)); }
+
+    T const &stored_object() const { return *static_cast<T *>(static_cast<void *>(&data)); }
+
+    TStorage data;
+};
+} // namespace Detail
+
+template <typename T> using storage_for = Detail::ObjectStorage<T, true>;
+
+template <typename T> using destructable_object = Detail::ObjectStorage<T, false>;
+} // namespace Benchmark
+} // namespace Catch
+
+// end catch_constructor.hpp
+// end catch_benchmarking_all.hpp
 #endif
 
 #endif // ! CATCH_CONFIG_IMPL_ONLY
@@ -8115,24 +8443,34 @@ struct NameAndLocation
     SourceLineInfo location;
 
     NameAndLocation(std::string const &_name, SourceLineInfo const &_location);
+    friend bool operator==(NameAndLocation const &lhs, NameAndLocation const &rhs)
+    {
+        return lhs.name == rhs.name && lhs.location == rhs.location;
+    }
 };
 
-struct ITracker;
+class ITracker;
 
 using ITrackerPtr = std::shared_ptr<ITracker>;
 
-struct ITracker
+class ITracker
 {
-    virtual ~ITracker();
+    NameAndLocation m_nameAndLocation;
+
+  public:
+    ITracker(NameAndLocation const &nameAndLoc) : m_nameAndLocation(nameAndLoc) {}
 
     // static queries
-    virtual NameAndLocation const &nameAndLocation() const = 0;
+    NameAndLocation const &nameAndLocation() const { return m_nameAndLocation; }
+
+    virtual ~ITracker();
 
     // dynamic queries
     virtual bool isComplete() const = 0; // Successfully completed or failed
     virtual bool isSuccessfullyCompleted() const = 0;
     virtual bool isOpen() const = 0; // Started but not complete
     virtual bool hasChildren() const = 0;
+    virtual bool hasStarted() const = 0;
 
     virtual ITracker &parent() = 0;
 
@@ -8190,7 +8528,6 @@ class TrackerBase : public ITracker
     };
 
     using Children = std::vector<ITrackerPtr>;
-    NameAndLocation m_nameAndLocation;
     TrackerContext &m_ctx;
     ITracker *m_parent;
     Children m_children;
@@ -8199,11 +8536,11 @@ class TrackerBase : public ITracker
   public:
     TrackerBase(NameAndLocation const &nameAndLocation, TrackerContext &ctx, ITracker *parent);
 
-    NameAndLocation const &nameAndLocation() const override;
     bool isComplete() const override;
     bool isSuccessfullyCompleted() const override;
     bool isOpen() const override;
     bool hasChildren() const override;
+    bool hasStarted() const override { return m_runState != NotStarted; }
 
     void addChild(ITrackerPtr const &child) override;
 
@@ -8229,6 +8566,7 @@ class TrackerBase : public ITracker
 class SectionTracker : public TrackerBase
 {
     std::vector<std::string> m_filters;
+    std::string m_trimmed_name;
 
   public:
     SectionTracker(NameAndLocation const &nameAndLocation, TrackerContext &ctx, ITracker *parent);
@@ -8243,6 +8581,10 @@ class SectionTracker : public TrackerBase
 
     void addInitialFilters(std::vector<std::string> const &filters);
     void addNextFilters(std::vector<std::string> const &filters);
+    //! Returns filters active in this tracker
+    std::vector<std::string> const &getFilters() const;
+    //! Returns whitespace-trimmed name of the tracked section
+    std::string const &trimmedName() const;
 };
 
 } // namespace TestCaseTracking
@@ -8428,7 +8770,7 @@ double outlier_variance(Estimate<double> mean, Estimate<double> stddev, int n)
     double sb = stddev.point;
     double mn = mean.point / n;
     double mg_min = mn / 2.;
-    double sg = std::min(mg_min / 4., sb / std::sqrt(n));
+    double sg = (std::min)(mg_min / 4., sb / std::sqrt(n));
     double sg2 = sg * sg;
     double sb2 = sb * sb;
 
@@ -8447,16 +8789,17 @@ double outlier_variance(Estimate<double> mean, Estimate<double> stddev, int n)
         return (nc / n) * (sb2 - nc * sg2);
     };
 
-    return std::min(var_out(1), var_out(std::min(c_max(0.), c_max(mg_min)))) / sb2;
+    return (std::min)(var_out(1), var_out((std::min)(c_max(0.), c_max(mg_min)))) / sb2;
 }
 
 bootstrap_analysis analyse_samples(double confidence_level, int n_resamples,
                                    std::vector<double>::iterator first,
                                    std::vector<double>::iterator last)
 {
+    CATCH_INTERNAL_START_WARNINGS_SUPPRESSION
     CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS
     static std::random_device entropy;
-    CATCH_INTERNAL_UNSUPPRESS_GLOBALS_WARNINGS
+    CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 
     auto n = static_cast<int>(last -
                               first); // seriously, one can't use integral types without hell in C++
@@ -8550,7 +8893,8 @@ bool Approx::equalityComparisonImpl(const double other) const
     // First try with fixed margin, then compute margin based on epsilon, scale and Approx's value
     // Thanks to Richard Harris for his help refining the scaled margin value
     return marginComparison(m_value, other, m_margin) ||
-           marginComparison(m_value, other, m_epsilon * (m_scale + std::fabs(m_value)));
+           marginComparison(m_value, other,
+                            m_epsilon * (m_scale + std::fabs(std::isinf(m_value) ? 0 : m_value)));
 }
 
 void Approx::setMargin(double newMargin)
@@ -8594,10 +8938,24 @@ bool isDebuggerActive();
 }
 
 #ifdef CATCH_PLATFORM_MAC
-#if defined(__x86_64__)
+
+#if defined(__i386__) || defined(__x86_64__)
 #define CATCH_TRAP() __asm__("int $3\n" : :) /* NOLINT */
-#else
-#define CATCH_TRAP()
+#elif defined(__aarch64__)
+#define CATCH_TRAP() __asm__(".inst 0xd4200000")
+#endif
+
+#elif defined(CATCH_PLATFORM_IPHONE)
+
+// use inline assembler
+#if defined(__i386__) || defined(__x86_64__)
+#define CATCH_TRAP() __asm__("int $3")
+#elif defined(__aarch64__)
+#define CATCH_TRAP() __asm__(".inst 0xd4200000")
+#elif defined(__arm__) && !defined(__thumb__)
+#define CATCH_TRAP() __asm__(".inst 0xe7f001f0")
+#elif defined(__arm__) && defined(__thumb__)
+#define CATCH_TRAP() __asm__(".inst 0xde01")
 #endif
 
 #elif defined(CATCH_PLATFORM_LINUX)
@@ -8606,7 +8964,7 @@ bool isDebuggerActive();
 // raise() called from it, i.e. one stack frame below.
 #if defined(__GNUC__) && (defined(__i386) || defined(__x86_64))
 #define CATCH_TRAP() asm volatile("int $3") /* NOLINT */
-#else // Fall back to the generic way.
+#else                                       // Fall back to the generic way.
 #include <signal.h>
 
 #define CATCH_TRAP() raise(SIGTRAP)
@@ -8618,6 +8976,7 @@ extern "C" __declspec(dllimport) void __stdcall DebugBreak();
 #define CATCH_TRAP() DebugBreak()
 #endif
 
+#ifndef CATCH_BREAK_INTO_DEBUGGER
 #ifdef CATCH_TRAP
 #define CATCH_BREAK_INTO_DEBUGGER()                                                                \
     [] {                                                                                           \
@@ -8629,97 +8988,70 @@ extern "C" __declspec(dllimport) void __stdcall DebugBreak();
 #else
 #define CATCH_BREAK_INTO_DEBUGGER() [] {}()
 #endif
+#endif
 
 // end catch_debugger.h
 // start catch_run_context.h
 
 // start catch_fatal_condition.h
 
-// start catch_windows_h_proxy.h
-
-#if defined(CATCH_PLATFORM_WINDOWS)
-
-#if !defined(NOMINMAX) && !defined(CATCH_CONFIG_NO_NOMINMAX)
-#define CATCH_DEFINED_NOMINMAX
-#define NOMINMAX
-#endif
-#if !defined(WIN32_LEAN_AND_MEAN) && !defined(CATCH_CONFIG_NO_WIN32_LEAN_AND_MEAN)
-#define CATCH_DEFINED_WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-
-#ifdef __AFXDLL
-#include <AfxWin.h>
-#else
-#include <windows.h>
-#endif
-
-#ifdef CATCH_DEFINED_NOMINMAX
-#undef NOMINMAX
-#endif
-#ifdef CATCH_DEFINED_WIN32_LEAN_AND_MEAN
-#undef WIN32_LEAN_AND_MEAN
-#endif
-
-#endif // defined(CATCH_PLATFORM_WINDOWS)
-
-// end catch_windows_h_proxy.h
-#if defined(CATCH_CONFIG_WINDOWS_SEH)
+#include <cassert>
 
 namespace Catch
 {
 
-struct FatalConditionHandler
+// Wrapper for platform-specific fatal error (signals/SEH) handlers
+//
+// Tries to be cooperative with other handlers, and not step over
+// other handlers. This means that unknown structured exceptions
+// are passed on, previous signal handlers are called, and so on.
+//
+// Can only be instantiated once, and assumes that once a signal
+// is caught, the binary will end up terminating. Thus, there
+class FatalConditionHandler
 {
+    bool m_started = false;
 
-    static LONG CALLBACK handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo);
-    FatalConditionHandler();
-    static void reset();
-    ~FatalConditionHandler();
+    // Install/disengage implementation for specific platform.
+    // Should be if-defed to work on current platform, can assume
+    // engage-disengage 1:1 pairing.
+    void engage_platform();
+    void disengage_platform();
 
-  private:
-    static bool isSet;
-    static ULONG guaranteeSize;
-    static PVOID exceptionHandlerHandle;
-};
-
-} // namespace Catch
-
-#elif defined(CATCH_CONFIG_POSIX_SIGNALS)
-
-#include <signal.h>
-
-namespace Catch
-{
-
-struct FatalConditionHandler
-{
-
-    static bool isSet;
-    static struct sigaction oldSigActions[];
-    static stack_t oldSigStack;
-    static char altStackMem[];
-
-    static void handleSignal(int sig);
-
+  public:
+    // Should also have platform-specific implementations as needed
     FatalConditionHandler();
     ~FatalConditionHandler();
-    static void reset();
+
+    void engage()
+    {
+        assert(!m_started && "Handler cannot be installed twice.");
+        m_started = true;
+        engage_platform();
+    }
+
+    void disengage()
+    {
+        assert(m_started && "Handler cannot be uninstalled without being installed first");
+        m_started = false;
+        disengage_platform();
+    }
 };
 
-} // namespace Catch
-
-#else
-
-namespace Catch
+//! Simple RAII guard for (dis)engaging the FatalConditionHandler
+class FatalConditionHandlerGuard
 {
-struct FatalConditionHandler
-{
-    void reset();
+    FatalConditionHandler *m_handler;
+
+  public:
+    FatalConditionHandlerGuard(FatalConditionHandler *handler) : m_handler(handler)
+    {
+        m_handler->engage();
+    }
+    ~FatalConditionHandlerGuard() { m_handler->disengage(); }
 };
-} // namespace Catch
 
-#endif
+} // end namespace Catch
 
 // end catch_fatal_condition.h
 #include <string>
@@ -8771,7 +9103,8 @@ class RunContext : public IResultCapture, public IRunner
     void sectionEnded(SectionEndInfo const &endInfo) override;
     void sectionEndedEarly(SectionEndInfo const &endInfo) override;
 
-    auto acquireGeneratorTracker(SourceLineInfo const &lineInfo) -> IGeneratorTracker & override;
+    auto acquireGeneratorTracker(StringRef generatorName, SourceLineInfo const &lineInfo)
+        -> IGeneratorTracker & override;
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
     void benchmarkPreparing(std::string const &name) override;
@@ -8832,11 +9165,14 @@ class RunContext : public IResultCapture, public IRunner
     std::vector<SectionEndInfo> m_unfinishedSections;
     std::vector<ITracker *> m_activeSections;
     TrackerContext m_trackerContext;
+    FatalConditionHandler m_fatalConditionhandler;
     bool m_lastAssertionPassed = false;
     bool m_shouldReportUnexpected = true;
     bool m_includeSuccessfulResults;
 };
 
+void seedRng(IConfig const &config);
+unsigned int rngSeed();
 } // end namespace Catch
 
 // end catch_run_context.h
@@ -8998,23 +9334,32 @@ bool AssertionResult::isOk() const
 
 ResultWas::OfType AssertionResult::getResultType() const { return m_resultData.resultType; }
 
-bool AssertionResult::hasExpression() const { return m_info.capturedExpression[0] != 0; }
+bool AssertionResult::hasExpression() const { return !m_info.capturedExpression.empty(); }
 
 bool AssertionResult::hasMessage() const { return !m_resultData.message.empty(); }
 
 std::string AssertionResult::getExpression() const
 {
+    // Possibly overallocating by 3 characters should be basically free
+    std::string expr;
+    expr.reserve(m_info.capturedExpression.size() + 3);
     if (isFalseTest(m_info.resultDisposition))
-        return "!(" + m_info.capturedExpression + ")";
-    else
-        return m_info.capturedExpression;
+    {
+        expr += "!(";
+    }
+    expr += m_info.capturedExpression;
+    if (isFalseTest(m_info.resultDisposition))
+    {
+        expr += ')';
+    }
+    return expr;
 }
 
 std::string AssertionResult::getExpressionInMacro() const
 {
     std::string expr;
-    if (m_info.macroName[0] == 0)
-        expr = m_info.capturedExpression;
+    if (m_info.macroName.empty())
+        expr = static_cast<std::string>(m_info.capturedExpression);
     else
     {
         expr.reserve(m_info.macroName.size() + m_info.capturedExpression.size() + 4);
@@ -9837,7 +10182,7 @@ inline auto convertInto(std::string const &source, bool &target) -> ParserResult
 {
     std::string srcLC = source;
     std::transform(srcLC.begin(), srcLC.end(), srcLC.begin(),
-                   [](char c) { return static_cast<char>(std::tolower(c)); });
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
     if (srcLC == "y" || srcLC == "1" || srcLC == "true" || srcLC == "yes" || srcLC == "on")
         target = true;
     else if (srcLC == "n" || srcLC == "0" || srcLC == "false" || srcLC == "no" || srcLC == "off")
@@ -10568,9 +10913,14 @@ clara::Parser makeCommandLineParser(ConfigData &config)
             {
                 if (!startsWith(line, '"'))
                     line = '"' + line + '"';
-                config.testsOrTags.push_back(line + ',');
+                config.testsOrTags.push_back(line);
+                config.testsOrTags.emplace_back(",");
             }
         }
+        // Remove comma in the end
+        if (!config.testsOrTags.empty())
+            config.testsOrTags.erase(config.testsOrTags.end() - 1);
+
         return ParserResult::ok(ParseResultType::Matched);
     };
     auto const setTestOrder = [&](std::string const &order) {
@@ -10606,7 +10956,9 @@ clara::Parser makeCommandLineParser(ConfigData &config)
     };
     auto const setWaitForKeypress = [&](std::string const &keypress) {
         auto keypressLc = toLower(keypress);
-        if (keypressLc == "start")
+        if (keypressLc == "never")
+            config.waitForKeypress = WaitForKeypress::Never;
+        else if (keypressLc == "start")
             config.waitForKeypress = WaitForKeypress::BeforeStart;
         else if (keypressLc == "exit")
             config.waitForKeypress = WaitForKeypress::BeforeExit;
@@ -10614,7 +10966,7 @@ clara::Parser makeCommandLineParser(ConfigData &config)
             config.waitForKeypress = WaitForKeypress::BeforeStartAndExit;
         else
             return ParserResult::runtimeError(
-                "keypress argument must be one of: start, exit or both. '" + keypress +
+                "keypress argument must be one of: never, start, exit or both. '" + keypress +
                 "' not recognised");
         return ParserResult::ok(ParseResultType::Matched);
     };
@@ -10665,6 +11017,8 @@ clara::Parser makeCommandLineParser(ConfigData &config)
                 config.showDurations = flag ? ShowDurations::Always : ShowDurations::Never;
             },
             "yes|no")["-d"]["--durations"]("show test durations") |
+        Opt(config.minDuration, "seconds")["-D"]["--min-duration"](
+            "show test durations for tests taking at least the given number of seconds") |
         Opt(loadTestNamesFromFile,
             "filename")["-f"]["--input-file"]("load test names to run from a file") |
         Opt(config.filenamesAsTags)["-#"]["--filenames-as-tags"]("adds a tag for the filename") |
@@ -10679,7 +11033,7 @@ clara::Parser makeCommandLineParser(ConfigData &config)
         Opt(config.libIdentify)["--libidentify"](
             "report name and version according to libidentify standard") |
         Opt(setWaitForKeypress,
-            "start|exit|both")["--wait-for-keypress"]("waits for a keypress before exiting") |
+            "never|start|exit|both")["--wait-for-keypress"]("waits for a keypress before exiting") |
         Opt(config.benchmarkSamples,
             "samples")["--benchmark-samples"]("number of samples to collect (default: 100)") |
         Opt(config.benchmarkResamples, "resamples")["--benchmark-resamples"](
@@ -10689,6 +11043,8 @@ clara::Parser makeCommandLineParser(ConfigData &config)
             "confidence interval for the bootstrap (between 0 and 1, default: 0.95)") |
         Opt(config.benchmarkNoAnalysis)["--benchmark-no-analysis"](
             "perform only measurements; do not perform any analysis") |
+        Opt(config.benchmarkWarmupTime, "benchmarkWarmupTime")["--benchmark-warmup-time"](
+            "amount of time in milliseconds spent on warming up each test (default: 100)") |
         Arg(config.testsOrTags, "test name|pattern|tags")("which test or tests to use");
 
     return cli;
@@ -10704,7 +11060,6 @@ clara::Parser makeCommandLineParser(ConfigData &config)
 namespace Catch
 {
 
-bool SourceLineInfo::empty() const noexcept { return file[0] == '\0'; }
 bool SourceLineInfo::operator==(SourceLineInfo const &other) const noexcept
 {
     return line == other.line && (file == other.file || std::strcmp(file, other.file) == 0);
@@ -10741,12 +11096,27 @@ namespace Catch
 
 Config::Config(ConfigData const &data) : m_data(data), m_stream(openStream())
 {
+    // We need to trim filter specs to avoid trouble with superfluous
+    // whitespace (esp. important for bdd macros, as those are manually
+    // aligned with whitespace).
+
+    for (auto &elem : m_data.testsOrTags)
+    {
+        elem = trim(elem);
+    }
+    for (auto &elem : m_data.sectionsToRun)
+    {
+        elem = trim(elem);
+    }
+
     TestSpecParser parser(ITagAliasRegistry::get());
-    if (!data.testsOrTags.empty())
+    if (!m_data.testsOrTags.empty())
     {
         m_hasTestFilters = true;
-        for (auto const &testOrTags : data.testsOrTags)
+        for (auto const &testOrTags : m_data.testsOrTags)
+        {
             parser.parse(testOrTags);
+        }
     }
     m_testSpec = parser.testSpec();
 }
@@ -10780,6 +11150,7 @@ bool Config::warnAboutMissingAssertions() const
 }
 bool Config::warnAboutNoTests() const { return !!(m_data.warnings & WarnAbout::NoTests); }
 ShowDurations::OrNot Config::showDurations() const { return m_data.showDurations; }
+double Config::minDuration() const { return m_data.minDuration; }
 RunTests::InWhatOrder Config::runOrder() const { return m_data.runOrder; }
 unsigned int Config::rngSeed() const { return m_data.rngSeed; }
 UseColour::YesOrNo Config::useColour() const { return m_data.useColour; }
@@ -10792,6 +11163,10 @@ bool Config::benchmarkNoAnalysis() const { return m_data.benchmarkNoAnalysis; }
 int Config::benchmarkSamples() const { return m_data.benchmarkSamples; }
 double Config::benchmarkConfidenceInterval() const { return m_data.benchmarkConfidenceInterval; }
 unsigned int Config::benchmarkResamples() const { return m_data.benchmarkResamples; }
+std::chrono::milliseconds Config::benchmarkWarmupTime() const
+{
+    return std::chrono::milliseconds(m_data.benchmarkWarmupTime);
+}
 
 IStream const *Config::openStream() { return Catch::makeStream(m_data.outputFilename); }
 
@@ -10822,6 +11197,35 @@ class ErrnoGuard
 } // namespace Catch
 
 // end catch_errno_guard.h
+// start catch_windows_h_proxy.h
+
+#if defined(CATCH_PLATFORM_WINDOWS)
+
+#if !defined(NOMINMAX) && !defined(CATCH_CONFIG_NO_NOMINMAX)
+#define CATCH_DEFINED_NOMINMAX
+#define NOMINMAX
+#endif
+#if !defined(WIN32_LEAN_AND_MEAN) && !defined(CATCH_CONFIG_NO_WIN32_LEAN_AND_MEAN)
+#define CATCH_DEFINED_WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#ifdef __AFXDLL
+#include <AfxWin.h>
+#else
+#include <windows.h>
+#endif
+
+#ifdef CATCH_DEFINED_NOMINMAX
+#undef NOMINMAX
+#endif
+#ifdef CATCH_DEFINED_WIN32_LEAN_AND_MEAN
+#undef WIN32_LEAN_AND_MEAN
+#endif
+
+#endif // defined(CATCH_PLATFORM_WINDOWS)
+
+// end catch_windows_h_proxy.h
 #include <sstream>
 
 namespace Catch
@@ -10837,7 +11241,7 @@ struct IColourImpl
 
 struct NoColourImpl : IColourImpl
 {
-    void use(Colour::Code) {}
+    void use(Colour::Code) override {}
 
     static IColourImpl *instance()
     {
@@ -11014,7 +11418,7 @@ class PosixColourImpl : public IColourImpl
 bool useColourOnPlatform()
 {
     return
-#ifdef CATCH_PLATFORM_MAC
+#if defined(CATCH_PLATFORM_MAC) || defined(CATCH_PLATFORM_IPHONE)
         !isDebuggerActive() &&
 #endif
 #if !(defined(__DJGPP__) && defined(__STRICT_ANSI__))
@@ -11052,15 +11456,15 @@ namespace Catch
 {
 
 Colour::Colour(Code _colourCode) { use(_colourCode); }
-Colour::Colour(Colour &&rhs) noexcept
+Colour::Colour(Colour &&other) noexcept
 {
-    m_moved = rhs.m_moved;
-    rhs.m_moved = true;
+    m_moved = other.m_moved;
+    other.m_moved = true;
 }
-Colour &Colour::operator=(Colour &&rhs) noexcept
+Colour &Colour::operator=(Colour &&other) noexcept
 {
-    m_moved = rhs.m_moved;
-    rhs.m_moved = true;
+    m_moved = other.m_moved;
+    other.m_moved = true;
     return *this;
 }
 
@@ -11077,7 +11481,7 @@ void Colour::use(Code _colourCode)
     // However, under some conditions it does happen (see #1626),
     // and this change is small enough that we can let practicality
     // triumph over purity in this case.
-    if (impl != NULL)
+    if (impl != nullptr)
     {
         impl->use(_colourCode);
     }
@@ -11136,6 +11540,13 @@ void cleanUpContext()
 IContext::~IContext() = default;
 IMutableContext::~IMutableContext() = default;
 Context::~Context() = default;
+
+SimplePcg32 &rng()
+{
+    static SimplePcg32 s_rng;
+    return s_rng;
+}
+
 } // namespace Catch
 // end catch_context.cpp
 // start catch_debug_console.cpp
@@ -11150,14 +11561,14 @@ void writeToDebugConsole(std::string const &text);
 }
 
 // end catch_debug_console.h
-#if defined(__ANDROID__)
+#if defined(CATCH_CONFIG_ANDROID_LOGWRITE)
 #include <android/log.h>
 
 namespace Catch
 {
 void writeToDebugConsole(std::string const &text)
 {
-    __android_log_print(ANDROID_LOG_DEBUG, "Catch", text.c_str());
+    __android_log_write(ANDROID_LOG_DEBUG, "Catch", text.c_str());
 }
 } // namespace Catch
 
@@ -11183,10 +11594,9 @@ void writeToDebugConsole(std::string const &text)
 // end catch_debug_console.cpp
 // start catch_debugger.cpp
 
-#ifdef CATCH_PLATFORM_MAC
+#if defined(CATCH_PLATFORM_MAC) || defined(CATCH_PLATFORM_IPHONE)
 
-#include <assert.h>
-#include <stdbool.h>
+#include <cassert>
 #include <sys/types.h>
 #include <unistd.h>
 #include <cstddef>
@@ -11377,7 +11787,7 @@ class EnumValuesRegistry : public IMutableEnumValuesRegistry
                                  std::vector<int> const &values) override;
 };
 
-std::vector<std::string> parseEnums(StringRef enums);
+std::vector<StringRef> parseEnums(StringRef enums);
 
 } // namespace Detail
 
@@ -11396,15 +11806,30 @@ IMutableEnumValuesRegistry::~IMutableEnumValuesRegistry() {}
 namespace Detail
 {
 
-std::vector<std::string> parseEnums(StringRef enums)
+namespace
+{
+// Extracts the actual name part of an enum instance
+// In other words, it returns the Blue part of Bikeshed::Colour::Blue
+StringRef extractInstanceName(StringRef enumInstance)
+{
+    // Find last occurrence of ":"
+    size_t name_start = enumInstance.size();
+    while (name_start > 0 && enumInstance[name_start - 1] != ':')
+    {
+        --name_start;
+    }
+    return enumInstance.substr(name_start, enumInstance.size() - name_start);
+}
+} // namespace
+
+std::vector<StringRef> parseEnums(StringRef enums)
 {
     auto enumValues = splitStringRef(enums, ',');
-    std::vector<std::string> parsed;
+    std::vector<StringRef> parsed;
     parsed.reserve(enumValues.size());
     for (auto const &enumValue : enumValues)
     {
-        auto identifiers = splitStringRef(enumValue, ':');
-        parsed.push_back(Catch::trim(identifiers.back()));
+        parsed.push_back(trim(extractInstanceName(enumValue)));
     }
     return parsed;
 }
@@ -11418,7 +11843,7 @@ StringRef EnumInfo::lookup(int value) const
         if (valueToName.first == value)
             return valueToName.second;
     }
-    return "{** unexpected enum value **}";
+    return "{** unexpected enum value **}"_sr;
 }
 
 std::unique_ptr<EnumInfo> makeEnumInfo(StringRef enumName, StringRef allValueNames,
@@ -11432,7 +11857,7 @@ std::unique_ptr<EnumInfo> makeEnumInfo(StringRef enumName, StringRef allValueNam
     assert(valueNames.size() == values.size());
     std::size_t i = 0;
     for (auto value : values)
-        enumInfo->m_values.push_back({value, valueNames[i++]});
+        enumInfo->m_values.emplace_back(value, valueNames[i++]);
 
     return enumInfo;
 }
@@ -11440,10 +11865,8 @@ std::unique_ptr<EnumInfo> makeEnumInfo(StringRef enumName, StringRef allValueNam
 EnumInfo const &EnumValuesRegistry::registerEnum(StringRef enumName, StringRef allValueNames,
                                                  std::vector<int> const &values)
 {
-    auto enumInfo = makeEnumInfo(enumName, allValueNames, values);
-    EnumInfo *raw = enumInfo.get();
-    m_enumInfos.push_back(std::move(enumInfo));
-    return *raw;
+    m_enumInfos.push_back(makeEnumInfo(enumName, allValueNames, values));
+    return *m_enumInfos.back();
 }
 
 } // namespace Detail
@@ -11582,28 +12005,52 @@ std::string ExceptionTranslatorRegistry::tryTranslators() const
 // end catch_exception_translator_registry.cpp
 // start catch_fatal_condition.cpp
 
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#endif
+#include <algorithm>
+
+#if !defined(CATCH_CONFIG_WINDOWS_SEH) && !defined(CATCH_CONFIG_POSIX_SIGNALS)
+
+namespace Catch
+{
+
+// If neither SEH nor signal handling is required, the handler impls
+// do not have to do anything, and can be empty.
+void FatalConditionHandler::engage_platform() {}
+void FatalConditionHandler::disengage_platform() {}
+FatalConditionHandler::FatalConditionHandler() = default;
+FatalConditionHandler::~FatalConditionHandler() = default;
+
+} // end namespace Catch
+
+#endif // !CATCH_CONFIG_WINDOWS_SEH && !CATCH_CONFIG_POSIX_SIGNALS
+
+#if defined(CATCH_CONFIG_WINDOWS_SEH) && defined(CATCH_CONFIG_POSIX_SIGNALS)
+#error                                                                                             \
+    "Inconsistent configuration: Windows' SEH handling and POSIX signals cannot be enabled at the same time"
+#endif // CATCH_CONFIG_WINDOWS_SEH && CATCH_CONFIG_POSIX_SIGNALS
 
 #if defined(CATCH_CONFIG_WINDOWS_SEH) || defined(CATCH_CONFIG_POSIX_SIGNALS)
 
 namespace
 {
-// Report the error condition
+//! Signals fatal error message to the run context
 void reportFatal(char const *const message)
 {
     Catch::getCurrentContext().getResultCapture()->handleFatalErrorCondition(message);
 }
-} // namespace
 
-#endif // signals/SEH handling
+//! Minimal size Catch2 needs for its own fatal error handling.
+//! Picked anecdotally, so it might not be sufficient on all
+//! platforms, and for all configurations.
+constexpr std::size_t minStackSizeForErrors = 32 * 1024;
+} // end unnamed namespace
+
+#endif // CATCH_CONFIG_WINDOWS_SEH || CATCH_CONFIG_POSIX_SIGNALS
 
 #if defined(CATCH_CONFIG_WINDOWS_SEH)
 
 namespace Catch
 {
+
 struct SignalDefs
 {
     DWORD id;
@@ -11620,7 +12067,7 @@ static SignalDefs signalDefs[] = {
     {static_cast<DWORD>(EXCEPTION_INT_DIVIDE_BY_ZERO), "Divide by zero error"},
 };
 
-LONG CALLBACK FatalConditionHandler::handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo)
+static LONG CALLBACK handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo)
 {
     for (auto const &def : signalDefs)
     {
@@ -11634,39 +12081,55 @@ LONG CALLBACK FatalConditionHandler::handleVectoredException(PEXCEPTION_POINTERS
     return EXCEPTION_CONTINUE_SEARCH;
 }
 
+// Since we do not support multiple instantiations, we put these
+// into global variables and rely on cleaning them up in outlined
+// constructors/destructors
+static PVOID exceptionHandlerHandle = nullptr;
+
+// For MSVC, we reserve part of the stack memory for handling
+// memory overflow structured exception.
 FatalConditionHandler::FatalConditionHandler()
 {
-    isSet = true;
-    // 32k seems enough for Catch to handle stack overflow,
-    // but the value was found experimentally, so there is no strong guarantee
-    guaranteeSize = 32 * 1024;
-    exceptionHandlerHandle = nullptr;
-    // Register as first handler in current chain
-    exceptionHandlerHandle = AddVectoredExceptionHandler(1, handleVectoredException);
-    // Pass in guarantee size to be filled
-    SetThreadStackGuarantee(&guaranteeSize);
-}
-
-void FatalConditionHandler::reset()
-{
-    if (isSet)
+    ULONG guaranteeSize = static_cast<ULONG>(minStackSizeForErrors);
+    if (!SetThreadStackGuarantee(&guaranteeSize))
     {
-        RemoveVectoredExceptionHandler(exceptionHandlerHandle);
-        SetThreadStackGuarantee(&guaranteeSize);
-        exceptionHandlerHandle = nullptr;
-        isSet = false;
+        // We do not want to fully error out, because needing
+        // the stack reserve should be rare enough anyway.
+        Catch::cerr() << "Failed to reserve piece of stack."
+                      << " Stack overflows will not be reported successfully.";
     }
 }
 
-FatalConditionHandler::~FatalConditionHandler() { reset(); }
+// We do not attempt to unset the stack guarantee, because
+// Windows does not support lowering the stack size guarantee.
+FatalConditionHandler::~FatalConditionHandler() = default;
 
-bool FatalConditionHandler::isSet = false;
-ULONG FatalConditionHandler::guaranteeSize = 0;
-PVOID FatalConditionHandler::exceptionHandlerHandle = nullptr;
+void FatalConditionHandler::engage_platform()
+{
+    // Register as first handler in current chain
+    exceptionHandlerHandle = AddVectoredExceptionHandler(1, handleVectoredException);
+    if (!exceptionHandlerHandle)
+    {
+        CATCH_RUNTIME_ERROR("Could not register vectored exception handler");
+    }
+}
 
-} // namespace Catch
+void FatalConditionHandler::disengage_platform()
+{
+    if (!RemoveVectoredExceptionHandler(exceptionHandlerHandle))
+    {
+        CATCH_RUNTIME_ERROR("Could not unregister vectored exception handler");
+    }
+    exceptionHandlerHandle = nullptr;
+}
 
-#elif defined(CATCH_CONFIG_POSIX_SIGNALS)
+} // end namespace Catch
+
+#endif // CATCH_CONFIG_WINDOWS_SEH
+
+#if defined(CATCH_CONFIG_POSIX_SIGNALS)
+
+#include <signal.h>
 
 namespace Catch
 {
@@ -11677,10 +12140,6 @@ struct SignalDefs
     const char *name;
 };
 
-// 32kb for the alternate stack seems to be sufficient. However, this value
-// is experimentally determined, so that's not guaranteed.
-static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
-
 static SignalDefs signalDefs[] = {{SIGINT, "SIGINT - Terminal interrupt signal"},
                                   {SIGILL, "SIGILL - Illegal instruction signal"},
                                   {SIGFPE, "SIGFPE - Floating point error signal"},
@@ -11688,7 +12147,34 @@ static SignalDefs signalDefs[] = {{SIGINT, "SIGINT - Terminal interrupt signal"}
                                   {SIGTERM, "SIGTERM - Termination request signal"},
                                   {SIGABRT, "SIGABRT - Abort (abnormal termination) signal"}};
 
-void FatalConditionHandler::handleSignal(int sig)
+// Older GCCs trigger -Wmissing-field-initializers for T foo = {}
+// which is zero initialization, but not explicit. We want to avoid
+// that.
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
+
+static char *altStackMem = nullptr;
+static std::size_t altStackSize = 0;
+static stack_t oldSigStack{};
+static struct sigaction oldSigActions[sizeof(signalDefs) / sizeof(SignalDefs)]{};
+
+static void restorePreviousSignalHandlers()
+{
+    // We set signal handlers back to the previous ones. Hopefully
+    // nobody overwrote them in the meantime, and doesn't expect
+    // their signal handlers to live past ours given that they
+    // installed them after ours..
+    for (std::size_t i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i)
+    {
+        sigaction(signalDefs[i].id, &oldSigActions[i], nullptr);
+    }
+    // Return the old stack
+    sigaltstack(&oldSigStack, nullptr);
+}
+
+static void handleSignal(int sig)
 {
     char const *name = "<unknown signal>";
     for (auto const &def : signalDefs)
@@ -11699,17 +12185,37 @@ void FatalConditionHandler::handleSignal(int sig)
             break;
         }
     }
-    reset();
+    // We need to restore previous signal handlers and let them do
+    // their thing, so that the users can have the debugger break
+    // when a signal is raised, and so on.
+    restorePreviousSignalHandlers();
     reportFatal(name);
     raise(sig);
 }
 
 FatalConditionHandler::FatalConditionHandler()
 {
-    isSet = true;
+    assert(!altStackMem && "Cannot initialize POSIX signal handler when one already exists");
+    if (altStackSize == 0)
+    {
+        altStackSize = std::max(static_cast<size_t>(SIGSTKSZ), minStackSizeForErrors);
+    }
+    altStackMem = new char[altStackSize]();
+}
+
+FatalConditionHandler::~FatalConditionHandler()
+{
+    delete[] altStackMem;
+    // We signal that another instance can be constructed by zeroing
+    // out the pointer.
+    altStackMem = nullptr;
+}
+
+void FatalConditionHandler::engage_platform()
+{
     stack_t sigStack;
     sigStack.ss_sp = altStackMem;
-    sigStack.ss_size = sigStackSize;
+    sigStack.ss_size = altStackSize;
     sigStack.ss_flags = 0;
     sigaltstack(&sigStack, &oldSigStack);
     struct sigaction sa = {};
@@ -11722,62 +12228,18 @@ FatalConditionHandler::FatalConditionHandler()
     }
 }
 
-FatalConditionHandler::~FatalConditionHandler() { reset(); }
-
-void FatalConditionHandler::reset()
-{
-    if (isSet)
-    {
-        // Set signals back to previous values -- hopefully nobody overwrote them in the meantime
-        for (std::size_t i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i)
-        {
-            sigaction(signalDefs[i].id, &oldSigActions[i], nullptr);
-        }
-        // Return the old stack
-        sigaltstack(&oldSigStack, nullptr);
-        isSet = false;
-    }
-}
-
-bool FatalConditionHandler::isSet = false;
-struct sigaction FatalConditionHandler::oldSigActions[sizeof(signalDefs) / sizeof(SignalDefs)] = {};
-stack_t FatalConditionHandler::oldSigStack = {};
-char FatalConditionHandler::altStackMem[sigStackSize] = {};
-
-} // namespace Catch
-
-#else
-
-namespace Catch
-{
-void FatalConditionHandler::reset() {}
-} // namespace Catch
-
-#endif // signals/SEH handling
-
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
+
+void FatalConditionHandler::disengage_platform() { restorePreviousSignalHandlers(); }
+
+} // end namespace Catch
+
+#endif // CATCH_CONFIG_POSIX_SIGNALS
 // end catch_fatal_condition.cpp
 // start catch_generators.cpp
 
-// start catch_random_number_generator.h
-
-#include <algorithm>
-#include <random>
-
-namespace Catch
-{
-
-struct IConfig;
-
-std::mt19937 &rng();
-void seedRng(IConfig const &config);
-unsigned int rngSeed();
-
-} // namespace Catch
-
-// end catch_random_number_generator.h
 #include <limits>
 #include <set>
 
@@ -11793,9 +12255,10 @@ namespace Generators
 
 GeneratorUntypedBase::~GeneratorUntypedBase() {}
 
-auto acquireGeneratorTracker(SourceLineInfo const &lineInfo) -> IGeneratorTracker &
+auto acquireGeneratorTracker(StringRef generatorName, SourceLineInfo const &lineInfo)
+    -> IGeneratorTracker &
 {
-    return getResultCapture().acquireGeneratorTracker(lineInfo);
+    return getResultCapture().acquireGeneratorTracker(generatorName, lineInfo);
 }
 
 } // namespace Generators
@@ -11855,6 +12318,8 @@ class ListeningReporter : public IStreamingReporter
     ReporterPreferences getPreferences() const override;
 
     void noMatchingTestCases(std::string const &spec) override;
+
+    void reportInvalidArguments(std::string const &arg) override;
 
     static std::set<Verbosity> getSupportedVerbosities();
 
@@ -12065,7 +12530,7 @@ namespace Catch
 
 std::size_t listTests(Config const &config)
 {
-    TestSpec testSpec = config.testSpec();
+    TestSpec const &testSpec = config.testSpec();
     if (config.hasTestFilters())
         Catch::cout() << "Matching test cases:\n";
     else
@@ -12103,7 +12568,7 @@ std::size_t listTests(Config const &config)
 
 std::size_t listTestsNamesOnly(Config const &config)
 {
-    TestSpec testSpec = config.testSpec();
+    TestSpec const &testSpec = config.testSpec();
     std::size_t matchedTests = 0;
     std::vector<TestCase> matchedTestCases =
         filterTests(getAllTestCasesSorted(config), testSpec, config);
@@ -12149,7 +12614,7 @@ std::string TagInfo::all() const
 
 std::size_t listTags(Config const &config)
 {
-    TestSpec testSpec = config.testSpec();
+    TestSpec const &testSpec = config.testSpec();
     if (config.hasTestFilters())
         Catch::cout() << "Tags for matching test cases:\n";
     else
@@ -12253,6 +12718,35 @@ using Matchers::Impl::MatcherBase;
 
 } // namespace Catch
 // end catch_matchers.cpp
+// start catch_matchers_exception.cpp
+
+namespace Catch
+{
+namespace Matchers
+{
+namespace Exception
+{
+
+bool ExceptionMessageMatcher::match(std::exception const &ex) const
+{
+    return ex.what() == m_message;
+}
+
+std::string ExceptionMessageMatcher::describe() const
+{
+    return "exception message matches \"" + m_message + "\"";
+}
+
+} // namespace Exception
+Exception::ExceptionMessageMatcher Message(std::string const &message)
+{
+    return Exception::ExceptionMessageMatcher(message);
+}
+
+// namespace Exception
+} // namespace Matchers
+} // namespace Catch
+// end catch_matchers_exception.cpp
 // start catch_matchers_floating.cpp
 
 // start catch_polyfills.hpp
@@ -12283,50 +12777,38 @@ template <typename T> std::string to_string(T const &t)
 } // end namespace Catch
 
 // end catch_to_string.hpp
+#include <algorithm>
+#include <cmath>
 #include <cstdlib>
 #include <cstdint>
 #include <cstring>
 #include <sstream>
+#include <type_traits>
 #include <iomanip>
 #include <limits>
 
 namespace Catch
 {
-namespace Matchers
-{
-namespace Floating
-{
-enum class FloatingPointKind : uint8_t
-{
-    Float,
-    Double
-};
-}
-} // namespace Matchers
-} // namespace Catch
-
 namespace
 {
 
-template <typename T> struct Converter;
-
-template <> struct Converter<float>
+int32_t convert(float f)
 {
     static_assert(sizeof(float) == sizeof(int32_t), "Important ULP matcher assumption violated");
-    Converter(float f) { std::memcpy(&i, &f, sizeof(f)); }
     int32_t i;
-};
+    std::memcpy(&i, &f, sizeof(f));
+    return i;
+}
 
-template <> struct Converter<double>
+int64_t convert(double d)
 {
     static_assert(sizeof(double) == sizeof(int64_t), "Important ULP matcher assumption violated");
-    Converter(double d) { std::memcpy(&i, &d, sizeof(d)); }
     int64_t i;
-};
+    std::memcpy(&i, &d, sizeof(d));
+    return i;
+}
 
-template <typename T> auto convert(T t) -> Converter<T> { return Converter<T>(t); }
-
-template <typename FP> bool almostEqualUlps(FP lhs, FP rhs, int maxUlpDiff)
+template <typename FP> bool almostEqualUlps(FP lhs, FP rhs, uint64_t maxUlpDiff)
 {
     // Comparison with NaN should always be false.
     // This way we can rule it out before getting into the ugly details
@@ -12338,33 +12820,64 @@ template <typename FP> bool almostEqualUlps(FP lhs, FP rhs, int maxUlpDiff)
     auto lc = convert(lhs);
     auto rc = convert(rhs);
 
-    if ((lc.i < 0) != (rc.i < 0))
+    if ((lc < 0) != (rc < 0))
     {
         // Potentially we can have +0 and -0
         return lhs == rhs;
     }
 
-    auto ulpDiff = std::abs(lc.i - rc.i);
-    return ulpDiff <= maxUlpDiff;
+    // static cast as a workaround for IBM XLC
+    auto ulpDiff = std::abs(static_cast<FP>(lc - rc));
+    return static_cast<uint64_t>(ulpDiff) <= maxUlpDiff;
 }
 
-template <typename FP> FP step(FP start, FP direction, int steps)
+#if defined(CATCH_CONFIG_GLOBAL_NEXTAFTER)
+
+float nextafter(float x, float y) { return ::nextafterf(x, y); }
+
+double nextafter(double x, double y) { return ::nextafter(x, y); }
+
+#endif // ^^^ CATCH_CONFIG_GLOBAL_NEXTAFTER ^^^
+
+template <typename FP> FP step(FP start, FP direction, uint64_t steps)
 {
-    for (int i = 0; i < steps; ++i)
+    for (uint64_t i = 0; i < steps; ++i)
     {
+#if defined(CATCH_CONFIG_GLOBAL_NEXTAFTER)
+        start = Catch::nextafter(start, direction);
+#else
         start = std::nextafter(start, direction);
+#endif
     }
     return start;
 }
 
+// Performs equivalent check of std::fabs(lhs - rhs) <= margin
+// But without the subtraction to allow for INFINITY in comparison
+bool marginComparison(double lhs, double rhs, double margin)
+{
+    return (lhs + margin >= rhs) && (rhs + margin >= lhs);
+}
+
+template <typename FloatingPoint> void write(std::ostream &out, FloatingPoint num)
+{
+    out << std::scientific
+        << std::setprecision(std::numeric_limits<FloatingPoint>::max_digits10 - 1) << num;
+}
+
 } // end anonymous namespace
 
-namespace Catch
-{
 namespace Matchers
 {
 namespace Floating
 {
+
+enum class FloatingPointKind : uint8_t
+{
+    Float,
+    Double
+};
+
 WithinAbsMatcher::WithinAbsMatcher(double target, double margin)
     : m_target{target}, m_margin{margin}
 {
@@ -12385,11 +12898,12 @@ std::string WithinAbsMatcher::describe() const
            ::Catch::Detail::stringify(m_target);
 }
 
-WithinUlpsMatcher::WithinUlpsMatcher(double target, int ulps, FloatingPointKind baseType)
+WithinUlpsMatcher::WithinUlpsMatcher(double target, uint64_t ulps, FloatingPointKind baseType)
     : m_target{target}, m_ulps{ulps}, m_type{baseType}
 {
-    CATCH_ENFORCE(ulps >= 0,
-                  "Invalid ULP setting: " << ulps << '.' << " ULPs have to be non-negative.");
+    CATCH_ENFORCE(m_type == FloatingPointKind::Double ||
+                      m_ulps < (std::numeric_limits<uint32_t>::max)(),
+                  "Provided ULP is impossibly large for a float comparison.");
 }
 
 #if defined(__clang__)
@@ -12420,40 +12934,65 @@ std::string WithinUlpsMatcher::describe() const
 {
     std::stringstream ret;
 
-    ret << "is within " << m_ulps << " ULPs of " << ::Catch::Detail::stringify(m_target);
+    ret << "is within " << m_ulps << " ULPs of ";
 
     if (m_type == FloatingPointKind::Float)
     {
+        write(ret, static_cast<float>(m_target));
         ret << 'f';
-    }
-
-    ret << " ([";
-    ret << std::fixed << std::setprecision(std::numeric_limits<double>::max_digits10);
-    if (m_type == FloatingPointKind::Double)
-    {
-        ret << step(m_target, static_cast<double>(-INFINITY), m_ulps) << ", "
-            << step(m_target, static_cast<double>(INFINITY), m_ulps);
     }
     else
     {
-        ret << step<float>(static_cast<float>(m_target), -INFINITY, m_ulps) << ", "
-            << step<float>(static_cast<float>(m_target), INFINITY, m_ulps);
+        write(ret, m_target);
+    }
+
+    ret << " ([";
+    if (m_type == FloatingPointKind::Double)
+    {
+        write(ret, step(m_target, static_cast<double>(-INFINITY), m_ulps));
+        ret << ", ";
+        write(ret, step(m_target, static_cast<double>(INFINITY), m_ulps));
+    }
+    else
+    {
+        // We have to cast INFINITY to float because of MinGW, see #1782
+        write(ret, step(static_cast<float>(m_target), static_cast<float>(-INFINITY), m_ulps));
+        ret << ", ";
+        write(ret, step(static_cast<float>(m_target), static_cast<float>(INFINITY), m_ulps));
     }
     ret << "])";
 
     return ret.str();
-    // return "is within " + Catch::to_string(m_ulps) + " ULPs of " +
-    // ::Catch::Detail::stringify(m_target) + ((m_type == FloatingPointKind::Float)? "f" : "");
+}
+
+WithinRelMatcher::WithinRelMatcher(double target, double epsilon)
+    : m_target(target), m_epsilon(epsilon)
+{
+    CATCH_ENFORCE(m_epsilon >= 0., "Relative comparison with epsilon <  0 does not make sense.");
+    CATCH_ENFORCE(m_epsilon < 1., "Relative comparison with epsilon >= 1 does not make sense.");
+}
+
+bool WithinRelMatcher::match(double const &matchee) const
+{
+    const auto relMargin = m_epsilon * (std::max)(std::fabs(matchee), std::fabs(m_target));
+    return marginComparison(matchee, m_target, std::isinf(relMargin) ? 0 : relMargin);
+}
+
+std::string WithinRelMatcher::describe() const
+{
+    Catch::ReusableStringStream sstr;
+    sstr << "and " << m_target << " are within " << m_epsilon * 100. << "% of each other";
+    return sstr.str();
 }
 
 } // namespace Floating
 
-Floating::WithinUlpsMatcher WithinULP(double target, int maxUlpDiff)
+Floating::WithinUlpsMatcher WithinULP(double target, uint64_t maxUlpDiff)
 {
     return Floating::WithinUlpsMatcher(target, maxUlpDiff, Floating::FloatingPointKind::Double);
 }
 
-Floating::WithinUlpsMatcher WithinULP(float target, int maxUlpDiff)
+Floating::WithinUlpsMatcher WithinULP(float target, uint64_t maxUlpDiff)
 {
     return Floating::WithinUlpsMatcher(target, maxUlpDiff, Floating::FloatingPointKind::Float);
 }
@@ -12463,9 +13002,28 @@ Floating::WithinAbsMatcher WithinAbs(double target, double margin)
     return Floating::WithinAbsMatcher(target, margin);
 }
 
+Floating::WithinRelMatcher WithinRel(double target, double eps)
+{
+    return Floating::WithinRelMatcher(target, eps);
+}
+
+Floating::WithinRelMatcher WithinRel(double target)
+{
+    return Floating::WithinRelMatcher(target, std::numeric_limits<double>::epsilon() * 100);
+}
+
+Floating::WithinRelMatcher WithinRel(float target, float eps)
+{
+    return Floating::WithinRelMatcher(target, eps);
+}
+
+Floating::WithinRelMatcher WithinRel(float target)
+{
+    return Floating::WithinRelMatcher(target, std::numeric_limits<float>::epsilon() * 100);
+}
+
 } // namespace Matchers
 } // namespace Catch
-
 // end catch_matchers_floating.cpp
 // start catch_matchers_generic.cpp
 
@@ -12677,11 +13235,11 @@ Capturer::Capturer(StringRef macroName, SourceLineInfo const &lineInfo,
                    ResultWas::OfType resultType, StringRef names)
 {
     auto trimmed = [&](size_t start, size_t end) {
-        while (names[start] == ',' || isspace(names[start]))
+        while (names[start] == ',' || isspace(static_cast<unsigned char>(names[start])))
         {
             ++start;
         }
-        while (names[end] == ',' || isspace(names[end]))
+        while (names[end] == ',' || isspace(static_cast<unsigned char>(names[end])))
         {
             --end;
         }
@@ -12724,18 +13282,18 @@ Capturer::Capturer(StringRef macroName, SourceLineInfo const &lineInfo,
             pos = skipq(pos, c);
             break;
         case ',':
-            if (start != pos && openings.size() == 0)
+            if (start != pos && openings.empty())
             {
                 m_messages.emplace_back(macroName, lineInfo, resultType);
-                m_messages.back().message = trimmed(start, pos);
+                m_messages.back().message = static_cast<std::string>(trimmed(start, pos));
                 m_messages.back().message += " := ";
                 start = pos;
             }
         }
     }
-    assert(openings.size() == 0 && "Mismatched openings");
+    assert(openings.empty() && "Mismatched openings");
     m_messages.emplace_back(macroName, lineInfo, resultType);
-    m_messages.back().message = trimmed(start, names.size() - 1);
+    m_messages.back().message = static_cast<std::string>(trimmed(start, names.size() - 1));
     m_messages.back().message += " := ";
 }
 Capturer::~Capturer()
@@ -12935,7 +13493,7 @@ TempFile::TempFile()
     {
         CATCH_RUNTIME_ERROR("Could not get a temp filename");
     }
-    if (fopen_s(&m_file, m_buffer, "w"))
+    if (fopen_s(&m_file, m_buffer, "w+"))
     {
         char buffer[100];
         if (strerror_s(buffer, errno))
@@ -13043,22 +13601,68 @@ bool isnan(double d) { return std::_isnan(d); }
 namespace Catch
 {
 
-std::mt19937 &rng()
+namespace
 {
-    static std::mt19937 s_rng;
-    return s_rng;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4146) // we negate uint32 during the rotate
+#endif
+// Safe rotr implementation thanks to John Regehr
+uint32_t rotate_right(uint32_t val, uint32_t count)
+{
+    const uint32_t mask = 31;
+    count &= mask;
+    return (val >> count) | (val << (-count & mask));
 }
 
-void seedRng(IConfig const &config)
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+} // namespace
+
+SimplePcg32::SimplePcg32(result_type seed_) { seed(seed_); }
+
+void SimplePcg32::seed(result_type seed_)
 {
-    if (config.rngSeed() != 0)
+    m_state = 0;
+    (*this)();
+    m_state += seed_;
+    (*this)();
+}
+
+void SimplePcg32::discard(uint64_t skip)
+{
+    // We could implement this to run in O(log n) steps, but this
+    // should suffice for our use case.
+    for (uint64_t s = 0; s < skip; ++s)
     {
-        std::srand(config.rngSeed());
-        rng().seed(config.rngSeed());
+        static_cast<void>((*this)());
     }
 }
 
-unsigned int rngSeed() { return getCurrentContext().getConfig()->rngSeed(); }
+SimplePcg32::result_type SimplePcg32::operator()()
+{
+    // prepare the output value
+    const uint32_t xorshifted = static_cast<uint32_t>(((m_state >> 18u) ^ m_state) >> 27u);
+    const auto output = rotate_right(xorshifted, m_state >> 59u);
+
+    // advance state
+    m_state = m_state * 6364136223846793005ULL + s_inc;
+
+    return output;
+}
+
+bool operator==(SimplePcg32 const &lhs, SimplePcg32 const &rhs)
+{
+    return lhs.m_state == rhs.m_state;
+}
+
+bool operator!=(SimplePcg32 const &lhs, SimplePcg32 const &rhs)
+{
+    return lhs.m_state != rhs.m_state;
+}
 } // namespace Catch
 // end catch_random_number_generator.cpp
 // start catch_registry_hub.cpp
@@ -13203,12 +13807,14 @@ namespace Catch
 
 class StartupExceptionRegistry
 {
+#if !defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
   public:
     void add(std::exception_ptr const &exception) noexcept;
     std::vector<std::exception_ptr> const &getExceptions() const noexcept;
 
   private:
     std::vector<std::exception_ptr> m_exceptions;
+#endif
 };
 
 } // end namespace Catch
@@ -13298,7 +13904,12 @@ class RegistryHub : public IRegistryHub, public IMutableRegistryHub, private Non
     }
     void registerStartupException() noexcept override
     {
+#if !defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
         m_exceptionRegistry.add(std::current_exception());
+#else
+        CATCH_INTERNAL_ERROR(
+            "Attempted to register active exception under CATCH_CONFIG_DISABLE_EXCEPTIONS!");
+#endif
     }
     IMutableEnumValuesRegistry &getMutableEnumValuesRegistry() override
     {
@@ -13410,7 +14021,26 @@ struct GeneratorTracker : TestCaseTracking::TrackerBase, IGeneratorTracker
         std::shared_ptr<GeneratorTracker> tracker;
 
         ITracker &currentTracker = ctx.currentTracker();
-        if (TestCaseTracking::ITrackerPtr childTracker = currentTracker.findChild(nameAndLocation))
+        // Under specific circumstances, the generator we want
+        // to acquire is also the current tracker. If this is
+        // the case, we have to avoid looking through current
+        // tracker's children, and instead return the current
+        // tracker.
+        // A case where this check is important is e.g.
+        //     for (int i = 0; i < 5; ++i) {
+        //         int n = GENERATE(1, 2);
+        //     }
+        //
+        // without it, the code above creates 5 nested generators.
+        if (currentTracker.nameAndLocation() == nameAndLocation)
+        {
+            auto thisTracker = currentTracker.parent().findChild(nameAndLocation);
+            assert(thisTracker);
+            assert(thisTracker->isGeneratorTracker());
+            tracker = std::static_pointer_cast<GeneratorTracker>(thisTracker);
+        }
+        else if (TestCaseTracking::ITrackerPtr childTracker =
+                     currentTracker.findChild(nameAndLocation))
         {
             assert(childTracker);
             assert(childTracker->isGeneratorTracker());
@@ -13422,7 +14052,7 @@ struct GeneratorTracker : TestCaseTracking::TrackerBase, IGeneratorTracker
             currentTracker.addChild(tracker);
         }
 
-        if (!ctx.completedCycle() && !tracker->isComplete())
+        if (!tracker->isComplete())
         {
             tracker->open();
         }
@@ -13436,8 +14066,65 @@ struct GeneratorTracker : TestCaseTracking::TrackerBase, IGeneratorTracker
     void close() override
     {
         TrackerBase::close();
-        // Generator interface only finds out if it has another item on atual move
-        if (m_runState == CompletedSuccessfully && m_generator->next())
+        // If a generator has a child (it is followed by a section)
+        // and none of its children have started, then we must wait
+        // until later to start consuming its values.
+        // This catches cases where `GENERATE` is placed between two
+        // `SECTION`s.
+        // **The check for m_children.empty cannot be removed**.
+        // doing so would break `GENERATE` _not_ followed by `SECTION`s.
+        const bool should_wait_for_child = [&]() {
+            // No children -> nobody to wait for
+            if (m_children.empty())
+            {
+                return false;
+            }
+            // If at least one child started executing, don't wait
+            if (std::find_if(m_children.begin(), m_children.end(),
+                             [](TestCaseTracking::ITrackerPtr tracker) {
+                                 return tracker->hasStarted();
+                             }) != m_children.end())
+            {
+                return false;
+            }
+
+            // No children have started. We need to check if they _can_
+            // start, and thus we should wait for them, or they cannot
+            // start (due to filters), and we shouldn't wait for them
+            auto *parent = m_parent;
+            // This is safe: there is always at least one section
+            // tracker in a test case tracking tree
+            while (!parent->isSectionTracker())
+            {
+                parent = &(parent->parent());
+            }
+            assert(parent && "Missing root (test case) level section");
+
+            auto const &parentSection = static_cast<SectionTracker &>(*parent);
+            auto const &filters = parentSection.getFilters();
+            // No filters -> no restrictions on running sections
+            if (filters.empty())
+            {
+                return true;
+            }
+
+            for (auto const &child : m_children)
+            {
+                if (child->isSectionTracker() &&
+                    std::find(filters.begin(), filters.end(),
+                              static_cast<SectionTracker &>(*child).trimmedName()) != filters.end())
+                {
+                    return true;
+                }
+            }
+            return false;
+        }();
+
+        // This check is a bit tricky, because m_generator->next()
+        // has a side-effect, where it consumes generator's current
+        // value, but we do not want to invoke the side-effect if
+        // this generator is still waiting for any child to start.
+        if (should_wait_for_child || (m_runState == CompletedSuccessfully && m_generator->next()))
         {
             m_children.clear();
             m_runState = Executing;
@@ -13581,12 +14268,13 @@ bool RunContext::sectionStarted(SectionInfo const &sectionInfo, Counts &assertio
 
     return true;
 }
-auto RunContext::acquireGeneratorTracker(SourceLineInfo const &lineInfo) -> IGeneratorTracker &
+auto RunContext::acquireGeneratorTracker(StringRef generatorName, SourceLineInfo const &lineInfo)
+    -> IGeneratorTracker &
 {
     using namespace Generators;
     GeneratorTracker &tracker = GeneratorTracker::acquire(
-        m_trackerContext, TestCaseTracking::NameAndLocation("generator", lineInfo));
-    assert(tracker.isOpen());
+        m_trackerContext,
+        TestCaseTracking::NameAndLocation(static_cast<std::string>(generatorName), lineInfo));
     m_lastAssertionInfo.lineInfo = lineInfo;
     return tracker;
 }
@@ -13677,7 +14365,7 @@ void RunContext::handleFatalErrorCondition(StringRef message)
     // Don't rebuild the result -- the stringification itself can cause more fatal errors
     // Instead, fake a result data.
     AssertionResultData tempResult(ResultWas::FatalErrorCondition, {false});
-    tempResult.message = message;
+    tempResult.message = static_cast<std::string>(message);
     AssertionResult result(m_lastAssertionInfo, tempResult);
 
     assertionEnded(result);
@@ -13785,9 +14473,8 @@ void RunContext::runCurrentTest(std::string &redirectedCout, std::string &redire
 
 void RunContext::invokeActiveTestCase()
 {
-    FatalConditionHandler fatalConditionHandler; // Handle signals
+    FatalConditionHandlerGuard _(&m_fatalConditionhandler);
     m_activeTestCase->invoke();
-    fatalConditionHandler.reset();
 }
 
 void RunContext::handleUnfinishedSections()
@@ -13846,7 +14533,7 @@ void RunContext::handleMessage(AssertionInfo const &info, ResultWas::OfType resu
     m_lastAssertionInfo = info;
 
     AssertionResultData data(resultType, LazyExpression(false));
-    data.message = message;
+    data.message = static_cast<std::string>(message);
     AssertionResult assertionResult{m_lastAssertionInfo, data};
     assertionEnded(assertionResult);
     if (!assertionResult.isOk())
@@ -13907,6 +14594,18 @@ IResultCapture &getResultCapture()
     else
         CATCH_INTERNAL_ERROR("No result capture instance");
 }
+
+void seedRng(IConfig const &config)
+{
+    if (config.rngSeed() != 0)
+    {
+        std::srand(config.rngSeed());
+        rng().seed(config.rngSeed());
+    }
+}
+
+unsigned int rngSeed() { return getCurrentContext().getConfig()->rngSeed(); }
+
 } // namespace Catch
 // end catch_run_context.cpp
 // start catch_section.cpp
@@ -14084,8 +14783,9 @@ class TestGroup
     {
         auto const &allTestCases = getAllTestCasesSorted(*m_config);
         m_matches = m_config->testSpec().matchesByFilter(allTestCases, *m_config);
+        auto const &invalidArgs = m_config->testSpec().getInvalidArgs();
 
-        if (m_matches.empty())
+        if (m_matches.empty() && invalidArgs.empty())
         {
             for (auto const &test : allTestCases)
                 if (!test.isHidden())
@@ -14100,6 +14800,7 @@ class TestGroup
 
     Totals execute()
     {
+        auto const &invalidArgs = m_config->testSpec().getInvalidArgs();
         Totals totals;
         m_context.testGroupStarting(m_config->name(), 1, 1);
         for (auto const &testCase : m_tests)
@@ -14118,6 +14819,13 @@ class TestGroup
                 totals.error = -1;
             }
         }
+
+        if (!invalidArgs.empty())
+        {
+            for (auto const &invalidArg : invalidArgs)
+                m_context.reporter().reportInvalidArguments(invalidArg);
+        }
+
         m_context.testGroupEnded(m_config->name(), totals, 1, 1);
         return totals;
     }
@@ -14144,6 +14852,10 @@ void applyFilenamesAsTags(Catch::IConfig const &config)
         {
             filename.erase(0, lastSlash);
             filename[0] = '#';
+        }
+        else
+        {
+            filename.insert(0, "#");
         }
 
         auto lastDot = filename.find_last_of('.');
@@ -14209,7 +14921,7 @@ void Session::showHelp() const
 void Session::libIdentify()
 {
     Catch::cout() << std::left << std::setw(16) << "description: "
-                  << "A Catch test executable\n"
+                  << "A Catch2 test executable\n"
                   << std::left << std::setw(16) << "category: "
                   << "testframework\n"
                   << std::left << std::setw(16) << "framework: "
@@ -14249,11 +14961,11 @@ int Session::applyCommandLine(int argc, wchar_t const *const *argv)
 
     for (int i = 0; i < argc; ++i)
     {
-        int bufSize = WideCharToMultiByte(CP_UTF8, 0, argv[i], -1, NULL, 0, NULL, NULL);
+        int bufSize = WideCharToMultiByte(CP_UTF8, 0, argv[i], -1, nullptr, 0, nullptr, nullptr);
 
         utf8Argv[i] = new char[bufSize];
 
-        WideCharToMultiByte(CP_UTF8, 0, argv[i], -1, utf8Argv[i], bufSize, NULL, NULL);
+        WideCharToMultiByte(CP_UTF8, 0, argv[i], -1, utf8Argv[i], bufSize, nullptr, nullptr);
     }
 
     int returnCode = applyCommandLine(argc, utf8Argv);
@@ -14380,6 +15092,7 @@ void cleanupSingletons()
 // end catch_singletons.cpp
 // start catch_startup_exception_registry.cpp
 
+#if !defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
 namespace Catch
 {
 void StartupExceptionRegistry::add(std::exception_ptr const &exception) noexcept
@@ -14398,6 +15111,7 @@ std::vector<std::exception_ptr> const &StartupExceptionRegistry::getExceptions()
 }
 
 } // end namespace Catch
+#endif
 // end catch_startup_exception_registry.cpp
 // start catch_stream.cpp
 
@@ -14603,7 +15317,7 @@ namespace Catch
 
 namespace
 {
-char toLowerCh(char c) { return static_cast<char>(std::tolower(c)); }
+char toLowerCh(char c) { return static_cast<char>(std::tolower(static_cast<unsigned char>(c))); }
 } // namespace
 
 bool startsWith(std::string const &s, std::string const &prefix)
@@ -14634,6 +15348,23 @@ std::string trim(std::string const &str)
     std::string::size_type end = str.find_last_not_of(whitespaceChars);
 
     return start != std::string::npos ? str.substr(start, 1 + end - start) : std::string();
+}
+
+StringRef trim(StringRef ref)
+{
+    const auto is_ws = [](char c) { return c == ' ' || c == '\t' || c == '\n' || c == '\r'; };
+    size_t real_begin = 0;
+    while (real_begin < ref.size() && is_ws(ref[real_begin]))
+    {
+        ++real_begin;
+    }
+    size_t real_end = ref.size();
+    while (real_end > real_begin && is_ws(ref[real_end - 1]))
+    {
+        --real_end;
+    }
+
+    return ref.substr(real_begin, real_end - real_begin);
 }
 
 bool replaceInPlace(std::string &str, std::string const &replaceThis, std::string const &withThis)
@@ -14686,21 +15417,10 @@ std::ostream &operator<<(std::ostream &os, pluralise const &pluraliser)
 // end catch_string_manip.cpp
 // start catch_stringref.cpp
 
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wexit-time-destructors"
-#endif
-
+#include <algorithm>
 #include <ostream>
 #include <cstring>
 #include <cstdint>
-
-namespace
-{
-const uint32_t byte_2_lead = 0xC0;
-const uint32_t byte_3_lead = 0xE0;
-const uint32_t byte_4_lead = 0xF0;
-} // namespace
 
 namespace Catch
 {
@@ -14709,107 +15429,42 @@ StringRef::StringRef(char const *rawChars) noexcept
 {
 }
 
-StringRef::operator std::string() const { return std::string(m_start, m_size); }
-
-void StringRef::swap(StringRef &other) noexcept
-{
-    std::swap(m_start, other.m_start);
-    std::swap(m_size, other.m_size);
-    std::swap(m_data, other.m_data);
-}
-
 auto StringRef::c_str() const -> char const *
 {
-    if (!isSubstring())
-        return m_start;
-
-    const_cast<StringRef *>(this)->takeOwnership();
-    return m_data;
+    CATCH_ENFORCE(isNullTerminated(),
+                  "Called StringRef::c_str() on a non-null-terminated instance");
+    return m_start;
 }
-auto StringRef::currentData() const noexcept -> char const * { return m_start; }
+auto StringRef::data() const noexcept -> char const * { return m_start; }
 
-auto StringRef::isOwned() const noexcept -> bool { return m_data != nullptr; }
-auto StringRef::isSubstring() const noexcept -> bool { return m_start[m_size] != '\0'; }
-
-void StringRef::takeOwnership()
-{
-    if (!isOwned())
-    {
-        m_data = new char[m_size + 1];
-        memcpy(m_data, m_start, m_size);
-        m_data[m_size] = '\0';
-    }
-}
 auto StringRef::substr(size_type start, size_type size) const noexcept -> StringRef
 {
     if (start < m_size)
-        return StringRef(m_start + start, size);
+    {
+        return StringRef(m_start + start, (std::min)(m_size - start, size));
+    }
     else
+    {
         return StringRef();
+    }
 }
 auto StringRef::operator==(StringRef const &other) const noexcept -> bool
 {
-    return size() == other.size() && (std::strncmp(m_start, other.m_start, size()) == 0);
-}
-auto StringRef::operator!=(StringRef const &other) const noexcept -> bool
-{
-    return !operator==(other);
-}
-
-auto StringRef::operator[](size_type index) const noexcept -> char { return m_start[index]; }
-
-auto StringRef::numberOfCharacters() const noexcept -> size_type
-{
-    size_type noChars = m_size;
-    // Make adjustments for uft encodings
-    for (size_type i = 0; i < m_size; ++i)
-    {
-        char c = m_start[i];
-        if ((c & byte_2_lead) == byte_2_lead)
-        {
-            noChars--;
-            if ((c & byte_3_lead) == byte_3_lead)
-                noChars--;
-            if ((c & byte_4_lead) == byte_4_lead)
-                noChars--;
-        }
-    }
-    return noChars;
-}
-
-auto operator+(StringRef const &lhs, StringRef const &rhs) -> std::string
-{
-    std::string str;
-    str.reserve(lhs.size() + rhs.size());
-    str += lhs;
-    str += rhs;
-    return str;
-}
-auto operator+(StringRef const &lhs, const char *rhs) -> std::string
-{
-    return std::string(lhs) + std::string(rhs);
-}
-auto operator+(char const *lhs, StringRef const &rhs) -> std::string
-{
-    return std::string(lhs) + std::string(rhs);
+    return m_size == other.m_size && (std::memcmp(m_start, other.m_start, m_size) == 0);
 }
 
 auto operator<<(std::ostream &os, StringRef const &str) -> std::ostream &
 {
-    return os.write(str.currentData(), str.size());
+    return os.write(str.data(), str.size());
 }
 
 auto operator+=(std::string &lhs, StringRef const &rhs) -> std::string &
 {
-    lhs.append(rhs.currentData(), rhs.size());
+    lhs.append(rhs.data(), rhs.size());
     return lhs;
 }
 
 } // namespace Catch
-
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
 // end catch_stringref.cpp
 // start catch_tag_alias.cpp
 
@@ -14946,8 +15601,7 @@ TestCase makeTestCase(ITestInvoker *_testCase, std::string const &_className,
     std::vector<std::string> tags;
     std::string desc, tag;
     bool inTag = false;
-    std::string _descOrTags = nameAndTags.tags;
-    for (char c : _descOrTags)
+    for (char c : nameAndTags.tags)
     {
         if (!inTag)
         {
@@ -14983,10 +15637,12 @@ TestCase makeTestCase(ITestInvoker *_testCase, std::string const &_className,
     }
     if (isHidden)
     {
-        tags.push_back(".");
+        // Add all "hidden" tags to make them behave identically
+        tags.insert(tags.end(), {".", "!hide"});
     }
 
-    TestCaseInfo info(nameAndTags.name, _className, desc, tags, _lineInfo);
+    TestCaseInfo info(static_cast<std::string>(nameAndTags.name), _className, desc, tags,
+                      _lineInfo);
     return TestCase(_testCase, std::move(info));
 }
 
@@ -15067,31 +15723,93 @@ TestCaseInfo const &TestCase::getTestCaseInfo() const { return *this; }
 // end catch_test_case_info.cpp
 // start catch_test_case_registry_impl.cpp
 
+#include <algorithm>
 #include <sstream>
 
 namespace Catch
 {
 
+namespace
+{
+struct TestHasher
+{
+    using hash_t = uint64_t;
+
+    explicit TestHasher(hash_t hashSuffix) : m_hashSuffix{hashSuffix} {}
+
+    uint32_t operator()(TestCase const &t) const
+    {
+        // FNV-1a hash with multiplication fold.
+        const hash_t prime = 1099511628211u;
+        hash_t hash = 14695981039346656037u;
+        for (const char c : t.name)
+        {
+            hash ^= c;
+            hash *= prime;
+        }
+        hash ^= m_hashSuffix;
+        hash *= prime;
+        const uint32_t low{static_cast<uint32_t>(hash)};
+        const uint32_t high{static_cast<uint32_t>(hash >> 32)};
+        return low * high;
+    }
+
+  private:
+    hash_t m_hashSuffix;
+};
+} // end unnamed namespace
+
 std::vector<TestCase> sortTests(IConfig const &config,
                                 std::vector<TestCase> const &unsortedTestCases)
 {
-
-    std::vector<TestCase> sorted = unsortedTestCases;
-
     switch (config.runOrder())
     {
-    case RunTests::InLexicographicalOrder:
-        std::sort(sorted.begin(), sorted.end());
-        break;
-    case RunTests::InRandomOrder:
-        seedRng(config);
-        std::shuffle(sorted.begin(), sorted.end(), rng());
-        break;
     case RunTests::InDeclarationOrder:
         // already in declaration order
         break;
+
+    case RunTests::InLexicographicalOrder:
+    {
+        std::vector<TestCase> sorted = unsortedTestCases;
+        std::sort(sorted.begin(), sorted.end());
+        return sorted;
     }
-    return sorted;
+
+    case RunTests::InRandomOrder:
+    {
+        seedRng(config);
+        TestHasher h{config.rngSeed()};
+
+        using hashedTest = std::pair<TestHasher::hash_t, TestCase const *>;
+        std::vector<hashedTest> indexed_tests;
+        indexed_tests.reserve(unsortedTestCases.size());
+
+        for (auto const &testCase : unsortedTestCases)
+        {
+            indexed_tests.emplace_back(h(testCase), &testCase);
+        }
+
+        std::sort(indexed_tests.begin(), indexed_tests.end(),
+                  [](hashedTest const &lhs, hashedTest const &rhs) {
+                      if (lhs.first == rhs.first)
+                      {
+                          return lhs.second->name < rhs.second->name;
+                      }
+                      return lhs.first < rhs.first;
+                  });
+
+        std::vector<TestCase> sorted;
+        sorted.reserve(indexed_tests.size());
+
+        for (auto const &hashed : indexed_tests)
+        {
+            sorted.emplace_back(*hashed.second);
+        }
+
+        return sorted;
+    }
+    }
+    return unsortedTestCases;
 }
 
 bool isThrowSafe(TestCase const &testCase, IConfig const &config)
@@ -15174,7 +15892,7 @@ void TestInvokerAsFunction::invoke() const { m_testAsFunction(); }
 
 std::string extractClassName(StringRef const &classOrQualifiedMethodName)
 {
-    std::string className = classOrQualifiedMethodName;
+    std::string className(classOrQualifiedMethodName);
     if (startsWith(className, '&'))
     {
         std::size_t lastColons = className.rfind("::");
@@ -15242,11 +15960,10 @@ void TrackerContext::setCurrentTracker(ITracker *tracker) { m_currentTracker = t
 
 TrackerBase::TrackerBase(NameAndLocation const &nameAndLocation, TrackerContext &ctx,
                          ITracker *parent)
-    : m_nameAndLocation(nameAndLocation), m_ctx(ctx), m_parent(parent)
+    : ITracker(nameAndLocation), m_ctx(ctx), m_parent(parent)
 {
 }
 
-NameAndLocation const &TrackerBase::nameAndLocation() const { return m_nameAndLocation; }
 bool TrackerBase::isComplete() const
 {
     return m_runState == CompletedSuccessfully || m_runState == Failed;
@@ -15344,7 +16061,7 @@ void TrackerBase::moveToThis() { m_ctx.setCurrentTracker(this); }
 
 SectionTracker::SectionTracker(NameAndLocation const &nameAndLocation, TrackerContext &ctx,
                                ITracker *parent)
-    : TrackerBase(nameAndLocation, ctx, parent)
+    : TrackerBase(nameAndLocation, ctx, parent), m_trimmed_name(trim(nameAndLocation.name))
 {
     if (parent)
     {
@@ -15360,9 +16077,11 @@ bool SectionTracker::isComplete() const
 {
     bool complete = true;
 
-    if ((m_filters.empty() || m_filters[0] == "") ||
-        std::find(m_filters.begin(), m_filters.end(), m_nameAndLocation.name) != m_filters.end())
+    if (m_filters.empty() || m_filters[0] == "" ||
+        std::find(m_filters.begin(), m_filters.end(), m_trimmed_name) != m_filters.end())
+    {
         complete = TrackerBase::isComplete();
+    }
     return complete;
 }
 
@@ -15391,8 +16110,7 @@ SectionTracker &SectionTracker::acquire(TrackerContext &ctx, NameAndLocation con
 
 void SectionTracker::tryOpen()
 {
-    if (!isComplete() &&
-        (m_filters.empty() || m_filters[0].empty() || m_filters[0] == m_nameAndLocation.name))
+    if (!isComplete())
         open();
 }
 
@@ -15400,16 +16118,21 @@ void SectionTracker::addInitialFilters(std::vector<std::string> const &filters)
 {
     if (!filters.empty())
     {
-        m_filters.push_back(""); // Root - should never be consulted
-        m_filters.push_back(""); // Test Case - not a section filter
+        m_filters.reserve(m_filters.size() + filters.size() + 2);
+        m_filters.emplace_back(""); // Root - should never be consulted
+        m_filters.emplace_back(""); // Test Case - not a section filter
         m_filters.insert(m_filters.end(), filters.begin(), filters.end());
     }
 }
 void SectionTracker::addNextFilters(std::vector<std::string> const &filters)
 {
     if (filters.size() > 1)
-        m_filters.insert(m_filters.end(), ++filters.begin(), filters.end());
+        m_filters.insert(m_filters.end(), filters.begin() + 1, filters.end());
 }
+
+std::vector<std::string> const &SectionTracker::getFilters() const { return m_filters; }
+
+std::string const &SectionTracker::trimmedName() const { return m_trimmed_name; }
 
 } // namespace TestCaseTracking
 
@@ -15480,7 +16203,7 @@ TestSpec::NamePattern::NamePattern(std::string const &name, std::string const &f
 
 bool TestSpec::NamePattern::matches(TestCaseInfo const &testCase) const
 {
-    return m_wildcardPattern.matches(toLower(testCase.name));
+    return m_wildcardPattern.matches(testCase.name);
 }
 
 TestSpec::TagPattern::TagPattern(std::string const &tag, std::string const &filterString)
@@ -15540,6 +16263,8 @@ TestSpec::Matches TestSpec::matchesByFilter(std::vector<TestCase> const &testCas
     return matches;
 }
 
+const TestSpec::vectorStrings &TestSpec::getInvalidArgs() const { return (m_invalidArgs); }
+
 } // namespace Catch
 // end catch_test_spec.cpp
 // start catch_test_spec_parser.cpp
@@ -15557,8 +16282,15 @@ TestSpecParser &TestSpecParser::parse(std::string const &arg)
     m_escapeChars.clear();
     m_substring.reserve(m_arg.size());
     m_patternName.reserve(m_arg.size());
+    m_realPatternPos = 0;
+
     for (m_pos = 0; m_pos < m_arg.size(); ++m_pos)
-        visitChar(m_arg[m_pos]);
+        // if visitChar fails
+        if (!visitChar(m_arg[m_pos]))
+        {
+            m_testSpec.m_invalidArgs.push_back(arg);
+            break;
+        }
     endMode();
     return *this;
 }
@@ -15567,38 +16299,47 @@ TestSpec TestSpecParser::testSpec()
     addFilter();
     return m_testSpec;
 }
-void TestSpecParser::visitChar(char c)
+bool TestSpecParser::visitChar(char c)
 {
-    if (c == ',')
+    if ((m_mode != EscapedName) && (c == '\\'))
     {
-        endMode();
-        addFilter();
-        return;
+        escape();
+        addCharToPattern(c);
+        return true;
+    }
+    else if ((m_mode != EscapedName) && (c == ','))
+    {
+        return separate();
     }
 
     switch (m_mode)
     {
     case None:
         if (processNoneChar(c))
-            return;
+            return true;
         break;
     case Name:
         processNameChar(c);
         break;
     case EscapedName:
         endMode();
-        break;
+        addCharToPattern(c);
+        return true;
     default:
     case Tag:
     case QuotedName:
         if (processOtherChar(c))
-            return;
+            return true;
         break;
     }
 
     m_substring += c;
     if (!isControlChar(c))
+    {
         m_patternName += c;
+        m_realPatternPos++;
+    }
+    return true;
 }
 // Two of the processing methods return true to signal the caller to return
 // without adding the given character to the current pattern strings
@@ -15617,9 +16358,6 @@ bool TestSpecParser::processNoneChar(char c)
     case '"':
         startNewMode(QuotedName);
         return false;
-    case '\\':
-        escape();
-        return true;
     default:
         startNewMode(Name);
         return false;
@@ -15651,11 +16389,12 @@ void TestSpecParser::endMode()
     {
     case Name:
     case QuotedName:
-        return addPattern<TestSpec::NamePattern>();
+        return addNamePattern();
     case Tag:
-        return addPattern<TestSpec::TagPattern>();
+        return addTagPattern();
     case EscapedName:
-        return startNewMode(Name);
+        revertBackToLastMode();
+        return;
     case None:
     default:
         return startNewMode(None);
@@ -15663,8 +16402,9 @@ void TestSpecParser::endMode()
 }
 void TestSpecParser::escape()
 {
+    saveLastMode();
     m_mode = EscapedName;
-    m_escapeChars.push_back(m_pos);
+    m_escapeChars.push_back(m_realPatternPos);
 }
 bool TestSpecParser::isControlChar(char c) const
 {
@@ -15692,6 +16432,93 @@ void TestSpecParser::addFilter()
         m_testSpec.m_filters.push_back(m_currentFilter);
         m_currentFilter = TestSpec::Filter();
     }
+}
+
+void TestSpecParser::saveLastMode() { lastMode = m_mode; }
+
+void TestSpecParser::revertBackToLastMode() { m_mode = lastMode; }
+
+bool TestSpecParser::separate()
+{
+    if ((m_mode == QuotedName) || (m_mode == Tag))
+    {
+        // invalid argument, signal failure to previous scope.
+        m_mode = None;
+        m_pos = m_arg.size();
+        m_substring.clear();
+        m_patternName.clear();
+        m_realPatternPos = 0;
+        return false;
+    }
+    endMode();
+    addFilter();
+    return true; // success
+}
+
+std::string TestSpecParser::preprocessPattern()
+{
+    std::string token = m_patternName;
+    for (std::size_t i = 0; i < m_escapeChars.size(); ++i)
+        token = token.substr(0, m_escapeChars[i] - i) + token.substr(m_escapeChars[i] - i + 1);
+    m_escapeChars.clear();
+    if (startsWith(token, "exclude:"))
+    {
+        m_exclusion = true;
+        token = token.substr(8);
+    }
+
+    m_patternName.clear();
+    m_realPatternPos = 0;
+
+    return token;
+}
+
+void TestSpecParser::addNamePattern()
+{
+    auto token = preprocessPattern();
+
+    if (!token.empty())
+    {
+        TestSpec::PatternPtr pattern = std::make_shared<TestSpec::NamePattern>(token, m_substring);
+        if (m_exclusion)
+            pattern = std::make_shared<TestSpec::ExcludedPattern>(pattern);
+        m_currentFilter.m_patterns.push_back(pattern);
+    }
+    m_substring.clear();
+    m_exclusion = false;
+    m_mode = None;
+}
+
+void TestSpecParser::addTagPattern()
+{
+    auto token = preprocessPattern();
+
+    if (!token.empty())
+    {
+        // If the tag pattern is the "hide and tag" shorthand (e.g. [.foo])
+        // we have to create a separate hide tag and shorten the real one
+        if (token.size() > 1 && token[0] == '.')
+        {
+            token.erase(token.begin());
+            TestSpec::PatternPtr pattern = std::make_shared<TestSpec::TagPattern>(".", m_substring);
+            if (m_exclusion)
+            {
+                pattern = std::make_shared<TestSpec::ExcludedPattern>(pattern);
+            }
+            m_currentFilter.m_patterns.push_back(pattern);
+        }
+
+        TestSpec::PatternPtr pattern = std::make_shared<TestSpec::TagPattern>(token, m_substring);
+
+        if (m_exclusion)
+        {
+            pattern = std::make_shared<TestSpec::ExcludedPattern>(pattern);
+        }
+        m_currentFilter.m_patterns.push_back(pattern);
+    }
+    m_substring.clear();
+    m_exclusion = false;
+    m_mode = None;
 }
 
 TestSpec parseTestSpec(std::string const &arg)
@@ -15812,14 +16639,11 @@ struct Endianness
 
     static Arch which()
     {
-        union _
-        {
-            int asInt;
-            char asChar[sizeof(int)];
-        } u;
-
-        u.asInt = 1;
-        return (u.asChar[sizeof(int) - 1] == 1) ? Big : Little;
+        int one = 1;
+        // If the lowest byte we read is non-zero, we can assume
+        // that little endian format is used.
+        auto value = *reinterpret_cast<char *>(&one);
+        return value ? Little : Big;
     }
 };
 } // namespace
@@ -16136,13 +16960,50 @@ Totals Totals::delta(Totals const &prevTotals) const
 // end catch_totals.cpp
 // start catch_uncaught_exceptions.cpp
 
+// start catch_config_uncaught_exceptions.hpp
+
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE_1_0.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+
+#ifndef CATCH_CONFIG_UNCAUGHT_EXCEPTIONS_HPP
+#define CATCH_CONFIG_UNCAUGHT_EXCEPTIONS_HPP
+
+#if defined(_MSC_VER)
+#if _MSC_VER >= 1900 // Visual Studio 2015 or newer
+#define CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS
+#endif
+#endif
+
+#include <exception>
+
+#if defined(__cpp_lib_uncaught_exceptions) &&                                                      \
+    !defined(CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS)
+
+#define CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS
+#endif // __cpp_lib_uncaught_exceptions
+
+#if defined(CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS) &&                                    \
+    !defined(CATCH_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS) &&                                         \
+    !defined(CATCH_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS)
+
+#define CATCH_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS
+#endif
+
+#endif // CATCH_CONFIG_UNCAUGHT_EXCEPTIONS_HPP
+// end catch_config_uncaught_exceptions.hpp
 #include <exception>
 
 namespace Catch
 {
 bool uncaught_exceptions()
 {
-#if defined(CATCH_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS)
+#if defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
+    return false;
+#elif defined(CATCH_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS)
     return std::uncaught_exceptions() > 0;
 #else
     return std::uncaught_exception();
@@ -16177,7 +17038,7 @@ std::ostream &operator<<(std::ostream &os, Version const &version)
 
 Version const &libraryVersion()
 {
-    static Version version(2, 9, 2, "", 0);
+    static Version version(2, 13, 9, "", 0);
     return version;
 }
 
@@ -16185,13 +17046,11 @@ Version const &libraryVersion()
 // end catch_version.cpp
 // start catch_wildcard_pattern.cpp
 
-#include <sstream>
-
 namespace Catch
 {
 
 WildcardPattern::WildcardPattern(std::string const &pattern, CaseSensitive::Choice caseSensitivity)
-    : m_caseSensitivity(caseSensitivity), m_pattern(adjustCase(pattern))
+    : m_caseSensitivity(caseSensitivity), m_pattern(normaliseString(pattern))
 {
     if (startsWith(m_pattern, '*'))
     {
@@ -16210,29 +17069,28 @@ bool WildcardPattern::matches(std::string const &str) const
     switch (m_wildcard)
     {
     case NoWildcard:
-        return m_pattern == adjustCase(str);
+        return m_pattern == normaliseString(str);
     case WildcardAtStart:
-        return endsWith(adjustCase(str), m_pattern);
+        return endsWith(normaliseString(str), m_pattern);
     case WildcardAtEnd:
-        return startsWith(adjustCase(str), m_pattern);
+        return startsWith(normaliseString(str), m_pattern);
     case WildcardAtBothEnds:
-        return contains(adjustCase(str), m_pattern);
+        return contains(normaliseString(str), m_pattern);
     default:
         CATCH_INTERNAL_ERROR("Unknown enum");
     }
 }
 
-std::string WildcardPattern::adjustCase(std::string const &str) const
+std::string WildcardPattern::normaliseString(std::string const &str) const
 {
-    return m_caseSensitivity == CaseSensitive::No ? toLower(str) : str;
+    return trim(m_caseSensitivity == CaseSensitive::No ? toLower(str) : str);
 }
 } // namespace Catch
 // end catch_wildcard_pattern.cpp
 // start catch_xmlwriter.cpp
 
 #include <iomanip>
-
-using uchar = unsigned char;
+#include <type_traits>
 
 namespace Catch
 {
@@ -16282,7 +17140,29 @@ void hexEscapeChar(std::ostream &os, unsigned char c)
     os.flags(f);
 }
 
+bool shouldNewline(XmlFormatting fmt)
+{
+    return !!(static_cast<std::underlying_type<XmlFormatting>::type>(fmt & XmlFormatting::Newline));
+}
+
+bool shouldIndent(XmlFormatting fmt)
+{
+    return !!(static_cast<std::underlying_type<XmlFormatting>::type>(fmt & XmlFormatting::Indent));
+}
+
 } // anonymous namespace
+
+XmlFormatting operator|(XmlFormatting lhs, XmlFormatting rhs)
+{
+    return static_cast<XmlFormatting>(static_cast<std::underlying_type<XmlFormatting>::type>(lhs) |
+                                      static_cast<std::underlying_type<XmlFormatting>::type>(rhs));
+}
+
+XmlFormatting operator&(XmlFormatting lhs, XmlFormatting rhs)
+{
+    return static_cast<XmlFormatting>(static_cast<std::underlying_type<XmlFormatting>::type>(lhs) &
+                                      static_cast<std::underlying_type<XmlFormatting>::type>(rhs));
+}
 
 XmlEncode::XmlEncode(std::string const &str, ForWhat forWhat) : m_str(str), m_forWhat(forWhat) {}
 
@@ -16293,7 +17173,7 @@ void XmlEncode::encodeTo(std::ostream &os) const
 
     for (std::size_t idx = 0; idx < m_str.size(); ++idx)
     {
-        uchar c = m_str[idx];
+        unsigned char c = m_str[idx];
         switch (c)
         {
         case '<':
@@ -16362,7 +17242,7 @@ void XmlEncode::encodeTo(std::ostream &os) const
             uint32_t value = headerValue(c);
             for (std::size_t n = 1; n < encBytes; ++n)
             {
-                uchar nc = m_str[idx + n];
+                unsigned char nc = m_str[idx + n];
                 valid &= ((nc & 0xC0) == 0x80);
                 value = (value << 6) | (nc & 0x3F);
             }
@@ -16397,11 +17277,16 @@ std::ostream &operator<<(std::ostream &os, XmlEncode const &xmlEncode)
     return os;
 }
 
-XmlWriter::ScopedElement::ScopedElement(XmlWriter *writer) : m_writer(writer) {}
+XmlWriter::ScopedElement::ScopedElement(XmlWriter *writer, XmlFormatting fmt)
+    : m_writer(writer), m_fmt(fmt)
+{
+}
 
-XmlWriter::ScopedElement::ScopedElement(ScopedElement &&other) noexcept : m_writer(other.m_writer)
+XmlWriter::ScopedElement::ScopedElement(ScopedElement &&other) noexcept
+    : m_writer(other.m_writer), m_fmt(other.m_fmt)
 {
     other.m_writer = nullptr;
+    other.m_fmt = XmlFormatting::None;
 }
 XmlWriter::ScopedElement &XmlWriter::ScopedElement::operator=(ScopedElement &&other) noexcept
 {
@@ -16411,18 +17296,23 @@ XmlWriter::ScopedElement &XmlWriter::ScopedElement::operator=(ScopedElement &&ot
     }
     m_writer = other.m_writer;
     other.m_writer = nullptr;
+    m_fmt = other.m_fmt;
+    other.m_fmt = XmlFormatting::None;
     return *this;
 }
 
 XmlWriter::ScopedElement::~ScopedElement()
 {
     if (m_writer)
-        m_writer->endElement();
+    {
+        m_writer->endElement(m_fmt);
+    }
 }
 
-XmlWriter::ScopedElement &XmlWriter::ScopedElement::writeText(std::string const &text, bool indent)
+XmlWriter::ScopedElement &XmlWriter::ScopedElement::writeText(std::string const &text,
+                                                              XmlFormatting fmt)
 {
-    m_writer->writeText(text, indent);
+    m_writer->writeText(text, fmt);
     return *this;
 }
 
@@ -16431,31 +17321,39 @@ XmlWriter::XmlWriter(std::ostream &os) : m_os(os) { writeDeclaration(); }
 XmlWriter::~XmlWriter()
 {
     while (!m_tags.empty())
+    {
         endElement();
+    }
+    newlineIfNecessary();
 }
 
-XmlWriter &XmlWriter::startElement(std::string const &name)
+XmlWriter &XmlWriter::startElement(std::string const &name, XmlFormatting fmt)
 {
     ensureTagClosed();
     newlineIfNecessary();
-    m_os << m_indent << '<' << name;
+    if (shouldIndent(fmt))
+    {
+        m_os << m_indent;
+        m_indent += "  ";
+    }
+    m_os << '<' << name;
     m_tags.push_back(name);
-    m_indent += "  ";
     m_tagIsOpen = true;
+    applyFormatting(fmt);
     return *this;
 }
 
-XmlWriter::ScopedElement XmlWriter::scopedElement(std::string const &name)
+XmlWriter::ScopedElement XmlWriter::scopedElement(std::string const &name, XmlFormatting fmt)
 {
-    ScopedElement scoped(this);
-    startElement(name);
+    ScopedElement scoped(this, fmt);
+    startElement(name, fmt);
     return scoped;
 }
 
-XmlWriter &XmlWriter::endElement()
+XmlWriter &XmlWriter::endElement(XmlFormatting fmt)
 {
-    newlineIfNecessary();
     m_indent = m_indent.substr(0, m_indent.size() - 2);
+
     if (m_tagIsOpen)
     {
         m_os << "/>";
@@ -16463,9 +17361,15 @@ XmlWriter &XmlWriter::endElement()
     }
     else
     {
-        m_os << m_indent << "</" << m_tags.back() << ">";
+        newlineIfNecessary();
+        if (shouldIndent(fmt))
+        {
+            m_os << m_indent;
+        }
+        m_os << "</" << m_tags.back() << ">";
     }
-    m_os << std::endl;
+    m_os << std::flush;
+    applyFormatting(fmt);
     m_tags.pop_back();
     return *this;
 }
@@ -16483,25 +17387,31 @@ XmlWriter &XmlWriter::writeAttribute(std::string const &name, bool attribute)
     return *this;
 }
 
-XmlWriter &XmlWriter::writeText(std::string const &text, bool indent)
+XmlWriter &XmlWriter::writeText(std::string const &text, XmlFormatting fmt)
 {
     if (!text.empty())
     {
         bool tagWasOpen = m_tagIsOpen;
         ensureTagClosed();
-        if (tagWasOpen && indent)
+        if (tagWasOpen && shouldIndent(fmt))
+        {
             m_os << m_indent;
+        }
         m_os << XmlEncode(text);
-        m_needsNewline = true;
+        applyFormatting(fmt);
     }
     return *this;
 }
 
-XmlWriter &XmlWriter::writeComment(std::string const &text)
+XmlWriter &XmlWriter::writeComment(std::string const &text, XmlFormatting fmt)
 {
     ensureTagClosed();
-    m_os << m_indent << "<!--" << text << "-->";
-    m_needsNewline = true;
+    if (shouldIndent(fmt))
+    {
+        m_os << m_indent;
+    }
+    m_os << "<!--" << text << "-->";
+    applyFormatting(fmt);
     return *this;
 }
 
@@ -16521,10 +17431,13 @@ void XmlWriter::ensureTagClosed()
 {
     if (m_tagIsOpen)
     {
-        m_os << ">" << std::endl;
+        m_os << '>' << std::flush;
+        newlineIfNecessary();
         m_tagIsOpen = false;
     }
 }
+
+void XmlWriter::applyFormatting(XmlFormatting fmt) { m_needsNewline = shouldNewline(fmt); }
 
 void XmlWriter::writeDeclaration() { m_os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"; }
 
@@ -16569,6 +17482,20 @@ std::string getFormattedDuration(double duration)
     std::sprintf(buffer, "%.3f", duration);
 #endif
     return std::string(buffer);
+}
+
+bool shouldShowDuration(IConfig const &config, double duration)
+{
+    if (config.showDurations() == ShowDurations::Always)
+    {
+        return true;
+    }
+    if (config.showDurations() == ShowDurations::Never)
+    {
+        return false;
+    }
+    const double min = config.minDuration();
+    return min >= 0 && duration >= min;
 }
 
 std::string serializeFilters(std::vector<std::string> const &container)
@@ -16868,8 +17795,6 @@ std::string CompactReporter::getDescription()
     return "Reports test results on a single line, suitable for IDEs";
 }
 
-ReporterPreferences CompactReporter::getPreferences() const { return m_reporterPrefs; }
-
 void CompactReporter::noMatchingTestCases(std::string const &spec)
 {
     stream << "No test cases matched '" << spec << '\'' << std::endl;
@@ -16900,10 +17825,11 @@ bool CompactReporter::assertionEnded(AssertionStats const &_assertionStats)
 
 void CompactReporter::sectionEnded(SectionStats const &_sectionStats)
 {
-    if (m_config->showDurations() == ShowDurations::Always)
+    double dur = _sectionStats.durationInSeconds;
+    if (shouldShowDuration(*m_config, dur))
     {
-        stream << getFormattedDuration(_sectionStats.durationInSeconds)
-               << " s: " << _sectionStats.sectionInfo.name << std::endl;
+        stream << getFormattedDuration(dur) << " s: " << _sectionStats.sectionInfo.name
+               << std::endl;
     }
 }
 
@@ -17147,16 +18073,11 @@ class Duration
     static const uint64_t s_nanosecondsInASecond = 1000 * s_nanosecondsInAMillisecond;
     static const uint64_t s_nanosecondsInAMinute = 60 * s_nanosecondsInASecond;
 
-    uint64_t m_inNanoseconds;
+    double m_inNanoseconds;
     Unit m_units;
 
   public:
     explicit Duration(double inNanoseconds, Unit units = Unit::Auto)
-        : Duration(static_cast<uint64_t>(inNanoseconds), units)
-    {
-    }
-
-    explicit Duration(uint64_t inNanoseconds, Unit units = Unit::Auto)
         : m_inNanoseconds(inNanoseconds), m_units(units)
     {
         if (m_units == Unit::Auto)
@@ -17187,7 +18108,7 @@ class Duration
         case Unit::Minutes:
             return m_inNanoseconds / static_cast<double>(s_nanosecondsInAMinute);
         default:
-            return static_cast<double>(m_inNanoseconds);
+            return m_inNanoseconds;
         }
     }
     auto unitsAsString() const -> std::string
@@ -17210,7 +18131,7 @@ class Duration
     }
     friend auto operator<<(std::ostream &os, Duration const &duration) -> std::ostream &
     {
-        return os << duration.value() << " " << duration.unitsAsString();
+        return os << duration.value() << ' ' << duration.unitsAsString();
     }
 };
 } // namespace
@@ -17245,9 +18166,9 @@ class TablePrinter
                 headerCols += Column(info.name).width(static_cast<std::size_t>(info.width - 2));
                 headerCols += spacer;
             }
-            m_os << headerCols << "\n";
+            m_os << headerCols << '\n';
 
-            m_os << Catch::getLineOfChars<'-'>() << "\n";
+            m_os << Catch::getLineOfChars<'-'>() << '\n';
         }
     }
     void close()
@@ -17269,25 +18190,24 @@ class TablePrinter
     friend TablePrinter &operator<<(TablePrinter &tp, ColumnBreak)
     {
         auto colStr = tp.m_oss.str();
-        // This takes account of utf8 encodings
-        auto strSize = Catch::StringRef(colStr).numberOfCharacters();
+        const auto strSize = colStr.size();
         tp.m_oss.str("");
         tp.open();
         if (tp.m_currentColumn == static_cast<int>(tp.m_columnInfos.size() - 1))
         {
             tp.m_currentColumn = -1;
-            tp.m_os << "\n";
+            tp.m_os << '\n';
         }
         tp.m_currentColumn++;
 
         auto colInfo = tp.m_columnInfos[tp.m_currentColumn];
-        auto padding = (strSize + 2 < static_cast<std::size_t>(colInfo.width))
-                           ? std::string(colInfo.width - (strSize + 2), ' ')
+        auto padding = (strSize + 1 < static_cast<std::size_t>(colInfo.width))
+                           ? std::string(colInfo.width - (strSize + 1), ' ')
                            : std::string();
         if (colInfo.justification == ColumnInfo::Left)
-            tp.m_os << colStr << padding << " ";
+            tp.m_os << colStr << padding << ' ';
         else
-            tp.m_os << padding << colStr << " ";
+            tp.m_os << padding << colStr << ' ';
         return tp;
     }
 
@@ -17295,7 +18215,7 @@ class TablePrinter
     {
         if (tp.m_currentColumn > 0)
         {
-            tp.m_os << "\n";
+            tp.m_os << '\n';
             tp.m_currentColumn = -1;
         }
         return tp;
@@ -17304,11 +18224,22 @@ class TablePrinter
 
 ConsoleReporter::ConsoleReporter(ReporterConfig const &config)
     : StreamingReporterBase(config),
-      m_tablePrinter(new TablePrinter(
-          config.stream(), {{"benchmark name", CATCH_CONFIG_CONSOLE_WIDTH - 32, ColumnInfo::Left},
-                            {"samples      mean       std dev", 14, ColumnInfo::Right},
-                            {"iterations   low mean   low std dev", 14, ColumnInfo::Right},
-                            {"estimated    high mean  high std dev", 14, ColumnInfo::Right}}))
+      m_tablePrinter(new TablePrinter(config.stream(), [&config]() -> std::vector<ColumnInfo> {
+          if (config.fullConfig()->benchmarkNoAnalysis())
+          {
+              return {{"benchmark name", CATCH_CONFIG_CONSOLE_WIDTH - 43, ColumnInfo::Left},
+                      {"     samples", 14, ColumnInfo::Right},
+                      {"  iterations", 14, ColumnInfo::Right},
+                      {"        mean", 14, ColumnInfo::Right}};
+          }
+          else
+          {
+              return {{"benchmark name", CATCH_CONFIG_CONSOLE_WIDTH - 43, ColumnInfo::Left},
+                      {"samples      mean       std dev", 14, ColumnInfo::Right},
+                      {"iterations   low mean   low std dev", 14, ColumnInfo::Right},
+                      {"estimated    high mean  high std dev", 14, ColumnInfo::Right}};
+          }
+      }()))
 {
 }
 ConsoleReporter::~ConsoleReporter() = default;
@@ -17321,6 +18252,11 @@ std::string ConsoleReporter::getDescription()
 void ConsoleReporter::noMatchingTestCases(std::string const &spec)
 {
     stream << "No test cases matched '" << spec << '\'' << std::endl;
+}
+
+void ConsoleReporter::reportInvalidArguments(std::string const &arg)
+{
+    stream << "Invalid Filter: " << arg << std::endl;
 }
 
 void ConsoleReporter::assertionStarting(AssertionInfo const &) {}
@@ -17362,10 +18298,11 @@ void ConsoleReporter::sectionEnded(SectionStats const &_sectionStats)
             stream << "\nNo assertions in test case";
         stream << " '" << _sectionStats.sectionInfo.name << "'\n" << std::endl;
     }
-    if (m_config->showDurations() == ShowDurations::Always)
+    double dur = _sectionStats.durationInSeconds;
+    if (shouldShowDuration(*m_config, dur))
     {
-        stream << getFormattedDuration(_sectionStats.durationInSeconds)
-               << " s: " << _sectionStats.sectionInfo.name << std::endl;
+        stream << getFormattedDuration(dur) << " s: " << _sectionStats.sectionInfo.name
+               << std::endl;
     }
     if (m_headerPrinted)
     {
@@ -17396,24 +18333,33 @@ void ConsoleReporter::benchmarkPreparing(std::string const &name)
 
 void ConsoleReporter::benchmarkStarting(BenchmarkInfo const &info)
 {
-    (*m_tablePrinter) << info.samples << ColumnBreak() << info.iterations << ColumnBreak()
-                      << Duration(info.estimatedDuration) << ColumnBreak();
+    (*m_tablePrinter) << info.samples << ColumnBreak() << info.iterations << ColumnBreak();
+    if (!m_config->benchmarkNoAnalysis())
+        (*m_tablePrinter) << Duration(info.estimatedDuration) << ColumnBreak();
 }
 void ConsoleReporter::benchmarkEnded(BenchmarkStats<> const &stats)
 {
-    (*m_tablePrinter) << ColumnBreak() << Duration(stats.mean.point.count()) << ColumnBreak()
-                      << Duration(stats.mean.lower_bound.count()) << ColumnBreak()
-                      << Duration(stats.mean.upper_bound.count()) << ColumnBreak() << ColumnBreak()
-                      << Duration(stats.standardDeviation.point.count()) << ColumnBreak()
-                      << Duration(stats.standardDeviation.lower_bound.count()) << ColumnBreak()
-                      << Duration(stats.standardDeviation.upper_bound.count()) << ColumnBreak()
-                      << ColumnBreak() << ColumnBreak() << ColumnBreak() << ColumnBreak();
+    if (m_config->benchmarkNoAnalysis())
+    {
+        (*m_tablePrinter) << Duration(stats.mean.point.count()) << ColumnBreak();
+    }
+    else
+    {
+        (*m_tablePrinter) << ColumnBreak() << Duration(stats.mean.point.count()) << ColumnBreak()
+                          << Duration(stats.mean.lower_bound.count()) << ColumnBreak()
+                          << Duration(stats.mean.upper_bound.count()) << ColumnBreak()
+                          << ColumnBreak() << Duration(stats.standardDeviation.point.count())
+                          << ColumnBreak() << Duration(stats.standardDeviation.lower_bound.count())
+                          << ColumnBreak() << Duration(stats.standardDeviation.upper_bound.count())
+                          << ColumnBreak() << ColumnBreak() << ColumnBreak() << ColumnBreak()
+                          << ColumnBreak();
+    }
 }
 
 void ConsoleReporter::benchmarkFailed(std::string const &error)
 {
     Colour colour(Colour::Red);
-    (*m_tablePrinter) << "Benchmark failed (" << error << ")" << ColumnBreak() << RowBreak();
+    (*m_tablePrinter) << "Benchmark failed (" << error << ')' << ColumnBreak() << RowBreak();
 }
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
@@ -17506,12 +18452,9 @@ void ConsoleReporter::printTestCaseAndSectionHeader()
 
     SourceLineInfo lineInfo = m_sectionStack.back().lineInfo;
 
-    if (!lineInfo.empty())
-    {
-        stream << getLineOfChars<'-'>() << '\n';
-        Colour colourGuard(Colour::FileName);
-        stream << lineInfo << '\n';
-    }
+    stream << getLineOfChars<'-'>() << '\n';
+    Colour colourGuard(Colour::FileName);
+    stream << lineInfo << '\n';
     stream << getLineOfChars<'.'>() << '\n' << std::endl;
 }
 
@@ -17656,8 +18599,10 @@ void ConsoleReporter::printSummaryDivider() { stream << getLineOfChars<'-'>() <<
 void ConsoleReporter::printTestFilters()
 {
     if (m_config->testSpec().hasFilters())
-        stream << Colour(Colour::BrightYellow)
-               << "Filters: " << serializeFilters(m_config->getTestsOrTags()) << '\n';
+    {
+        Colour guard(Colour::BrightYellow);
+        stream << "Filters: " << serializeFilters(m_config->getTestsOrTags()) << '\n';
+    }
 }
 
 CATCH_REGISTER_REPORTER("console", ConsoleReporter)
@@ -17678,6 +18623,7 @@ CATCH_REGISTER_REPORTER("console", ConsoleReporter)
 #include <sstream>
 #include <ctime>
 #include <algorithm>
+#include <iomanip>
 
 namespace Catch
 {
@@ -17708,7 +18654,7 @@ std::string getCurrentTimestamp()
 #else
     std::strftime(timeStamp, timeStampSize, fmt, timeInfo);
 #endif
-    return std::string(timeStamp);
+    return std::string(timeStamp, timeStampSize - 1);
 }
 
 std::string fileNameTag(const std::vector<std::string> &tags)
@@ -17719,6 +18665,18 @@ std::string fileNameTag(const std::vector<std::string> &tags)
         return it->substr(1);
     return std::string();
 }
+
+// Formats the duration in seconds to 3 decimal places.
+// This is done because some genius defined Maven Surefire schema
+// in a way that only accepts 3 decimal places, and tools like
+// Jenkins use that schema for validation JUnit reporter output.
+std::string formatDuration(double seconds)
+{
+    ReusableStringStream rss;
+    rss << std::fixed << std::setprecision(3) << seconds;
+    return rss.str();
+}
+
 } // anonymous namespace
 
 JunitReporter::JunitReporter(ReporterConfig const &_config)
@@ -17793,7 +18751,7 @@ void JunitReporter::writeGroup(TestGroupNode const &groupNode, double suiteTime)
     if (m_config->showDurations() == ShowDurations::Never)
         xml.writeAttribute("time", "");
     else
-        xml.writeAttribute("time", suiteTime);
+        xml.writeAttribute("time", formatDuration(suiteTime));
     xml.writeAttribute("timestamp", getCurrentTimestamp());
 
     // Write properties if there are any
@@ -17818,8 +18776,8 @@ void JunitReporter::writeGroup(TestGroupNode const &groupNode, double suiteTime)
     for (auto const &child : groupNode.children)
         writeTestCase(*child);
 
-    xml.scopedElement("system-out").writeText(trim(stdOutForSuite), false);
-    xml.scopedElement("system-err").writeText(trim(stdErrForSuite), false);
+    xml.scopedElement("system-out").writeText(trim(stdOutForSuite), XmlFormatting::Newline);
+    xml.scopedElement("system-err").writeText(trim(stdErrForSuite), XmlFormatting::Newline);
 }
 
 void JunitReporter::writeTestCase(TestCaseNode const &testCaseNode)
@@ -17843,11 +18801,11 @@ void JunitReporter::writeTestCase(TestCaseNode const &testCaseNode)
     if (!m_config->name().empty())
         className = m_config->name() + "." + className;
 
-    writeSection(className, "", rootSection);
+    writeSection(className, "", rootSection, stats.testInfo.okToFail());
 }
 
 void JunitReporter::writeSection(std::string const &className, std::string const &rootName,
-                                 SectionNode const &sectionNode)
+                                 SectionNode const &sectionNode, bool testOkToFail)
 {
     std::string name = trim(sectionNode.stats.sectionInfo.name);
     if (!rootName.empty())
@@ -17867,20 +18825,33 @@ void JunitReporter::writeSection(std::string const &className, std::string const
             xml.writeAttribute("classname", className);
             xml.writeAttribute("name", name);
         }
-        xml.writeAttribute("time", ::Catch::Detail::stringify(sectionNode.stats.durationInSeconds));
+        xml.writeAttribute("time", formatDuration(sectionNode.stats.durationInSeconds));
+        // This is not ideal, but it should be enough to mimic gtest's
+        // junit output.
+        // Ideally the JUnit reporter would also handle `skipTest`
+        // events and write those out appropriately.
+        xml.writeAttribute("status", "run");
+
+        if (sectionNode.stats.assertions.failedButOk)
+        {
+            xml.scopedElement("skipped").writeAttribute("message",
+                                                        "TEST_CASE tagged with !mayfail");
+        }
 
         writeAssertions(sectionNode);
 
         if (!sectionNode.stdOut.empty())
-            xml.scopedElement("system-out").writeText(trim(sectionNode.stdOut), false);
+            xml.scopedElement("system-out")
+                .writeText(trim(sectionNode.stdOut), XmlFormatting::Newline);
         if (!sectionNode.stdErr.empty())
-            xml.scopedElement("system-err").writeText(trim(sectionNode.stdErr), false);
+            xml.scopedElement("system-err")
+                .writeText(trim(sectionNode.stdErr), XmlFormatting::Newline);
     }
     for (auto const &childNode : sectionNode.childSections)
         if (className.empty())
-            writeSection(name, "", *childNode);
+            writeSection(name, "", *childNode, testOkToFail);
         else
-            writeSection(className, name, *childNode);
+            writeSection(className, name, *childNode, testOkToFail);
 }
 
 void JunitReporter::writeAssertions(SectionNode const &sectionNode)
@@ -17902,11 +18873,7 @@ void JunitReporter::writeAssertion(AssertionStats const &stats)
             elementName = "error";
             break;
         case ResultWas::ExplicitFailure:
-            elementName = "failure";
-            break;
         case ResultWas::ExpressionFailed:
-            elementName = "failure";
-            break;
         case ResultWas::DidntThrowException:
             elementName = "failure";
             break;
@@ -17924,10 +18891,31 @@ void JunitReporter::writeAssertion(AssertionStats const &stats)
 
         XmlWriter::ScopedElement e = xml.scopedElement(elementName);
 
-        xml.writeAttribute("message", result.getExpandedExpression());
+        xml.writeAttribute("message", result.getExpression());
         xml.writeAttribute("type", result.getTestMacroName());
 
         ReusableStringStream rss;
+        if (stats.totals.assertions.total() > 0)
+        {
+            rss << "FAILED"
+                << ":\n";
+            if (result.hasExpression())
+            {
+                rss << "  ";
+                rss << result.getExpressionInMacro();
+                rss << '\n';
+            }
+            if (result.hasExpandedExpression())
+            {
+                rss << "with expansion:\n";
+                rss << Column(result.getExpandedExpression()).indent(2) << '\n';
+            }
+        }
+        else
+        {
+            rss << '\n';
+        }
+
         if (!result.getMessage().empty())
             rss << result.getMessage() << '\n';
         for (auto const &msg : stats.infoMessages)
@@ -17935,7 +18923,7 @@ void JunitReporter::writeAssertion(AssertionStats const &stats)
                 rss << msg.message << '\n';
 
         rss << "at " << result.getSourceInfo();
-        xml.writeText(rss.str(), false);
+        xml.writeText(rss.str(), XmlFormatting::Newline);
     }
 }
 
@@ -17979,6 +18967,15 @@ void ListeningReporter::noMatchingTestCases(std::string const &spec)
         listener->noMatchingTestCases(spec);
     }
     m_reporter->noMatchingTestCases(spec);
+}
+
+void ListeningReporter::reportInvalidArguments(std::string const &arg)
+{
+    for (auto const &listener : m_listeners)
+    {
+        listener->reportInvalidArguments(arg);
+    }
+    m_reporter->reportInvalidArguments(arg);
 }
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
@@ -18308,9 +19305,9 @@ void XmlReporter::testCaseEnded(TestCaseStats const &testCaseStats)
         e.writeAttribute("durationInSeconds", m_testCaseTimer.getElapsedSeconds());
 
     if (!testCaseStats.stdOut.empty())
-        m_xml.scopedElement("StdOut").writeText(trim(testCaseStats.stdOut), false);
+        m_xml.scopedElement("StdOut").writeText(trim(testCaseStats.stdOut), XmlFormatting::Newline);
     if (!testCaseStats.stdErr.empty())
-        m_xml.scopedElement("StdErr").writeText(trim(testCaseStats.stdErr), false);
+        m_xml.scopedElement("StdErr").writeText(trim(testCaseStats.stdErr), XmlFormatting::Newline);
 
     m_xml.endElement();
 }
@@ -18323,6 +19320,10 @@ void XmlReporter::testGroupEnded(TestGroupStats const &testGroupStats)
         .writeAttribute("successes", testGroupStats.totals.assertions.passed)
         .writeAttribute("failures", testGroupStats.totals.assertions.failed)
         .writeAttribute("expectedFailures", testGroupStats.totals.assertions.failedButOk);
+    m_xml.scopedElement("OverallResultsCases")
+        .writeAttribute("successes", testGroupStats.totals.testCases.passed)
+        .writeAttribute("failures", testGroupStats.totals.testCases.failed)
+        .writeAttribute("expectedFailures", testGroupStats.totals.testCases.failedButOk);
     m_xml.endElement();
 }
 
@@ -18333,6 +19334,10 @@ void XmlReporter::testRunEnded(TestRunStats const &testRunStats)
         .writeAttribute("successes", testRunStats.totals.assertions.passed)
         .writeAttribute("failures", testRunStats.totals.assertions.failed)
         .writeAttribute("expectedFailures", testRunStats.totals.assertions.failedButOk);
+    m_xml.scopedElement("OverallResultsCases")
+        .writeAttribute("successes", testRunStats.totals.testCases.passed)
+        .writeAttribute("failures", testRunStats.totals.testCases.failed)
+        .writeAttribute("expectedFailures", testRunStats.totals.testCases.failedButOk);
     m_xml.endElement();
 }
 
@@ -18347,19 +19352,17 @@ void XmlReporter::benchmarkStarting(BenchmarkInfo const &info)
     m_xml.writeAttribute("samples", info.samples)
         .writeAttribute("resamples", info.resamples)
         .writeAttribute("iterations", info.iterations)
-        .writeAttribute("clockResolution", static_cast<uint64_t>(info.clockResolution))
-        .writeAttribute("estimatedDuration", static_cast<uint64_t>(info.estimatedDuration))
+        .writeAttribute("clockResolution", info.clockResolution)
+        .writeAttribute("estimatedDuration", info.estimatedDuration)
         .writeComment("All values in nano seconds");
 }
 
 void XmlReporter::benchmarkEnded(BenchmarkStats<> const &benchmarkStats)
 {
     m_xml.startElement("mean")
-        .writeAttribute("value", static_cast<uint64_t>(benchmarkStats.mean.point.count()))
-        .writeAttribute("lowerBound",
-                        static_cast<uint64_t>(benchmarkStats.mean.lower_bound.count()))
-        .writeAttribute("upperBound",
-                        static_cast<uint64_t>(benchmarkStats.mean.upper_bound.count()))
+        .writeAttribute("value", benchmarkStats.mean.point.count())
+        .writeAttribute("lowerBound", benchmarkStats.mean.lower_bound.count())
+        .writeAttribute("upperBound", benchmarkStats.mean.upper_bound.count())
         .writeAttribute("ci", benchmarkStats.mean.confidence_interval);
     m_xml.endElement();
     m_xml.startElement("standardDeviation")
@@ -18411,7 +19414,8 @@ LeakDetector leakDetector;
 
 #ifndef __OBJC__
 
-#if defined(CATCH_CONFIG_WCHAR) && defined(WIN32) && defined(_UNICODE) && !defined(DO_NOT_USE_WMAIN)
+#if defined(CATCH_CONFIG_WCHAR) && defined(CATCH_PLATFORM_WINDOWS) && defined(_UNICODE) &&         \
+    !defined(DO_NOT_USE_WMAIN)
 // Standard C/C++ Win32 Unicode wmain entry point
 extern "C" int wmain(int argc, wchar_t *argv[], wchar_t *[])
 {
@@ -18617,12 +19621,11 @@ int main(int argc, char *const argv[])
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
 #define CATCH_BENCHMARK(...)                                                                       \
-    INTERNAL_CATCH_BENCHMARK(INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____B_E_N_C_H____),           \
+    INTERNAL_CATCH_BENCHMARK(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_B_E_N_C_H_),                     \
                              INTERNAL_CATCH_GET_1_ARG(__VA_ARGS__, , ),                            \
                              INTERNAL_CATCH_GET_2_ARG(__VA_ARGS__, , ))
 #define CATCH_BENCHMARK_ADVANCED(name)                                                             \
-    INTERNAL_CATCH_BENCHMARK_ADVANCED(INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____B_E_N_C_H____),  \
-                                      name)
+    INTERNAL_CATCH_BENCHMARK_ADVANCED(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_B_E_N_C_H_), name)
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
 // If CATCH_CONFIG_PREFIX_ALL is not defined then the CATCH_ prefix is not required
@@ -18791,12 +19794,11 @@ int main(int argc, char *const argv[])
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
 #define BENCHMARK(...)                                                                             \
-    INTERNAL_CATCH_BENCHMARK(INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____B_E_N_C_H____),           \
+    INTERNAL_CATCH_BENCHMARK(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_B_E_N_C_H_),                     \
                              INTERNAL_CATCH_GET_1_ARG(__VA_ARGS__, , ),                            \
                              INTERNAL_CATCH_GET_2_ARG(__VA_ARGS__, , ))
 #define BENCHMARK_ADVANCED(name)                                                                   \
-    INTERNAL_CATCH_BENCHMARK_ADVANCED(INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____B_E_N_C_H____),  \
-                                      name)
+    INTERNAL_CATCH_BENCHMARK_ADVANCED(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_B_E_N_C_H_), name)
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
 using Catch::Detail::Approx;
@@ -18844,11 +19846,9 @@ using Catch::Detail::Approx;
 #define CATCH_CAPTURE(msg) (void)(0)
 
 #define CATCH_TEST_CASE(...)                                                                       \
-    INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(                                                       \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_S_T____))
+    INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_S_T_))
 #define CATCH_TEST_CASE_METHOD(className, ...)                                                     \
-    INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(                                                       \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_S_T____))
+    INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_S_T_))
 #define CATCH_METHOD_AS_TEST_CASE(method, ...)
 #define CATCH_REGISTER_TEST_CASE(Function, ...) (void)(0)
 #define CATCH_SECTION(...)
@@ -18858,8 +19858,7 @@ using Catch::Detail::Approx;
 #define CATCH_SUCCEED(...) (void)(0)
 
 #define CATCH_ANON_TEST_CASE()                                                                     \
-    INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(                                                       \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_S_T____))
+    INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_S_T_))
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
 #define CATCH_TEMPLATE_TEST_CASE(...) INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION(__VA_ARGS__)
@@ -18896,11 +19895,10 @@ using Catch::Detail::Approx;
 
 // "BDD-style" convenience wrappers
 #define CATCH_SCENARIO(...)                                                                        \
-    INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(                                                       \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_S_T____))
+    INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_S_T_))
 #define CATCH_SCENARIO_METHOD(className, ...)                                                      \
-    INTERNAL_CATCH_TESTCASE_METHOD_NO_REGISTRATION(                                                \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_S_T____), className)
+    INTERNAL_CATCH_TESTCASE_METHOD_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_S_T_), \
+                                                   className)
 #define CATCH_GIVEN(desc)
 #define CATCH_AND_GIVEN(desc)
 #define CATCH_WHEN(desc)
@@ -18948,14 +19946,12 @@ using Catch::Detail::Approx;
 #define INFO(msg) (void)(0)
 #define UNSCOPED_INFO(msg) (void)(0)
 #define WARN(msg) (void)(0)
-#define CAPTURE(msg) (void)(0)
+#define CAPTURE(...) (void)(0)
 
 #define TEST_CASE(...)                                                                             \
-    INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(                                                       \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_S_T____))
+    INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_S_T_))
 #define TEST_CASE_METHOD(className, ...)                                                           \
-    INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(                                                       \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_S_T____))
+    INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_S_T_))
 #define METHOD_AS_TEST_CASE(method, ...)
 #define REGISTER_TEST_CASE(Function, ...) (void)(0)
 #define SECTION(...)
@@ -18964,8 +19960,7 @@ using Catch::Detail::Approx;
 #define FAIL_CHECK(...) (void)(0)
 #define SUCCEED(...) (void)(0)
 #define ANON_TEST_CASE()                                                                           \
-    INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(                                                       \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_S_T____))
+    INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_S_T_))
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
 #define TEMPLATE_TEST_CASE(...) INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION(__VA_ARGS__)
@@ -19011,11 +20006,10 @@ using Catch::Detail::Approx;
 
 // "BDD-style" convenience wrappers
 #define SCENARIO(...)                                                                              \
-    INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(                                                       \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_S_T____))
+    INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_S_T_))
 #define SCENARIO_METHOD(className, ...)                                                            \
-    INTERNAL_CATCH_TESTCASE_METHOD_NO_REGISTRATION(                                                \
-        INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____T_E_S_T____), className)
+    INTERNAL_CATCH_TESTCASE_METHOD_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_T_E_S_T_), \
+                                                   className)
 
 #define GIVEN(desc)
 #define AND_GIVEN(desc)


### PR DESCRIPTION
The tests fail with gcc 12
`MINSIGSTKSZ` is no longer constant in linux since glibc 2.34
Upgrading catch provides a fix
- upgrade to v2.13.9
- rename to catch2.hpp
- format