### PR TITLE
Reorder and add some includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ cmake_policy(SET CMP0091 NEW)
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14 CACHE STRING "Minimum macOS version")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 project(ShortCircuit VERSION 0.5.0.0 LANGUAGES C CXX ASM)
 
@@ -27,11 +28,6 @@ message(STATUS "Targeting ${BITS}-bit configuration")
 # Share some information about the  build
 message(STATUS "ShortCircuit ${CMAKE_PROJECT_VERSION}")
 message(STATUS "Compiler Version is ${CMAKE_CXX_COMPILER_VERSION}")
-
-
-# Optional variables
-option(SCXT_SKIP_PYTHON "Skip the Python Wrapper" FALSE)
-
 
 # Everything here is C++ 17 now
 set(CMAKE_CXX_STANDARD 17)

--- a/README.md
+++ b/README.md
@@ -82,17 +82,12 @@ cmake -Bbuild
 cmake --build build --config Release --target ShortcircuitXT_Standalone
 ```
 
-This will build the rudimentary standalone app. Other targets exist for Python as a wrapper, as well as `sc3-test`
+This will build the rudimentary standalone app. Other targets exist, such as `sc3-test`
 which runs the existing test suite.
 
-If you don't have the prerequisites for build installed it might fail, but many Windows users don't have python
-installed, which will make cmake complain. So if you want to build skipping the python libs you can also do
-
-```
-git submodule update --init --recursive
-cmake -Bbuild -DSHORTCIRCUIT_XT_SKIP_PYTHON=TRUE
-cmake --build build --config Release --target ShortcircuitXT_Standalone
-```
+If you don't have the prerequisites for build installed it might fail,
+(We will update this section soon. For now please have a look at the Surge XT docs for
+prerequisites and dependencies)
 
 # Issues building
 

--- a/src/infrastructure/sc3_mmio.cpp
+++ b/src/infrastructure/sc3_mmio.cpp
@@ -86,7 +86,7 @@ int mmioDescend(HMMIO h, MMCKINFO *target, MMCKINFO *parent, int type)
     case MMIO_FINDRIFF:
     {
         /*
-         * A naieve implementation but assume that only first time through is a RIFF
+         * A naive implementation but assume that only first time through is a RIFF
          */
         if (h->memFile.RIFFPeekChunk(&tag, &ds, &has, &ltag))
         {

--- a/src/loaders/dls.h
+++ b/src/loaders/dls.h
@@ -220,7 +220,7 @@ typedef struct _DLSHEADER
 
 /*****  For level 1 only WAVELINK_CHANNEL_MONO is valid  ****
   ulChannel allows for up to 32 channels of audio with each bit position
-  specifiying a channel of playback */
+  specifying a channel of playback */
 
 #define WAVELINK_CHANNEL_LEFT 0x0001l
 #define WAVELINK_CHANNEL_RIGHT 0x0002l

--- a/src/loaders/load_riff_wave.cpp
+++ b/src/loaders/load_riff_wave.cpp
@@ -30,7 +30,7 @@
 size_t sample::SaveWaveChunk(void *data)
 {
     // save the sample in a WAVE-compatible chunk
-    // both used for persistance and .wav export
+    // both used for persistence and .wav export
     size_t samplesize = channels * sample_length * (UseInt16 ? 2 : 4);
     size_t datasize = (8 + sizeof(wavheader)) + (8 + samplesize) +
                       (12 + scxt::Memfile::RIFFMemFile::RIFFTextChunkSize(name));

--- a/src/loaders/riff_wave.h
+++ b/src/loaders/riff_wave.h
@@ -57,7 +57,7 @@ struct wave_acid_chunk
     /*
     0x01 On: One Shot         Off: Loop
     0x02 On: Root note is Set Off: No root
-    0x04 On: Stretch is On,   Off: Strech is OFF
+    0x04 On: Stretch is On,   Off: Stretch is OFF
     0x08 On: Disk Based       Off: Ram based
     0x10 On: ??????????       Off: ????????? (Acidizer puts that ON)
     */

--- a/src/loaders/sf2_import.cpp
+++ b/src/loaders/sf2_import.cpp
@@ -87,7 +87,7 @@ int get_sf2_patchlist(const fs::path &filename, void **plist, scxt::log::StreamL
         return false;
     }
 
-    // ok, we're in the presets chunk, put all the data in bufffers
+    // ok, we're in the presets chunk, put all the data in buffers
 
     int i;
     int n_ph, n_pb, n_pg, n_ih, n_ib, n_ig, n_shdr;
@@ -295,7 +295,7 @@ bool sampler::load_sf2_preset(const fs::path &filename, int *new_group, char cha
         return false;
     }
 
-    // ok, we're in the presets chunk, put all the data in bufffers
+    // ok, we're in the presets chunk, put all the data in buffers
 
     int i;
     int n_ph, n_pb, n_pg, n_ih, n_ib, n_ig, n_shdr;
@@ -488,7 +488,7 @@ spawn_patch_dialog((HWND)((AEffGUIEditor*)editor)->getFrame()->getSystemWindow()
                 p_generators_set[preset_gen[pg].sfGenOper] = true;
             }
 
-            // traverse trough the instrumentbags
+            // traverse through the instrument bags
             int inst_id = p_generators[instrument].wAmount;
             if (!p_generators_set[instrument])
                 break;

--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -243,7 +243,7 @@ void sample::init_grains()
                     if(samplepos > sample_length)
                             break;
 
-                    // check if upwards zc has occured
+                    // check if upwards zc has occurred
                     if ((sample_data[samplepos+FIRoffset]>0) &&
     (sample_data[samplepos+FIRoffset-1]<0))
                     {

--- a/src/sampler_notelogic.cpp
+++ b/src/sampler_notelogic.cpp
@@ -543,7 +543,7 @@ void sampler::ReleaseNote(char channel, char key, char velocity)
             }
             else
             {
-                // hold pedal is down, add to bufffer
+                // hold pedal is down, add to buffer
                 holdbuffer.push_back(i);
             }
         }

--- a/src/sampler_state.h
+++ b/src/sampler_state.h
@@ -458,7 +458,7 @@ struct sample_part
     // int					polymode_partlevel;
     int polymode, polylimit;
     int portamento_mode, transpose, formant;
-    int MIDIchannel; // channel part recieves on (defaults to its id but can be stored in multi, but
+    int MIDIchannel; // channel part receives on (defaults to its id but can be stored in multi, but
                      // not patches)
 
     filterstruct Filter[num_filters_per_part]; // filters / fx

--- a/src/sampler_wrapper_actiondata.h
+++ b/src/sampler_wrapper_actiondata.h
@@ -52,7 +52,7 @@
  * then are what are the messages wrapper -> engine, engine -> wrapper, and the thread
  * patterns of both.
  *
- * Lets do thred patterns first
+ * Let's do thread patterns first
  *
  * 1. The wrapper can call `postEventsFromWrapper` from any thread it wants
  * 2. The engine will process events on the audio thread

--- a/src/sampler_wrapper_interaction.cpp
+++ b/src/sampler_wrapper_interaction.cpp
@@ -1143,7 +1143,7 @@ void sampler::post_data_from_structure(char *pointr, int id_start, int id_end)
             else
             {
                 post = false;
-                std::cout << "Not pusting " << ip_data[i].vtype << std::endl;
+                std::cout << "Not posting " << ip_data[i].vtype << std::endl;
             }
             if (post)
                 postEventsToWrapper(ad);

--- a/src/synthesis/filter.h
+++ b/src/synthesis/filter.h
@@ -56,7 +56,7 @@ class filter
                                 float pitch)
     {
     }
-    // filters are required to be able to process stereo blocks if stereo is true in the contructor
+    // filters are required to be able to process stereo blocks if stereo is true in the constructor
     virtual void suspend() {}
     virtual int tail_length() { return 1000; }
 

--- a/src/vembertech/vt_dsp/lattice.cpp
+++ b/src/vembertech/vt_dsp/lattice.cpp
@@ -15,13 +15,6 @@
 ** open source in December 2020.
 */
 
-#if defined(__aarch64__)
-#define SIMDE_ENABLE_NATIVE_ALIASES
-#include "simde/x86/sse2.h"
-
-#else
-#include <emmintrin.h>
-#endif
 #include <cmath>
 #include "lattice.h"
 #include "basic_dsp.h"

--- a/src/vembertech/vt_dsp/lattice.h
+++ b/src/vembertech/vt_dsp/lattice.h
@@ -15,6 +15,14 @@
 ** open source in December 2020.
 */
 
+#if defined(__aarch64__)
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#include "simde/x86/sse2.h"
+
+#else
+#include <emmintrin.h>
+#endif
+
 struct lattice_sd
 {
     struct

--- a/src/vembertech/vt_dsp/lipol.h
+++ b/src/vembertech/vt_dsp/lipol.h
@@ -74,7 +74,7 @@ class alignas(16) lipol_ps
     void subtract_block(float *src, unsigned int nquads);
     void trixpan_blocks(float *L, float *R, float *dL, float *dR,
                         unsigned int nquads); // panning that always lets both channels through
-                                              // unattenuated (seperate hard-panning)
+                                              // unattenuated (separate hard-panning)
     void multiply_block_to(float *src, float *dst, unsigned int nquads);
     void multiply_2_blocks(float *src1, float *src2, unsigned int nquads);
     void multiply_2_blocks_to(float *src1, float *src2, float *dst1, float *dst2,

--- a/wrappers/juce/data/ParameterProxy.h
+++ b/wrappers/juce/data/ParameterProxy.h
@@ -18,13 +18,16 @@
 #ifndef SHORTCIRCUIT_PARAMETERPROXY_H
 #define SHORTCIRCUIT_PARAMETERPROXY_H
 
+#include <algorithm>
 #include <fmt/core.h>
 
 #include "configuration.h"
+#include "juce_core/juce_core.h"
 #include "sampler_wrapper_actiondata.h"
 #include "wrapper_msg_to_string.h"
 #include "data/BasicTypes.h"
 #include <cmath>
+#include <set>
 
 namespace scxt
 {
@@ -393,7 +396,7 @@ template <>
 inline void ParameterProxy<float, vga_steplfo_data_single>::sendValue(const float &value,
                                                                       ActionSender *s)
 {
-    // This shuld never be called; because of the message layout the message is generated
+    // This should never be called; because of the message layout the message is generated
     // specially in the ZonePage
     std::terminate();
 }

--- a/wrappers/juce/data/UIStateProxy.h
+++ b/wrappers/juce/data/UIStateProxy.h
@@ -20,6 +20,7 @@
 
 #include "sampler_wrapper_actiondata.h"
 #include "data/BasicTypes.h"
+#include <unordered_set>
 
 namespace scxt
 {
@@ -28,8 +29,8 @@ namespace data
 
 /*
  * The UIStateProxy is a class which handles messages and keeps an appropriate state.
- * Components can render it for bulk action. For instance there woudl be a ZoneMapProxy
- * and so on. Each UIStateProxy registerred with the editor gets all the messages.
+ * Components can render it for bulk action. For instance there would be a ZoneMapProxy
+ * and so on. Each UIStateProxy registered with the editor gets all the messages.
  */
 class UIStateProxy
 {


### PR DESCRIPTION
- to silence linter warnings in the editor
- turn compile commands exporting on in cmake
- remove remaining py wrapper traces
- typos