### PR TITLE
Use clang-format-12 in pipeline

### DIFF
--- a/cmake/code-quality.cmake
+++ b/cmake/code-quality.cmake
@@ -12,6 +12,6 @@ endforeach ()
 add_custom_command(TARGET code-quality-pipeline-checks
         POST_BUILD
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        COMMAND ${CMAKE_COMMAND} -E echo About to check clang-format
-        COMMAND git ls-files -- ${CLANG_FORMAT_GLOBS} | xargs clang-format --dry-run --Werror
+        COMMAND ${CMAKE_COMMAND} -E echo About to check clang-format using clang-format-12
+        COMMAND git ls-files -- ${CLANG_FORMAT_GLOBS} | xargs clang-format-12 --dry-run --Werror
         )

--- a/src/generator.cpp
+++ b/src/generator.cpp
@@ -429,7 +429,9 @@ store:
             {
                 Direction = -1;
             }
+            // clang-format off
             else if (SamplePos <= LowerBound) { Direction = 1; }
+            // clang-format on
             SamplePos = limit_range(SamplePos, 0, WaveSize);
         }
         break;


### PR DESCRIPTION
and disable where it breaks with 14
to allow for correct formating on a wider variety of systems