### PR TITLE
Move Lo-FI / BF to placement new

### DIFF
--- a/src/synthesis/filter_defs.h
+++ b/src/synthesis/filter_defs.h
@@ -636,7 +636,7 @@ class alignas(16) BF : public filter
     // Switch to a placement-new strategy here first
     LP2B *lp{nullptr};
     static constexpr size_t lps{sizeof(LP2B)};
-    uint8_t lpMemory alignas(16) [lps];
+    uint8_t lpMemory alignas(16)[lps];
     static_assert(lps < 4096); // just in case someone changes the base class to blow out mem
 };
 

--- a/src/synthesis/filter_defs.h
+++ b/src/synthesis/filter_defs.h
@@ -632,7 +632,12 @@ class alignas(16) BF : public filter
 
   protected:
     float time[2], level[2], postslew[2], lp_params[6];
-    LP2B *lp;
+
+    // Switch to a placement-new strategy here first
+    LP2B *lp{nullptr};
+    static constexpr size_t lps{sizeof(LP2B)};
+    uint8_t lpMemory alignas(16) [lps];
+    static_assert(lps < 4096); // just in case someone changes the base class to blow out mem
 };
 
 //-------------------------------------------------------------------------------------------------------

--- a/src/synthesis/filters_destruction.cpp
+++ b/src/synthesis/filters_destruction.cpp
@@ -24,6 +24,8 @@
 #include <cmath>
 #include <cstring>
 #include <math.h>
+#include <iostream>
+
 using std::max;
 using std::min;
 
@@ -66,24 +68,14 @@ BF::BF(float *fp) : filter(fp)
         lp_params[0] = fp[3];
         lp_params[1] = fp[4];
     }
-    // lp = new LP2B(lp_params);
-#if MAC
-    lp = (LP2B *)malloc(sizeof(LP2B));
-#else
-#if WIN
-    lp = (LP2B *)_aligned_malloc(sizeof(LP2B), 16);
-#else
-    lp = (LP2B *)std::aligned_alloc(16, sizeof(LP2B));
-#endif
-#endif
 
-    new (lp) LP2B(lp_params);
+    lp = new (lpMemory) LP2B(lp_params);
 }
 
 BF::~BF()
 {
-    // delete lp;
-    free(lp);
+    if (lp)
+        lp->~LP2B(); // call the destructor explicitly since I am placement newed
 }
 
 void BF::init_params()


### PR DESCRIPTION
MOve Lo-FI/BF to placement new for internal filter allocation. This also happens to solve the unaligned free which caused a crash on windows so closes #311 but is really the first step on the path to #298