### PR TITLE
Day 20: Processors, ControlModes and C++ Macros

### DIFF
--- a/src-ui/CMakeLists.txt
+++ b/src-ui/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(${PROJECT_NAME} STATIC
         components/multi/ModPane.cpp
         components/multi/OutputPane.cpp
         components/multi/PartGroupSidebar.cpp
+        components/multi/ProcessorPane.cpp
 
         connectors/SCXTStyleSheetCreator.cpp
 

--- a/src-ui/components/MultiScreen.cpp
+++ b/src-ui/components/MultiScreen.cpp
@@ -31,6 +31,7 @@
 #include "multi/MappingPane.h"
 #include "multi/ModPane.h"
 #include "multi/OutputPane.h"
+#include "multi/ProcessorPane.h"
 #include "multi/PartGroupSidebar.h"
 
 namespace scxt::ui
@@ -75,11 +76,10 @@ MultiScreen::MultiScreen(SCXTEditor *e) : HasEditor(e)
 
     for (int i = 0; i < 4; ++i)
     {
-        auto ff = std::make_unique<DebugRect>(juce::Colour(i * 60, 255, (4 - i) * 60),
-                                            "FX " + std::to_string(i));
+        auto ff = std::make_unique<multi::ProcessorPane>(editor, i);
         ff->hasHamburger = true;
-        fx[i] = std::move(ff);
-        addAndMakeVisible(*(fx[i]));
+        processors[i] = std::move(ff);
+        addAndMakeVisible(*(processors[i]));
     }
     mod = std::make_unique<multi::ModPane>(editor);
     addAndMakeVisible(*mod);
@@ -114,7 +114,7 @@ void MultiScreen::layout()
     auto tfr = fxRect.withWidth(fw);
     for (int i = 0; i < 4; ++i)
     {
-        fx[i]->setBounds(tfr);
+        processors[i]->setBounds(tfr);
         tfr.translate(fw, 0);
     }
 

--- a/src-ui/components/MultiScreen.h
+++ b/src-ui/components/MultiScreen.h
@@ -39,6 +39,7 @@ namespace multi
 struct AdsrPane;
 struct PartGroupSidebar;
 struct MappingPane;
+struct ProcessorPane;
 } // namespace multi
 
 struct MultiScreen : juce::Component, HasEditor
@@ -49,10 +50,11 @@ struct MultiScreen : juce::Component, HasEditor
     static constexpr int envHeight = 160, modHeight = 160, fxHeight = 176;
     static constexpr int pad = 0;
 
-    std::unique_ptr<juce::Component> browser, fx[4], mod, mix, lfo;
+    std::unique_ptr<juce::Component> browser, mod, mix, lfo;
     std::unique_ptr<multi::MappingPane> sample;
     std::unique_ptr<multi::PartGroupSidebar> parts;
     std::unique_ptr<multi::AdsrPane> eg[2];
+    std::unique_ptr<multi::ProcessorPane> processors[4];
     MultiScreen(SCXTEditor *e);
     ~MultiScreen();
     void resized() override { layout(); }

--- a/src-ui/components/SCXTEditor.cpp
+++ b/src-ui/components/SCXTEditor.cpp
@@ -169,7 +169,7 @@ void SCXTEditor::filesDropped(const juce::StringArray &files, int, int)
 {
     assert(files.size() == 1);
     namespace cmsg = scxt::messaging::client;
-    cmsg::clientSendToSerialization(cmsg::AddSample(fs::path{(const char *)(files[0].toUTF8())}),
+    cmsg::clientSendToSerialization(cmsg::AddSample(std::string{(const char *)(files[0].toUTF8())}),
                                     msgCont);
 }
 

--- a/src-ui/components/SCXTEditor.h
+++ b/src-ui/components/SCXTEditor.h
@@ -34,6 +34,7 @@
 #include "sst/jucegui/components/HSlider.h"
 #include "datamodel/adsr_storage.h"
 #include "sst/jucegui/components/WindowPanel.h"
+#include "messaging/client/zone_messages.h"
 
 namespace scxt::ui
 {
@@ -93,9 +94,15 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::FileDragAndDrop
 
     // Serialization to Client Messages
     void onVoiceCount(const uint32_t &v);
-    void onEnvelopeUpdated(const int &which, const bool &active, const datamodel::AdsrStorage &);
-    void onMappingUpdated(const bool &active, const engine::Zone::ZoneMappingData &);
+    void onEnvelopeUpdated(const scxt::messaging::client::adsrViewResponsePayload_t &);
+    void onMappingUpdated(const scxt::messaging::client::mappingSelectedZoneViewResposne_t &);
     void onStructureUpdated(const engine::Engine::pgzStructure_t &);
+
+    std::vector<dsp::processor::ProcessorDescription> allProcessors;
+    void onAllProcessorDescriptions(const std::vector<dsp::processor::ProcessorDescription> &v)
+    {
+        allProcessors = v;
+    }
 
     // Originate client to serialization messages
     void singleSelectItem(const selection::SelectionManager::ZoneAddress &);

--- a/src-ui/components/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/components/SCXTEditorResponseHandlers.cpp
@@ -40,13 +40,14 @@ void SCXTEditor::onVoiceCount(const uint32_t &v)
         headerRegion->setVoiceCount(v);
 }
 
-void SCXTEditor::onEnvelopeUpdated(const int &which, const bool &active,
-                                   const datamodel::AdsrStorage &v)
+void SCXTEditor::onEnvelopeUpdated(
+    const scxt::messaging::client::adsrViewResponsePayload_t &payload)
 {
+    const auto &[which, active, env] = payload;
     if (active)
     {
         // TODO - do I want a multiScreen->onEnvelopeUpdated or just
-        multiScreen->eg[which]->adsrChangedFromModel(v);
+        multiScreen->eg[which]->adsrChangedFromModel(env);
     }
     else
     {
@@ -54,8 +55,9 @@ void SCXTEditor::onEnvelopeUpdated(const int &which, const bool &active,
     }
 }
 
-void SCXTEditor::onMappingUpdated(const bool &active, const engine::Zone::ZoneMappingData &m)
+void SCXTEditor::onMappingUpdated(const scxt::messaging::client::mappingSelectedZoneViewResposne_t &payload)
 {
+    const auto &[active, m] = payload;
     if (active)
     {
         multiScreen->sample->setMappingData(m);

--- a/src-ui/components/multi/AdsrPane.cpp
+++ b/src-ui/components/multi/AdsrPane.cpp
@@ -65,19 +65,19 @@ AdsrPane::AdsrPane(SCXTEditor *e, int index)
     };
 
     attachSlider(
-        Ctrl::A, "Attack", "A", datamodel::AdsrStorage::ahdrDescription,
-        [](const auto &pl) { return pl.a; }, adsrView.a);
+        Ctrl::A, "Attack", "A", datamodel::AdsrStorage::cdAHDR, [](const auto &pl) { return pl.a; },
+        adsrView.a);
     attachSlider(
-        Ctrl::H, "Hold", "H", datamodel::AdsrStorage::sDescription,
-        [](const auto &pl) { return pl.h; }, adsrView.h);
+        Ctrl::H, "Hold", "H", datamodel::AdsrStorage::cdS, [](const auto &pl) { return pl.h; },
+        adsrView.h);
     attachSlider(
-        Ctrl::D, "Decay", "D", datamodel::AdsrStorage::ahdrDescription,
-        [](const auto &pl) { return pl.d; }, adsrView.d);
+        Ctrl::D, "Decay", "D", datamodel::AdsrStorage::cdAHDR, [](const auto &pl) { return pl.d; },
+        adsrView.d);
     attachSlider(
-        Ctrl::S, "Sustain", "S", datamodel::AdsrStorage::sDescription,
-        [](const auto &pl) { return pl.s; }, adsrView.s);
+        Ctrl::S, "Sustain", "S", datamodel::AdsrStorage::cdS, [](const auto &pl) { return pl.s; },
+        adsrView.s);
     attachSlider(
-        Ctrl::R, "Release", "R", datamodel::AdsrStorage::ahdrDescription,
+        Ctrl::R, "Release", "R", datamodel::AdsrStorage::cdAHDR,
         [](const auto &pl) { return pl.r; }, adsrView.r);
 
     auto attachKnob = [this](Ctrl c, const std::string &l, const auto &d, const auto &fn,
@@ -98,13 +98,13 @@ AdsrPane::AdsrPane(SCXTEditor *e, int index)
     };
 
     attachKnob(
-        Ctrl::Ash, "A Shape", datamodel::AdsrStorage::shapeDescription,
+        Ctrl::Ash, "A Shape", datamodel::AdsrStorage::cdShape,
         [](const auto &pl) { return pl.aShape; }, adsrView.aShape);
     attachKnob(
-        Ctrl::Dsh, "D Shape", datamodel::AdsrStorage::shapeDescription,
+        Ctrl::Dsh, "D Shape", datamodel::AdsrStorage::cdShape,
         [](const auto &pl) { return pl.dShape; }, adsrView.dShape);
     attachKnob(
-        Ctrl::Rsh, "R Shape", datamodel::AdsrStorage::shapeDescription,
+        Ctrl::Rsh, "R Shape", datamodel::AdsrStorage::cdShape,
         [](const auto &pl) { return pl.rShape; }, adsrView.rShape);
 
     cmsg::clientSendToSerialization(cmsg::AdsrSelectedZoneView(index), e->msgCont);
@@ -136,7 +136,7 @@ void AdsrPane::updateTooltip(const attachment_t &at)
 void AdsrPane::adsrChangedFromGui(const attachment_t &at)
 {
     updateTooltip(at);
-    cmsg::clientSendToSerialization(cmsg::AdsrSelectedZoneUpdateRequest(index, adsrView),
+    cmsg::clientSendToSerialization(cmsg::AdsrSelectedZoneUpdateRequest({index, adsrView}),
                                     editor->msgCont);
 }
 

--- a/src-ui/components/multi/MappingPane.cpp
+++ b/src-ui/components/multi/MappingPane.cpp
@@ -67,15 +67,11 @@ struct MappingDisplay : juce::Component, HasEditor
         };
 
         attachEditor(
-            Ctrl::KeyStart, "Key Start",
-            datamodel::ControlDescription{datamodel::ControlDescription::INT,
-                                          datamodel::ControlDescription::LINEAR, 0, 1, 127},
+            Ctrl::KeyStart, "Key Start", datamodel::cdMidiNote,
             [](const auto &pl) { return pl.keyboardRange.keyStart; },
             mappingView.keyboardRange.keyStart);
         attachEditor(
-            Ctrl::KeyEnd, "Key Ed",
-            datamodel::ControlDescription{datamodel::ControlDescription::INT,
-                                          datamodel::ControlDescription::LINEAR, 0, 1, 127},
+            Ctrl::KeyEnd, "Key Ed", datamodel::cdMidiNote,
             [](const auto &pl) { return pl.keyboardRange.keyEnd; },
             mappingView.keyboardRange.keyEnd);
     }
@@ -97,7 +93,8 @@ struct MappingDisplay : juce::Component, HasEditor
         textEds[KeyEnd]->setBounds(r);
     }
 
-    void mappingChangedFromGUI(const zone_attachment_t &at) {
+    void mappingChangedFromGUI(const zone_attachment_t &at)
+    {
         cmsg::clientSendToSerialization(cmsg::MappingSelectedZoneUpdateRequest(mappingView),
                                         editor->msgCont);
     }

--- a/src-ui/components/multi/ProcessorPane.cpp
+++ b/src-ui/components/multi/ProcessorPane.cpp
@@ -1,0 +1,77 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2023, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "ProcessorPane.h"
+#include "components/SCXTEditor.h"
+
+#include "messaging/client/client_serial.h"
+#include "messaging/client/client_messages.h"
+#include "connectors/SCXTStyleSheetCreator.h"
+#include "sst/jucegui/components/Label.h"
+
+namespace scxt::ui::multi
+{
+namespace cmsg = scxt::messaging::client;
+
+ProcessorPane::ProcessorPane(SCXTEditor *e, int index)
+    : HasEditor(e), sst::jucegui::components::NamedPanel("PROCESSOR " + std::to_string(index + 1)),
+      index(index)
+{
+    hasHamburger = true;
+    // cmsg::clientSendToSerialization(cmsg::AdsrSelectedZoneView(index), e->msgCont);
+
+    onHamburger = [safeThis = juce::Component::SafePointer(this)]() {
+        if (safeThis)
+            safeThis->showHamburgerMenu();
+    };
+}
+
+void ProcessorPane::updateTooltip(const attachment_t &at)
+{
+    editor->setTooltipContents(at.label + " = " + at.description.valueToString(at.value));
+}
+
+void ProcessorPane::resized()
+{
+    auto r = getContentArea();
+}
+
+void ProcessorPane::showHamburgerMenu()
+{
+    juce::PopupMenu p;
+    p.addSectionHeader("Processors");
+    for (const auto &pd: editor->allProcessors)
+    {
+        p.addItem(pd.displayName, [idx = pd.id]() {
+            std::cout << "Would Load " << idx << std::endl;
+        });
+    }
+
+    p.showMenuAsync(juce::PopupMenu::Options());
+}
+
+} // namespace scxt::ui::multi

--- a/src-ui/components/multi/ProcessorPane.h
+++ b/src-ui/components/multi/ProcessorPane.h
@@ -25,37 +25,36 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#include <cassert>
-#include "sample_manager.h"
+#ifndef SHORTCIRCUIT_PROCESSORPANE_H
+#define SHORTCIRCUIT_PROCESSORPANE_H
 
+#include <unordered_map>
+#include <juce_gui_basics/juce_gui_basics.h>
+#include "sst/jucegui/components/NamedPanel.h"
+#include "sst/jucegui/components/VSlider.h"
+#include "sst/jucegui/components/Knob.h"
+#include "sst/jucegui/data/Continuous.h"
+#include "dsp/processor/processor.h"
+#include "components/HasEditor.h"
+#include "connectors/PayloadDataAttachment.h"
 
-namespace scxt::sample
+namespace scxt::ui::multi
 {
-std::optional<SampleID> SampleManager::loadSampleByPath(const fs::path &p)
+struct ProcessorPane : sst::jucegui::components::NamedPanel, HasEditor
 {
-    return loadSampleByPathToID(p, SampleID::next());
-}
+    // ToDo: shapes of course
+    typedef connectors::PayloadDataAttachment<ProcessorPane, dsp::processor::ProcessorStorage> attachment_t;
 
+    dsp::processor::ProcessorStorage processorView;
+    int index{0};
+    ProcessorPane(SCXTEditor *, int index);
 
-std::optional<SampleID> SampleManager::loadSampleByPathToID(const fs::path &p, const SampleID &id)
-{
-    assert(threadingChecker.isSerialThread());
-    SampleID::guaranteeNextAbove(id);
+    void resized() override;
 
-    for (const auto &[id, sm] : samples)
-    {
-        if (sm->getPath() == p)
-        {
-            return id;
-        }
-    }
+    void updateTooltip(const attachment_t &);
 
-    auto sp = std::make_shared<Sample>(id);
+    void showHamburgerMenu();
+};
+} // namespace scxt::ui::multi
 
-    if (!sp->load(p))
-        return {};
-
-    samples[sp->id] = sp;
-    return sp->id;
-}
-} // namespace scxt::sample
+#endif // SHORTCIRCUIT_ADSRPANE_H

--- a/src/Sprints.md
+++ b/src/Sprints.md
@@ -2,6 +2,13 @@
 
 Week of Feb 21:
 - Then: Processor views
+  - Plan of Attack
+  - Have default be 'none'
+  - if you select one grab the meta data in request one and set the type
+  - Do the filter storage trick the same way we did adsr etc with a generic editor
+  - move to custom editors by type
+  - document how to do the DSP side and the UI side
+  - Set the world on porting
 - Then: Mod Matrix
 - ReallY: Can ADSR and Mapping message be more share-y with tempaltes?
 - Then: Add a zone by sample revisit
@@ -57,6 +64,20 @@ Open Questions and ToDos and Reviews:
 
 ----------
 Sprint Log I posted on Discord
+
+## Day 20 (2023-02-22 for a smidge then a smidge more on the 23)
+
+Start with some evening cleanup removing the old unused ControlMode enum as
+part of my approach to cleaning up ControlDescriptions and making Processors work.
+Then look at those message types and realize its enough of a pattern to introduce a
+few helper macros; so rewrite the messaging to use those and reduce the code enormously.
+
+With these newfound bits and bobs, start cracking on processors. Begin by
+creating the list of implemetned processors and sending it to the UI on 
+registration. This let me make the hamburger menu on processors which is
+the start of the processor round-trip (which is kinda like a dynamic version
+of the ADSR round trip). But then I ran out of steam, so processors tomorrow.
+
 
 ## Day 19 (2023-02-21 for a smidge then really the 22)
 

--- a/src/datamodel/adsr_storage.h
+++ b/src/datamodel/adsr_storage.h
@@ -45,21 +45,8 @@ struct AdsrStorage
     // TODO: What are these going to be when they grow up?
     float aShape{0}, dShape{0}, rShape{0};
 
-    static constexpr ControlDescription ahdrDescription{
-        ControlDescription::FLOAT,
-        ControlDescription::TWO_TO_THE_X,
-        0,
-        0.01,
-        1,
-        0.5,
-        "seconds",
-        sst::basic_blocks::modulators::ThirtyTwoSecondRange::etMax -
-            sst::basic_blocks::modulators::ThirtyTwoSecondRange::etMin,
-        sst::basic_blocks::modulators::ThirtyTwoSecondRange::etMin},
-        sDescription{
-            ControlDescription::FLOAT, ControlDescription::LINEAR, 0, 0.01, 1, 0.5, "percent"},
-        shapeDescription{
-            ControlDescription::FLOAT, ControlDescription::LINEAR, -1, 0.01, 1, 0.0, "percent"};
+    static constexpr ControlDescription cdAHDR{cdEnvelopeThirtyTwo}, cdS{cdPercent},
+        cdShape{cdPercentBipolar};
 
     auto asTuple() const { return std::tie(a, d, s, r, isDigital, aShape, dShape, rShape); }
     bool operator==(const AdsrStorage &other) const { return asTuple() == other.asTuple(); }

--- a/src/datamodel/parameter.cpp
+++ b/src/datamodel/parameter.cpp
@@ -1,6 +1,29 @@
-//
-// Created by Paul Walker on 2/22/23.
-//
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2023, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
 
 #include "parameter.h"
 #include <cmath>

--- a/src/datamodel/parameter.cpp
+++ b/src/datamodel/parameter.cpp
@@ -28,6 +28,7 @@
 #include "parameter.h"
 #include <cmath>
 #include <cassert>
+#include <algorithm>
 #include <fmt/core.h>
 
 namespace scxt::datamodel

--- a/src/datamodel/parameter.h
+++ b/src/datamodel/parameter.h
@@ -31,53 +31,10 @@
 #include <string>
 #include <optional>
 
+#include "sst/basic-blocks/modulators/ADSREnvelope.h"
+
 namespace scxt::datamodel
 {
-
-// TODO: Do we need this if we have robust descriptions? I think "no"
-enum ControlMode
-{
-    cm_none = 0,
-    cm_integer,
-    cm_notename,
-    cm_float,
-    cm_percent,
-    cm_percent_bipolar,
-    cm_decibel,
-    cm_decibel_squared,
-    cm_envelopetime,
-    cm_lforate,
-    cm_midichannel,
-    cm_mutegroup,
-    cm_lag,
-    cm_frequency20_20k,
-    cm_frequency50_50k,
-    cm_bitdepth_16,
-    cm_frequency0_2k,
-    cm_decibelboost12,
-    cm_octaves3,
-    cm_frequency1hz,
-    cm_time1s,
-    cm_frequency_audible,
-    cm_frequency_samplerate,
-    cm_frequency_khz,
-    cm_frequency_khz_bi,
-    cm_frequency_hz_bi,
-    cm_eq_bandwidth,
-    cm_stereowidth,
-    cm_mod_decibel,
-    cm_mod_pitch,
-    cm_mod_freq,
-    cm_mod_percent,
-    cm_mod_time,
-    cm_polyphony,
-    cm_envshape,
-    cm_osccount,
-    cm_count4,
-    cm_noyes,
-    cm_temposync,
-    cm_int_menu,
-};
 
 struct ControlDescription
 {
@@ -91,6 +48,7 @@ struct ControlDescription
         LINEAR,       // mapScale * value + mapBase
         TWO_TO_THE_X, // 2 ^ (mapScale * value + mapBase)
         FREQUENCY,    // 261.5etc * 2 ^ (mapScale * value + mapBase) / 12
+        MIDI_NOTE,
         DECIBEL
     } displayMode{LINEAR};
     float min{0};
@@ -104,6 +62,26 @@ struct ControlDescription
     std::string valueToString(float value) const;
     std::optional<float> stringToValue(const std::string &s) const;
 };
+
+/*
+ * We have commonly used instances here
+ */
+static constexpr ControlDescription cdPercent{
+    ControlDescription::FLOAT, ControlDescription::LINEAR, 0, 0.01, 1, 0, "%", 100.0},
+    cdPercentBipolar{
+        ControlDescription::FLOAT, ControlDescription::LINEAR, -1, 0.01, 1, 0, "%", 100.0},
+    cdMidiNote{ControlDescription::INT, ControlDescription::MIDI_NOTE, 0, 1, 127, 60, "note"},
+    cdEnvelopeThirtyTwo{ControlDescription::FLOAT,
+                        ControlDescription::TWO_TO_THE_X,
+                        0,
+                        0.01,
+                        1,
+                        0.5,
+                        "seconds",
+                        sst::basic_blocks::modulators::ThirtyTwoSecondRange::etMax -
+                            sst::basic_blocks::modulators::ThirtyTwoSecondRange::etMin,
+                        sst::basic_blocks::modulators::ThirtyTwoSecondRange::etMin};
+
 } // namespace scxt::datamodel
 
 #endif // __SCXT_PARAMETER_H

--- a/src/dsp/processor/processor.cpp
+++ b/src/dsp/processor/processor.cpp
@@ -72,7 +72,7 @@ template <size_t I> bool implIsProcessorImplemented()
     if constexpr (I == ProcessorType::proct_none)
         return true;
 
-    return std::is_same<typename ProcessorImplementor<(ProcessorType)I>::T, unimpl_t>::value;
+    return !std::is_same<typename ProcessorImplementor<(ProcessorType)I>::T, unimpl_t>::value;
 }
 
 template <size_t... Is> auto isProcessorImplemented(size_t ft, std::index_sequence<Is...>)
@@ -135,7 +135,7 @@ template <size_t... Is> auto isFXProcessor(size_t ft, std::index_sequence<Is...>
 template <size_t I> const char *implGetProcessorName()
 {
     if constexpr (I == ProcessorType::proct_none)
-        return "none";
+        return "Off";
 
     if constexpr (std::is_same<typename ProcessorImplementor<(ProcessorType)I>::T, unimpl_t>::value)
         return "error";
@@ -242,6 +242,23 @@ std::optional<ProcessorType> fromProcessorStreamingName(const std::string &s)
             return (ProcessorType)i;
     }
     return {};
+}
+
+processorList_t getAllProcessorDescriptions()
+{
+    processorList_t res;
+    for (auto i = 0U; i < (size_t)ProcessorType::proct_num_types; ++i)
+    {
+        auto pt = (ProcessorType)i;
+        if (isProcessorImplemented(pt))
+        {
+            res.push_back({pt,
+                             getProcessorStreamingName(pt), getProcessorName(pt),
+                             isZoneProcessor(pt), isPartProcessor(pt), isFXProcessor(pt)}
+                             );
+        }
+    }
+    return res;
 }
 
 /**

--- a/src/dsp/processor/processor.h
+++ b/src/dsp/processor/processor.h
@@ -31,6 +31,8 @@
 #include <cstdint>
 #include <array>
 #include <optional>
+#include <vector>
+#include <utility>
 #include "datamodel/parameter.h"
 #include "utils.h"
 
@@ -99,6 +101,16 @@ bool isFXProcessor(ProcessorType id);
 const char *getProcessorName(ProcessorType id);
 const char *getProcessorStreamingName(ProcessorType id);
 std::optional<ProcessorType> fromProcessorStreamingName(const std::string &s);
+
+struct ProcessorDescription
+{
+    ProcessorType id;
+    std::string streamingName{"ERROR"}, displayName{"ERROR"};
+    bool isZone{false}, isPart{false}, isFX{false};
+};
+
+typedef std::vector<ProcessorDescription> processorList_t;
+processorList_t getAllProcessorDescriptions();
 
 /**
  * If you choose to spawnProcessorOnto you need a block at least this size.
@@ -176,7 +188,6 @@ struct Processor : MoveableOnly<Processor>, SampleRateSupport
     float lastparam[maxProcessorFloatParams];
     int lastiparam[maxProcessorIntParams];
     int parameter_count{0};
-    datamodel::ControlMode ctrlmode[maxProcessorFloatParams];
     char ctrllabel[maxProcessorFloatParams][processorLabelSize];
     datamodel::ControlDescription ctrlmode_desc[maxProcessorFloatParams];
     bool is_stereo{true};

--- a/src/dsp/processor/processor_oscillators.cpp
+++ b/src/dsp/processor/processor_oscillators.cpp
@@ -46,15 +46,12 @@ OscPulseSync::OscPulseSync(float *fp, int32_t *ip, bool stereo)
     parameter_count = 3;
 
     setStr(ctrllabel[0], "tune");
-    ctrlmode[0] = datamodel::cm_mod_pitch;
     ctrlmode_desc[0] = cdMPitch;
 
     setStr(ctrllabel[1], "width");
-    ctrlmode[1] = datamodel::cm_percent;
     ctrlmode_desc[1] = cdPercentDef;
 
     setStr(ctrllabel[2], "sync");
-    ctrlmode[2] = datamodel::cm_mod_pitch;
     ctrlmode_desc[2] = scxt::datamodel::ControlDescription{datamodel::ControlDescription::FLOAT, datamodel::ControlDescription::LINEAR, 0, 0.05, 96, 0, "semitones"};
 
     first_run = true;

--- a/src/dsp/processor/processor_supersvf.cpp
+++ b/src/dsp/processor/processor_supersvf.cpp
@@ -56,9 +56,7 @@ SuperSVF::SuperSVF(float *fp, int *ip, bool stereo)
 {
     parameter_count = 2;
     setStr(ctrllabel[0], ("cutoff"));
-    ctrlmode[0] = datamodel::ControlMode::cm_frequency_audible;
     setStr(ctrllabel[1], ("resonance"));
-    ctrlmode[1] = datamodel::ControlMode::cm_percent;
 
     ctrlmode_desc[0] = cdFreqDef;
     ctrlmode_desc[1] = cdPercentDef;

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -302,5 +302,8 @@ void Engine::loadSampleIntoSelectedPartAndGroup(const fs::path &p)
 
 void Engine::sendMetadataToClient() const {
     // On register send metadata
+    messaging::client::serializationSendToClient(messaging::client::s2c_send_all_processor_descriptions,
+                                                 dsp::processor::getAllProcessorDescriptions(),
+                                                 *messageController);
 }
 } // namespace scxt::engine

--- a/src/json/dsp_traits.h
+++ b/src/json/dsp_traits.h
@@ -69,5 +69,33 @@ template <> struct scxt_traits<scxt::dsp::processor::ProcessorStorage>
         v.at("intParams").to(result.intParams);
     }
 };
+
+template <> struct scxt_traits<scxt::dsp::processor::ProcessorDescription>
+{
+    template <template <typename...> class Traits>
+    static void assign(tao::json::basic_value<Traits> &v,
+                       const scxt::dsp::processor::ProcessorDescription &t)
+    {
+        v = {
+            {"id", (int32_t)t.id},          {"streamingName", t.streamingName},
+            {"displayName", t.displayName}, {"isZone", t.isZone},
+            {"isPart", t.isZone},           {"isFX", t.isZone},
+        };
+    }
+
+    template <template <typename...> class Traits>
+    static void to(const tao::json::basic_value<Traits> &v,
+                   scxt::dsp::processor::ProcessorDescription &result)
+    {
+        int32_t tr;
+        v.at("id").to(tr);
+        result.id = (dsp::processor::ProcessorType)tr;
+        v.at("streamingName").to(result.streamingName);
+        v.at("displayName").to(result.displayName);
+        v.at("isZone").to(result.isZone);
+        v.at("isPart").to(result.isPart);
+        v.at("isFX").to(result.isFX);
+    }
+};
 } // namespace scxt::json
 #endif // SHORTCIRCUIT_DSP_TRAITS_H

--- a/src/messaging/client/client_macros.h
+++ b/src/messaging/client/client_macros.h
@@ -1,0 +1,99 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2023, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_MESSAGING_CLIENT_CLIENT_MACROS_H
+#define SCXT_SRC_MESSAGING_CLIENT_CLIENT_MACROS_H
+
+/*
+ * A set of macros useful for generating client messages more compactly
+ */
+
+#define CLIENT_TO_SERIAL(className, id, payloadType, executeBody)                                  \
+    struct className                                                                               \
+    {                                                                                              \
+        static constexpr ClientToSerializationMessagesIds c2s_id{id};                              \
+        typedef payloadType c2s_payload_t;                                                         \
+        c2s_payload_t payload{};                                                                   \
+        explicit className(const c2s_payload_t &v) : payload(v) {}                                 \
+        static void executeOnSerialization(const c2s_payload_t &payload, engine::Engine &engine,   \
+                                           MessageController &cont)                                \
+        {                                                                                          \
+            executeBody;                                                                           \
+        }                                                                                          \
+    };                                                                                             \
+    template <> struct ClientToSerializationType<className::c2s_id>                                \
+    {                                                                                              \
+        typedef className T;                                                                       \
+    };
+
+#define CLIENT_SERIAL_REQUEST_RESPONSE(className, c2id, c2payloadType, s2id, s2payloadType,        \
+                                       execSer, cliMethod)                                         \
+    struct className                                                                               \
+    {                                                                                              \
+        static constexpr ClientToSerializationMessagesIds c2s_id{c2id};                            \
+        static constexpr SerializationToClientMessageIds s2c_id{s2id};                             \
+        typedef c2payloadType c2s_payload_t;                                                       \
+        typedef s2payloadType s2c_payload_t;                                                       \
+        c2s_payload_t payload{};                                                                   \
+        explicit className(const c2s_payload_t &v) : payload(v) {}                                 \
+        static void executeOnSerialization(const c2s_payload_t &payload, engine::Engine &engine,   \
+                                           MessageController &cont)                                \
+        {                                                                                          \
+            execSer;                                                                               \
+        }                                                                                          \
+        template <typename Client>                                                                 \
+        static void executeOnClient(Client *c, const s2c_payload_t &payload)                       \
+        {                                                                                          \
+            c->cliMethod(payload);                                                                 \
+        }                                                                                          \
+    };                                                                                             \
+    template <> struct ClientToSerializationType<className::c2s_id>                                \
+    {                                                                                              \
+        typedef className T;                                                                       \
+    };                                                                                             \
+    template <> struct SerializationToClientType<className::s2c_id>                                \
+    {                                                                                              \
+        typedef className T;                                                                       \
+    };
+
+#define SERIAL_TO_CLIENT(className, s2id, s2payloadType, cliMethod)                                \
+    struct className                                                                               \
+    {                                                                                              \
+        static constexpr SerializationToClientMessageIds s2c_id{s2id};                             \
+        typedef s2payloadType s2c_payload_t;                                                       \
+        template <typename Client>                                                                 \
+        static void executeOnClient(Client *c, const s2c_payload_t &payload)                       \
+        {                                                                                          \
+            c->cliMethod(payload);                                                                 \
+        }                                                                                          \
+    };                                                                                             \
+    template <> struct SerializationToClientType<className::s2c_id>                                \
+    {                                                                                              \
+        typedef className T;                                                                       \
+    };
+
+#endif // SHORTCIRCUIT_CLIENT_MACROS_H

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -63,6 +63,7 @@ enum SerializationToClientMessageIds
     s2c_respond_zone_adsr_view,
     s2c_respond_zone_mapping,
     s2c_send_pgz_structure,
+    s2c_send_all_processor_descriptions,
 
     num_serializationToClientMessages
 };

--- a/src/messaging/client/enginestatus_messages.h
+++ b/src/messaging/client/enginestatus_messages.h
@@ -32,24 +32,11 @@
 #include "json/engine_traits.h"
 #include "json/datamodel_traits.h"
 #include "selection/selection_manager.h"
+#include "client_macros.h"
 
 namespace scxt::messaging::client
 {
-struct VoiceCountUpdate
-{
-    static constexpr SerializationToClientMessageIds s2c_id{s2c_voice_count};
-    typedef uint32_t s2c_payload_t;
-    template <typename Client> static void executeOnClient(Client *c, const s2c_payload_t &payload)
-    {
-        c->onVoiceCount(payload);
-    }
-};
-
-template <> struct SerializationToClientType<VoiceCountUpdate::s2c_id>
-{
-    typedef VoiceCountUpdate T;
-};
-
+SERIAL_TO_CLIENT(VoiceCountUpdate, s2c_voice_count, uint32_t, onVoiceCount);
 } // namespace scxt::messaging::client
 
 #endif // SHORTCIRCUIT_ENGINESTATUS_MESSAGES_H

--- a/src/messaging/client/selection_messages.h
+++ b/src/messaging/client/selection_messages.h
@@ -28,29 +28,17 @@
 #ifndef SCXT_SRC_MESSAGING_CLIENT_SELECTION_MESSAGES_H
 #define SCXT_SRC_MESSAGING_CLIENT_SELECTION_MESSAGES_H
 
+#include "client_macros.h"
 #include "selection/selection_manager.h"
 
 namespace scxt::messaging::client
 {
-struct SingleSelectAddress
+inline void singleSelectAddress(const selection::SelectionManager::ZoneAddress &za,
+                                const engine::Engine &engine)
 {
-    static constexpr ClientToSerializationMessagesIds c2s_id{c2s_single_select_address};
-    typedef selection::SelectionManager::ZoneAddress
-        c2s_payload_t; // the part number, or -1 for all parts
-    c2s_payload_t payload{-1, -1, -1};
-
-    SingleSelectAddress(const c2s_payload_t &p) : payload(p) {}
-
-    static void executeOnSerialization(const c2s_payload_t &which, const engine::Engine &engine,
-                                       MessageController &cont)
-    {
-        engine.getSelectionManager()->singleSelect(which);
-    }
-};
-
-template <> struct ClientToSerializationType<SingleSelectAddress::c2s_id>
-{
-    typedef SingleSelectAddress T;
-};
+    engine.getSelectionManager()->singleSelect(za);
+}
+CLIENT_TO_SERIAL(SingleSelectAddress, c2s_single_select_address,
+                 selection::SelectionManager::ZoneAddress, singleSelectAddress(payload, engine));
 } // namespace scxt::messaging::client
 #endif // SHORTCIRCUIT_SELECTION_MESSAGES_H

--- a/src/messaging/client/zone_messages.h
+++ b/src/messaging/client/zone_messages.h
@@ -35,180 +35,102 @@
 
 namespace scxt::messaging::client
 {
-
-struct AdsrSelectedZoneView
+typedef std::tuple<int, bool, datamodel::AdsrStorage> adsrViewResponsePayload_t;
+inline void adsrSelectedViewResponse(const int &which, const engine::Engine &engine,
+                                     MessageController &cont)
 {
-    static constexpr ClientToSerializationMessagesIds c2s_id{c2s_request_zone_adsr_view};
-    static constexpr SerializationToClientMessageIds s2c_id{s2c_respond_zone_adsr_view};
+    // TODO Selected Zone State
+    // const auto &selectedZone = engine.getPatch()->getPart(0)->getGroup(0)->getZone(0);
+    auto addr = engine.getSelectionManager()->getSelectedZone();
 
-    typedef int c2s_payload_t;
-    typedef std::tuple<int, bool, datamodel::AdsrStorage> s2c_payload_t;
-
-    c2s_payload_t payload;
-
-    AdsrSelectedZoneView(int whichEnv) : payload(whichEnv) {}
-
-    static void executeOnSerialization(const c2s_payload_t &which, const engine::Engine &engine,
-                                       MessageController &cont)
+    if (addr.has_value())
     {
-        // TODO Selected Zone State
-        // const auto &selectedZone = engine.getPatch()->getPart(0)->getGroup(0)->getZone(0);
-        auto addr = engine.getSelectionManager()->getSelectedZone();
-
-        if (addr.has_value())
-        {
-            const auto &selectedZone =
-                engine.getPatch()->getPart(addr->part)->getGroup(addr->group)->getZone(addr->zone);
-            if (which == 0)
-                serializationSendToClient(s2c_respond_zone_adsr_view,
-                                          s2c_payload_t{which, true, selectedZone->aegStorage},
-                                          cont);
-            if (which == 1)
-                serializationSendToClient(s2c_respond_zone_adsr_view,
-                                          s2c_payload_t{which, true, selectedZone->eg2Storage},
-                                          cont);
-        }
-        else
-        {
-            // It is a wee bit wasteful re-sending a default ADSR here but easier
-            // than two messages
-            serializationSendToClient(s2c_respond_zone_adsr_view, s2c_payload_t{which, false, {}},
-                                      cont);
-        }
+        const auto &selectedZone =
+            engine.getPatch()->getPart(addr->part)->getGroup(addr->group)->getZone(addr->zone);
+        if (which == 0)
+            serializationSendToClient(
+                s2c_respond_zone_adsr_view,
+                adsrViewResponsePayload_t{which, true, selectedZone->aegStorage}, cont);
+        if (which == 1)
+            serializationSendToClient(
+                s2c_respond_zone_adsr_view,
+                adsrViewResponsePayload_t{which, true, selectedZone->eg2Storage}, cont);
     }
-
-    template <typename Client> static void executeOnClient(Client *c, const s2c_payload_t &payload)
+    else
     {
-        const auto &[which, active, env] = payload;
-        c->onEnvelopeUpdated(which, active, env);
+        // It is a wee bit wasteful re-sending a default ADSR here but easier
+        // than two messages
+        serializationSendToClient(s2c_respond_zone_adsr_view,
+                                  adsrViewResponsePayload_t{which, false, {}}, cont);
     }
-};
+}
+CLIENT_SERIAL_REQUEST_RESPONSE(AdsrSelectedZoneView, c2s_request_zone_adsr_view, int,
+                               s2c_respond_zone_adsr_view, adsrViewResponsePayload_t,
+                               adsrSelectedViewResponse(payload, engine, cont), onEnvelopeUpdated);
 
-template <> struct ClientToSerializationType<AdsrSelectedZoneView::c2s_id>
+typedef std::tuple<int, datamodel::AdsrStorage> adsrSelectedZoneC2SPayload_t;
+inline void adsrSelectedZoneUpdate(const adsrSelectedZoneC2SPayload_t &payload,
+                                   const engine::Engine &engine, MessageController &cont)
 {
-    typedef AdsrSelectedZoneView T;
-};
-
-template <> struct SerializationToClientType<AdsrSelectedZoneView::s2c_id>
-{
-    typedef AdsrSelectedZoneView T;
-};
-
-struct AdsrSelectedZoneUpdateRequest
-{
-    static constexpr ClientToSerializationMessagesIds c2s_id{c2s_update_zone_adsr_view};
-    static constexpr bool hasC2SPayload{true};
-    typedef std::tuple<int, datamodel::AdsrStorage> c2s_payload_t;
-
-    c2s_payload_t payload;
-
-    AdsrSelectedZoneUpdateRequest(int whichEnv, const datamodel::AdsrStorage &a)
-        : payload{whichEnv, a}
+    // TODO Selected Zone State
+    const auto &[e, adsr] = payload;
+    auto sz = engine.getSelectionManager()->getSelectedZone();
+    if (sz.has_value())
     {
+        auto [ps, gs, zs] = *sz;
+        cont.scheduleAudioThreadCallback([p = ps, g = gs, z = zs, ew = e, adsrv = adsr](auto &eng) {
+            if (ew == 0)
+                eng.getPatch()->getPart(p)->getGroup(g)->getZone(z)->aegStorage = adsrv;
+            if (ew == 1)
+                eng.getPatch()->getPart(p)->getGroup(g)->getZone(z)->eg2Storage = adsrv;
+        });
     }
+}
+CLIENT_TO_SERIAL(AdsrSelectedZoneUpdateRequest, c2s_update_zone_adsr_view,
+                 adsrSelectedZoneC2SPayload_t, adsrSelectedZoneUpdate(payload, engine, cont));
 
-    static void executeOnSerialization(const c2s_payload_t &payload, const engine::Engine &engine,
-                                       MessageController &cont)
+typedef std::tuple<bool, engine::Zone::ZoneMappingData> mappingSelectedZoneViewResposne_t;
+inline void mappingSelectedZoneViewSerial(const engine::Engine &engine, MessageController(&cont))
+{
+    // TODO Selected Zone State
+    // const auto &selectedZone = engine.getPatch()->getPart(0)->getGroup(0)->getZone(0);
+    auto addr = engine.getSelectionManager()->getSelectedZone();
+
+    if (addr.has_value())
     {
-        // TODO Selected Zone State
-        const auto &[e, adsr] = payload;
-        auto sz = engine.getSelectionManager()->getSelectedZone();
-        if (sz.has_value())
-        {
-            auto [ps, gs, zs] = *sz;
-            cont.scheduleAudioThreadCallback(
-                [p = ps, g = gs, z = zs, ew = e, adsrv = adsr](auto &eng) {
-                    if (ew == 0)
-                        eng.getPatch()->getPart(p)->getGroup(g)->getZone(z)->aegStorage = adsrv;
-                    if (ew == 1)
-                        eng.getPatch()->getPart(p)->getGroup(g)->getZone(z)->eg2Storage = adsrv;
-                });
-        }
+        const auto &selectedZone =
+            engine.getPatch()->getPart(addr->part)->getGroup(addr->group)->getZone(addr->zone);
+        serializationSendToClient(s2c_respond_zone_mapping,
+                                  mappingSelectedZoneViewResposne_t{true, selectedZone->mapping},
+                                  cont);
     }
-};
-
-template <> struct ClientToSerializationType<AdsrSelectedZoneUpdateRequest::c2s_id>
-{
-    typedef AdsrSelectedZoneUpdateRequest T;
-};
-
-struct MappingSelectedZoneView
-{
-    static constexpr ClientToSerializationMessagesIds c2s_id{c2s_request_zone_mapping};
-    static constexpr SerializationToClientMessageIds s2c_id{s2c_respond_zone_mapping};
-
-    typedef uint8_t c2s_payload_t;
-    typedef std::tuple<bool, engine::Zone::ZoneMappingData> s2c_payload_t;
-
-    c2s_payload_t payload{0};
-
-    MappingSelectedZoneView() {}
-
-    static void executeOnSerialization(const c2s_payload_t &which, const engine::Engine &engine,
-                                       MessageController &cont)
+    else
     {
-        // TODO Selected Zone State
-        // const auto &selectedZone = engine.getPatch()->getPart(0)->getGroup(0)->getZone(0);
-        auto addr = engine.getSelectionManager()->getSelectedZone();
-
-        if (addr.has_value())
-        {
-            const auto &selectedZone =
-                engine.getPatch()->getPart(addr->part)->getGroup(addr->group)->getZone(addr->zone);
-            serializationSendToClient(s2c_id, s2c_payload_t{true, selectedZone->mapping}, cont);
-        }
-        else
-        {
-            serializationSendToClient(s2c_id, s2c_payload_t{false, {}}, cont);
-        }
+        serializationSendToClient(s2c_respond_zone_mapping,
+                                  mappingSelectedZoneViewResposne_t{false, {}}, cont);
     }
+}
+CLIENT_SERIAL_REQUEST_RESPONSE(MappingSelectedZoneView, c2s_request_zone_mapping, uint8_t,
+                               s2c_respond_zone_mapping, mappingSelectedZoneViewResposne_t,
+                               mappingSelectedZoneViewSerial(engine, cont), onMappingUpdated);
 
-    template <typename Client> static void executeOnClient(Client *c, const s2c_payload_t &payload)
+inline void mappingSelectedZoneUpdate(const engine::Zone::ZoneMappingData &payload,
+                                      const engine::Engine &engine, MessageController &cont)
+{
+    // TODO Selected Zone State
+    const auto &mapping = payload;
+    auto sz = engine.getSelectionManager()->getSelectedZone();
+    if (sz.has_value())
     {
-        const auto &[active, map] = payload;
-        c->onMappingUpdated(active, map);
+        auto [ps, gs, zs] = *sz;
+        cont.scheduleAudioThreadCallback([p = ps, g = gs, z = zs, mapv = mapping](auto &eng) {
+            eng.getPatch()->getPart(p)->getGroup(g)->getZone(z)->mapping = mapv;
+        });
     }
-};
+}
+CLIENT_TO_SERIAL(MappingSelectedZoneUpdateRequest, c2s_update_zone_mapping,
+                 engine::Zone::ZoneMappingData, mappingSelectedZoneUpdate(payload, engine, cont));
 
-template <> struct ClientToSerializationType<MappingSelectedZoneView::c2s_id>
-{
-    typedef MappingSelectedZoneView T;
-};
-
-template <> struct SerializationToClientType<MappingSelectedZoneView::s2c_id>
-{
-    typedef MappingSelectedZoneView T;
-};
-
-struct MappingSelectedZoneUpdateRequest
-{
-    static constexpr ClientToSerializationMessagesIds c2s_id{c2s_update_zone_mapping};
-    typedef std::tuple<engine::Zone::ZoneMappingData> c2s_payload_t;
-
-    c2s_payload_t payload;
-
-    MappingSelectedZoneUpdateRequest(const engine::Zone::ZoneMappingData &a) : payload{a} {}
-
-    static void executeOnSerialization(const c2s_payload_t &payload, const engine::Engine &engine,
-                                       MessageController &cont)
-    {
-        // TODO Selected Zone State
-        const auto &[mapping] = payload;
-        auto sz = engine.getSelectionManager()->getSelectedZone();
-        if (sz.has_value())
-        {
-            auto [ps, gs, zs] = *sz;
-            cont.scheduleAudioThreadCallback([p = ps, g = gs, z = zs, mapv = mapping](auto &eng) {
-                eng.getPatch()->getPart(p)->getGroup(g)->getZone(z)->mapping = mapv;
-            });
-        }
-    }
-};
-
-template <> struct ClientToSerializationType<MappingSelectedZoneUpdateRequest::c2s_id>
-{
-    typedef MappingSelectedZoneUpdateRequest T;
-};
 } // namespace scxt::messaging::client
 
 #endif // SHORTCIRCUIT_ZONE_MESSAGES_H

--- a/src/utils.h
+++ b/src/utils.h
@@ -59,6 +59,12 @@ template <int32_t idType_v> struct ID
         return res;
     }
 
+    static void guaranteeNextAbove(const ID<idType_v> &other)
+    {
+        if (nextID <= other.id)
+            nextID = other.id + 1;
+    }
+
     bool operator==(const ID<idType_v> &other) const { return (id == other.id); }
     bool operator!=(const ID<idType_v> &other) const { return !(id == other.id); }
 


### PR DESCRIPTION
- Remove the ControlModes and make constexpr ControlDescriptions instead
- Add a function to get all the processors we support
- Add some C++ macros to make messages way more compact and move all messaging
- Fix Sample Reload bug
- Send processor info on onRegister
- Specific Panel and Hamburger for Processor Types works