### PR TITLE
Day 29: SF2 structure and Engine Stop

### DIFF
--- a/doc/Sprints.md
+++ b/doc/Sprints.md
@@ -2,7 +2,7 @@
 
 
 Early March
-- MultiSamples - at least SF2 with start/Stop engine
+- MultiSamples - at least SF2 making sound some
 - Stereo and Mono Samples in the Zone and Processors
   - Output section 
 - Zone Edits
@@ -89,7 +89,9 @@ Sprint Log I posted on Discord
 ## Day 29 (2023-03-10)
 
 Start with integrating libgig so we can do SF2, Korg, Akai and GIG files
-as load points.
+as load points. Get it building and use it to at least parse out some SF2
+structure. This weekend lets see if I can make it play those samples!
+(along the way added the mutate-from-audio-thread-safe-stop thing too).
 
 ## Day 28 (2023-03-08)
 

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -174,6 +174,8 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
 
     const std::unique_ptr<MemoryPool> &getMemoryPool() { return memoryPool; }
 
+    std::atomic<int32_t> stopEngineRequests{0};
+
   private:
     std::unique_ptr<Patch> patch;
     std::unique_ptr<MemoryPool> memoryPool;

--- a/src/messaging/messaging.cpp
+++ b/src/messaging/messaging.cpp
@@ -125,6 +125,19 @@ void MessageController::scheduleAudioThreadCallback(
     serializationToAudioQueue.try_emplace(s2a);
 }
 
+void MessageController::stopAudioThreadThenRunOnSerial(
+    std::function<void(const engine::Engine &)> f)
+{
+    assert(threadingChecker.isSerialThread());
+    scheduleAudioThreadCallback([](engine::Engine &e) { e.stopEngineRequests++; }, f);
+}
+
+void MessageController::restartAudioThreadFromSerial()
+{
+    assert(threadingChecker.isSerialThread());
+    scheduleAudioThreadCallback([](engine::Engine &e) { e.stopEngineRequests--; });
+}
+
 void MessageController::runSerialization()
 {
     threadingChecker.registerAsSerialThread();

--- a/src/messaging/messaging.h
+++ b/src/messaging/messaging.h
@@ -235,6 +235,8 @@ struct MessageController : MoveableOnly<MessageController>
      */
     void scheduleAudioThreadCallback(std::function<void(engine::Engine &)> f,
                                      std::function<void(const engine::Engine &)> cb = nullptr);
+    void stopAudioThreadThenRunOnSerial(std::function<void(const engine::Engine &)> f);
+    void restartAudioThreadFromSerial();
     struct AudioThreadCallback
     {
       public:


### PR DESCRIPTION
If you want to manipulate the engine structure from the serial thread you need to stop the engine; make that possible. And add a 'stop and then' round trip callback.

Use this to do larger scale structural reworks from the serial thread when we load an SF2