### PR TITLE
Day 30: SF2 Restore on Stream/Unstream

### DIFF
--- a/src/engine/part.h
+++ b/src/engine/part.h
@@ -54,7 +54,8 @@ struct Part : MoveableOnly<Part>
     static constexpr int16_t omniChannel{-1};
 
     // TODO: editable name
-    std::string getName() const { return id.to_string(); }
+    std::string getName() const { return fmt::format("Part ch={}",
+                           (channel == omniChannel ? "OMNI" : std::to_string(channel + 1))); }
 
     // TODO: Multiple outputs
     size_t getNumOutputs() const { return 1; }

--- a/src/sample/sample.cpp
+++ b/src/sample/sample.cpp
@@ -61,14 +61,19 @@ bool Sample::load(const fs::path &path)
     return false;
 }
 
-bool Sample::loadFromSF2(sf2::File *f, int inst, int region)
+bool Sample::loadFromSF2(const fs::path &p, sf2::File *f, int inst, int reg)
 {
+    mFileName = p;
+    instrument = inst;
+    region = reg;
+    type = SF2_FILE;
     auto sfsample = f->GetInstrument(inst)->GetRegion(region)->GetSample();
 
     UseInt16 = sfsample->GetFrameSize() == 2;
     channels = sfsample->GetChannelCount();
     sample_length = sfsample->GetTotalFrameCount();
     sample_rate = sfsample->SampleRate;
+
 
     auto s = sfsample;
     using namespace std;
@@ -82,10 +87,7 @@ bool Sample::loadFromSF2(sf2::File *f, int inst, int region)
          << endl;
 
     auto fnp = fs::path{f->GetRiffFile()->GetFileName()};
-    displayName = fmt::format("{} ({}/{}/{})",
-                              s->Name,
-                              fnp.filename().u8string(),
-                              inst, region);
+    displayName = fmt::format("{} ({}/{}/{})", s->Name, fnp.filename().u8string(), inst, region);
 
     if (!UseInt16)
         return false;

--- a/src/sample/sample.h
+++ b/src/sample/sample.h
@@ -49,14 +49,23 @@ struct alignas(16) Sample : MoveableOnly<Sample>
     std::string displayName{};
     std::string getDisplayName() const { return displayName; }
     bool load(const fs::path &path);
-    bool loadFromSF2(sf2::File *f, int inst, int region);
+    bool loadFromSF2(const fs::path &path, sf2::File *f, int inst, int region);
 
     const fs::path &getPath() const { return mFileName; }
-    const int getCompoundInstrument() const { return 0; }
-    const int getCompoundRegion() const { return 0; }
 
-    typedef std::tuple<SourceType, fs::path, int, int> sampleFileAddress_t;
-    sampleFileAddress_t getSampleFileAddress() const
+    int instrument{-1}, region{-1};
+    const int getCompoundInstrument() const { return instrument; }
+    const int getCompoundRegion() const { return region; }
+
+    struct SampleFileAddress
+    {
+        SourceType type{WAV_FILE};
+        fs::path path{};
+        int instrument{-1};
+        int region{-1};
+    };
+
+    SampleFileAddress getSampleFileAddress() const
     {
         return {type, getPath(), getCompoundInstrument(), getCompoundRegion()};
     }


### PR DESCRIPTION
The SF2 restores samples from the file on stream/unstream. Missing or moved file is still not dealt with of course.