### PR TITLE
Day 33: Loop Modes and so on

### DIFF
--- a/doc/NextSteps.md
+++ b/doc/NextSteps.md
@@ -4,7 +4,6 @@ Ideally this would become the issue list over the next fortnight with the header
 
 * Voice Management 
   * Voice Lifetime
-      * Active voice data structure not comically bad
       * AEG (not Sample End) terminates voice
       * Optimization: Sample end, no processor, no loop, no repeat, kill voice ahead of AEG
   * Zone from Key Cache (from linear search to cached data structure on noteOn/noteOff)
@@ -128,6 +127,8 @@ Ideally this would become the issue list over the next fortnight with the header
 
 * User Interface
   * Add a robust about screen
+  * Add the User Options code from plugininfra
+  * NoteNames (C3/C4/C5) vs hardcoded "C4 == MIDI 60"
   * User Interface Styling 
     * Map phsyical style sheet to logical style sheet
     * StyleSheet Editable 
@@ -135,6 +136,7 @@ Ideally this would become the issue list over the next fortnight with the header
     * Overall header
       * Save/Restore
       * VU Meter
+      * Playing Zone Display
       * etc
     * etc
 

--- a/doc/Sprints.md
+++ b/doc/Sprints.md
@@ -1,3 +1,10 @@
+## Day 33 (2023-03-14)
+
+It's all playmodes, loops, and zones today. Basically get some of this in the UI
+and get some of the play modes working. For now I used the legacy non-parameterized
+play modes from the old generator which map to a set of new cool switches which
+is way better. Fix that, but it's good enough to merge. You can set up loops and
+play them and activate and deactivate them on a sample and it more or less works.
 
 ## Day 32 (3032-03-13)
 

--- a/src-ui/components/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/components/SCXTEditorResponseHandlers.cpp
@@ -87,10 +87,6 @@ void SCXTEditor::onSamplesUpdated(
     {
         multiScreen->sample->setActive(false);
     }
-    for (const auto &ss : s)
-        if (ss.active)
-            std::cout << ss.active << " " << ss.sampleID.to_string() << " "
-                      << sampleManager.getSample(ss.sampleID)->getDisplayName() << std::endl;
 }
 
 void SCXTEditor::onStructureUpdated(const engine::Engine::pgzStructure_t &s)

--- a/src-ui/connectors/PayloadDataAttachment.h
+++ b/src-ui/connectors/PayloadDataAttachment.h
@@ -32,6 +32,7 @@
 #include "sst/jucegui/data/Discrete.h"
 #include "datamodel/parameter.h"
 #include <functional>
+#include "sample/sample.h"
 
 namespace scxt::ui::connectors
 {
@@ -196,6 +197,44 @@ struct BooleanPayloadDataAttachment : DiscretePayloadDataAttachment<Parent, Payl
     int getMax() const override { return (int)1; }
 
     std::string getValueAsStringFor(int i) const override { return i == 0 ? "Off" : "On"; }
+};
+
+struct SamplePointDataAttachment : sst::jucegui::data::ContinunousModulatable
+{
+    int64_t &value;
+    std::string label;
+    int64_t sampleCount{0};
+    std::function<void(const SamplePointDataAttachment &)> onGuiChanged{nullptr};
+
+    SamplePointDataAttachment(int64_t &v,
+                              std::function<void(const SamplePointDataAttachment &)> ogc)
+        : value(v), onGuiChanged(ogc)
+    {
+    }
+
+    float getValue() const override { return value; }
+    std::string getValueAsStringFor(float f) const override
+    {
+        if (f < 0)
+            return "";
+        return fmt::format("{}", (int64_t)f);
+    }
+    void setValueFromGUI(const float &f) override
+    {
+        value = (int64_t)f;
+        if (onGuiChanged)
+            onGuiChanged(*this);
+    }
+    std::string getLabel() const override { return label; }
+    float getQuantizedStepSize() const override { return 1; }
+    float getMin() const override { return -1; }
+    float getMax() const override { return sampleCount; }
+    float getDefaultValue() const override { return 0; }
+    void setValueFromModel(const float &f) override { value = (int64_t)f; }
+
+    float getModulationValuePM1() const override { return 0; }
+    void setModulationValuePM1(const float &f) override {}
+    bool isModulationBipolar() const override { return false; }
 };
 
 } // namespace scxt::ui::connectors

--- a/src/dsp/generator.cpp
+++ b/src/dsp/generator.cpp
@@ -248,12 +248,15 @@ void GeneratorSample(GeneratorState *__restrict GD, GeneratorIO *__restrict IO)
             {
                 SamplePos = UpperBound;
                 SampleSubPos = 0;
-                IsFinished = true;
+                if (GD->direction == 1)
+                    IsFinished = true;
             }
             if (SamplePos < LowerBound)
             {
                 SamplePos = LowerBound;
                 SampleSubPos = 0;
+                if (GD->direction == -1)
+                    IsFinished = true;
             }
         }
         break;

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -73,9 +73,6 @@ Engine::~Engine()
     {
         if (v)
         {
-            if (v->playState != voice::Voice::OFF)
-                v->release();
-
             v->~Voice();
             v = nullptr;
         }
@@ -88,7 +85,7 @@ void Engine::initiateVoice(const pathToZone_t &path)
     assert(zoneByPath(path));
     for (const auto &[idx, v] : sst::cpputils::enumerate(voices))
     {
-        if (!v || v->playState == voice::Voice::OFF)
+        if (!v || !v->isVoiceAssigned)
         {
             if (v)
             {
@@ -113,7 +110,7 @@ void Engine::releaseVoice(const pathToZone_t &path)
     auto targetId = zoneByPath(path)->id;
     for (auto &v : voices)
     {
-        if (v && v->playState != voice::Voice::OFF && v->zone->id == targetId && v->key == path.key)
+        if (v && v->isVoiceAssigned && v->zone->id == targetId && v->key == path.key)
         {
             v->release();
         }
@@ -210,7 +207,7 @@ uint32_t Engine::activeVoiceCount()
     for (const auto v : voices)
     {
         if (v)
-            res += (v->playState != voice::Voice::OFF);
+            res += (v->isVoiceAssigned && v->isVoicePlaying);
     }
     return res;
 }

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -150,24 +150,6 @@ template <> struct scxt_traits<scxt::engine::Group>
     }
 };
 
-template <> struct scxt_traits<scxt::engine::Zone::PlayModes>
-{
-    template <template <typename...> class Traits>
-    static void assign(tao::json::basic_value<Traits> &v, const scxt::engine::Zone::PlayModes &t)
-    {
-        v = {{"playMode", scxt::engine::Zone::toStreamingNamePlayModes(t)}};
-    }
-
-    template <template <typename...> class Traits>
-    static void to(const tao::json::basic_value<Traits> &v, scxt::engine::Zone::PlayModes &zmd)
-    {
-        std::string r;
-        zmd = engine::Zone::STANDARD;
-        if (findIf(v, "playMode", r))
-            zmd = engine::Zone::fromStreamingNamePlayModes(r);
-    }
-};
-
 template <> struct scxt_traits<scxt::engine::Zone::ZoneMappingData>
 {
     template <template <typename...> class Traits>
@@ -183,9 +165,14 @@ template <> struct scxt_traits<scxt::engine::Zone::ZoneMappingData>
              {"exclusiveGroup", t.exclusiveGroup},
              {"velocitySens", t.velocitySens},
              {"amplitude", t.amplitude},
-             {"pan", t.pan},
+             ASSIGN(t, pan),
              {"pitchOffset", t.pitchOffset},
-             {"playbackMode", t.playbackMode}};
+             ASSIGN(t, triggerOnNoteOff),
+             ASSIGN(t, voiceTerminateWithEnvelope),
+             ASSIGN(t, loopActive),
+             ASSIGN(t, loopOnlyUntilNoteOff),
+             ASSIGN(t, loopBidirectional),
+             ASSIGN(t, playReverse)};
     }
 
     template <template <typename...> class Traits>
@@ -202,7 +189,13 @@ template <> struct scxt_traits<scxt::engine::Zone::ZoneMappingData>
         findIf(v, "pitchOffset", zmd.pitchOffset);
         findOrSet(v, "velocitySens", 1.0, zmd.velocitySens);
         findOrSet(v, "exclusiveGroup", 0, zmd.exclusiveGroup);
-        findOrSet(v, "playbackMode", engine::Zone::STANDARD, zmd.playbackMode);
+
+        FINDOR(zmd, triggerOnNoteOff, false);
+        FINDOR(zmd, voiceTerminateWithEnvelope, true);
+        FINDOR(zmd, loopActive, false);
+        FINDOR(zmd, loopOnlyUntilNoteOff, false);
+        FINDOR(zmd, loopBidirectional, false);
+        FINDOR(zmd, playReverse, false);
     }
 };
 
@@ -240,7 +233,7 @@ template <> struct scxt_traits<scxt::engine::Zone>
                     r.depth != 0 || !r.active || r.curve != scxt::modulation::vmc_none);
         });
 
-        v = {{"associatedSamples", t.samples},
+        v = {{"sampleData", t.sampleData},
              {"mappingData", t.mapping},
              {"processorStorage", t.processorStorage},
              {"routingTable", rtArray},
@@ -252,7 +245,7 @@ template <> struct scxt_traits<scxt::engine::Zone>
     template <template <typename...> class Traits>
     static void to(const tao::json::basic_value<Traits> &v, scxt::engine::Zone &zone)
     {
-        findIf(v, "associatedSamples", zone.samples);
+        findIf(v, "sampleData", zone.sampleData);
         findIf(v, "mappingData", zone.mapping);
         fromArrayWithSizeDifference<Traits>(v.at("processorStorage"), zone.processorStorage);
 

--- a/src/json/scxt_traits.h
+++ b/src/json/scxt_traits.h
@@ -67,5 +67,13 @@ template <typename V, typename R> void findOrDefault(V &v, const std::string &ke
     findOrSet(v, key, R{}, r);
 }
 
+#define ASSIGN(x, y)                                                                               \
+    {                                                                                              \
+#y, x.y                                                                                    \
+    }
+
+#define FIND(x, y) findIf(v, #y, x.y)
+#define FINDOR(x, y, d) findOrSet(v, #y, d, x.y);
+
 } // namespace scxt::json
 #endif // SHORTCIRCUIT_SCXT_TRAITS_H

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -46,7 +46,7 @@ enum ClientToSerializationMessagesIds
     c2s_update_zone_adsr_view,
 
     c2s_update_zone_mapping,
-
+    c2s_update_zone_samples,
     c2s_update_zone_routing_row,
 
     c2s_update_individual_lfo,

--- a/src/selection/selection_manager.cpp
+++ b/src/selection/selection_manager.cpp
@@ -54,7 +54,7 @@ void SelectionManager::singleSelect(const ZoneAddress &a)
                                   cms::MappingSelectedZoneView::s2c_payload_t{true, zp->mapping},
                                   *(engine.getMessageController()));
         serializationSendToClient(cms::s2c_respond_zone_samples,
-                                  cms::SampleSelectedZoneView::s2c_payload_t{true, zp->samples},
+                                  cms::SampleSelectedZoneView::s2c_payload_t{true, zp->sampleData},
                                   *(engine.getMessageController()));
         serializationSendToClient(cms::s2c_respond_zone_adsr_view,
                                   cms::AdsrSelectedZoneView::s2c_payload_t{0, true, zp->aegStorage},

--- a/src/voice/voice.h
+++ b/src/voice/voice.h
@@ -123,39 +123,31 @@ struct alignas(16) Voice : MoveableOnly<Voice>, SampleRateSupport
     // TODO - this should be more carefully structured for modulation onto the entire filter
     lipol_ps processorMix[engine::processorsPerZone];
 
-    // TODO This is obvious garbage from hereon down
-    size_t sp{0};
-    enum PlayState
-    {
-        GATED,
-        RELEASED,
-        FINISHED,
-        CLEANUP,
-        OFF
-    } playState{OFF};
+    /*
+     * Voice State Model.
+     */
+    bool isGated{false};
+    bool isGeneratorRunning{false};
+    bool isAEGRunning{false};
+
+    bool isVoicePlaying{false};
+    bool isVoiceAssigned{false};
 
     void attack()
     {
-        assert(zone->samples[0].sample);
-        playState = GATED;
+        assert(zone->samplePointers[0]);
+        isGated = true;
+        isGeneratorRunning = true;
+        isAEGRunning = true;
+
+        isVoicePlaying = true;
+        isVoiceAssigned = true;
         voiceStarted();
     }
-    void release()
-    {
-        if (playState == FINISHED)
-        {
-            playState = CLEANUP;
-        }
-        else
-        {
-            playState = RELEASED;
-        }
-    }
-
-    void cleanupVoice()
-    {
+    void release() { isGated = false; }
+    void cleanupVoice() {
         zone->removeVoice(this);
-        playState = OFF;
+        isVoiceAssigned = false;
     }
 };
 } // namespace scxt::voice


### PR DESCRIPTION
- Refactor the various loop enums into switches in the engine
- Transfer information from sample metadata to voice properly Closes #265 along with a reminder to put the info in the NextSteps
- Start on AEG terminated voice
- Terminate generator-terminated voices with solence properly
- Start cleaning up the 'playstate' mess in exchange for clear booleans on voice
- Sample doesn't set up root note etc.. on json unstream
- Play Modes in the UI; Reverse and Standard actually work too!
- Edit sample start and end position and loop position
- In playmodes, implement start and end position
- Enough modes to commit

Sprints