### PR TITLE
Day 35: Sample Loop and Playback Data Structure

### DIFF
--- a/doc/NextSteps.md
+++ b/doc/NextSteps.md
@@ -49,6 +49,7 @@ Ideally this would become the issue list over the next fortnight with the header
     * AEG/EG2 implement shape
     * LFO Presets are kinda screwed. Revisit them.
     * MPE Modulators
+    * What parts of sample etc... are modulatable (list all the targets)
   * Temposync Support
   * Generator
     * DSP Support for alternate bit depths beyond I16 and F32

--- a/doc/Sprints.md
+++ b/doc/Sprints.md
@@ -1,6 +1,7 @@
-## Day 32 (2023-03-15)
+## Day 34 (2023-03-15)
 
-It's still all playmodes.
+It's still all playmodes. Restructure to the per-variation switches-based version in the UI
+and the data structure and merge it.
 
 ## Day 33 (2023-03-14)
 

--- a/doc/Sprints.md
+++ b/doc/Sprints.md
@@ -1,3 +1,7 @@
+## Day 32 (2023-03-15)
+
+It's still all playmodes.
+
 ## Day 33 (2023-03-14)
 
 It's all playmodes, loops, and zones today. Basically get some of this in the UI

--- a/src-ui/components/multi/MappingPane.cpp
+++ b/src-ui/components/multi/MappingPane.cpp
@@ -629,10 +629,10 @@ struct SampleDisplay : juce::Component, HasEditor
         }
         switch (sampleView[0].loopDirection)
         {
-        case engine::Zone::FORWARD:
+        case engine::Zone::FORWARD_ONLY:
             loopDirectionButton->setButtonText("Loop Forward");
             break;
-        case engine::Zone::ALTERNATE:
+        case engine::Zone::ALTERNATE_DIRECTIONS:
             loopDirectionButton->setButtonText("Loop Alternate");
             break;
         }
@@ -700,8 +700,8 @@ struct SampleDisplay : juce::Component, HasEditor
                 rebuild();
             });
         };
-        add(engine::Zone::LoopDirection::FORWARD, "Loop Forward");
-        add(engine::Zone::LoopDirection::ALTERNATE, "Loop Alternate");
+        add(engine::Zone::LoopDirection::FORWARD_ONLY, "Loop Forward");
+        add(engine::Zone::LoopDirection::ALTERNATE_DIRECTIONS, "Loop Alternate");
 
         p.showMenuAsync({});
     }

--- a/src-ui/components/multi/MappingPane.cpp
+++ b/src-ui/components/multi/MappingPane.cpp
@@ -381,17 +381,25 @@ struct SampleDisplay : juce::Component, HasEditor
     std::unordered_map<Ctrl, std::unique_ptr<sst::jucegui::components::DraggableTextEditableValue>>
         sampleEditors;
 
-    std::unique_ptr<
-        connectors::BooleanPayloadDataAttachment<SampleDisplay, engine::Zone::ZoneMappingData>>
-        loopAttachment;
-    std::unique_ptr<sst::jucegui::components::ToggleButton> loopActive;
+    std::unique_ptr<connectors::BooleanPayloadDataAttachment<SampleDisplay,
+                                                             engine::Zone::AssociatedSampleArray>>
+        loopAttachment, reverseAttachment;
+    std::unique_ptr<sst::jucegui::components::ToggleButton> loopActive, reverseActive;
 
     SampleDisplay(MappingPane *p)
         : HasEditor(p->editor), sampleView(p->sampleView), mappingView(p->mappingView)
     {
-        modeButton = std::make_unique<juce::TextButton>("mode");
-        modeButton->onClick = [this]() { showModeMenu(); };
-        addAndMakeVisible(*modeButton);
+        playModeButton = std::make_unique<juce::TextButton>("mode");
+        playModeButton->onClick = [this]() { showPlayModeMenu(); };
+        addAndMakeVisible(*playModeButton);
+
+        loopModeButton = std::make_unique<juce::TextButton>("loopmode");
+        loopModeButton->onClick = [this]() { showLoopModeMenu(); };
+        addAndMakeVisible(*loopModeButton);
+
+        loopDirectionButton = std::make_unique<juce::TextButton>("loopdir");
+        loopDirectionButton->onClick = [this]() { showLoopDirectionMenu(); };
+        addAndMakeVisible(*loopDirectionButton);
 
         rebuild();
 
@@ -409,22 +417,35 @@ struct SampleDisplay : juce::Component, HasEditor
         attachSamplePoint(startL, "StartS", sampleView[0].startLoop);
         attachSamplePoint(endL, "EndS", sampleView[0].endLoop);
 
-        loopAttachment = std::make_unique<
-            connectors::BooleanPayloadDataAttachment<SampleDisplay, engine::Zone::ZoneMappingData>>(
+        loopAttachment = std::make_unique<connectors::BooleanPayloadDataAttachment<
+            SampleDisplay, engine::Zone::AssociatedSampleArray>>(
             this, "Loop",
             [w = juce::Component::SafePointer(this)](const auto &a) {
                 if (w)
                 {
-                    cmsg::clientSendToSerialization(
-                        cmsg::MappingSelectedZoneUpdateRequest(w->mappingView), w->editor->msgCont);
-                    w->repaint();
+                    w->onSamplePointChangedFromGUI();
                 }
             },
-            [](const auto &pl) { return pl.loopActive; }, mappingView.loopActive);
+            [](const auto &pl) { return pl[0].loopActive; }, sampleView[0].loopActive);
         loopActive = std::make_unique<sst::jucegui::components::ToggleButton>();
         loopActive->setLabel("Loop Active");
         loopActive->setSource(loopAttachment.get());
         addAndMakeVisible(*loopActive);
+
+        reverseAttachment = std::make_unique<connectors::BooleanPayloadDataAttachment<
+            SampleDisplay, engine::Zone::AssociatedSampleArray>>(
+            this, "Reverse",
+            [w = juce::Component::SafePointer(this)](const auto &a) {
+                if (w)
+                {
+                    w->onSamplePointChangedFromGUI();
+                }
+            },
+            [](const auto &pl) { return pl[0].playReverse; }, sampleView[0].playReverse);
+        reverseActive = std::make_unique<sst::jucegui::components::ToggleButton>();
+        reverseActive->setLabel("Reverse");
+        reverseActive->setSource(reverseAttachment.get());
+        addAndMakeVisible(*reverseActive);
     }
 
     ~SampleDisplay() { reset(); }
@@ -490,7 +511,7 @@ struct SampleDisplay : juce::Component, HasEditor
                     if (c >= v.startLoop && c <= v.endLoop)
                     {
                         g.setColour(juce::Colour(80, 80, 170));
-                        if (!mappingView.loopActive)
+                        if (!v.loopActive)
                             g.setColour(juce::Colour(40, 40, 90));
                         g.drawVerticalLine(ct, 0, getHeight());
                     }
@@ -552,7 +573,7 @@ struct SampleDisplay : juce::Component, HasEditor
         auto p = getLocalBounds().withLeft(getLocalBounds().getWidth() - sidePanelWidth).reduced(2);
 
         p = p.withHeight(18);
-        modeButton->setBounds(p);
+        playModeButton->setBounds(p);
         p = p.translated(0, 20);
 
         for (const auto m : {startP, endP, startL, endL})
@@ -561,13 +582,19 @@ struct SampleDisplay : juce::Component, HasEditor
             p = p.translated(0, 20);
         }
         loopActive->setBounds(p);
+        p = p.translated(0, 20);
+        reverseActive->setBounds(p);
+        p = p.translated(0, 20);
+        loopModeButton->setBounds(p);
+        p = p.translated(0, 20);
+        loopDirectionButton->setBounds(p);
     }
 
     bool active{false};
     void setActive(bool b)
     {
         active = b;
-        modeButton->setVisible(b);
+        playModeButton->setVisible(b);
         if (active)
             rebuild();
         repaint();
@@ -575,7 +602,41 @@ struct SampleDisplay : juce::Component, HasEditor
 
     void rebuild()
     {
-        modeButton->setButtonText(getModeName());
+        switch (sampleView[0].playMode)
+        {
+        case engine::Zone::NORMAL:
+            playModeButton->setButtonText("Normal");
+            break;
+        case engine::Zone::ONE_SHOT:
+            playModeButton->setButtonText("Oneshot");
+            break;
+        case engine::Zone::ON_RELEASE:
+            playModeButton->setButtonText("On Release (t/k)");
+            break;
+        }
+
+        switch (sampleView[0].loopMode)
+        {
+        case engine::Zone::LOOP_DURING_VOICE:
+            loopModeButton->setButtonText("Loop");
+            break;
+        case engine::Zone::LOOP_WHILE_GATED:
+            loopModeButton->setButtonText("Loop While Gated");
+            break;
+        case engine::Zone::LOOP_FOR_COUNT:
+            loopModeButton->setButtonText("For Count (t/k)");
+            break;
+        }
+        switch (sampleView[0].loopDirection)
+        {
+        case engine::Zone::FORWARD:
+            loopDirectionButton->setButtonText("Loop Forward");
+            break;
+        case engine::Zone::ALTERNATE:
+            loopDirectionButton->setButtonText("Loop Alternate");
+            break;
+        }
+
         auto samp = editor->sampleManager.getSample(sampleView[0].sampleID);
         size_t end = 0;
         if (samp)
@@ -588,53 +649,64 @@ struct SampleDisplay : juce::Component, HasEditor
         repaint();
     }
 
-    void showModeMenu()
+    void showPlayModeMenu()
     {
         juce::PopupMenu p;
         p.addSectionHeader("PlayMode");
         p.addSeparator();
-        for (int i = 0; i < modes.size(); ++i)
-        {
-            p.addItem(modes[i].first, [this, i]() { setMode(i); });
-        }
+
+        auto add = [&p, this](auto e, auto n) {
+            p.addItem(n, true, sampleView[0].playMode == e, [this, e]() {
+                sampleView[0].playMode = e;
+                onSamplePointChangedFromGUI();
+                rebuild();
+            });
+        };
+        add(engine::Zone::PlayMode::NORMAL, "Normal");
+        add(engine::Zone::PlayMode::ONE_SHOT, "OneShot");
+        add(engine::Zone::PlayMode::ON_RELEASE, "On Release (t/k)");
+
+        p.showMenuAsync({});
+    }
+    void showLoopModeMenu()
+    {
+        juce::PopupMenu p;
+        p.addSectionHeader("Loop Mode");
+        p.addSeparator();
+
+        auto add = [&p, this](auto e, auto n) {
+            p.addItem(n, true, sampleView[0].loopMode == e, [this, e]() {
+                sampleView[0].loopMode = e;
+                onSamplePointChangedFromGUI();
+                rebuild();
+            });
+        };
+        add(engine::Zone::LoopMode::LOOP_DURING_VOICE, "Loop");
+        add(engine::Zone::LoopMode::LOOP_WHILE_GATED, "Loop While Gated");
+        add(engine::Zone::LoopMode::LOOP_FOR_COUNT, "For Count (t/k)");
+
+        p.showMenuAsync({});
+    }
+    void showLoopDirectionMenu()
+    {
+        juce::PopupMenu p;
+        p.addSectionHeader("Loop Direction");
+        p.addSeparator();
+
+        auto add = [&p, this](auto e, auto n) {
+            p.addItem(n, true, sampleView[0].loopDirection == e, [this, e]() {
+                sampleView[0].loopDirection = e;
+                onSamplePointChangedFromGUI();
+                rebuild();
+            });
+        };
+        add(engine::Zone::LoopDirection::FORWARD, "Loop Forward");
+        add(engine::Zone::LoopDirection::ALTERNATE, "Loop Alternate");
+
         p.showMenuAsync({});
     }
 
-    std::vector<std::pair<std::string, std::array<bool, 5>>> modes{
-        {"Standard", {0, 1, 0, 0, 0}},
-        {"Reverse", {0, 1, 0, 0, 1}},
-        {"Loop Until Release", {0, 1, 1, 0, 0}},
-        {"Loop Bidirectional", {0, 1, 0, 1, 0}},
-        {"OneShot", {0, 0, 0, 0, 0}},
-        {"OnRelease", {1, 0, 0, 0, 0}}};
-
-    std::string getModeName()
-    {
-        for (const auto &[n, b] : modes)
-        {
-            if (mappingView.triggerOnNoteOff == b[0] &&
-                mappingView.voiceTerminateWithEnvelope == b[1] &&
-                mappingView.loopOnlyUntilNoteOff == b[2] && mappingView.loopBidirectional == b[3] &&
-                mappingView.playReverse == b[4])
-                return n;
-        }
-        return "ERROR";
-    }
-    void setMode(int m)
-    {
-        const auto &[n, b] = modes[m];
-        mappingView.triggerOnNoteOff = b[0];
-        mappingView.voiceTerminateWithEnvelope = b[1];
-        mappingView.loopOnlyUntilNoteOff = b[2];
-        mappingView.loopBidirectional = b[3];
-        mappingView.playReverse = b[4];
-
-        cmsg::clientSendToSerialization(cmsg::MappingSelectedZoneUpdateRequest(mappingView),
-                                        editor->msgCont);
-        rebuild();
-    }
-
-    std::unique_ptr<juce::TextButton> modeButton;
+    std::unique_ptr<juce::TextButton> playModeButton, loopModeButton, loopDirectionButton;
     engine::Zone::AssociatedSampleArray &sampleView;
     engine::Zone::ZoneMappingData &mappingView;
 };

--- a/src/engine/zone.cpp
+++ b/src/engine/zone.cpp
@@ -250,4 +250,71 @@ bool Zone::attachToSample(const sample::SampleManager &manager, int index)
     return samplePointers[index] != nullptr;
 }
 
+std::string Zone::toStringPlayMode(const PlayMode &p)
+{
+    switch (p)
+    {
+    case NORMAL:
+        return "normal";
+    case ONE_SHOT:
+        return "oneshot";
+    case ON_RELEASE:
+        return "onrelease";
+    }
+}
+
+Zone::PlayMode Zone::fromStringPlayMode(const std::string &s)
+{
+    static auto inverse = makeEnumInverse<Zone::PlayMode, Zone::toStringPlayMode>(
+        Zone::PlayMode::NORMAL, Zone::PlayMode::ON_RELEASE);
+    auto p = inverse.find(s);
+    if (p == inverse.end())
+        return NORMAL;
+    return p->second;
+}
+
+std::string Zone::toStringLoopMode(const LoopMode &p)
+{
+    switch (p)
+    {
+    case LOOP_DURING_VOICE:
+        return "during_voice";
+    case LOOP_WHILE_GATED:
+        return "while_gated";
+    case LOOP_FOR_COUNT:
+        return "for_count";
+    }
+}
+
+Zone::LoopMode Zone::fromStringLoopMode(const std::string &s)
+{
+    static auto inverse = makeEnumInverse<Zone::LoopMode, Zone::toStringLoopMode>(
+        Zone::LoopMode::LOOP_DURING_VOICE, Zone::LoopMode::LOOP_FOR_COUNT);
+    auto p = inverse.find(s);
+    if (p == inverse.end())
+        return LOOP_DURING_VOICE;
+    return p->second;
+}
+
+std::string Zone::toStringLoopDirection(const LoopDirection &p)
+{
+    switch (p)
+    {
+    case FORWARD:
+        return "forward";
+    case ALTERNATE:
+        return "alternate";
+    }
+}
+
+Zone::LoopDirection Zone::fromStringLoopDirection(const std::string &s)
+{
+    static auto inverse = makeEnumInverse<Zone::LoopDirection, Zone::toStringLoopDirection>(
+        Zone::LoopDirection::FORWARD, Zone::LoopDirection::ALTERNATE);
+    auto p = inverse.find(s);
+    if (p == inverse.end())
+        return FORWARD;
+    return p->second;
+}
+
 } // namespace scxt::engine

--- a/src/engine/zone.cpp
+++ b/src/engine/zone.cpp
@@ -261,6 +261,7 @@ std::string Zone::toStringPlayMode(const PlayMode &p)
     case ON_RELEASE:
         return "onrelease";
     }
+    return "normal";
 }
 
 Zone::PlayMode Zone::fromStringPlayMode(const std::string &s)
@@ -284,6 +285,7 @@ std::string Zone::toStringLoopMode(const LoopMode &p)
     case LOOP_FOR_COUNT:
         return "for_count";
     }
+    return "during_voice";
 }
 
 Zone::LoopMode Zone::fromStringLoopMode(const std::string &s)
@@ -300,20 +302,21 @@ std::string Zone::toStringLoopDirection(const LoopDirection &p)
 {
     switch (p)
     {
-    case FORWARD:
+    case FORWARD_ONLY:
         return "forward";
-    case ALTERNATE:
+    case ALTERNATE_DIRECTIONS:
         return "alternate";
     }
+    return "forward";
 }
 
 Zone::LoopDirection Zone::fromStringLoopDirection(const std::string &s)
 {
     static auto inverse = makeEnumInverse<Zone::LoopDirection, Zone::toStringLoopDirection>(
-        Zone::LoopDirection::FORWARD, Zone::LoopDirection::ALTERNATE);
+        Zone::LoopDirection::FORWARD_ONLY, Zone::LoopDirection::ALTERNATE_DIRECTIONS);
     auto p = inverse.find(s);
     if (p == inverse.end())
-        return FORWARD;
+        return FORWARD_ONLY;
     return p->second;
 }
 

--- a/src/engine/zone.h
+++ b/src/engine/zone.h
@@ -70,11 +70,43 @@ struct Zone : MoveableOnly<Zone>
 
     ZoneID id;
 
+    enum PlayMode
+    {
+        NORMAL,     // AEG gates; play on note on
+        ONE_SHOT,   // SAMPLE playback gates; play on note on
+        ON_RELEASE, // SAMPLE playback gates. play on note off
+    };
+    DECLARE_ENUM_STRING(PlayMode);
+
+    enum LoopMode
+    {
+        LOOP_DURING_VOICE, // If a loop begins, stay in it for the life of teh voice
+        LOOP_WHILE_GATED,  // If a loop begins, loop while gated
+        LOOP_FOR_COUNT     // Loop exactly (n) times
+    };
+    DECLARE_ENUM_STRING(LoopMode);
+
+    enum LoopDirection
+    {
+        FORWARD,
+        ALTERNATE
+    };
+    DECLARE_ENUM_STRING(LoopDirection);
+
     struct AssociatedSample
     {
         bool active{false};
         SampleID sampleID;
         int64_t startSample{-1}, endSample{-1}, startLoop{-1}, endLoop{-1};
+
+        PlayMode playMode{NORMAL};
+        bool loopActive{false};
+        bool playReverse{false};
+        LoopMode loopMode{LOOP_DURING_VOICE};
+        LoopDirection loopDirection{FORWARD};
+        int loopCountWhenCounted{0};
+
+        int64_t loopFade{0};
 
         bool operator==(const AssociatedSample &other) const
         {
@@ -119,17 +151,6 @@ struct Zone : MoveableOnly<Zone>
         float amplitude{1.0};   // linear
         float pan{0.0};         // -1..1
         float pitchOffset{0.0}; // semitones/keys
-
-        /*
-         * How a zone plays has a few characteristics
-         */
-        bool triggerOnNoteOff{false};          // trigger on note off vs note on
-        bool voiceTerminateWithEnvelope{true}; // terminate with envelope or not (oneshot)
-        bool loopOnlyUntilNoteOff{false};      // if we loop, do we stop looping on release
-        bool loopBidirectional{false}; // if we loop, do we loop forward only or back and forth
-        bool playReverse{false};       // do we traverse the sample start to end or vice versa
-
-        bool loopActive{false}; // should we loop at all
 
         auto asTuple() const
         {

--- a/src/engine/zone.h
+++ b/src/engine/zone.h
@@ -88,8 +88,8 @@ struct Zone : MoveableOnly<Zone>
 
     enum LoopDirection
     {
-        FORWARD,
-        ALTERNATE
+        FORWARD_ONLY,
+        ALTERNATE_DIRECTIONS
     };
     DECLARE_ENUM_STRING(LoopDirection);
 
@@ -103,7 +103,7 @@ struct Zone : MoveableOnly<Zone>
         bool loopActive{false};
         bool playReverse{false};
         LoopMode loopMode{LOOP_DURING_VOICE};
-        LoopDirection loopDirection{FORWARD};
+        LoopDirection loopDirection{FORWARD_ONLY};
         int loopCountWhenCounted{0};
 
         int64_t loopFade{0};

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -228,7 +228,7 @@ template <> struct scxt_traits<scxt::engine::Zone::AssociatedSample>
         findOrSet(v, "loopActive", false, s.loopActive);
         findOrSet(v, "playReverse", false, s.playReverse);
         findOrSet(v, "loopMode", engine::Zone::LoopMode::LOOP_DURING_VOICE, s.loopMode);
-        findOrSet(v, "loopDirection", engine::Zone::LoopDirection::FORWARD, s.loopDirection);
+        findOrSet(v, "loopDirection", engine::Zone::LoopDirection::FORWARD_ONLY, s.loopDirection);
         findOrSet(v, "loopFade", 0, s.loopFade);
         findOrSet(v, "loopCountWhenCounted", 0, s.loopCountWhenCounted);
     }

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -166,13 +166,7 @@ template <> struct scxt_traits<scxt::engine::Zone::ZoneMappingData>
              {"velocitySens", t.velocitySens},
              {"amplitude", t.amplitude},
              ASSIGN(t, pan),
-             {"pitchOffset", t.pitchOffset},
-             ASSIGN(t, triggerOnNoteOff),
-             ASSIGN(t, voiceTerminateWithEnvelope),
-             ASSIGN(t, loopActive),
-             ASSIGN(t, loopOnlyUntilNoteOff),
-             ASSIGN(t, loopBidirectional),
-             ASSIGN(t, playReverse)};
+             {"pitchOffset", t.pitchOffset}};
     }
 
     template <template <typename...> class Traits>
@@ -189,15 +183,15 @@ template <> struct scxt_traits<scxt::engine::Zone::ZoneMappingData>
         findIf(v, "pitchOffset", zmd.pitchOffset);
         findOrSet(v, "velocitySens", 1.0, zmd.velocitySens);
         findOrSet(v, "exclusiveGroup", 0, zmd.exclusiveGroup);
-
-        FINDOR(zmd, triggerOnNoteOff, false);
-        FINDOR(zmd, voiceTerminateWithEnvelope, true);
-        FINDOR(zmd, loopActive, false);
-        FINDOR(zmd, loopOnlyUntilNoteOff, false);
-        FINDOR(zmd, loopBidirectional, false);
-        FINDOR(zmd, playReverse, false);
     }
 };
+
+STREAM_ENUM(engine::Zone::PlayMode, engine::Zone::toStringPlayMode,
+            engine::Zone::fromStringPlayMode);
+STREAM_ENUM(engine::Zone::LoopMode, engine::Zone::toStringLoopMode,
+            engine::Zone::fromStringLoopMode);
+STREAM_ENUM(engine::Zone::LoopDirection, engine::Zone::toStringLoopDirection,
+            engine::Zone::fromStringLoopDirection);
 
 template <> struct scxt_traits<scxt::engine::Zone::AssociatedSample>
 {
@@ -206,8 +200,19 @@ template <> struct scxt_traits<scxt::engine::Zone::AssociatedSample>
     static void assign(tao::json::basic_value<Traits> &v,
                        const scxt::engine::Zone::AssociatedSample &s)
     {
-        v = {{"active", s.active},       {"id", s.sampleID},         {"startSample", s.startSample},
-             {"endSample", s.endSample}, {"startLoop", s.startLoop}, {"endLoop", s.endLoop}};
+        v = {{"active", s.active},
+             {"id", s.sampleID},
+             {"startSample", s.startSample},
+             {"endSample", s.endSample},
+             {"startLoop", s.startLoop},
+             {"endLoop", s.endLoop},
+             {"playMode", s.playMode},
+             {"loopActive", s.loopActive},
+             {"playReverse", s.playReverse},
+             {"loopMode", s.loopMode},
+             {"loopDirection", s.loopDirection},
+             {"loopCountWhenCounted", s.loopCountWhenCounted},
+             {"loopFade", s.loopFade}};
     }
 
     template <template <typename...> class Traits>
@@ -219,6 +224,13 @@ template <> struct scxt_traits<scxt::engine::Zone::AssociatedSample>
         findOrSet(v, "endSample", -1, s.endSample);
         findOrSet(v, "startLoop", -1, s.startLoop);
         findOrSet(v, "endLoop", -1, s.endLoop);
+        findOrSet(v, "playMode", engine::Zone::PlayMode::NORMAL, s.playMode);
+        findOrSet(v, "loopActive", false, s.loopActive);
+        findOrSet(v, "playReverse", false, s.playReverse);
+        findOrSet(v, "loopMode", engine::Zone::LoopMode::LOOP_DURING_VOICE, s.loopMode);
+        findOrSet(v, "loopDirection", engine::Zone::LoopDirection::FORWARD, s.loopDirection);
+        findOrSet(v, "loopFade", 0, s.loopFade);
+        findOrSet(v, "loopCountWhenCounted", 0, s.loopCountWhenCounted);
     }
 };
 

--- a/src/json/scxt_traits.h
+++ b/src/json/scxt_traits.h
@@ -75,5 +75,22 @@ template <typename V, typename R> void findOrDefault(V &v, const std::string &ke
 #define FIND(x, y) findIf(v, #y, x.y)
 #define FINDOR(x, y, d) findOrSet(v, #y, d, x.y);
 
+#define STREAM_ENUM(E, toS, fromS)                                                                 \
+    template <> struct scxt_traits<E>                                                              \
+    {                                                                                              \
+        template <template <typename...> class Traits>                                             \
+        static void assign(tao::json::basic_value<Traits> &v, const E &s)                          \
+        {                                                                                          \
+            v = {{#E, toS(s)}};                                                                    \
+        }                                                                                          \
+        template <template <typename...> class Traits>                                             \
+        static void to(const tao::json::basic_value<Traits> &v, E &r)                              \
+        {                                                                                          \
+            std::string s;                                                                         \
+            findIf(v, #E, s);                                                                      \
+            r = fromS(s);                                                                          \
+        }                                                                                          \
+    };
+
 } // namespace scxt::json
 #endif // SHORTCIRCUIT_SCXT_TRAITS_H

--- a/src/utils.h
+++ b/src/utils.h
@@ -36,6 +36,7 @@
 #include <iostream>
 #include <map>
 #include <thread>
+#include "unordered_map"
 
 namespace scxt
 {
@@ -224,6 +225,22 @@ struct ThreadingChecker
 };
 
 #define SCDBGCOUT std::cout << __FILE__ << ":" << __LINE__ << " "
+#define SCXBGV(x) #x << " = " << (x)
+
+#define DECLARE_ENUM_STRING(E)                                                                     \
+    static std::string toString##E(const E &);                                                     \
+    static E fromString##E(const std::string &);
+
+template <typename E, std::string (*F)(const E &)>
+inline std::unordered_map<std::string, E> makeEnumInverse(const E &from, const E &to)
+{
+    std::unordered_map<std::string, E> res;
+    for (auto i = (int32_t)from; i <= to; ++i)
+    {
+        res[F((E)i)] = (E)i;
+    }
+    return res;
+}
 
 } // namespace scxt
 

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -342,7 +342,7 @@ void Voice::initializeGenerator()
             break;
         }
 
-        if (sampleData.loopDirection == engine::Zone::ALTERNATE)
+        if (sampleData.loopDirection == engine::Zone::ALTERNATE_DIRECTIONS)
             generateMode = dsp::GSM_Bidirectional;
     }
 


### PR DESCRIPTION
Add a more comprehensive 'switch-' based way to configure the play back (is looping, does loop reverse, etc...) which reflects in the (crude) ui and (partly) works in the generator. Also make enum streaming a bit less cumbersome.