### PR TITLE
Day 34: Generator Refactor

### DIFF
--- a/doc/NextSteps.md
+++ b/doc/NextSteps.md
@@ -4,8 +4,7 @@ Ideally this would become the issue list over the next fortnight with the header
 
 * Voice Management 
   * Voice Lifetime
-      * AEG (not Sample End) terminates voice
-      * Optimization: Sample end, no processor, no loop, no repeat, kill voice ahead of AEG
+    * Optimization: Sample end, no processor, no loop, no repeat, kill voice ahead of AEG
   * Zone from Key Cache (from linear search to cached data structure on noteOn/noteOff)
   * Voice Creation/Delete/Reuse modes
     * Poly mode works (this should be "done" but lets check it) 
@@ -52,10 +51,12 @@ Ideally this would become the issue list over the next fortnight with the header
     * What parts of sample etc... are modulatable (list all the targets)
   * Temposync Support
   * Generator
+    * Loop Fades
     * DSP Support for alternate bit depths beyond I16 and F32
-      * 24 bit
-      * 8 bit
+      * 24 bit - currently upscales to F32. OK?
+      * 8 bit - currently upscales to I16. OK?
       * 12 bit
+      
 
 * Structure
   * Zone
@@ -140,6 +141,7 @@ Ideally this would become the issue list over the next fortnight with the header
       * Playing Zone Display
       * etc
     * etc
+  * Playing Zone indicator and perhaps Playing POsition in Sample Indicator
 
 * User Journeys
   * Each journey would be an issue ideally, and we would close it when we could do it and have it 

--- a/doc/Sprints.md
+++ b/doc/Sprints.md
@@ -1,7 +1,9 @@
 ## Day 34 (2023-03-15)
 
 It's still all playmodes. Restructure to the per-variation switches-based version in the UI
-and the data structure and merge it.
+and the data structure and merge it. Then basically rewrite the generator object for every
+part except the sinc window resampler, cleaning up and improving the looping and so on
+support.
 
 ## Day 33 (2023-03-14)
 

--- a/libs/catch2/include/catch2/catch2.hpp
+++ b/libs/catch2/include/catch2/catch2.hpp
@@ -19361,14 +19361,14 @@ void XmlReporter::benchmarkEnded(BenchmarkStats<> const &benchmarkStats)
 {
     m_xml.startElement("mean")
         .writeAttribute("value", benchmarkStats.mean.point.count())
-        .writeAttribute("lowerBound", benchmarkStats.mean.lower_bound.count())
-        .writeAttribute("upperBound", benchmarkStats.mean.upper_bound.count())
+        .writeAttribute("loopLowerBound", benchmarkStats.mean.lower_bound.count())
+        .writeAttribute("loopUpperBound", benchmarkStats.mean.upper_bound.count())
         .writeAttribute("ci", benchmarkStats.mean.confidence_interval);
     m_xml.endElement();
     m_xml.startElement("standardDeviation")
         .writeAttribute("value", benchmarkStats.standardDeviation.point.count())
-        .writeAttribute("lowerBound", benchmarkStats.standardDeviation.lower_bound.count())
-        .writeAttribute("upperBound", benchmarkStats.standardDeviation.upper_bound.count())
+        .writeAttribute("loopLowerBound", benchmarkStats.standardDeviation.lower_bound.count())
+        .writeAttribute("loopUpperBound", benchmarkStats.standardDeviation.upper_bound.count())
         .writeAttribute("ci", benchmarkStats.standardDeviation.confidence_interval);
     m_xml.endElement();
     m_xml.startElement("outliers")

--- a/src-ui/components/multi/MappingPane.cpp
+++ b/src-ui/components/multi/MappingPane.cpp
@@ -489,7 +489,7 @@ struct SampleDisplay : juce::Component, HasEditor
 
         auto l = samp->getSampleLength();
 
-        if (samp->UseInt16)
+        if (samp->bitDepth == sample::Sample::BD_I16)
         {
             auto fac = 1.0 * l / r.getWidth();
             auto d = samp->GetSamplePtrI16(0);
@@ -537,7 +537,7 @@ struct SampleDisplay : juce::Component, HasEditor
                 mn = std::min(d[s], mn);
             }
         }
-        else
+        else if (samp->bitDepth == sample::Sample::BD_F32)
         {
             auto fac = 1.0 * l / r.getWidth();
             auto d = samp->GetSamplePtrF32(0);
@@ -565,6 +565,10 @@ struct SampleDisplay : juce::Component, HasEditor
                 mx = std::max(d[s], mx);
                 mn = std::min(d[s], mn);
             }
+        }
+        else
+        {
+            jassertfalse;
         }
     }
 

--- a/src/dsp/generator.cpp
+++ b/src/dsp/generator.cpp
@@ -35,6 +35,7 @@
 
 #include "sst/basic-blocks/mechanics/simd-ops.h"
 #include <array>
+#include <cassert>
 
 namespace scxt::dsp
 {

--- a/src/dsp/generator.cpp
+++ b/src/dsp/generator.cpp
@@ -34,100 +34,67 @@
 #include <algorithm>
 
 #include "sst/basic-blocks/mechanics/simd-ops.h"
+#include <array>
 
 namespace scxt::dsp
 {
 const float I16InvScale = (1.f / (16384.f * 32768.f));
 const __m128 I16InvScale_m128 = _mm_set1_ps(I16InvScale);
 
-template <bool stereo, bool floatingPoint, int loopMode>
+template <int compoundConfig>
 void GeneratorSample(GeneratorState *__restrict GD, GeneratorIO *__restrict IO);
 
-GeneratorFPtr GetFPtrGeneratorSample(bool Stereo, bool Float, int LoopMode)
+int toLoopValue(bool active, bool forward, bool whileGated, bool isFloat, bool isStereo)
 {
-    if (Stereo)
-    {
-        if (Float)
-        {
-            switch (LoopMode)
-            {
-            case 0:
-                return GeneratorSample<1, 1, 0>;
-            case 1:
-                return GeneratorSample<1, 1, 1>;
-            case 2:
-                return GeneratorSample<1, 1, 2>;
-            case 3:
-                return GeneratorSample<1, 1, 3>;
-            case 4:
-                return GeneratorSample<1, 1, 4>;
-            }
-        }
-        else
-        {
-            switch (LoopMode)
-            {
-            case 0:
-                return GeneratorSample<1, 0, 0>;
-            case 1:
-                return GeneratorSample<1, 0, 1>;
-            case 2:
-                return GeneratorSample<1, 0, 2>;
-            case 3:
-                return GeneratorSample<1, 0, 3>;
-            case 4:
-                return GeneratorSample<1, 0, 4>;
-            }
-        }
-    }
-    else
-    {
-        if (Float)
-        {
-            switch (LoopMode)
-            {
-            case 0:
-                return GeneratorSample<0, 1, 0>;
-            case 1:
-                return GeneratorSample<0, 1, 1>;
-            case 2:
-                return GeneratorSample<0, 1, 2>;
-            case 3:
-                return GeneratorSample<0, 1, 3>;
-            case 4:
-                return GeneratorSample<0, 1, 4>;
-            }
-        }
-        else
-        {
-            switch (LoopMode)
-            {
-            case 0:
-                return GeneratorSample<0, 0, 0>;
-            case 1:
-                return GeneratorSample<0, 0, 1>;
-            case 2:
-                return GeneratorSample<0, 0, 2>;
-            case 3:
-                return GeneratorSample<0, 0, 3>;
-            case 4:
-                return GeneratorSample<0, 0, 4>;
-            }
-        }
-    }
-    return 0;
+    return ((isStereo * 1) << 4) + ((isFloat * 1) << 3) + ((active * 1) << 2) +
+           ((forward * 1) << 1) + (whileGated * 1);
 }
 
-template <bool stereo, bool fp, int playmode>
+constexpr std::array<bool, 5> fromLoopValue(int lv)
+{
+    bool whileGated = (lv & (1 << 0));
+    bool forward = (lv & (1 << 1));
+    bool active = (lv & (1 << 2));
+    bool isfl = (lv & (1 << 3));
+    bool stereo = (lv & (1 << 4));
+    return {active, forward, whileGated, isfl, stereo};
+}
+
+namespace detail
+{
+using genOp_t = GeneratorFPtr (*)();
+template <size_t I> GeneratorFPtr implGeneratorGetImpl() { return GeneratorSample<I>; }
+
+template <size_t... Is> auto generatorGet(size_t ft, std::index_sequence<Is...>)
+{
+    constexpr genOp_t fnc[] = {detail::implGeneratorGetImpl<Is>...};
+    return fnc[ft]();
+}
+} // namespace detail
+
+GeneratorFPtr GetFPtrGeneratorSample(bool Stereo, bool Float, bool loopActive, bool loopForward,
+                                     bool loopWhileGated)
+{
+    auto loopValue = toLoopValue(loopActive, loopForward, loopWhileGated, Float, Stereo);
+    assert(loopValue >= 0 && loopValue < (1 << 5));
+    return detail::generatorGet(loopValue, std::make_index_sequence<(1 << 5) - 1>());
+}
+
+template <int loopValue>
 void GeneratorSample(GeneratorState *__restrict GD, GeneratorIO *__restrict IO)
 {
+    static constexpr auto mode = fromLoopValue(loopValue);
+    static constexpr auto loopActive = std::get<0>(mode);
+    static constexpr auto loopForward = std::get<1>(mode);
+    static constexpr auto loopWhileGated = std::get<2>(mode);
+    static constexpr auto fp = std::get<3>(mode);
+    static constexpr auto stereo = std::get<4>(mode);
+
     int SamplePos = GD->samplePos;
     int SampleSubPos = GD->sampleSubPos;
-    int LowerBound = GD->lowerBound;
-    int UpperBound = GD->upperBound;
     int IsFinished = GD->isFinished;
     int WaveSize = IO->waveSize;
-    int LoopOffset = std::max(1, UpperBound - LowerBound);
+    int LoopOffset = std::max(1, GD->loopUpperBound - GD->loopLowerBound);
     int Ratio = GD->ratio;
     int RatioSign = Ratio < 0 ? -1 : 1;
     Ratio = std::abs(Ratio);
@@ -156,7 +123,8 @@ void GeneratorSample(GeneratorState *__restrict GD, GeneratorIO *__restrict IO)
     }
     int NSamples = GD->blockSize;
 
-    for (int i = 0; i < NSamples; i++)
+    int i;
+    for (i = 0; i < NSamples && !IsFinished; i++)
     {
         // 2. Resample
         unsigned int m0 = ((SampleSubPos >> 12) & 0xff0);
@@ -239,115 +207,144 @@ void GeneratorSample(GeneratorState *__restrict GD, GeneratorIO *__restrict IO)
         SamplePos += incr;
         SampleSubPos = SampleSubPos - (incr << 24);
 
-        // if (samplePos > upperBound) samplePos = upperBound;
-        switch (playmode)
+        if constexpr (!loopActive) // these constexprs just remind us not to refactor to break ce
         {
-        case GSM_Normal:
-        {
-            if (SamplePos > UpperBound)
+            // No loop, simple case: Play the bounds then done.
+            if (SamplePos > GD->playbackUpperBound)
             {
-                SamplePos = UpperBound;
+                SamplePos = GD->playbackUpperBound;
                 SampleSubPos = 0;
                 if (GD->direction == 1)
                     IsFinished = true;
             }
-            if (SamplePos < LowerBound)
+            if (SamplePos < GD->playbackLowerBound)
             {
-                SamplePos = LowerBound;
+                SamplePos = GD->playbackLowerBound;
                 SampleSubPos = 0;
                 if (GD->direction == -1)
                     IsFinished = true;
             }
         }
-        break;
-        case GSM_Loop:
+        else if constexpr (!loopWhileGated && loopForward)
         {
             int offset = SamplePos;
 
             if (Direction)
             {
                 // Upper
-                if (offset > UpperBound)
+                if (offset > GD->loopUpperBound)
                     offset -= LoopOffset;
             }
             else
             {
                 // Lower
-                if (offset < LowerBound)
+                if (offset < GD->loopLowerBound)
                     offset += LoopOffset;
             }
 
             if (offset > WaveSize || offset < 0)
-                offset = UpperBound;
+                offset = GD->loopUpperBound;
 
             SamplePos = offset;
         }
-        break;
-        case GSM_LoopUntilRelease:
+        else if constexpr (!loopWhileGated && !loopForward)
         {
+            // bidirectional
+            if (SamplePos >= GD->loopUpperBound)
+            {
+                Direction = -1;
+            }
+            else if (SamplePos <= GD->loopLowerBound)
+            {
+                Direction = 1;
+            }
+
+            SamplePos = std::clamp(SamplePos, 0, WaveSize);
+        }
+        else if constexpr (loopForward)
+        {
+            // gated forward
             if (GD->gated)
             {
-                auto offset = SamplePos;
+                int offset = SamplePos;
+
                 if (Direction)
                 {
-                    // Upper
-                    if (offset > UpperBound)
+                    if (offset > GD->loopUpperBound)
                         offset -= LoopOffset;
                 }
                 else
                 {
-                    // Lower
-                    if (offset < LowerBound)
+                    if (offset < GD->loopLowerBound)
                         offset += LoopOffset;
                 }
 
                 if (offset > WaveSize || offset < 0)
-                    offset = UpperBound;
+                    offset = GD->loopUpperBound;
 
                 SamplePos = offset;
             }
             else
             {
-                // In this mode the Lower/Upper are the loop markers so use the zone sample
-                // start/stop
-                if (SamplePos > GD->sampleStop)
+                if (SamplePos > GD->playbackUpperBound)
                 {
-                    SamplePos = GD->sampleStop;
+                    SamplePos = GD->playbackUpperBound;
                     SampleSubPos = 0;
-                    IsFinished = true;
+                    if (GD->direction == 1)
+                        IsFinished = true;
                 }
-                if (SamplePos < GD->sampleStart)
+                if (SamplePos < GD->playbackLowerBound)
                 {
-                    SamplePos = GD->sampleStart;
+                    SamplePos = GD->playbackLowerBound;
                     SampleSubPos = 0;
+                    if (GD->direction == -1)
+                        IsFinished = true;
                 }
             }
         }
-        break;
-        case GSM_Bidirectional:
+        else if constexpr (!loopForward && loopWhileGated)
         {
-            if (SamplePos >= UpperBound)
+            // gated bidirecational
+            if (GD->gated || (GD->direction != GD->directionAtOutset))
             {
-                Direction = -1;
+                if (SamplePos >= GD->loopUpperBound)
+                {
+                    Direction = -1;
+                }
+                else if (SamplePos <= GD->loopLowerBound)
+                {
+                    Direction = 1;
+                }
+
+                SamplePos = std::clamp(SamplePos, 0, WaveSize);
             }
-            // clang-format off
-            else if (SamplePos <= LowerBound) { Direction = 1; }
-            // clang-format on
-            SamplePos = std::clamp(SamplePos, 0, WaveSize);
-        }
-        break;
-        case GSM_Shot:
-        {
-            if (!((SamplePos >= LowerBound) && (SamplePos <= UpperBound)))
+            else
             {
-                // TODO this should end the voice no matter what
-                /*sampler_voice *v = (sampler_voice*)IO->voicePtr;
-                if (v) v->uberrelease();*/
-                IsFinished = true;
-                SamplePos = std::clamp(SamplePos, LowerBound, UpperBound);
+                // TODO : Careful with releasing a loop while going backwards
+                if (SamplePos > GD->playbackUpperBound)
+                {
+                    SamplePos = GD->playbackUpperBound;
+                    SampleSubPos = 0;
+                    if (GD->direction == 1)
+                        IsFinished = true;
+                }
+                if (SamplePos < GD->playbackLowerBound)
+                {
+                    SamplePos = GD->playbackLowerBound;
+                    SampleSubPos = 0;
+                    if (GD->direction == -1)
+                        IsFinished = true;
+                }
             }
         }
-        }
+    }
+
+    // Clean up any items left
+    for (; i < NSamples; ++i)
+    {
+        OutputL[i] = 0.f;
+        if (stereo)
+            OutputR[i] = 0.f;
     }
 
     GD->direction = Direction * RatioSign;
@@ -355,30 +352,29 @@ void GeneratorSample(GeneratorState *__restrict GD, GeneratorIO *__restrict IO)
     GD->sampleSubPos = SampleSubPos;
     GD->isFinished = IsFinished;
 
-    switch (playmode)
+    if constexpr (loopActive)
     {
-    case GSM_Loop:
-    case GSM_Bidirectional:
-        GD->isInLoop = (SamplePos >= GD->lowerBound);
-        GD->positionWithinLoop =
-            std::clamp((SamplePos - GD->lowerBound) * GD->invertedBounds, 0.f, 1.f);
-        break;
-
-    case GSM_LoopUntilRelease:
-        if (GD->gated)
+        if (!loopWhileGated)
         {
-            GD->isInLoop = (SamplePos >= GD->lowerBound);
+            GD->isInLoop = (SamplePos >= GD->loopLowerBound);
             GD->positionWithinLoop =
-                std::clamp((SamplePos - GD->lowerBound) * GD->invertedBounds, 0.f, 1.f);
+                std::clamp((SamplePos - GD->loopLowerBound) * GD->loopInvertedBounds, 0.f, 1.f);
         }
         else
         {
-            GD->isInLoop = false;
-            GD->positionWithinLoop =
-                std::clamp((SamplePos - GD->lowerBound) * GD->invertedBounds, 0.f, 1.f);
+            if (GD->gated || (GD->directionAtOutset != GD->direction))
+            {
+                GD->isInLoop = (SamplePos >= GD->loopLowerBound);
+                GD->positionWithinLoop =
+                    std::clamp((SamplePos - GD->loopLowerBound) * GD->loopInvertedBounds, 0.f, 1.f);
+            }
+            else
+            {
+                GD->isInLoop = false;
+                GD->positionWithinLoop =
+                    std::clamp((SamplePos - GD->loopLowerBound) * GD->loopInvertedBounds, 0.f, 1.f);
+            }
         }
-    default:
-        break;
     }
 }
 } // namespace scxt::dsp

--- a/src/sample/sample.h
+++ b/src/sample/sample.h
@@ -70,7 +70,7 @@ struct alignas(16) Sample : MoveableOnly<Sample>
         return {type, getPath(), getCompoundInstrument(), getCompoundRegion()};
     }
 
-    size_t getDataSize() const { return sample_length * (UseInt16 ? 2 : 4) * channels; }
+    size_t getDataSize() const { return sample_length * bitDepthByteSize(bitDepth) * channels; }
     size_t getSampleLength() const { return sample_length; }
 
     void *__restrict sampleData[2]{nullptr, nullptr};
@@ -92,7 +92,32 @@ struct alignas(16) Sample : MoveableOnly<Sample>
 
     // TODO: Consistent Names here for goodness sake
     // public data
-    bool UseInt16{false}; // TODO: Make this an enum not a binary
+    enum BitDepth
+    {
+        // Right now 8 -> I16 at load and 24 -> F32 at load and noone supports 12 so just make this
+        // BD_I8,
+        // BD_I12,
+        BD_I16,
+        // BD_I24,
+        BD_F32
+    } bitDepth{BD_F32};
+
+    static constexpr int bitDepthByteSize(BitDepth bd)
+    {
+        switch (bd)
+        {
+            // case BD_I8:
+            return 1;
+        // case BD_I12:
+        case BD_I16:
+            return 2;
+        // case BD_I24:
+        //     return 3; // this maybe should be 4?
+        case BD_F32:
+            return 4;
+        }
+    }
+
     uint8_t channels{0};
     bool Embedded{false}; // if true, sample data will be stored inside the patch/multi
     uint32_t sample_length{0};


### PR DESCRIPTION
The generator had non-mece playmodes which was odd, and they were a somewhat arbitrary list. So implement it with the various switches properly in place. Then use a few little template tricks to make it less tedious. And implement all the various modes except loop crossfade we may want.