### PR TITLE
Day 36: Some voice life and half rate fixes

### DIFF
--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -82,6 +82,10 @@ Engine::~Engine()
 
 void Engine::initiateVoice(const pathToZone_t &path)
 {
+#if DEBUG_VOICE_LIFECYCLE
+    SCDBGCOUT << "Initializing Voice at " << SCDBGV((int)path.key) << std::endl;
+#endif
+
     assert(zoneByPath(path));
     for (const auto &[idx, v] : sst::cpputils::enumerate(voices))
     {
@@ -113,8 +117,21 @@ void Engine::releaseVoice(const pathToZone_t &path)
         if (v && v->isVoiceAssigned && v->zone->id == targetId && v->key == path.key)
         {
             v->release();
+#if DEBUG_VOICE_LIFECYCLE
+            SCDBGCOUT << "Release Voice at " << SCDBGV(path.key) << std::endl;
+#endif
         }
     }
+
+#if DEBUG_VOICE_LIFECYCLE
+    for (auto &v : voices)
+    {
+        if (v && v->isVoiceAssigned)
+        {
+            SCDBGCOUT << "     PostRelease Voice at " << SCDBGV((int)v->key) << std::endl;
+        }
+    }
+#endif
 }
 
 bool Engine::processAudio()

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -44,6 +44,8 @@
 #include "selection/selection_manager.h"
 #include "memory_pool.h"
 
+#define DEBUG_VOICE_LIFECYCLE 0
+
 namespace scxt::voice
 {
 struct Voice;

--- a/src/engine/zone.cpp
+++ b/src/engine/zone.cpp
@@ -61,6 +61,10 @@ void Zone::process()
     }
     for (int i = 0; i < cleanupIdx; ++i)
     {
+
+#if DEBUG_VOICE_LIFECYCLE
+        SCDBGCOUT << "Cleanup Voice at " << SCDBGV((int)toCleanUp[i]->key) << std::endl;
+#endif
         toCleanUp[i]->cleanupVoice();
     }
 }

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -85,8 +85,7 @@ bool Voice::process()
 {
     namespace mech = sst::basic_blocks::mechanics;
 
-    assert(zone);
-    if (!isVoicePlaying)
+    if (!isVoicePlaying || !isVoiceAssigned || !zone)
     {
         memset(output, 0, sizeof(output));
         return true;

--- a/src/voice/voice.h
+++ b/src/voice/voice.h
@@ -47,7 +47,7 @@ namespace scxt::voice
 {
 struct alignas(16) Voice : MoveableOnly<Voice>, SampleRateSupport
 {
-    float output alignas(16)[2][blockSize];
+    float output alignas(16)[2][blockSize << 1];
     engine::Zone *zone{nullptr}; // I do *not* own this. The engine guarantees it outlives the voice
 
     dsp::GeneratorState GD;
@@ -156,6 +156,7 @@ struct alignas(16) Voice : MoveableOnly<Voice>, SampleRateSupport
     void cleanupVoice()
     {
         zone->removeVoice(this);
+        zone = nullptr;
         isVoiceAssigned = false;
     }
 };


### PR DESCRIPTION
1. That half rate change worked "poorly" when oversampled
2. Some more conservative fixes for resetting voices on reap which seems to avoid a crash ALiv was seeing