### PR TITLE
Day 37: The Plane Ride Back

### DIFF
--- a/doc/NextSteps.md
+++ b/doc/NextSteps.md
@@ -31,7 +31,7 @@ Ideally this would become the issue list over the next fortnight with the header
     * Split azure pipeline on mac for x86 and arm to speed up CI
   * Turn on SSE 4.1 correctly and use `mm_hadd_ps` in the generator sum
   * Review and rememdiate all the `// TODO` points I put in the new code either by making them issues or fixing
-  
+  * Promulgate the attachment pattern form ADSR ui to other bits ASAP
 
 * Multi-Output
   * Where are the mixer and router screens? Group or Part?
@@ -156,6 +156,8 @@ Ideally this would become the issue list over the next fortnight with the header
   * UI State generally. What tab is selected and so on doesn't survive editor open/close and
     selection state isn't streamed anywhere beyond the session
   * JUCE_DECLARE_COPYABLE_ everywhere
+  * Inactive knobs shouldn't draw
+  * Waveform draw and edit
 
 * User Journeys
   * Each journey would be an issue ideally, and we would close it when we could do it and have it 

--- a/doc/Sprints.md
+++ b/doc/Sprints.md
@@ -1,3 +1,14 @@
+## Day 37 (the plane ride back)
+
+- Selection Manager streamed
+- Attachment pattern gets a bit tigher
+- Mapping Region highlights selected zone in sync with sidebar
+- Keyboard layout which actually plays notes (at fixed velocity)
+- Click Zone to Select works
+- Sidebar shows selection in sync with zones and startup path
+- Drag to edit zone mappings
+
+
 ## The 10 day break (2023-03-18 - )
 
 Smaller stuff in this period.

--- a/src-ui/components/SCXTEditor.cpp
+++ b/src-ui/components/SCXTEditor.cpp
@@ -172,7 +172,9 @@ void SCXTEditor::drainCallbackQueue()
 void SCXTEditor::singleSelectItem(const selection::SelectionManager::ZoneAddress &a)
 {
     namespace cmsg = scxt::messaging::client;
+    currentSingleSelection = a;
     cmsg::clientSendToSerialization(cmsg::SingleSelectAddress(a), msgCont);
+    repaint();
 }
 
 bool SCXTEditor::isInterestedInFileDrag(const juce::StringArray &files)

--- a/src-ui/components/SCXTEditor.h
+++ b/src-ui/components/SCXTEditor.h
@@ -117,6 +117,7 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::FileDragAndDrop
     void onZoneLfoUpdated(const scxt::messaging::client::indexedLfoUpdate_t &);
 
     void onGroupZoneMappingSummary(const scxt::engine::Group::zoneMappingSummary_t &);
+    void onSingleSelection(const scxt::selection::SelectionManager::ZoneAddress &);
 
     std::vector<dsp::processor::ProcessorDescription> allProcessors;
     void onAllProcessorDescriptions(const std::vector<dsp::processor::ProcessorDescription> &v)
@@ -126,6 +127,7 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::FileDragAndDrop
 
     // Originate client to serialization messages
     void singleSelectItem(const selection::SelectionManager::ZoneAddress &);
+    selection::SelectionManager::ZoneAddress currentSingleSelection;
 
     void showTooltip(const juce::Component &relativeTo);
     void hideTooltip();

--- a/src-ui/components/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/components/SCXTEditorResponseHandlers.cpp
@@ -140,4 +140,12 @@ void SCXTEditor::onErrorFromEngine(const scxt::messaging::client::s2cError_t &e)
     auto &[title, msg] = e;
     juce::AlertWindow::showMessageBoxAsync(juce::MessageBoxIconType::WarningIcon, title, msg, "OK");
 }
+
+void SCXTEditor::onSingleSelection(const scxt::selection::SelectionManager::ZoneAddress &s)
+{
+    currentSingleSelection = s;
+    multiScreen->parts->setCurrentSelection(s);
+    multiScreen->sample->setCurrentSelection(s);
+    repaint();
+}
 } // namespace scxt::ui

--- a/src-ui/components/multi/MappingPane.h
+++ b/src-ui/components/multi/MappingPane.h
@@ -32,6 +32,7 @@
 #include "components/HasEditor.h"
 #include "engine/zone.h"
 #include "engine/group.h"
+#include "selection/selection_manager.h"
 
 namespace scxt::ui::multi
 {
@@ -50,6 +51,7 @@ struct MappingPane : sst::jucegui::components::NamedPanel, HasEditor
     void setMappingData(const engine::Zone::ZoneMappingData &);
     void setSampleData(const engine::Zone::AssociatedSampleArray &);
     void setGroupZoneMappingSummary(const engine::Group::zoneMappingSummary_t &);
+    void setCurrentSelection(const selection::SelectionManager::ZoneAddress &);
     void setActive(bool b);
 
     std::unique_ptr<MappingDisplay> mappingDisplay;

--- a/src-ui/components/multi/PartGroupSidebar.cpp
+++ b/src-ui/components/multi/PartGroupSidebar.cpp
@@ -116,6 +116,26 @@ void PartGroupSidebar::setPartGroupZoneStructure(const engine::Engine::pgzStruct
 {
     pgzStructure = p;
     pgzList->updateContent();
+    setCurrentSelection(editor->currentSingleSelection);
+    repaint();
+}
+
+void PartGroupSidebar::setCurrentSelection(const selection::SelectionManager::ZoneAddress &a)
+{
+    int selR = -1;
+    for (const auto &[i, r] : sst::cpputils::enumerate(pgzStructure))
+    {
+        if ((r.first.part == a.part) && (r.first.group == a.group) && (r.first.zone == a.zone))
+        {
+            selR = i;
+        }
+    }
+    if (selR > 0)
+    {
+        juce::SparseSet<int> rows;
+        rows.addRange({selR, selR + 1});
+        pgzList->setSelectedRows(rows, juce::dontSendNotification);
+    }
     repaint();
 }
 } // namespace scxt::ui::multi

--- a/src-ui/components/multi/PartGroupSidebar.h
+++ b/src-ui/components/multi/PartGroupSidebar.h
@@ -42,6 +42,7 @@ struct PartGroupSidebar : sst::jucegui::components::NamedPanel, HasEditor
 
     engine::Engine::pgzStructure_t pgzStructure;
     void setPartGroupZoneStructure(const engine::Engine::pgzStructure_t &p);
+    void setCurrentSelection(const selection::SelectionManager::ZoneAddress &a);
 
     // TODO this is all just temporary hackitude of course
     std::unique_ptr<juce::ListBox> pgzList;

--- a/src-ui/connectors/Connectors.h
+++ b/src-ui/connectors/Connectors.h
@@ -1,0 +1,61 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2023, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_UI_CONNECTORS_CONNECTORS_H
+#define SCXT_SRC_UI_CONNECTORS_CONNECTORS_H
+
+#include <utility>
+#include <memory>
+#include <string>
+namespace scxt::ui::connectors
+{
+template <typename attachment_t, typename widget_t> struct ConnectorFactory
+{
+    typedef std::function<void(const attachment_t &a)> onGuiChange_t;
+    onGuiChange_t onGuiChange{nullptr};
+    typename attachment_t::parent_t *parent{nullptr};
+    typename attachment_t::payload_t &payload;
+    ConnectorFactory(onGuiChange_t fn, typename attachment_t::parent_t *that,
+                     typename attachment_t::payload_t &pl)
+        : onGuiChange(fn), parent(that), payload(pl)
+    {
+    }
+
+    template <typename D, typename M>
+    std::pair<std::unique_ptr<attachment_t>, std::unique_ptr<widget_t>> attach(const std::string &l,
+                                                                               D &d, M m)
+    {
+        auto at = std::make_unique<attachment_t>(
+            parent, d, l, onGuiChange,
+            [m](const typename attachment_t::payload_t &pl) { return pl.*m; }, payload.*m);
+        auto w = std::make_unique<widget_t>();
+        w->setSource(at.get());
+        return {std::move(at), std::move(w)};
+    }
+};
+} // namespace scxt::ui::connectors
+#endif // SHORTCIRCUIT_CONNECTORS_H

--- a/src-ui/connectors/PayloadDataAttachment.h
+++ b/src-ui/connectors/PayloadDataAttachment.h
@@ -40,6 +40,9 @@ namespace scxt::ui::connectors
 template <typename Parent, typename Payload, typename ValueType = float>
 struct PayloadDataAttachment : sst::jucegui::data::ContinunousModulatable
 {
+    typedef Parent parent_t;
+    typedef Payload payload_t;
+
     ValueType &value;
     std::string label;
     std::function<void(const PayloadDataAttachment &at)> onGuiValueChanged;

--- a/src-ui/connectors/SCXTStyleSheetCreator.cpp
+++ b/src-ui/connectors/SCXTStyleSheetCreator.cpp
@@ -57,4 +57,11 @@ const sheet_t::ptr_t SCXTStyleSheetCreator::setup()
     return base;
 }
 
+juce::Font SCXTStyleSheetCreator::interMediumFor(int ht)
+{
+    static auto interMed = juce::Typeface::createSystemTypefaceFor(
+        scxt::ui::binary::InterMedium_ttf, scxt::ui::binary::InterMedium_ttfSize);
+    return juce::Font(interMed).withHeight(ht);
+}
+
 } // namespace scxt::ui::connectors

--- a/src-ui/connectors/SCXTStyleSheetCreator.h
+++ b/src-ui/connectors/SCXTStyleSheetCreator.h
@@ -40,6 +40,8 @@ struct SCXTStyleSheetCreator
     static constexpr sheet_t::Class ModulationTabs{"modulation.tabs"};
 
     static const sheet_t::ptr_t setup();
+
+    static juce::Font interMediumFor(int ht);
 };
 } // namespace scxt::ui::connectors
 #endif // SHORTCIRCUIT_SCXTSTYLESHEET_H

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -38,11 +38,15 @@
 #include "gig.h"
 #include "SF.h"
 
+#include "version.h"
 namespace scxt::engine
 {
 
 Engine::Engine()
 {
+    std::cout << "Shortcircuit XT : Constructing Engine - Version " << scxt::build::FullVersionStr
+              << std::endl;
+
     id.id = rand() % 1024;
 
     messageController = std::make_unique<messaging::MessageController>(*this);

--- a/src/engine/group.h
+++ b/src/engine/group.h
@@ -35,6 +35,7 @@
 
 #include "utils.h"
 #include "zone.h"
+#include "selection/selection_manager.h"
 
 namespace scxt::engine
 {

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -49,6 +49,7 @@
 #include "dsp_traits.h"
 #include "modulation_traits.h"
 #include "datamodel_traits.h"
+#include "selection_traits.h"
 
 namespace scxt::json
 {
@@ -59,6 +60,7 @@ template <> struct scxt_traits<scxt::engine::Engine>
     {
         v = {{"streamingVersion", scxt::json::currentStreamingVersion},
              {"patch", e.getPatch()},
+             {"selectionManager", e.getSelectionManager()},
              {"sampleManager", e.getSampleManager()}};
     }
 
@@ -66,9 +68,10 @@ template <> struct scxt_traits<scxt::engine::Engine>
     static void to(const tao::json::basic_value<Traits> &v, scxt::engine::Engine &engine)
     {
         // TODO: engine gets a SV? Guess maybe
-        // Order matters here. Samples need to be there before the patch
+        // Order matters here. Samples need to be there before the patch and patch before selection
         findIf(v, "sampleManager", *(engine.getSampleManager()));
         findIf(v, "patch", *(engine.getPatch()));
+        findIf(v, "selectionManager", *(engine.getSelectionManager()));
     }
 };
 

--- a/src/json/selection_traits.h
+++ b/src/json/selection_traits.h
@@ -58,6 +58,26 @@ template <> struct scxt_traits<scxt::selection::SelectionManager::ZoneAddress>
         findIf(v, "zone", z.zone);
     }
 };
+
+template <> struct scxt_traits<selection::SelectionManager>
+{
+    typedef selection::SelectionManager sm_t;
+    template <template <typename...> class Traits>
+    static void assign(tao::json::basic_value<Traits> &v, const sm_t &e)
+    {
+        v = {{"zone", *(e.getSelectedZone())}, {"tabs", e.otherTabSelection}};
+        auto z = e.getSelectedZone();
+    }
+
+    template <template <typename...> class Traits>
+    static void to(const tao::json::basic_value<Traits> &v, sm_t &z)
+    {
+        selection::SelectionManager::ZoneAddress za;
+        findIf(v, "tabs", z.otherTabSelection);
+        findIf(v, "zone", za);
+        z.singleSelect(za);
+    }
+};
 } // namespace scxt::json
 
 #endif // SHORTCIRCUIT_SELECTION_TRAITS_H

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -61,6 +61,8 @@ enum ClientToSerializationMessagesIds
 
     c2s_set_tuning_mode,
 
+    c2s_noteonoff,
+
     num_clientToSerializationMessages
 };
 
@@ -81,6 +83,7 @@ enum SerializationToClientMessageIds
     s2c_respond_single_processor_metadata_and_data,
 
     s2c_send_selected_group_zone_mapping_summary,
+    s2c_send_single_selection,
 
     num_serializationToClientMessages
 };

--- a/src/messaging/client/group_messages.h
+++ b/src/messaging/client/group_messages.h
@@ -30,11 +30,13 @@
 
 #include "client_macros.h"
 #include "engine/group.h"
+#include "selection/selection_manager.h"
 
 namespace scxt::messaging::client
 {
 SERIAL_TO_CLIENT(SelectedGroupZoneMappingSummary, s2c_send_selected_group_zone_mapping_summary,
                  engine::Group::zoneMappingSummary_t, onGroupZoneMappingSummary);
-
-}
+SERIAL_TO_CLIENT(SetSingleSelection, s2c_send_single_selection,
+                 selection::SelectionManager::ZoneAddress, onSingleSelection);
+} // namespace scxt::messaging::client
 #endif // SHORTCIRCUIT_GROUP_MESSAGES_H

--- a/src/messaging/client/structure_messages.h
+++ b/src/messaging/client/structure_messages.h
@@ -62,7 +62,9 @@ inline void onRegister(engine::Engine &engine, MessageController &cont)
     assert(cont.threadingChecker.isSerialThread());
     engine.sendMetadataToClient();
     PartGroupZoneStructure::executeOnSerialization(-1, engine, cont);
-    engine.getSelectionManager()->singleSelect({});
+    engine.getSelectionManager()->singleSelect(
+        engine.getSelectionManager()->getSelectedZone().value_or(
+            selection::SelectionManager::ZoneAddress()));
 }
 CLIENT_TO_SERIAL(OnRegister, c2s_on_register, bool, onRegister(engine, cont));
 

--- a/src/messaging/messaging.cpp
+++ b/src/messaging/messaging.cpp
@@ -181,7 +181,6 @@ void MessageController::runSerialization()
         }
         else
         {
-            SCDBGCOUT << "Serial thread complete" << std::endl;
         }
     }
 }

--- a/src/sample/sample.h
+++ b/src/sample/sample.h
@@ -171,8 +171,9 @@ struct alignas(16) Sample : MoveableOnly<Sample>
   private:
     void clear_data()
     {
-        std::cout << __FILE__ << ":" << __LINE__ << " " << __func__ << std::endl;
-    }; // deletes sample data and marks sample as unused
+        // TODO: Figure Out and Implement clear_data
+        // deletes sample data and marks sample as unused
+    }
 
     bool allocateI16(int Channel, int Samples);
     bool allocateF32(int Channel, int Samples);

--- a/src/selection/selection_manager.cpp
+++ b/src/selection/selection_manager.cpp
@@ -38,6 +38,7 @@ namespace cms = messaging::client;
 void SelectionManager::singleSelect(const ZoneAddress &a)
 {
     auto [p, g, z] = a;
+    serializationSendToClient(cms::s2c_send_single_selection, a, *(engine.getMessageController()));
     if (p >= 0 && g >= 0)
     {
         serializationSendToClient(

--- a/src/selection/selection_manager.h
+++ b/src/selection/selection_manager.h
@@ -32,6 +32,8 @@
 #include <vector>
 #include <cstdint>
 #include <map>
+#include <string>
+#include <unordered_map>
 
 namespace scxt::engine
 {
@@ -59,8 +61,10 @@ struct SelectionManager
         int32_t zone{-1};
     };
 
-    std::optional<ZoneAddress> getSelectedZone() { return singleSelection; }
+    std::optional<ZoneAddress> getSelectedZone() const { return singleSelection; }
     void singleSelect(const ZoneAddress &z);
+
+    std::unordered_map<std::string, std::string> otherTabSelection;
 
   protected:
     MainSelection mainSelection{MULTI};

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -34,12 +34,12 @@ namespace scxt
 std::map<std::string, std::pair<int, int>> allocLog;
 void showLeakLog()
 {
-    std::cout << "\nMemory Allocation Log of NoCopy classes\n";
     for (const auto &[k, v] : allocLog)
     {
         auto [a, d] = v;
-        std::cout << "   class=" << k << "  ctor=" << a << " dtor=" << d
-                  << ((a != d) ? " ERROR!!" : " OK") << std::endl;
+        if (a != d)
+            std::cout << "LEAK:   class=" << k << "  ctor=" << a << " dtor=" << d
+                      << ((a != d) ? " ERROR!!" : " OK") << std::endl;
     }
 }
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -229,6 +229,7 @@ struct ThreadingChecker
 
 #define SCDBGCOUT std::cout << __FILE__ << ":" << __LINE__ << " "
 #define SCDBGV(x) #x << "=" << (x) << " "
+#define SCD(x) SCDBGV(x)
 
 #define DECLARE_ENUM_STRING(E)                                                                     \
     static std::string toString##E(const E &);                                                     \


### PR DESCRIPTION
- SelectionManager streams and remembers the selected zone
- Improve but don't perfect the attachment coding model
- Mapping Region highlights selected zone in sync with sidebar
- Keyboard layout which actually plays notes (at fixed velocity)
- Click Zone selects zone (with rotation on overlaps)
- Sidebar shows selection in sync with startup and click to select
- Drag hotzons in note/vel space on selected zone work
- Slightly more reasonable mapping draw
- Push selection through so we can make hot zones
- Correct Directional Drags on Mapping Zones
- Correct font available from the Stylesheet
- Use the correct font for the sample regions