### PR TITLE
Day 41: Stereo SF2 Fixed

### DIFF
--- a/doc/Sprints.md
+++ b/doc/Sprints.md
@@ -1,3 +1,7 @@
+## Day 41 (2023-04-01)
+
+Welcome to April! Anyway start by fixing stereo SF2 (#492).
+
 ## Day 40 (2023-03-31)
 
 Again a slow dev day. Added FLAC support; added a single function to push an error to the client.

--- a/src-ui/components/SCXTEditor.cpp
+++ b/src-ui/components/SCXTEditor.cpp
@@ -173,6 +173,7 @@ void SCXTEditor::singleSelectItem(const selection::SelectionManager::ZoneAddress
 {
     namespace cmsg = scxt::messaging::client;
     currentSingleSelection = a;
+    SCDBGCOUT << __func__ << " " << SCD(a.part) << SCD(a.group) << SCD(a.zone) << std::endl;
     cmsg::clientSendToSerialization(cmsg::SingleSelectAddress(a), msgCont);
     repaint();
 }

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -411,9 +411,6 @@ void Engine::sendMetadataToClient() const
 void Engine::loadSf2MultiSampleIntoSelectedPart(const fs::path &p)
 {
     assert(messageController->threadingChecker.isSerialThread());
-    // TODO: Make this (obvioosly) do something else
-    // TODO: Make this stop the engine as well duh
-    SCDBGCOUT << "SF2 Load " << p.u8string() << std::endl;
 
     try
     {
@@ -521,7 +518,7 @@ void Engine::loadSf2MultiSampleIntoSelectedPart(const fs::path &p)
                 zn->eg2Storage.d = s2a(reg->GetEG2Decay());
                 zn->eg2Storage.s = sus2l(reg->GetEG2Sustain());
                 zn->eg2Storage.r = s2a(reg->GetEG2Release());
-
+#if 0
                 std::cout << "STUFF I HAVEN'T DEALT WITH YET" << std::endl;
                 cout << "\t\t    Modulation Envelope Generator" << endl;
                 cout << "\t\t\tPitch=" << GetValue(reg->modEnvToPitch) << "cents, Cutoff=";
@@ -583,6 +580,7 @@ void Engine::loadSf2MultiSampleIntoSelectedPart(const fs::path &p)
                 if (reg->exclusiveClass)
                     cout << ", Exclusive group=" << reg->exclusiveClass;
                 cout << endl;
+#endif
 
                 grp->addZone(zn);
             }


### PR DESCRIPTION
Use the correct SampleType left/right handling for stereo samples in SF2 import (since all regions are mono basically).

Closes #492