### PR TITLE
Day 42: SF2 Bounds Correction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ option(SCXT_COPY_PLUGIN_AFTER_BUILD "Copy plugin after build if possible" ON)
 
 option(SCXT_USE_FLAC "Include flac support from xiph/flac" ON)
 
+option(SCXT_SANITIZE "Build with CLang/gcc address and undef sanitizer" OFF)
+
 
 # Calculate bitness
 math(EXPR BITS "8*${CMAKE_SIZEOF_VOID_P}")

--- a/doc/Sprints.md
+++ b/doc/Sprints.md
@@ -1,3 +1,8 @@
+## Day 42 (2023-04-02)
+
+Again a slow dev day. Some more fixes to my SF2 fixes which I think will solve
+oddy's linux problem.
+
 ## Day 41 (2023-04-01)
 
 Welcome to April! Anyway start by fixing stereo SF2 (#492). Make extension

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -420,7 +420,10 @@ void Engine::loadSf2MultiSampleIntoSelectedPart(const fs::path &p)
         auto pt = 0;
         if (sz.has_value())
             pt = sz->part;
+        if (pt < 0 || pt >= Patch::numParts)
+            pt = 0;
 
+        SCDBGCOUT << "Adding SF2 to part " << SCD(pt) << std::endl;
         auto &part = getPatch()->getPart(pt);
         for (int i = 0; i < sf->GetInstrumentCount(); ++i)
         {

--- a/src/sample/sample.cpp
+++ b/src/sample/sample.cpp
@@ -122,7 +122,8 @@ bool Sample::loadFromSF2(const fs::path &p, sf2::File *f, int inst, int reg)
         sfsample->SampleType == sf2::Sample::MONO_SAMPLE)
     {
         auto buf = sfsample->LoadSampleData();
-        load_data_i16(0, buf.pStart, buf.Size, sfsample->GetFrameSize());
+        // >> 1 here because void* -> int16_t is byte to two bytes
+        load_data_i16(0, buf.pStart, buf.Size >> 1, sfsample->GetFrameSize());
         sfsample->ReleaseSampleData();
         return true;
     }
@@ -133,12 +134,14 @@ bool Sample::loadFromSF2(const fs::path &p, sf2::File *f, int inst, int reg)
         bool loaded{false};
         if (sfsample->SampleType == sf2::Sample::LEFT_SAMPLE)
         {
-            load_data_i16(0, (int16_t *)(buf.pStart), buf.Size >> 1, sfsample->GetFrameSize());
+            // >> 2 here because void* -> int16_t is byte to two bytes, plus two channels with a
+            // stride
+            load_data_i16(0, (int16_t *)(buf.pStart), buf.Size >> 2, sfsample->GetFrameSize());
             loaded = true;
         }
         else if (sfsample->SampleType == sf2::Sample::RIGHT_SAMPLE)
         {
-            load_data_i16(0, (int16_t *)(buf.pStart) + 1, buf.Size >> 1, sfsample->GetFrameSize());
+            load_data_i16(0, (int16_t *)(buf.pStart) + 1, buf.Size >> 2, sfsample->GetFrameSize());
             loaded = true;
         }
         sfsample->ReleaseSampleData();

--- a/src/sample/sample_manager.cpp
+++ b/src/sample/sample_manager.cpp
@@ -129,6 +129,8 @@ std::optional<SampleID> SampleManager::loadSampleFromSF2ToID(const fs::path &p, 
 
     auto sp = std::make_shared<Sample>(sid);
 
+    SCDBGCOUT << "Loading individual sf2 saample " << SCD(instrument) << SCD(region) << SCD(f)
+              << SCD(p.u8string()) << std::endl;
     if (!sp->loadFromSF2(p, f, instrument, region))
         return {};
 


### PR DESCRIPTION
SF2 loaded too much sample which would crash linux occasionally. Rememdiate.