### PR TITLE
Day 43: the "is" questions

### DIFF
--- a/clients/juce-plugin/SCXTProcessor.cpp
+++ b/clients/juce-plugin/SCXTProcessor.cpp
@@ -44,9 +44,16 @@ SCXTProcessor::SCXTProcessor()
 {
     engine = std::make_unique<scxt::engine::Engine>();
 
-    // engine->getMessageController()->threadingChecker.bypassThreadChecks = true;
-    // temporaryInitPatch();
-    // engine->getMessageController()->threadingChecker.bypassThreadChecks = false;
+    std::string wrapperTypeString = getWrapperTypeDescription(wrapperType);
+    if (wrapperType == wrapperType_Undefined && is_clap)
+        wrapperTypeString = std::string("CLAP");
+
+    std::string phd = juce::PluginHostType().getHostDescription();
+    if (phd != "Unknown")
+    {
+        wrapperTypeString += std::string(" in ") + juce::PluginHostType().getHostDescription();
+    }
+    engine->runningEnvironment = wrapperTypeString;
 }
 
 SCXTProcessor::~SCXTProcessor()

--- a/clients/juce-plugin/SCXTProcessor.h
+++ b/clients/juce-plugin/SCXTProcessor.h
@@ -29,8 +29,9 @@
 
 #include <juce_audio_processors/juce_audio_processors.h>
 #include <engine/engine.h>
+#include "clap-juce-extensions/clap-juce-extensions.h"
 
-class SCXTProcessor : public juce::AudioProcessor
+class SCXTProcessor : public juce::AudioProcessor, public clap_juce_extensions::clap_properties
 {
   public:
     //==============================================================================

--- a/doc/Sprints.md
+++ b/doc/Sprints.md
@@ -1,6 +1,9 @@
 ## Day 43 (2023-04-03)
 
-Superquickly, select the first new zone when importing an SF2.
+Superquickly, select the first new zone when importing an SF2. Then turn to the
+"is" questions state (isAudioRunning, isClientConnected; #430) which lets me also
+do things like engine status up to the UI properly (although I dont paint the
+audio state now jsut the rest in the about screen).
 
 ## Day 42 (2023-04-02)
 
@@ -13,7 +16,7 @@ very simple SFZs work. Tomorrow is either pixels or processors or playing state.
 ## Day 41 (2023-04-01)
 
 Welcome to April! Anyway start by fixing stereo SF2 (#492). Make extension
-checks on files case insnsitive.
+checks on files case insensitive.
 
 I think my next big swaths of work are: port more of the
 zone processors, make the ui match the wireframe for a zone pixel perfectly, and

--- a/src-ui/components/AboutScreen.cpp
+++ b/src-ui/components/AboutScreen.cpp
@@ -31,6 +31,7 @@
 #include "utils.h"
 #include "version.h"
 #include "sst/plugininfra/cpufeatures.h"
+#include "SCXTEditor.h"
 
 namespace scxt::ui
 {
@@ -50,6 +51,12 @@ AboutScreen::AboutScreen(SCXTEditor *e) : HasEditor(e)
     aboutFont = juce::Font(interMed);
     aboutFont.setHeight(20);
 
+    resetInfo();
+}
+
+void AboutScreen::resetInfo()
+{
+    info.clear();
     info.push_back({"Version", scxt::build::FullVersionStr, false});
 
     std::string platform = juce::SystemStats::getOperatingSystemName().toStdString();
@@ -65,7 +72,10 @@ AboutScreen::AboutScreen(SCXTEditor *e) : HasEditor(e)
                     std::string() + scxt::build::BuildDate + " " + scxt::build::BuildTime +
                         " with " + scxt::build::BuildCompiler,
                     false});
-    info.push_back({"Env", "(PluginType) at (SampleRate)", false});
+    info.push_back({"Env",
+                    fmt::format("{} at {} Hz", editor->engineStatus.runningEnvironment,
+                                (int)editor->engineStatus.sampleRate),
+                    false});
 }
 void AboutScreen::paint(juce::Graphics &g)
 {
@@ -135,5 +145,10 @@ void AboutScreen::resized()
                  .withY(getHeight() - (info.size() + 1.5) * infoh - 5)
                  .withTrimmedLeft(5);
     copyButton->setBounds(r);
+}
+void AboutScreen::visibilityChanged()
+{
+    if (isVisible())
+        resetInfo();
 }
 } // namespace scxt::ui

--- a/src-ui/components/AboutScreen.h
+++ b/src-ui/components/AboutScreen.h
@@ -51,8 +51,11 @@ struct AboutScreen : juce::Component, HasEditor
 
     juce::Font titleFont, subtitleFont, infoFont, aboutFont;
 
+    void resetInfo();
     void copyInfo();
     void resized() override;
+
+    void visibilityChanged() override;
 
     static constexpr int infoh = 23;
 

--- a/src-ui/components/SCXTEditor.h
+++ b/src-ui/components/SCXTEditor.h
@@ -106,6 +106,7 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::FileDragAndDrop
     // Serialization to Client Messages
     void onErrorFromEngine(const scxt::messaging::client::s2cError_t &);
     void onVoiceCount(const uint32_t &v);
+    void onEngineStatus(const engine::Engine::EngineStatusMessage &e);
     void onEnvelopeUpdated(const scxt::messaging::client::adsrViewResponsePayload_t &);
     void onMappingUpdated(const scxt::messaging::client::mappingSelectedZoneViewResposne_t &);
     void onSamplesUpdated(const scxt::messaging::client::sampleSelectedZoneViewResposne_t &);
@@ -135,6 +136,7 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::FileDragAndDrop
 
     std::mutex callbackMutex;
     std::queue<std::string> callbackQueue;
+    engine::Engine::EngineStatusMessage engineStatus;
 };
 } // namespace scxt::ui
 

--- a/src-ui/components/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/components/SCXTEditorResponseHandlers.cpp
@@ -34,6 +34,7 @@
 #include "multi/PartGroupSidebar.h"
 #include "HeaderRegion.h"
 #include "components/multi/MappingPane.h"
+#include "components/AboutScreen.h"
 
 namespace scxt::ui
 {
@@ -146,6 +147,13 @@ void SCXTEditor::onSingleSelection(const scxt::selection::SelectionManager::Zone
     currentSingleSelection = s;
     multiScreen->parts->setCurrentSelection(s);
     multiScreen->sample->setCurrentSelection(s);
+    repaint();
+}
+
+void SCXTEditor::onEngineStatus(const engine::Engine::EngineStatusMessage &e)
+{
+    engineStatus = e;
+    aboutScreen->resetInfo();
     repaint();
 }
 } // namespace scxt::ui

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -68,6 +68,11 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     const std::unique_ptr<sample::SampleManager> &getSampleManager() const { return sampleManager; }
 
     /**
+     * An option to add a description of your running environment, like "VST3 in Reaper"
+     */
+    std::string runningEnvironment{"Unknown"};
+
+    /**
      * Audio processing
      */
     int getStereoOutputs() const { return 1; }
@@ -167,6 +172,18 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
      * OnRegister generate and send all the metdata the client needs
      */
     void sendMetadataToClient() const;
+
+    /*
+     * Update the audio playing state
+     */
+    void sendEngineStatusToClient() const;
+
+    struct EngineStatusMessage
+    {
+        bool isAudioRunning;
+        double sampleRate;
+        std::string runningEnvironment;
+    };
 
     /*
      * Data Query APIs

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -317,5 +317,26 @@ template <> struct scxt_traits<scxt::engine::VelocityRange>
         findIf(v, "fadeEnd", r.fadeEnd);
     }
 };
+
+template <> struct scxt_traits<engine::Engine::EngineStatusMessage>
+{
+    template <template <typename...> class Traits>
+    static void assign(tao::json::basic_value<Traits> &v,
+                       const engine::Engine::EngineStatusMessage &t)
+    {
+        v = {{"isAudioRunning", t.isAudioRunning},
+             {"sampleRate", t.sampleRate},
+             {"runningEnvironment", t.runningEnvironment}};
+    }
+
+    template <template <typename...> class Traits>
+    static void to(const tao::json::basic_value<Traits> &v, engine::Engine::EngineStatusMessage &r)
+    {
+        findIf(v, "isAudioRunning", r.isAudioRunning);
+        findIf(v, "sampleRate", r.sampleRate);
+        findIf(v, "runningEnvironment", r.runningEnvironment);
+    }
+};
+
 } // namespace scxt::json
 #endif // SHORTCIRCUIT_ENGINE_TRAITS_H

--- a/src/messaging/audio/audio_messages.cpp
+++ b/src/messaging/audio/audio_messages.cpp
@@ -50,5 +50,4 @@ void sendStructureRefresh(MessageController &mc)
     a2s.payloadType = AudioToSerialization::NONE;
     mc.sendAudioToSerialization(a2s);
 }
-
 } // namespace scxt::messaging::audio

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -71,6 +71,7 @@ enum SerializationToClientMessageIds
     s2c_report_error,
     s2c_send_initial_metadata,
     s2c_voice_count,
+    s2c_engine_status,
     s2c_respond_zone_adsr_view,
     s2c_respond_zone_mapping,
     s2c_respond_zone_samples,

--- a/src/messaging/client/enginestatus_messages.h
+++ b/src/messaging/client/enginestatus_messages.h
@@ -37,6 +37,9 @@
 namespace scxt::messaging::client
 {
 SERIAL_TO_CLIENT(VoiceCountUpdate, s2c_voice_count, uint32_t, onVoiceCount);
+
+SERIAL_TO_CLIENT(EngineStatusUpdate, s2c_engine_status, engine::Engine::EngineStatusMessage,
+                 onEngineStatus);
 } // namespace scxt::messaging::client
 
 #endif // SHORTCIRCUIT_ENGINESTATUS_MESSAGES_H

--- a/src/messaging/messaging.h
+++ b/src/messaging/messaging.h
@@ -163,6 +163,14 @@ struct MessageController : MoveableOnly<MessageController>
     ~MessageController();
 
     /**
+     * State variables for connection
+     */
+    std::atomic<bool> isClientConnected{false}, isAudioRunning{false};
+    std::atomic<int64_t> engineProcessRuns{0}; // each time process is called this updates
+    std::atomic<bool> forceStatusUpdate{false};
+    bool updateAudioRunning(); // returns true if there is a state change
+
+    /**
      * start. Called from the startup thread after the engine is created.
      * Will begin a serialization thread.
      */
@@ -303,6 +311,11 @@ struct MessageController : MoveableOnly<MessageController>
     std::atomic<bool> shouldRun{false};
 
     std::unique_ptr<std::thread> serializationThread;
+
+    int64_t localCopyOfEngineProcessRuns{engineProcessRuns};
+    int64_t localCopyOfIsAudioRunning{isAudioRunning};
+    static constexpr int32_t engineOffCountdownInit{4};
+    int32_t engineOffCountdown{engineOffCountdownInit};
 };
 
 } // namespace scxt::messaging


### PR DESCRIPTION
- Implement isClientConnected and isAudioRunning with a reliable update to isAudiorunning by a collaboration with the engine process and audio thread.
- If no audio running, run engine commands on serial thread
- Push the engine status up to client
- Show it in about screen

Closes #430
Addresses #415