### PR TITLE
Day 44: Processor Code Restructuring

### DIFF
--- a/doc/Sprints.md
+++ b/doc/Sprints.md
@@ -1,3 +1,9 @@
+## Day 44 (2023-04-04)
+
+Start with cleaning up the files for the processors some so you get
+more like a 'one pair per processor' pattern which is way easier to
+navigate.
+
 ## Day 43 (2023-04-03)
 
 Superquickly, select the first new zone when importing an SF2. Then turn to the

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,9 +7,10 @@ add_library(${PROJECT_NAME} STATIC
         dsp/data_tables.cpp
         dsp/processor/processor.cpp
 
-        dsp/processor/processor_supersvf.cpp
-        dsp/processor/processor_oscillators.cpp
-        dsp/processor/processor_distortions.cpp
+        dsp/processor/distortion/microgate.cpp
+        dsp/processor/filter/supersvf.cpp
+        dsp/processor/oscillator/oscpulsesync.cpp
+        dsp/processor/oscillator/phasemodulation.cpp
 
         engine/engine.cpp
         engine/zone.cpp

--- a/src/dsp/processor/distortion/microgate.cpp
+++ b/src/dsp/processor/distortion/microgate.cpp
@@ -25,14 +25,15 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#include "processor_defs.h"
+#include "microgate.h"
+
 #include "engine/memory_pool.h"
 #include "configuration.h"
 #include "sst/basic-blocks/mechanics/block-ops.h"
 #include "tuning/equal.h"
 #include "dsp/data_tables.h"
 
-namespace scxt::dsp::processor
+namespace scxt::dsp::processor::distortion
 {
 
 namespace mech = sst::basic_blocks::mechanics;
@@ -180,4 +181,4 @@ MicroGate::~MicroGate()
         memoryPool->returnBlock((engine::MemoryPool::data_t *)loopbuffer[0], microgateBlockSize);
     }
 }
-} // namespace scxt::dsp::processor
+} // namespace scxt::dsp::processor::distortion

--- a/src/dsp/processor/distortion/microgate.h
+++ b/src/dsp/processor/distortion/microgate.h
@@ -1,0 +1,76 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2023, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_DSP_PROCESSOR_DISTORTION_MICROGATE_H
+#define SCXT_SRC_DSP_PROCESSOR_DISTORTION_MICROGATE_H
+
+#include "dsp/processor/processor.h"
+
+namespace scxt::dsp::processor
+{
+namespace distortion
+{
+struct alignas(16) MicroGate : public Processor
+{
+    static constexpr int microgateBufferSize{4096};
+    static constexpr int microgateBlockSize{microgateBufferSize * sizeof(float) * 2};
+
+    // Must be a power of 2
+    static_assert((microgateBufferSize >= 1) & !(microgateBufferSize & (microgateBufferSize - 1)));
+
+    static constexpr bool isZoneProcessor{true};
+    static constexpr bool isPartProcessor{true};
+    static constexpr bool isFXProcessor{false};
+    static constexpr const char *processorName{"MicroGate"};
+    static constexpr const char *processorStreamingName{"micro-gate-fx"};
+
+    MicroGate(engine::MemoryPool *mp, float *f, int32_t *i);
+    ~MicroGate();
+
+    void process_stereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
+                        float pitch) override;
+    void init() override;
+    void init_params() override;
+    int tail_length() override { return tailInfinite; }
+
+  protected:
+    int holdtime{0};
+    bool gate_state{false}, gate_zc_sync[2]{false, false};
+    float onesampledelay[2]{-1, -1};
+    // float loopbuffer[2][microgateBufferSize];
+    float *loopbuffer[2]{nullptr, nullptr};
+    int bufpos[2]{0, 0}, buflength[2]{0, 0};
+    bool is_recording[2]{false, false};
+};
+} // namespace distortion
+template <> struct ProcessorImplementor<ProcessorType::proct_fx_microgate>
+{
+    typedef distortion::MicroGate T;
+    static_assert(sizeof(T) < processorMemoryBufferSize);
+};
+} // namespace scxt::dsp::processor
+#endif // SHORTCIRCUITXT_MICROGATE_H

--- a/src/dsp/processor/filter/supersvf.cpp
+++ b/src/dsp/processor/filter/supersvf.cpp
@@ -25,18 +25,13 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#include <algorithm>
-#include <cmath>
-
-#include "processor_defs.h"
-#include "infrastructure/sse_include.h"
-#include "datamodel/parameter.h"
-#include "tuning/equal.h"
+#include "supersvf.h"
 #include "configuration.h"
+#include "dsp/processor/processor_ctrldescriptions.h"
+#include "tuning/equal.h"
 
-namespace scxt::dsp::processor
+namespace scxt::dsp::processor::filter
 {
-//-------------------------------------------------------------------------------------------------------
 
 // TODO: A bit more of a comprehensive review of this code
 static constexpr float INV_2BLOCK_SIZE{1.f / float(BLOCK_SIZE << 1)};
@@ -357,5 +352,4 @@ const char *SuperSVF::getIntParameterChoicesLabel(int ip_id, int c_id)
     return ("");
 }
 
-//-------------------------------------------------------------------------------------------------------
-} // namespace scxt::dsp::processor
+} // namespace scxt::dsp::processor::filter

--- a/src/dsp/processor/filter/supersvf.h
+++ b/src/dsp/processor/filter/supersvf.h
@@ -1,0 +1,83 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2023, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_DSP_PROCESSOR_FILTER_SUPERSVF_H
+#define SCXT_SRC_DSP_PROCESSOR_FILTER_SUPERSVF_H
+
+#include "dsp/processor/processor.h"
+#include "infrastructure/sse_include.h"
+#include "sst/filters/HalfRateFilter.h"
+
+namespace scxt::dsp::processor
+{
+namespace filter
+{
+
+struct alignas(16) SuperSVF : public Processor
+{
+  private:
+    __m128 Freq, dFreq, Q, dQ, MD, dMD, ClipDamp, dClipDamp, Gain, dGain, Reg[3], LastOutput;
+
+    sst::filters::HalfRate::HalfRateFilter mPolyphase;
+
+    inline __m128 process_internal(__m128 x, int Mode);
+
+  public:
+    static constexpr bool isZoneProcessor{true};
+    static constexpr bool isPartProcessor{true};
+    static constexpr bool isFXProcessor{false};
+    static constexpr const char *processorName{"Super SVF"};
+    static constexpr const char *processorStreamingName{"super-svf"};
+
+    SuperSVF(engine::MemoryPool *, float *, int *);
+    void process_stereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
+                        float pitch) override;
+    bool canProcessMono() override { return true; }
+    bool monoInputCreatesStereoOutput() override { return false; }
+    void process_mono(float *datain, float *dataoutL, float *dataoutR, float pitch) override;
+
+    template <bool Stereo, bool FourPole>
+    void ProcessT(float *datainL, float *datainR, float *dataoutL, float *dataoutR, float pitch);
+
+    void init_params() override;
+    void suspend() override;
+    void calc_coeffs();
+    size_t getIntParameterCount() override;
+    const char *getIntParameterLabel(int ip_id) override;
+    size_t getIntParameterChoicesCount(int ip_id) override;
+    const char *getIntParameterChoicesLabel(int ip_id, int c_id) override;
+    int tail_length() override { return tailInfinite; }
+};
+
+} // namespace filter
+
+template <> struct ProcessorImplementor<ProcessorType::proct_SuperSVF>
+{
+    typedef filter::SuperSVF T;
+};
+} // namespace scxt::dsp::processor
+#endif // SHORTCIRCUITXT_SUPERSVC_H

--- a/src/dsp/processor/oscillator/oscpulsesync.cpp
+++ b/src/dsp/processor/oscillator/oscpulsesync.cpp
@@ -25,17 +25,24 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#include "processor_defs.h"
-#include "dsp/resampling.h"
-#include "configuration.h"
-#include "dsp/data_tables.h"
 #include <cmath>
 #include <algorithm>
+
+#include "oscpulsesync.h"
+
+#include "configuration.h"
+
+#include "infrastructure/sse_include.h"
+
+#include "dsp/resampling.h"
+#include "dsp/data_tables.h"
+#include "dsp/processor/processor_ctrldescriptions.h"
+
 #include "sst/basic-blocks/mechanics/block-ops.h"
 #include "sst/basic-blocks/dsp/FastMath.h"
 #include "tuning/equal.h"
 
-namespace scxt::dsp::processor
+namespace scxt::dsp::processor::oscillator
 {
 namespace mech = sst::basic_blocks::mechanics;
 
@@ -169,112 +176,4 @@ void OscPulseSync::process_mono(float *datain, float *dataout, float *dataoutR, 
     }
 }
 
-PhaseModulation::PhaseModulation(engine::MemoryPool *mp, float *fp, int32_t *ip)
-    : Processor(ProcessorType::proct_osc_phasemod, mp, fp, ip), pre(6, true), post(6, true)
-{
-    parameter_count = 2;
-
-    setStr(ctrllabel[0], "transpose");
-    ctrlmode_desc[0] = cdMPitch;
-
-    setStr(ctrllabel[1], "depth");
-    ctrlmode_desc[1] = datamodel::cdDecibel;
-
-    phase = 0;
-}
-void PhaseModulation::init_params()
-{
-    if (!param)
-        return;
-
-    param[0] = 0.f;
-    param[1] = 0.f;
-}
-void PhaseModulation::process_stereo(float *datainL, float *datainR, float *dataoutL,
-                                     float *dataoutR, float pitch)
-{
-    omega.set_target(0.5 * 440 * tuning::equalTuning.note_to_pitch(pitch + param[0]) * M_PI_2 *
-                     samplerate_inv);
-    pregain.set_target(3.1415 * dbTable.dbToLinear(param[1]));
-
-    constexpr int bs2 = BLOCK_SIZE << 1;
-    float OS alignas(16)[2][bs2];
-    float omInterp alignas(16)[bs2];
-    float phVals alignas(16)[bs2];
-
-    pregain.multiply_2_blocks_to(datainL, datainR, OS[0], OS[1]);
-    pre.process_block_U2(OS[0], OS[1], OS[0], OS[1], bs2);
-
-    omega.store_block(omInterp);
-    phVals[0] = phase + omInterp[0];
-    for (int k = 1; k < bs2; ++k)
-    {
-        phVals[k] = phVals[k - 1] + omInterp[k];
-    }
-    phase = phVals[bs2 - 1];
-    if (phase > M_PI)
-        phase -= 2 * M_PI;
-
-    namespace bd = sst::basic_blocks::dsp;
-    const auto half = _mm_set1_ps(0.5f);
-    for (int k = 0; k < bs2; k += 4)
-    {
-        auto ph = _mm_load_ps(phVals + k);
-        auto s0 = _mm_load_ps(OS[0] + k);
-        auto s1 = _mm_load_ps(OS[1] + k);
-        auto w0 = bd::clampToPiRangeSSE(_mm_add_ps(s0, ph));
-        auto w1 = bd::clampToPiRangeSSE(_mm_add_ps(s1, ph));
-        ph = bd::clampToPiRangeSSE(ph);
-        auto sph = bd::fastsinSSE(ph);
-
-        auto r0 = _mm_mul_ps(half, _mm_sub_ps(bd::fastsinSSE(w0), sph));
-        auto r1 = _mm_mul_ps(half, _mm_sub_ps(bd::fastsinSSE(w1), sph));
-        _mm_store_ps(OS[0] + k, r0);
-        _mm_store_ps(OS[1] + k, r1);
-    }
-
-    post.process_block_D2(OS[0], OS[1], bs2, dataoutL, dataoutR);
-}
-
-void PhaseModulation::process_mono(float *datain, float *dataoutL, float *dataoutR, float pitch)
-{
-    omega.set_target(0.5 * 440 * tuning::equalTuning.note_to_pitch(pitch + param[0]) * M_PI_2 *
-                     samplerate_inv);
-    pregain.set_target(3.1415 * dbTable.dbToLinear(param[1]));
-
-    constexpr int bs2 = BLOCK_SIZE << 1;
-    float OS alignas(16)[2][bs2];
-    float omInterp alignas(16)[bs2];
-    float phVals alignas(16)[bs2];
-
-    pregain.multiply_block_to(datain, OS[0]);
-    pre.process_block_U2(OS[0], OS[0], OS[0], OS[1], bs2);
-
-    omega.store_block(omInterp);
-    phVals[0] = phase + omInterp[0];
-    for (int k = 1; k < bs2; ++k)
-    {
-        phVals[k] = phVals[k - 1] + omInterp[k];
-    }
-    phase = phVals[bs2 - 1];
-    if (phase > M_PI)
-        phase -= 2 * M_PI;
-
-    namespace bd = sst::basic_blocks::dsp;
-    const auto half = _mm_set1_ps(0.5f);
-    for (int k = 0; k < bs2; k += 4)
-    {
-        auto ph = _mm_load_ps(phVals + k);
-        auto s0 = _mm_load_ps(OS[0] + k);
-        auto w0 = bd::clampToPiRangeSSE(_mm_add_ps(s0, ph));
-        ph = bd::clampToPiRangeSSE(ph);
-        auto sph = bd::fastsinSSE(ph);
-
-        auto r0 = _mm_mul_ps(half, _mm_sub_ps(bd::fastsinSSE(w0), sph));
-        _mm_store_ps(OS[0] + k, r0);
-    }
-
-    post.process_block_D2(OS[0], OS[0], bs2, dataoutL, 0);
-}
-
-} // namespace scxt::dsp::processor
+} // namespace scxt::dsp::processor::oscillator

--- a/src/dsp/processor/oscillator/oscpulsesync.h
+++ b/src/dsp/processor/oscillator/oscpulsesync.h
@@ -1,0 +1,78 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2023, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_DSP_PROCESSOR_OSCILLATOR_OSCPULSESYNC_H
+#define SCXT_SRC_DSP_PROCESSOR_OSCILLATOR_OSCPULSESYNC_H
+
+#include "dsp/processor/processor.h"
+
+namespace scxt::dsp::processor
+{
+namespace oscillator
+{
+
+struct alignas(16) OscPulseSync : public Processor
+{
+    static constexpr bool isZoneProcessor{true};
+    static constexpr bool isPartProcessor{false};
+    static constexpr bool isFXProcessor{false};
+    static constexpr const char *processorName{"OSC Pulse Sync"};
+    static constexpr const char *processorStreamingName{"osc-pulse-sync"};
+
+    static constexpr int oscillatorBufferLength{16}; // TODO should this be block size really?
+
+    OscPulseSync(engine::MemoryPool *mp, float *f, int32_t *i);
+
+    void process_stereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
+                        float pitch) override;
+
+    bool canProcessMono() override { return true; }
+    bool monoInputCreatesStereoOutput() override { return false; }
+    void process_mono(float *datain, float *dataoutL, float *dataoutR, float pitch) override;
+
+    void init_params() override;
+    int tail_length() override { return tailInfinite; }
+
+  protected:
+    float oscbuffer alignas(16)[oscillatorBufferLength];
+
+    void convolute();
+    bool first_run{true};
+    int64_t oscstate{0}, syncstate{0};
+    float pitch{0};
+    bool polarity{false};
+    float osc_out{0};
+    size_t bufpos{0};
+};
+} // namespace oscillator
+
+template <> struct ProcessorImplementor<ProcessorType::proct_osc_pulse_sync>
+{
+    typedef oscillator::OscPulseSync T;
+};
+} // namespace scxt::dsp::processor
+#endif // SHORTCIRCUITXT_OSCPULSESYNC_H

--- a/src/dsp/processor/oscillator/phasemodulation.cpp
+++ b/src/dsp/processor/oscillator/phasemodulation.cpp
@@ -1,0 +1,157 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2023, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "phasemodulation.h"
+
+#include <algorithm>
+
+#include "oscpulsesync.h"
+
+#include "configuration.h"
+
+#include "infrastructure/sse_include.h"
+
+#include "dsp/resampling.h"
+#include "dsp/data_tables.h"
+#include "dsp/processor/processor_ctrldescriptions.h"
+
+#include "sst/basic-blocks/mechanics/block-ops.h"
+#include "sst/basic-blocks/dsp/FastMath.h"
+#include "tuning/equal.h"
+
+namespace scxt::dsp::processor::oscillator
+{
+namespace mech = sst::basic_blocks::mechanics;
+
+PhaseModulation::PhaseModulation(engine::MemoryPool *mp, float *fp, int32_t *ip)
+    : Processor(ProcessorType::proct_osc_phasemod, mp, fp, ip), pre(6, true), post(6, true)
+{
+    parameter_count = 2;
+
+    setStr(ctrllabel[0], "transpose");
+    ctrlmode_desc[0] = cdMPitch;
+
+    setStr(ctrllabel[1], "depth");
+    ctrlmode_desc[1] = datamodel::cdDecibel;
+
+    phase = 0;
+}
+void PhaseModulation::init_params()
+{
+    if (!param)
+        return;
+
+    param[0] = 0.f;
+    param[1] = 0.f;
+}
+void PhaseModulation::process_stereo(float *datainL, float *datainR, float *dataoutL,
+                                     float *dataoutR, float pitch)
+{
+    omega.set_target(0.5 * 440 * tuning::equalTuning.note_to_pitch(pitch + param[0]) * M_PI_2 *
+                     samplerate_inv);
+    pregain.set_target(3.1415 * dbTable.dbToLinear(param[1]));
+
+    constexpr int bs2 = BLOCK_SIZE << 1;
+    float OS alignas(16)[2][bs2];
+    float omInterp alignas(16)[bs2];
+    float phVals alignas(16)[bs2];
+
+    pregain.multiply_2_blocks_to(datainL, datainR, OS[0], OS[1]);
+    pre.process_block_U2(OS[0], OS[1], OS[0], OS[1], bs2);
+
+    omega.store_block(omInterp);
+    phVals[0] = phase + omInterp[0];
+    for (int k = 1; k < bs2; ++k)
+    {
+        phVals[k] = phVals[k - 1] + omInterp[k];
+    }
+    phase = phVals[bs2 - 1];
+    if (phase > M_PI)
+        phase -= 2 * M_PI;
+
+    namespace bd = sst::basic_blocks::dsp;
+    const auto half = _mm_set1_ps(0.5f);
+    for (int k = 0; k < bs2; k += 4)
+    {
+        auto ph = _mm_load_ps(phVals + k);
+        auto s0 = _mm_load_ps(OS[0] + k);
+        auto s1 = _mm_load_ps(OS[1] + k);
+        auto w0 = bd::clampToPiRangeSSE(_mm_add_ps(s0, ph));
+        auto w1 = bd::clampToPiRangeSSE(_mm_add_ps(s1, ph));
+        ph = bd::clampToPiRangeSSE(ph);
+        auto sph = bd::fastsinSSE(ph);
+
+        auto r0 = _mm_mul_ps(half, _mm_sub_ps(bd::fastsinSSE(w0), sph));
+        auto r1 = _mm_mul_ps(half, _mm_sub_ps(bd::fastsinSSE(w1), sph));
+        _mm_store_ps(OS[0] + k, r0);
+        _mm_store_ps(OS[1] + k, r1);
+    }
+
+    post.process_block_D2(OS[0], OS[1], bs2, dataoutL, dataoutR);
+}
+
+void PhaseModulation::process_mono(float *datain, float *dataoutL, float *dataoutR, float pitch)
+{
+    omega.set_target(0.5 * 440 * tuning::equalTuning.note_to_pitch(pitch + param[0]) * M_PI_2 *
+                     samplerate_inv);
+    pregain.set_target(3.1415 * dbTable.dbToLinear(param[1]));
+
+    constexpr int bs2 = BLOCK_SIZE << 1;
+    float OS alignas(16)[2][bs2];
+    float omInterp alignas(16)[bs2];
+    float phVals alignas(16)[bs2];
+
+    pregain.multiply_block_to(datain, OS[0]);
+    pre.process_block_U2(OS[0], OS[0], OS[0], OS[1], bs2);
+
+    omega.store_block(omInterp);
+    phVals[0] = phase + omInterp[0];
+    for (int k = 1; k < bs2; ++k)
+    {
+        phVals[k] = phVals[k - 1] + omInterp[k];
+    }
+    phase = phVals[bs2 - 1];
+    if (phase > M_PI)
+        phase -= 2 * M_PI;
+
+    namespace bd = sst::basic_blocks::dsp;
+    const auto half = _mm_set1_ps(0.5f);
+    for (int k = 0; k < bs2; k += 4)
+    {
+        auto ph = _mm_load_ps(phVals + k);
+        auto s0 = _mm_load_ps(OS[0] + k);
+        auto w0 = bd::clampToPiRangeSSE(_mm_add_ps(s0, ph));
+        ph = bd::clampToPiRangeSSE(ph);
+        auto sph = bd::fastsinSSE(ph);
+
+        auto r0 = _mm_mul_ps(half, _mm_sub_ps(bd::fastsinSSE(w0), sph));
+        _mm_store_ps(OS[0] + k, r0);
+    }
+
+    post.process_block_D2(OS[0], OS[0], bs2, dataoutL, 0);
+}
+} // namespace scxt::dsp::processor::oscillator

--- a/src/dsp/processor/oscillator/phasemodulation.h
+++ b/src/dsp/processor/oscillator/phasemodulation.h
@@ -1,0 +1,73 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2023, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_DSP_PROCESSOR_OSCILLATOR_PHASEMODULATION_H
+#define SCXT_SRC_DSP_PROCESSOR_OSCILLATOR_PHASEMODULATION_H
+
+#include "dsp/processor/processor.h"
+#include "infrastructure/sse_include.h"
+#include "configuration.h"
+#include "sst/basic-blocks/dsp/BlockInterpolators.h"
+#include "sst/filters/HalfRateFilter.h"
+
+namespace scxt::dsp::processor
+{
+namespace oscillator
+{
+struct alignas(16) PhaseModulation : public Processor
+{
+    static constexpr bool isZoneProcessor{true};
+    static constexpr bool isPartProcessor{true};
+    static constexpr bool isFXProcessor{true};
+    static constexpr const char *processorName{"Phase Modulation"};
+    static constexpr const char *processorStreamingName{"osc-phase-mod"};
+
+    PhaseModulation(engine::MemoryPool *mp, float *f, int32_t *i);
+
+    void process_stereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
+                        float pitch) override;
+
+    bool canProcessMono() override { return true; }
+    bool monoInputCreatesStereoOutput() override { return false; }
+    void process_mono(float *datain, float *dataoutL, float *dataoutR, float pitch) override;
+
+    void init_params() override;
+    int tail_length() override { return tailInfinite; }
+
+  private:
+    double phase{0.0};
+    sst::filters::HalfRate::HalfRateFilter pre, post;
+    sst::basic_blocks::dsp::lipol_sse<BLOCK_SIZE> pregain;
+    sst::basic_blocks::dsp::lipol_sse<BLOCK_SIZE << 1, true> omega;
+};
+} // namespace oscillator
+template <> struct ProcessorImplementor<ProcessorType::proct_osc_phasemod>
+{
+    typedef oscillator::PhaseModulation T;
+};
+} // namespace scxt::dsp::processor
+#endif // SHORTCIRCUITXT_PHASEMODULATION_H

--- a/src/dsp/processor/processor.h
+++ b/src/dsp/processor/processor.h
@@ -293,5 +293,11 @@ Processor *spawnProcessorInPlace(ProcessorType id, engine::MemoryPool *mp, uint8
  */
 void unspawnProcessor(Processor *f);
 
+typedef uint8_t unimpl_t;
+template <ProcessorType ft> struct ProcessorImplementor
+{
+    typedef unimpl_t T;
+};
+
 } // namespace scxt::dsp::processor
 #endif // __SCXT_DSP_PROCESSOR_PROCESSOR_H

--- a/src/dsp/processor/processor_ctrldescriptions.h
+++ b/src/dsp/processor/processor_ctrldescriptions.h
@@ -1,0 +1,65 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2023, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_DSP_PROCESSOR_PROCESSOR_CTRLDESCRIPTIONS_H
+#define SCXT_SRC_DSP_PROCESSOR_PROCESSOR_CTRLDESCRIPTIONS_H
+
+namespace scxt::dsp::processor
+{
+
+/*const char str_freqdef[] = ("f,-5,0.04,6,5,Hz"), str_freqmoddef[] = ("f,-12,0.04,12,0,oct"),
+           str_timedef[] = ("f,-10,0.1,10,4,s"), str_lfofreqdef[] = ("f,-5,0.04,6,4,Hz"),
+           str_percentdef[] = ("f,0,0.005,1,1,%"), str_percentbpdef[] = ("f,-1,0.005,1,1,%"),
+           str_percentmoddef[] = ("f,-32,0.005,32,1,%"), str_dbdef[] = ("f,-96,0.1,12,0,dB"),
+           str_dbbpdef[] = ("f,-48,0.1,48,0,dB"), str_dbmoddef[] = ("f,-96,0.1,96,0,dB"),
+           str_mpitch[] = ("f,-96,0.04,96,0,cents"), str_bwdef[] = ("f,0.001,0.005,6,0,oct");*/
+
+static constexpr datamodel::ControlDescription cdPercentDef{datamodel::ControlDescription::FLOAT,
+                                                            datamodel::ControlDescription::LINEAR,
+                                                            0,
+                                                            0.005,
+                                                            1,
+                                                            1,
+                                                            "%"},
+    cdMPitch{datamodel::ControlDescription::FLOAT,
+             datamodel::ControlDescription::LINEAR,
+             -96,
+             0.04,
+             96,
+             0,
+             "semitones"},
+    cdFreqDef{datamodel::ControlDescription::FLOAT,
+              datamodel::ControlDescription::FREQUENCY,
+              -5,
+              0.04,
+              6,
+              5,
+              "Hz"};
+
+} // namespace scxt::dsp::processor
+
+#endif // SHORTCIRCUITXT_PROCESSOR_CTRLDESCRIPTIONS_H

--- a/src/dsp/processor/processor_defs.h
+++ b/src/dsp/processor/processor_defs.h
@@ -42,7 +42,7 @@
  * driven by templates (see "processor.cpp" for some hairy template code you never need to touch).
  * So to add a processor
  *
- * 1. Add it here as a subtype of Processor
+ * 1. Add it in a .c/.hpp as a subtype of Processor
  * 2. Implement these four constexpr values
  *       static constexpr bool isZoneProcessor{true};
  *       static constexpr bool isPartProcessor{false};
@@ -58,205 +58,14 @@
  *          typedef OscPulseSync T;
  *      };
  *
- *  and then evyerthing else will work
+ *  and then include the h here and everything will work
  */
 
-namespace scxt::dsp::processor
-{
-typedef uint8_t unimpl_t;
-template <ProcessorType ft> struct ProcessorImplementor
-{
-    typedef unimpl_t T;
-};
-/*const char str_freqdef[] = ("f,-5,0.04,6,5,Hz"), str_freqmoddef[] = ("f,-12,0.04,12,0,oct"),
-           str_timedef[] = ("f,-10,0.1,10,4,s"), str_lfofreqdef[] = ("f,-5,0.04,6,4,Hz"),
-           str_percentdef[] = ("f,0,0.005,1,1,%"), str_percentbpdef[] = ("f,-1,0.005,1,1,%"),
-           str_percentmoddef[] = ("f,-32,0.005,32,1,%"), str_dbdef[] = ("f,-96,0.1,12,0,dB"),
-           str_dbbpdef[] = ("f,-48,0.1,48,0,dB"), str_dbmoddef[] = ("f,-96,0.1,96,0,dB"),
-           str_mpitch[] = ("f,-96,0.04,96,0,cents"), str_bwdef[] = ("f,0.001,0.005,6,0,oct");*/
+#include "distortion/microgate.h"
 
-static constexpr datamodel::ControlDescription cdPercentDef{datamodel::ControlDescription::FLOAT,
-                                                            datamodel::ControlDescription::LINEAR,
-                                                            0,
-                                                            0.005,
-                                                            1,
-                                                            1,
-                                                            "%"},
-    cdMPitch{datamodel::ControlDescription::FLOAT,
-             datamodel::ControlDescription::LINEAR,
-             -96,
-             0.04,
-             96,
-             0,
-             "cents"},
-    cdFreqDef{datamodel::ControlDescription::FLOAT,
-              datamodel::ControlDescription::FREQUENCY,
-              -5,
-              0.04,
-              6,
-              5,
-              "Hz"};
+#include "filter/supersvf.h"
 
-/**
- * Standard filters
- */
+#include "oscillator/oscpulsesync.h"
+#include "oscillator/phasemodulation.h"
 
-struct alignas(16) SuperSVF : public Processor
-{
-  private:
-    __m128 Freq, dFreq, Q, dQ, MD, dMD, ClipDamp, dClipDamp, Gain, dGain, Reg[3], LastOutput;
-
-    sst::filters::HalfRate::HalfRateFilter mPolyphase;
-
-    inline __m128 process_internal(__m128 x, int Mode);
-
-  public:
-    static constexpr bool isZoneProcessor{true};
-    static constexpr bool isPartProcessor{true};
-    static constexpr bool isFXProcessor{false};
-    static constexpr const char *processorName{"Super SVF"};
-    static constexpr const char *processorStreamingName{"super-svf"};
-
-    SuperSVF(engine::MemoryPool *, float *, int *);
-    void process_stereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                        float pitch) override;
-    bool canProcessMono() override { return true; }
-    bool monoInputCreatesStereoOutput() override { return false; }
-    void process_mono(float *datain, float *dataoutL, float *dataoutR, float pitch) override;
-
-    template <bool Stereo, bool FourPole>
-    void ProcessT(float *datainL, float *datainR, float *dataoutL, float *dataoutR, float pitch);
-
-    void init_params() override;
-    void suspend() override;
-    void calc_coeffs();
-    size_t getIntParameterCount() override;
-    const char *getIntParameterLabel(int ip_id) override;
-    size_t getIntParameterChoicesCount(int ip_id) override;
-    const char *getIntParameterChoicesLabel(int ip_id, int c_id) override;
-    int tail_length() override { return tailInfinite; }
-};
-
-template <> struct ProcessorImplementor<ProcessorType::proct_SuperSVF>
-{
-    typedef SuperSVF T;
-};
-
-/**
- * Distortion and Destruction
- */
-struct alignas(16) MicroGate : public Processor
-{
-    static constexpr int microgateBufferSize{4096};
-    static constexpr int microgateBlockSize{microgateBufferSize * sizeof(float) * 2};
-
-    // Must be a power of 2
-    static_assert((microgateBufferSize >= 1) & !(microgateBufferSize & (microgateBufferSize - 1)));
-
-    static constexpr bool isZoneProcessor{true};
-    static constexpr bool isPartProcessor{true};
-    static constexpr bool isFXProcessor{false};
-    static constexpr const char *processorName{"MicroGate"};
-    static constexpr const char *processorStreamingName{"micro-gate-fx"};
-
-    MicroGate(engine::MemoryPool *mp, float *f, int32_t *i);
-    ~MicroGate();
-
-    void process_stereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                        float pitch) override;
-    void init() override;
-    void init_params() override;
-    int tail_length() override { return tailInfinite; }
-
-  protected:
-    int holdtime{0};
-    bool gate_state{false}, gate_zc_sync[2]{false, false};
-    float onesampledelay[2]{-1, -1};
-    // float loopbuffer[2][microgateBufferSize];
-    float *loopbuffer[2]{nullptr, nullptr};
-    int bufpos[2]{0, 0}, buflength[2]{0, 0};
-    bool is_recording[2]{false, false};
-};
-
-template <> struct ProcessorImplementor<ProcessorType::proct_fx_microgate>
-{
-    static_assert(sizeof(MicroGate) < processorMemoryBufferSize);
-
-    typedef MicroGate T;
-};
-
-/**
- * Oscillators and Synthesizers
- */
-
-static constexpr int oscillatorBufferLength{16}; // TODO should this be block size really?
-
-struct alignas(16) OscPulseSync : public Processor
-{
-    static constexpr bool isZoneProcessor{true};
-    static constexpr bool isPartProcessor{false};
-    static constexpr bool isFXProcessor{false};
-    static constexpr const char *processorName{"OSC Pulse Sync"};
-    static constexpr const char *processorStreamingName{"osc-pulse-sync"};
-
-    OscPulseSync(engine::MemoryPool *mp, float *f, int32_t *i);
-
-    void process_stereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                        float pitch) override;
-
-    bool canProcessMono() override { return true; }
-    bool monoInputCreatesStereoOutput() override { return false; }
-    void process_mono(float *datain, float *dataoutL, float *dataoutR, float pitch) override;
-
-    void init_params() override;
-    int tail_length() override { return tailInfinite; }
-
-  protected:
-    float oscbuffer alignas(16)[oscillatorBufferLength];
-
-    void convolute();
-    bool first_run{true};
-    int64_t oscstate{0}, syncstate{0};
-    float pitch{0};
-    bool polarity{false};
-    float osc_out{0};
-    size_t bufpos{0};
-};
-template <> struct ProcessorImplementor<ProcessorType::proct_osc_pulse_sync>
-{
-    typedef OscPulseSync T;
-};
-
-struct alignas(16) PhaseModulation : public Processor
-{
-    static constexpr bool isZoneProcessor{true};
-    static constexpr bool isPartProcessor{true};
-    static constexpr bool isFXProcessor{true};
-    static constexpr const char *processorName{"Phase Modulation"};
-    static constexpr const char *processorStreamingName{"osc-phase-mod"};
-
-    PhaseModulation(engine::MemoryPool *mp, float *f, int32_t *i);
-
-    void process_stereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                        float pitch) override;
-
-    bool canProcessMono() override { return true; }
-    bool monoInputCreatesStereoOutput() override { return false; }
-    void process_mono(float *datain, float *dataoutL, float *dataoutR, float pitch) override;
-
-    void init_params() override;
-    int tail_length() override { return tailInfinite; }
-
-  private:
-    double phase{0.0};
-    sst::filters::HalfRate::HalfRateFilter pre, post;
-    sst::basic_blocks::dsp::lipol_sse<BLOCK_SIZE> pregain;
-    sst::basic_blocks::dsp::lipol_sse<BLOCK_SIZE << 1, true> omega;
-};
-template <> struct ProcessorImplementor<ProcessorType::proct_osc_phasemod>
-{
-    typedef PhaseModulation T;
-};
-
-} // namespace scxt::dsp::processor
 #endif // __SCXT_PROCESSOR_DEFS_H

--- a/src/sfz_support/sfz_import.cpp
+++ b/src/sfz_support/sfz_import.cpp
@@ -1,6 +1,29 @@
-//
-// Created by Paul Walker on 4/2/23.
-//
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2023, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
 
 #include "sfz_import.h"
 #include "sfz_parse.h"

--- a/src/sfz_support/sfz_import.h
+++ b/src/sfz_support/sfz_import.h
@@ -1,9 +1,32 @@
-//
-// Created by Paul Walker on 4/2/23.
-//
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2023, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
 
-#ifndef SHORTCIRCUITXT_SFZ_IMPORT_H
-#define SHORTCIRCUITXT_SFZ_IMPORT_H
+#ifndef SCXT_SRC_SFZ_SUPPORT_SFZ_IMPORT_H
+#define SCXT_SRC_SFZ_SUPPORT_SFZ_IMPORT_H
 
 #include <filesystem>
 #include <engine/engine.h>


### PR DESCRIPTION
Each processor lives in its own cpp/h pair and is appropriately included and built, reducing 'where is the x' confusion that SC originally had at the cost of a bushier filesystem.