### PR TITLE
Day 45: Sample Loops abut the End

### DIFF
--- a/doc/Sprints.md
+++ b/doc/Sprints.md
@@ -1,3 +1,7 @@
+## Day 45 (2023-04-06)
+
+Really a micro-day; fix the generator loop if it abuts the end of the sample.
+
 ## Day 44 (2023-04-04)
 
 Start with cleaning up the files for the processors some so you get


### PR DESCRIPTION
If a sample loop had its last point be the end wavepoint the FIR reached into the 0 padding at the loop leading to a click. Fix this by adding an indirection pointer which almost all the time is a direct pointer into the sample but at that loop endpoint, fills with the wrapped-sample-set for the FIR.

Tnis will let us do loop fades similarly in the future (namely make a fake input buffer which is the fade of the samples since the combination is linear) so let me tag #439 here also.