### PR TITLE
Day 46: Prep for MultiSelect; Add voice state to UI

### DIFF
--- a/clients/juce-plugin/SCXTProcessor.h
+++ b/clients/juce-plugin/SCXTProcessor.h
@@ -73,7 +73,6 @@ class SCXTProcessor : public juce::AudioProcessor, public clap_juce_extensions::
     std::unique_ptr<scxt::engine::Engine> engine;
     size_t blockPos{0};
 
-    void temporaryInitPatch();
     void applyMidi(const juce::MidiMessageMetadata &msg);
     //==============================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SCXTProcessor)

--- a/doc/Sprints.md
+++ b/doc/Sprints.md
@@ -1,3 +1,7 @@
+## Day 46 (2023-04-07 with a squinch on the 6th)
+
+Start thinking about multi-select and voice state.
+
 ## Day 45 (2023-04-06)
 
 Really a micro-day; fix the generator loop if it abuts the end of the sample.

--- a/src-ui/components/SCXTEditor.h
+++ b/src-ui/components/SCXTEditor.h
@@ -105,7 +105,7 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::FileDragAndDrop
 
     // Serialization to Client Messages
     void onErrorFromEngine(const scxt::messaging::client::s2cError_t &);
-    void onVoiceCount(const uint32_t &v);
+    void onVoiceDisplayState(const engine::Engine::VoiceDisplayState &e);
     void onEngineStatus(const engine::Engine::EngineStatusMessage &e);
     void onEnvelopeUpdated(const scxt::messaging::client::adsrViewResponsePayload_t &);
     void onMappingUpdated(const scxt::messaging::client::mappingSelectedZoneViewResposne_t &);

--- a/src-ui/components/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/components/SCXTEditorResponseHandlers.cpp
@@ -38,12 +38,6 @@
 
 namespace scxt::ui
 {
-void SCXTEditor::onVoiceCount(const uint32_t &v)
-{
-    if (headerRegion)
-        headerRegion->setVoiceCount(v);
-}
-
 void SCXTEditor::onEnvelopeUpdated(
     const scxt::messaging::client::adsrViewResponsePayload_t &payload)
 {
@@ -155,5 +149,28 @@ void SCXTEditor::onEngineStatus(const engine::Engine::EngineStatusMessage &e)
     engineStatus = e;
     aboutScreen->resetInfo();
     repaint();
+}
+
+void SCXTEditor::onVoiceDisplayState(const engine::Engine::VoiceDisplayState &e)
+{
+    int idx{0};
+    int ac{0};
+    for (const auto &i : e.items)
+    {
+        if (i.active)
+        {
+            SCDBGCOUT << SCD(idx) << SCD(i.zonePath.zone) << SCD(i.midiNote) << SCD(i.gated)
+                      << std::endl;
+            ac++;
+        }
+        idx++;
+    }
+    if (!ac)
+    {
+        SCDBGCOUT << "No active voices" << std::endl;
+    }
+
+    if (headerRegion)
+        headerRegion->setVoiceCount(e.voiceCount);
 }
 } // namespace scxt::ui

--- a/src/messaging/audio/audio_messages.cpp
+++ b/src/messaging/audio/audio_messages.cpp
@@ -32,13 +32,12 @@
 
 namespace scxt::messaging::audio
 {
-void sendVoiceCount(uint32_t voiceCount, MessageController &mc)
+void sendVoiceState(uint32_t voiceCount, MessageController &mc)
 {
     assert(mc.threadingChecker.isAudioThread());
     AudioToSerialization a2s;
-    a2s.id = a2s_voice_count;
-    a2s.payloadType = AudioToSerialization::UINT;
-    a2s.payload.u[0] = voiceCount;
+    a2s.id = a2s_voice_state;
+    a2s.payloadType = AudioToSerialization::NONE;
     mc.sendAudioToSerialization(a2s);
 }
 

--- a/src/messaging/audio/audio_messages.h
+++ b/src/messaging/audio/audio_messages.h
@@ -34,7 +34,7 @@
 namespace scxt::messaging::audio
 {
 // Audio thread
-void sendVoiceCount(uint32_t voiceCount, MessageController &mc);
+void sendVoiceState(uint32_t voiceCount, MessageController &mc);
 void sendStructureRefresh(MessageController &mc);
 
 } // namespace scxt::messaging::audio

--- a/src/messaging/audio/audio_serial.h
+++ b/src/messaging/audio/audio_serial.h
@@ -47,7 +47,7 @@ enum AudioToSerializationMessageId
 {
     a2s_none,
     a2s_pointer_complete,
-    a2s_voice_count,
+    a2s_voice_state,
     a2s_note_on,
     a2s_note_off,
     a2s_structure_refresh

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -69,7 +69,7 @@ enum SerializationToClientMessageIds
 {
     s2c_report_error,
     s2c_send_initial_metadata,
-    s2c_voice_count,
+    s2c_voice_display_status,
     s2c_engine_status,
     s2c_respond_zone_adsr_view,
     s2c_respond_zone_mapping,

--- a/src/messaging/client/enginestatus_messages.h
+++ b/src/messaging/client/enginestatus_messages.h
@@ -28,6 +28,7 @@
 #ifndef SCXT_SRC_MESSAGING_CLIENT_ENGINESTATUS_MESSAGES_H
 #define SCXT_SRC_MESSAGING_CLIENT_ENGINESTATUS_MESSAGES_H
 
+#include "messaging/client/client_serial.h"
 #include "messaging/client/detail/client_json_details.h"
 #include "json/engine_traits.h"
 #include "json/datamodel_traits.h"
@@ -36,8 +37,8 @@
 
 namespace scxt::messaging::client
 {
-SERIAL_TO_CLIENT(VoiceCountUpdate, s2c_voice_count, uint32_t, onVoiceCount);
-
+SERIAL_TO_CLIENT(VoiceDisplayStatusUpdate, s2c_voice_display_status,
+                 engine::Engine::VoiceDisplayState, onVoiceDisplayState);
 SERIAL_TO_CLIENT(EngineStatusUpdate, s2c_engine_status, engine::Engine::EngineStatusMessage,
                  onEngineStatus);
 } // namespace scxt::messaging::client

--- a/src/voice/voice.h
+++ b/src/voice/voice.h
@@ -29,6 +29,7 @@
 #define SCXT_SRC_VOICE_VOICE_H
 
 #include "engine/zone.h"
+#include "engine/engine.h"
 #include "dsp/data_tables.h"
 #include "dsp/generator.h"
 #include "dsp/processor/processor.h"
@@ -51,6 +52,7 @@ struct alignas(16) Voice : MoveableOnly<Voice>, SampleRateSupport
 {
     float output alignas(16)[2][blockSize << 1];
     engine::Zone *zone{nullptr}; // I do *not* own this. The engine guarantees it outlives the voice
+    engine::Engine::pathToZone_t zonePath{};
 
     dsp::GeneratorState GD;
     dsp::GeneratorIO GDIO;


### PR DESCRIPTION
This is basically a structural-only commit which does a couple of larger things

First it adds a structure mutation mutex. Since only the running engine or the serialization thread with a paused engine can mutate the state, this is *not* locked in audio playback but is locked when we add zones and so on. But it means that the serialization thread can lock it so it can always get a coherent view of the structure (but maybe not the values in the sturcture). Good.

Then add a voice status structure which we use to communicate which zones are playing and which midi notes are pressed to the UI but for now just show those in the log don't actually repaint based on them.