### PR TITLE
Woefully crude Integration of the sst-effects

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(${PROJECT_NAME} STATIC
         engine/zone.cpp
         engine/group.cpp
         engine/part.cpp
+        engine/part_effects.cpp
         engine/memory_pool.cpp
 
         json/stream.cpp
@@ -54,7 +55,7 @@ add_library(${PROJECT_NAME} STATIC
 target_include_directories(${PROJECT_NAME} PUBLIC .)
 target_link_libraries(${PROJECT_NAME} PUBLIC
         fmt
-        sst-cpputils sst-filters sst-basic-blocks sst-plugininfra
+        sst-cpputils sst-filters sst-basic-blocks sst-effects sst-plugininfra
         libgig libakai
         mts-esp-client
         shortcircuit::simde

--- a/src/engine/part.h
+++ b/src/engine/part.h
@@ -37,12 +37,16 @@
 #include "group.h"
 #include "dsp/smoothers.h"
 
+#include "part_effects.h"
+
 namespace scxt::engine
 {
 struct Patch;
 
 struct Part : MoveableOnly<Part>, SampleRateSupport
 {
+    static constexpr int maxEffectsPerPart{4};
+
     Part(int16_t c) : id(PartID::next()), channel(c) { pitchBendSmoother.setTarget(0); }
 
     PartID id;
@@ -109,6 +113,9 @@ struct Part : MoveableOnly<Part>, SampleRateSupport
         activeGroups--;
     }
 
+    std::array<std::unique_ptr<PartEffect>, maxEffectsPerPart> partEffects;
+    std::array<PartEffectStorage, maxEffectsPerPart> partEffectStorage;
+
     std::array<dsp::Smoother, 128> midiCCSmoothers;
     dsp::Smoother pitchBendSmoother;
     void onSampleRateChanged() override
@@ -119,7 +126,6 @@ struct Part : MoveableOnly<Part>, SampleRateSupport
     }
 
     // TODO: A group by ID which throws an SCXTError
-
     typedef std::vector<std::unique_ptr<Group>> groupContainer_t;
 
     const groupContainer_t &getGroups() const { return groups; }

--- a/src/engine/part_effects.cpp
+++ b/src/engine/part_effects.cpp
@@ -1,0 +1,107 @@
+//
+// Created by Paul Walker on 4/25/23.
+//
+
+#include "part_effects.h"
+#include "configuration.h"
+
+#include "dsp/data_tables.h"
+#include "engine.h"
+
+#include "infrastructure/sse_include.h"
+
+#include "dsp/data_tables.h"
+#include "tuning/equal.h"
+
+#include "sst/effects/EffectCore.h"
+#include "sst/effects/Reverb1.h"
+#include "sst/effects/Flanger.h"
+
+namespace scxt::engine
+{
+namespace dtl
+{
+struct EngineBiquadAdapter
+{
+    static inline float dbToLinear(Engine *e, float f) { return dsp::dbTable.dbToLinear(f); }
+    static inline float noteToPitchIgnoringTuning(Engine *e, float f)
+    {
+        return tuning::equalTuning.note_to_pitch(f);
+    }
+    static inline float sampleRateInv(Engine *e) { return e->getSampleRateInv(); }
+};
+struct Config
+{
+    static constexpr int blockSize{scxt::blockSize};
+    using BaseClass = PartEffect;
+    using GlobalStorage = Engine;
+    using EffectStorage = PartEffectStorage;
+    using ValueStorage = float;
+
+    using BiquadAdapter = EngineBiquadAdapter;
+
+    static inline float floatValueAt(const BaseClass *const e, const ValueStorage *const v, int idx)
+    {
+        return v[idx];
+    }
+    static inline int intValueAt(const BaseClass *const e, const ValueStorage *const v, int idx)
+    {
+        return (int)std::round(v[idx]);
+    }
+
+    static inline float envelopeRateLinear(GlobalStorage *s, float f) { return 0; }
+
+    static inline float temposyncRatio(GlobalStorage *s, EffectStorage *e, int idx) { return 1; }
+
+    static inline bool isDeactivated(EffectStorage *e, int idx) { return false; }
+
+    // TODO: Fix Me obvs
+    static inline float rand01(GlobalStorage *s) { return (float)rand() / (float)RAND_MAX; }
+
+    static inline double sampleRate(GlobalStorage *s) { return 48000; }
+
+    static inline float noteToPitch(GlobalStorage *s, float p) { return 1; }
+    static inline float noteToPitchIgnoringTuning(GlobalStorage *s, float p)
+    {
+        return tuning::equalTuning.note_to_pitch(p);
+    }
+
+    static inline float noteToPitchInv(GlobalStorage *s, float p)
+    {
+        return 1.f / tuning::equalTuning.note_to_pitch(p);
+    }
+
+    static inline float dbToLinear(GlobalStorage *s, float f) { return dsp::dbTable.dbToLinear(f); }
+};
+
+template <typename T> struct Impl : T
+{
+    static_assert(T::numParams <= PartEffectStorage::maxPartEffectParams);
+    Engine *engine{nullptr};
+    PartEffectStorage *pes{nullptr};
+    float *values{nullptr};
+    Impl(Engine *e, PartEffectStorage *f, float *v) : engine(e), pes(f), values(v), T(e, f, v) {}
+    void init() override
+    {
+        for (int i = 0; i < T::numParams && i < PartEffectStorage::maxPartEffectParams; ++i)
+        {
+            values[i] = this->paramAt(i).defaultVal;
+        }
+        T::initialize();
+    }
+    void process(float *__restrict L, float *__restrict R) override { T::processBlock(L, R); }
+};
+} // namespace dtl
+std::unique_ptr<PartEffect> createEffect(AvailablePartEffects p, Engine *e, PartEffectStorage *s)
+{
+    namespace sfx = sst::effects;
+    switch (p)
+    {
+    case reverb1:
+        return std::make_unique<dtl::Impl<sfx::Reverb1<dtl::Config>>>(e, s, s->params);
+    case flanger:
+        return nullptr;
+    }
+    return nullptr;
+}
+} // namespace scxt::engine

--- a/src/engine/part_effects.h
+++ b/src/engine/part_effects.h
@@ -1,0 +1,36 @@
+//
+// Created by Paul Walker on 4/25/23.
+//
+
+#ifndef SHORTCIRCUITXT_PART_FX_H
+#define SHORTCIRCUITXT_PART_FX_H
+
+#include <memory>
+namespace scxt::engine
+{
+struct Engine;
+
+struct PartEffectStorage
+{
+    static constexpr int maxPartEffectParams{12};
+    float params[maxPartEffectParams];
+};
+struct PartEffect
+{
+    PartEffect(Engine *, PartEffectStorage *, float *) {}
+    virtual ~PartEffect() = default;
+
+    virtual void init() = 0;
+    virtual void process(float *__restrict L, float *__restrict R) = 0;
+};
+
+enum AvailablePartEffects
+{
+    reverb1,
+    flanger
+};
+
+std::unique_ptr<PartEffect> createEffect(AvailablePartEffects p, Engine *e, PartEffectStorage *s);
+} // namespace scxt::engine
+
+#endif // SHORTCIRCUITXT_PART_FX_H

--- a/src/utils.h
+++ b/src/utils.h
@@ -173,6 +173,7 @@ struct SampleRateSupport
         sync();
     }
     double getSampleRate() const { return sampleRate; }
+    double getSampleRateInv() const { return sampleRateInv; }
 
     void sync()
     {


### PR DESCRIPTION
This lets us compile in a Reverb1 effect and force it always on non editable with an off-in-git compile time flag. It will change immensely between now and completion of the synth but it acts as a test bed for coupling the FX and SC.