### PR TITLE
Fix bugs from ParamMetaData port

### DIFF
--- a/src/datamodel/parameter.h
+++ b/src/datamodel/parameter.h
@@ -84,10 +84,11 @@ inline pmd envelopeThirtyTwo()
         .withType(pmd::FLOAT)
         .withRange(0.f, 1.f)
         .withDefault(0.2f)
-        .withATwoToTheBFormatting(sst::basic_blocks::modulators::ThirtyTwoSecondRange::etMin,
-                                  sst::basic_blocks::modulators::ThirtyTwoSecondRange::etMax -
-                                      sst::basic_blocks::modulators::ThirtyTwoSecondRange::etMin,
-                                  "s");
+        .withATwoToTheBPlusCFormatting(
+            1.f,
+            sst::basic_blocks::modulators::ThirtyTwoSecondRange::etMax -
+                sst::basic_blocks::modulators::ThirtyTwoSecondRange::etMin,
+            sst::basic_blocks::modulators::ThirtyTwoSecondRange::etMin, "s");
 }
 
 inline pmd lfoModulationRate()
@@ -100,6 +101,8 @@ inline pmd lfoModulationRate()
 }
 
 inline pmd lfoSmoothing() { return pmd().withType(pmd::FLOAT).withRange(0, 2).withDefault(0); }
+
+inline pmd unusedParam() { return pmd().withType(pmd::NONE); }
 
 } // namespace scxt::datamodel
 

--- a/src/dsp/processor/processor.cpp
+++ b/src/dsp/processor/processor.cpp
@@ -292,7 +292,7 @@ ProcessorControlDescription Processor::getControlDescription()
     }
     for (int i = res.numFloatParams; i < maxProcessorFloatParams; ++i)
     {
-        res.floatControlDescriptions[i] = {};
+        res.floatControlDescriptions[i] = datamodel::unusedParam();
     }
 
     res.numIntParams = getIntParameterCount();

--- a/src/modulation/voice_matrix.cpp
+++ b/src/modulation/voice_matrix.cpp
@@ -402,7 +402,7 @@ getVoiceModMatrixDestDisplayName(const VoiceModMatrixDestinationAddress &dest,
         if (z.processorStorage[idx].type == dsp::processor::proct_none)
         {
             // this should in theory get filtered out of the user choices
-            return {};
+            return std::nullopt;
         }
         pfx += z.processorDescription[idx].typeDisplayName + " ";
         if (vmd == vmd_Processor_Mix)
@@ -411,9 +411,11 @@ getVoiceModMatrixDestDisplayName(const VoiceModMatrixDestinationAddress &dest,
         {
             auto ct = (int)(vmd - vmd_Processor_FP1);
 
-            return pfx + z.processorDescription[idx]
-                             .floatControlDescriptions[(int)(vmd - vmd_Processor_FP1)]
-                             .name;
+            if (z.processorDescription[idx].floatControlDescriptions[ct].type ==
+                datamodel::pmd::NONE)
+                return std::nullopt;
+
+            return pfx + z.processorDescription[idx].floatControlDescriptions[ct].name;
         }
     }
 


### PR DESCRIPTION
1. AHDR times displayed correctly
2. Restore 'NONE' behavior for unused processor slots

Closes #526