### PR TITLE
Add a shared memory read onlyl direct message region

### DIFF
--- a/clients/juce-plugin/SCXTPluginEditor.cpp
+++ b/clients/juce-plugin/SCXTPluginEditor.cpp
@@ -32,11 +32,12 @@
 
 //==============================================================================
 SCXTPluginEditor::SCXTPluginEditor(SCXTProcessor &p, scxt::messaging::MessageController &mc,
+                                   scxt::infrastructure::DefaultsProvider &d,
                                    const scxt::sample::SampleManager &s,
-                                   scxt::infrastructure::DefaultsProvider &d)
+                                   const scxt::engine::Engine::SharedUIMemoryState &st)
     : juce::AudioProcessorEditor(&p)
 {
-    ed = std::make_unique<scxt::ui::SCXTEditor>(mc, s, d);
+    ed = std::make_unique<scxt::ui::SCXTEditor>(mc, d, s, st);
     ed->onZoomChanged = [this](auto f) {
         setSize(scxt::ui::SCXTEditor::edWidth * f, scxt::ui::SCXTEditor::edHeight * f);
     };

--- a/clients/juce-plugin/SCXTPluginEditor.h
+++ b/clients/juce-plugin/SCXTPluginEditor.h
@@ -40,7 +40,8 @@ class SCXTPluginEditor : public juce::AudioProcessorEditor
 {
   public:
     SCXTPluginEditor(SCXTProcessor &p, scxt::messaging::MessageController &,
-                     const scxt::sample::SampleManager &, scxt::infrastructure::DefaultsProvider &);
+                     scxt::infrastructure::DefaultsProvider &, const scxt::sample::SampleManager &,
+                     const scxt::engine::Engine::SharedUIMemoryState &);
     ~SCXTPluginEditor();
 
     //==============================================================================

--- a/clients/juce-plugin/SCXTProcessor.cpp
+++ b/clients/juce-plugin/SCXTProcessor.cpp
@@ -283,8 +283,8 @@ bool SCXTProcessor::hasEditor() const
 
 juce::AudioProcessorEditor *SCXTProcessor::createEditor()
 {
-    return new SCXTPluginEditor(*this, *(engine->getMessageController()),
-                                *(engine->getSampleManager()), *(engine->defaults));
+    return new SCXTPluginEditor(*this, *(engine->getMessageController()), *(engine->defaults),
+                                *(engine->getSampleManager()), engine->sharedUIMemoryState);
 }
 
 //==============================================================================

--- a/src-ui/components/HeaderRegion.h
+++ b/src-ui/components/HeaderRegion.h
@@ -54,6 +54,13 @@ struct HeaderRegion : juce::Component, HasEditor
 
     void paint(juce::Graphics &g) override
     {
+        std::cout << "HEADER REGION PAINT" << std::endl;
+#if DEBUG_VOICE_COUNT
+        auto vc = fmt::format("Voices: {}", voiceCount);
+        g.setColour(juce::Colours::white);
+        g.drawText(vc, getLocalBounds().reduced(3, 1), juce::Justification::centred);
+#endif
+
         return;
 #if BUILD_IS_DEBUG
         g.fillAll(juce::Colours::red);
@@ -66,8 +73,6 @@ struct HeaderRegion : juce::Component, HasEditor
         g.setFont(juce::Font("Comic Sans MS", 14, juce::Font::plain));
         g.drawText("header", getLocalBounds(), juce::Justification::centred);
 #endif
-        auto vc = fmt::format("Voices: {}", voiceCount);
-        g.drawText(vc, getLocalBounds().reduced(3, 1), juce::Justification::topRight);
     }
 
     void resized() override;
@@ -75,8 +80,11 @@ struct HeaderRegion : juce::Component, HasEditor
     uint32_t voiceCount{0};
     void setVoiceCount(uint32_t vc)
     {
-        voiceCount = vc;
-        repaint();
+        if (vc != voiceCount)
+        {
+            voiceCount = vc;
+            repaint();
+        }
     }
 };
 } // namespace scxt::ui

--- a/src-ui/components/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/components/SCXTEditorResponseHandlers.cpp
@@ -159,29 +159,4 @@ void SCXTEditor::onEngineStatus(const engine::Engine::EngineStatusMessage &e)
     aboutScreen->resetInfo();
     repaint();
 }
-
-void SCXTEditor::onVoiceDisplayState(const engine::Engine::VoiceDisplayState &e)
-{
-    int idx{0};
-    int ac{0};
-    for (const auto &i : e.items)
-    {
-        if (i.active)
-        {
-            /*
-            SCDBGCOUT << SCD(idx) << SCD(i.zonePath.zone) << SCD(i.midiNote) << SCD(i.gated)
-                      << std::endl;
-                      */
-            ac++;
-        }
-        idx++;
-    }
-    if (!ac)
-    {
-        // SCDBGCOUT << "No active voices" << std::endl;
-    }
-
-    if (headerRegion)
-        headerRegion->setVoiceCount(e.voiceCount);
-}
 } // namespace scxt::ui

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -281,30 +281,30 @@ bool Engine::processAudio()
         lastUpdateVoiceDisplayState = 0;
         lastMidiNoteStateCounter = midiNoteStateCounter;
 
-        if (voiceDisplayStateReadCounter == voiceDisplayStateWriteCounter)
+        int i{0};
+        for (const auto *v : voices)
         {
-            int i{0};
-            for (const auto *v : voices)
+            auto &itm = sharedUIMemoryState.voiceDisplayItems[i];
+
+            if (v && (v->isVoiceAssigned && v->isVoicePlaying))
             {
-                if (v && (v->isVoiceAssigned && v->isVoicePlaying))
-                {
-                    voiceDisplayState.items[i].active = true;
-                    voiceDisplayState.items[i].zonePath = v->zonePath;
-                    voiceDisplayState.items[i].samplePos = v->GD.samplePos;
-                    voiceDisplayState.items[i].midiNote = v->originalMidiKey;
-                    voiceDisplayState.items[i].midiChannel = v->channel;
-                    voiceDisplayState.items[i].gated = v->isGated;
-                }
-                else
-                {
-                    voiceDisplayState.items[i].active = false;
-                }
-                i++;
+                itm.active = true;
+                itm.part = v->zonePath.part;
+                itm.group = v->zonePath.group;
+                itm.zone = v->zonePath.zone;
+                itm.samplePos = v->GD.samplePos;
+                itm.midiNote = v->originalMidiKey;
+                itm.midiChannel = v->channel;
+                itm.gated = v->isGated;
             }
-            voiceDisplayState.voiceCount = pav;
-            voiceDisplayStateWriteCounter++;
+            else
+            {
+                itm.active = false;
+            }
+            i++;
         }
-        messaging::audio::sendVoiceState(pav, *messageController);
+        sharedUIMemoryState.voiceCount = pav;
+        sharedUIMemoryState.voiceDisplayStateWriteCounter++;
     }
     lastUpdateVoiceDisplayState++;
 

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -338,53 +338,5 @@ template <> struct scxt_traits<engine::Engine::EngineStatusMessage>
     }
 };
 
-template <> struct scxt_traits<engine::Engine::VoiceDisplayStateItem>
-{
-    template <template <typename...> class Traits>
-    static void assign(tao::json::basic_value<Traits> &v,
-                       const engine::Engine::VoiceDisplayStateItem &t)
-    {
-        auto zp = std::make_tuple(t.zonePath.part, t.zonePath.group, t.zonePath.zone);
-        v = {{"active", t.active},           {"zoneAddress", zp}, {"midiNote", t.midiNote},
-             {"midiChannel", t.midiChannel}, {"gated", t.gated},  {"samplePos", t.samplePos}};
-    }
-
-    template <template <typename...> class Traits>
-    static void to(const tao::json::basic_value<Traits> &v,
-                   engine::Engine::VoiceDisplayStateItem &r)
-    {
-        findIf(v, "active", r.active);
-        std::tuple<int32_t, int32_t, int32_t> zp;
-        findIf(v, "zoneAddress", zp);
-        r.zonePath.part = std::get<0>(zp);
-        r.zonePath.group = std::get<1>(zp);
-        r.zonePath.zone = std::get<2>(zp);
-        findIf(v, "samplePos", r.samplePos);
-        findIf(v, "midiNote", r.midiNote);
-        findIf(v, "midiChannel", r.midiChannel);
-        findIf(v, "gated", r.gated);
-    }
-};
-
-template <> struct scxt_traits<engine::Engine::VoiceDisplayState>
-{
-    template <template <typename...> class Traits>
-    static void assign(tao::json::basic_value<Traits> &v,
-                       const engine::Engine::VoiceDisplayState &t)
-    {
-        auto itemsArray = toIndexedArrayIf<Traits>(t.items, [](const auto &r) { return r.active; });
-        v = {{"items", itemsArray}, {"voiceCount", t.voiceCount}};
-    }
-
-    template <template <typename...> class Traits>
-    static void to(const tao::json::basic_value<Traits> &v, engine::Engine::VoiceDisplayState &r)
-    {
-        for (auto &i : r.items)
-            i.active = false;
-        fromIndexedArray<Traits>(v.at("items"), r.items);
-        findOrSet(v, "voiceCount", 0, r.voiceCount);
-    }
-};
-
 } // namespace scxt::json
 #endif // SHORTCIRCUIT_ENGINE_TRAITS_H

--- a/src/messaging/audio/audio_messages.cpp
+++ b/src/messaging/audio/audio_messages.cpp
@@ -32,15 +32,6 @@
 
 namespace scxt::messaging::audio
 {
-void sendVoiceState(uint32_t voiceCount, MessageController &mc)
-{
-    assert(mc.threadingChecker.isAudioThread());
-    AudioToSerialization a2s;
-    a2s.id = a2s_voice_state;
-    a2s.payloadType = AudioToSerialization::NONE;
-    mc.sendAudioToSerialization(a2s);
-}
-
 void sendStructureRefresh(MessageController &mc)
 {
     assert(mc.threadingChecker.isAudioThread());

--- a/src/messaging/audio/audio_serial.h
+++ b/src/messaging/audio/audio_serial.h
@@ -47,7 +47,6 @@ enum AudioToSerializationMessageId
 {
     a2s_none,
     a2s_pointer_complete,
-    a2s_voice_state,
     a2s_note_on,
     a2s_note_off,
     a2s_structure_refresh

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -71,7 +71,6 @@ enum SerializationToClientMessageIds
 {
     s2c_report_error,
     s2c_send_initial_metadata,
-    s2c_voice_display_status,
     s2c_engine_status,
     s2c_respond_zone_adsr_view,
     s2c_respond_zone_mapping,

--- a/src/messaging/client/enginestatus_messages.h
+++ b/src/messaging/client/enginestatus_messages.h
@@ -37,8 +37,6 @@
 
 namespace scxt::messaging::client
 {
-SERIAL_TO_CLIENT(VoiceDisplayStatusUpdate, s2c_voice_display_status,
-                 engine::Engine::VoiceDisplayState, onVoiceDisplayState);
 SERIAL_TO_CLIENT(EngineStatusUpdate, s2c_engine_status, engine::Engine::EngineStatusMessage,
                  onEngineStatus);
 } // namespace scxt::messaging::client

--- a/src/messaging/messaging.cpp
+++ b/src/messaging/messaging.cpp
@@ -42,17 +42,6 @@ void MessageController::parseAudioMessageOnSerializationThread(
     // TODO - we could do the template shuffle later if this becomes too big
     switch (as.id)
     {
-    case audio::a2s_voice_state:
-    {
-        if (engine.voiceDisplayStateWriteCounter != engine.voiceDisplayStateReadCounter)
-        {
-            client::serializationSendToClient(client::s2c_voice_display_status,
-                                              engine.voiceDisplayState, *this);
-
-            engine.voiceDisplayStateReadCounter = (int)engine.voiceDisplayStateWriteCounter;
-        }
-    }
-    break;
     case audio::a2s_pointer_complete:
         returnAudioThreadCallback(static_cast<AudioThreadCallback *>(as.payload.p));
         break;


### PR DESCRIPTION
For some non-structural things, like vu meters, sample position, and playing voices, we don't really need to send json messages, but instead can just make a shared memory region with atomics which is const & loaded in the editor. But placing this in one structure we know what we would lose in a fully remote situation (like a far away web browser). But we can also send higher frequency updates with asimple tail chasing int64_t. Closes #535

Along the way, put the voice info into the
structure, which stops that little update chase we had. But a different way. Closes #531