### PR TITLE
Deadlock absent Audio on File Drop

### DIFF
--- a/src/messaging/audio/audio_serial.h
+++ b/src/messaging/audio/audio_serial.h
@@ -91,7 +91,8 @@ inline std::string toDebugString(const AudioToSerialization &a)
 enum SerializationToAudioMessageId
 {
     s2a_none,
-    s2a_dispatch_to_pointer
+    s2a_dispatch_to_pointer,
+    s2a_dispatch_to_pointer_under_structurelock
 };
 
 /**

--- a/src/messaging/messaging.h
+++ b/src/messaging/messaging.h
@@ -247,7 +247,23 @@ struct MessageController : MoveableOnly<MessageController>
      * @param f
      */
     void scheduleAudioThreadCallback(std::function<void(engine::Engine &)> f,
-                                     std::function<void(const engine::Engine &)> cb = nullptr);
+                                     std::function<void(const engine::Engine &)> cb = nullptr)
+    {
+        scheduleAudioThreadFunctionCallback(audio::s2a_dispatch_to_pointer, f, cb);
+    }
+
+    void scheduleAudioThreadCallbackUnderStructureLock(
+        std::function<void(engine::Engine &)> f,
+        std::function<void(const engine::Engine &)> cb = nullptr)
+    {
+        scheduleAudioThreadFunctionCallback(audio::s2a_dispatch_to_pointer_under_structurelock, f,
+                                            cb);
+    }
+
+    void scheduleAudioThreadFunctionCallback(audio::SerializationToAudioMessageId id,
+                                             std::function<void(engine::Engine &)> f,
+                                             std::function<void(const engine::Engine &)> cb);
+
     void stopAudioThreadThenRunOnSerial(std::function<void(const engine::Engine &)> f);
     void restartAudioThreadFromSerial();
     struct AudioThreadCallback


### PR DESCRIPTION
If a file was dropped and we had no audio engine so we ran the structure mutation on the serialization thread, we recursively locked the non-recursive structure mutex. rather than face the horrors of recursive mutexes, add a new callback to separate messages based on locking or not on the engine, and have the no engine case use the existing lock for both.

Closes #547