### PR TITLE
Implement busses; bus effects; UI for bus effects

### DIFF
--- a/clients/juce-plugin/SCXTProcessor.cpp
+++ b/clients/juce-plugin/SCXTProcessor.cpp
@@ -213,8 +213,8 @@ void SCXTProcessor::processBlock(juce::AudioBuffer<float> &buffer, juce::MidiBuf
 
             if (bus == 0)
             {
-                *outL = engine->busses.mainBus.output[0][blockPos];
-                *outR = engine->busses.mainBus.output[1][blockPos];
+                *outL = engine->getPatch()->busses.mainBus.output[0][blockPos];
+                *outR = engine->getPatch()->busses.mainBus.output[1][blockPos];
             }
             else
             {

--- a/scripts/fix_file_comments.pl
+++ b/scripts/fix_file_comments.pl
@@ -117,5 +117,6 @@ EOH
         close(IN);
         close(OUT);
         system("mv ${q}.bak ${q}");
+        system("clang-format -i ${q}");
     }
 }

--- a/src-ui/CMakeLists.txt
+++ b/src-ui/CMakeLists.txt
@@ -17,9 +17,14 @@ add_library(${PROJECT_NAME} STATIC
         components/SCXTEditorResponseHandlers.cpp
 
         components/HeaderRegion.cpp
+        components/MixerScreen.cpp
         components/MultiScreen.cpp
         components/SendFXScreen.cpp
         components/AboutScreen.cpp
+
+        components/browser/BrowserPane.cpp
+
+        components/mixer/PartEffectsPane.cpp
 
         components/multi/AdsrPane.cpp
         components/multi/LFOPane.cpp

--- a/src-ui/components/MixerScreen.cpp
+++ b/src-ui/components/MixerScreen.cpp
@@ -1,0 +1,99 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2023, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "HasEditor.h"
+#include "browser/BrowserPane.h"
+#include "mixer/BusPane.h"
+#include "mixer/PartEffectsPane.h"
+
+#include "messaging/messaging.h"
+#include "utils.h"
+#include "MixerScreen.h"
+#include "SCXTEditor.h"
+
+namespace scxt::ui
+{
+namespace cmsg = scxt::messaging::client;
+
+MixerScreen::MixerScreen(SCXTEditor *e) : HasEditor(e)
+{
+    browser = std::make_unique<browser::BrowserPane>();
+    addAndMakeVisible(*browser);
+
+    busPane = std::make_unique<mixer::BusPane>();
+    addAndMakeVisible(*busPane);
+
+    for (auto i = 0; i < partPanes.size(); ++i)
+    {
+        auto pp = std::make_unique<mixer::PartEffectsPane>(editor, this, i);
+        pp->setBusAddress(0);
+
+        addAndMakeVisible(*pp);
+        partPanes[i] = std::move(pp);
+    }
+}
+
+MixerScreen::~MixerScreen() {}
+
+void MixerScreen::visibilityChanged()
+{
+    if (isVisible())
+    {
+    }
+}
+void MixerScreen::resized()
+{
+    int pad = 0;
+    int busHeight = 330;
+    browser->setBounds(getWidth() - sideWidths - pad, pad, sideWidths, getHeight() - 3 * pad);
+
+    auto rest = getLocalBounds().withTrimmedRight(sideWidths + pad);
+
+    auto busArea = rest.withTrimmedTop(getHeight() - busHeight);
+    busPane->setBounds(busArea);
+    auto fxArea = rest.withTrimmedBottom(busHeight).reduced(0);
+
+    auto fxq = fxArea.getWidth() * 1.f / partPanes.size();
+    auto ifx = fxArea.withWidth(fxq);
+    for (int i = 0; i < partPanes.size(); ++i)
+    {
+        partPanes[i]->setBounds(ifx.reduced(0));
+        ifx = ifx.translated(fxq, 0);
+    }
+}
+
+void MixerScreen::onBusEffectFullData(
+    int bus, int slot,
+    const std::array<datamodel::pmd, engine::BusEffectStorage::maxBusEffectParams> &pmd,
+    const engine::BusEffectStorage &bes)
+{
+    busEffectsData[bus][slot].first = pmd;
+    busEffectsData[bus][slot].second = bes;
+    if (partPanes[slot]->busAddress == bus)
+        partPanes[slot]->rebuild();
+}
+} // namespace scxt::ui

--- a/src-ui/components/MultiScreen.cpp
+++ b/src-ui/components/MultiScreen.cpp
@@ -26,6 +26,7 @@
  */
 
 #include "MultiScreen.h"
+#include "browser/BrowserPane.h"
 #include "multi/AdsrPane.h"
 #include "multi/LFOPane.h"
 #include "multi/MappingPane.h"
@@ -69,8 +70,7 @@ MultiScreen::MultiScreen(SCXTEditor *e) : HasEditor(e)
     parts = std::make_unique<multi::PartGroupSidebar>(editor);
     addAndMakeVisible(*parts);
 
-    auto br = std::make_unique<DebugRect>(juce::Colour(200, 120, 100), "BROWSER");
-    br->hasHamburger = true;
+    auto br = std::make_unique<browser::BrowserPane>();
     browser = std::move(br);
     addAndMakeVisible(*browser);
     sample = std::make_unique<multi::MappingPane>(editor);

--- a/src-ui/components/MultiScreen.h
+++ b/src-ui/components/MultiScreen.h
@@ -29,7 +29,9 @@
 #define SCXT_SRC_UI_COMPONENTS_MULTISCREEN_H
 
 #include <juce_gui_basics/juce_gui_basics.h>
+#include <memory>
 #include "HasEditor.h"
+#include "browser/BrowserPane.h"
 #include "sst/jucegui/components/NamedPanel.h"
 
 namespace scxt::ui
@@ -44,16 +46,22 @@ struct ProcessorPane;
 struct LfoPane;
 } // namespace multi
 
+namespace browser
+{
+struct BrowserPane;
+}
+
 struct MultiScreen : juce::Component, HasEditor
 {
     static constexpr int numProcessorDisplays{4};
-    static constexpr int sideWidths = 196;
+    static constexpr int sideWidths = 196; // copied from mixer for now
     static constexpr int edgeDistance = 6;
 
     static constexpr int envHeight = 160, modHeight = 160, fxHeight = 176;
     static constexpr int pad = 0;
 
-    std::unique_ptr<juce::Component> browser, mix;
+    std::unique_ptr<juce::Component> mix;
+    std::unique_ptr<browser::BrowserPane> browser;
     std::unique_ptr<multi::LfoPane> lfo;
     std::unique_ptr<multi::MappingPane> sample;
     std::unique_ptr<multi::PartGroupSidebar> parts;

--- a/src-ui/components/SCXTEditor.cpp
+++ b/src-ui/components/SCXTEditor.cpp
@@ -91,7 +91,7 @@ SCXTEditor::SCXTEditor(messaging::MessageController &e, infrastructure::Defaults
     multiScreen = std::make_unique<MultiScreen>(this);
     addAndMakeVisible(*multiScreen);
 
-    mixerScreen = std::make_unique<MixerScreen>();
+    mixerScreen = std::make_unique<MixerScreen>(this);
     addChildComponent(*mixerScreen);
 
     playScreen = std::make_unique<PlayScreen>();

--- a/src-ui/components/SCXTEditor.h
+++ b/src-ui/components/SCXTEditor.h
@@ -34,6 +34,7 @@
 #include "PlayScreen.h"
 #include "SCXTJuceLookAndFeel.h"
 #include "engine/engine.h"
+#include "engine/patch.h"
 #include "messaging/client/selection_messages.h"
 #include "messaging/messaging.h"
 #include "selection/selection_manager.h"
@@ -159,6 +160,8 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::FileDragAndDrop
 
     void onGroupZoneMappingSummary(const scxt::engine::Part::zoneMappingSummary_t &);
     void onSelectionState(const scxt::messaging::client::selectedStateMessage_t &);
+
+    void onMixerBusEffectFullData(const scxt::messaging::client::busEffectFullData_t &);
 
     std::vector<dsp::processor::ProcessorDescription> allProcessors;
     void onAllProcessorDescriptions(const std::vector<dsp::processor::ProcessorDescription> &v)

--- a/src-ui/components/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/components/SCXTEditorResponseHandlers.cpp
@@ -32,9 +32,10 @@
 #include "multi/ModPane.h"
 #include "multi/ProcessorPane.h"
 #include "multi/PartGroupSidebar.h"
+#include "MixerScreen.h"
 #include "HeaderRegion.h"
-#include "components/multi/MappingPane.h"
-#include "components/AboutScreen.h"
+#include "multi/MappingPane.h"
+#include "AboutScreen.h"
 
 namespace scxt::ui
 {
@@ -159,4 +160,16 @@ void SCXTEditor::onEngineStatus(const engine::Engine::EngineStatusMessage &e)
     aboutScreen->resetInfo();
     repaint();
 }
+
+void SCXTEditor::onMixerBusEffectFullData(const scxt::messaging::client::busEffectFullData_t &d)
+{
+    if (mixerScreen)
+    {
+        auto busi = std::get<0>(d);
+        auto slti = std::get<1>(d);
+        const auto &bes = std::get<2>(d);
+        mixerScreen->onBusEffectFullData(busi, slti, bes.first, bes.second);
+    }
+}
+
 } // namespace scxt::ui

--- a/src-ui/components/browser/BrowserPane.cpp
+++ b/src-ui/components/browser/BrowserPane.cpp
@@ -25,31 +25,4 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#include <random>
-#include <chrono>
-
-#ifndef SCXT_SRC_INFRASTRUCTURE_RNG_GEN_H
-#define SCXT_SRC_INFRASTRUCTURE_RNG_GEN_H
-
-namespace scxt::infrastructure
-{
-struct RNGGen
-{
-    RNGGen()
-        : g(std::chrono::system_clock::now().time_since_epoch().count()), pm1(-1.f, 1.f),
-          z1(0.f, 1.f), u32(0, 0xFFFFFFFF)
-    {
-    }
-
-    inline float rand01() { return z1(g); }
-    inline float randPM1() { return pm1(g); }
-    inline uint32_t randU32() { return u32(g); }
-
-  private:
-    std::minstd_rand g;
-    std::uniform_real_distribution<float> pm1, z1;
-    std::uniform_int_distribution<uint32_t> u32;
-};
-} // namespace scxt::infrastructure
-
-#endif // SHORTCIRCUITXT_RNG_GEN_H
+#include "BrowserPane.h"

--- a/src-ui/components/browser/BrowserPane.h
+++ b/src-ui/components/browser/BrowserPane.h
@@ -25,25 +25,39 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_PLAYSCREEN_H
-#define SCXT_SRC_UI_COMPONENTS_PLAYSCREEN_H
+#ifndef SCXT_SRC_UI_COMPONENTS_BROWSER_BROWSERPANE_H
+#define SCXT_SRC_UI_COMPONENTS_BROWSER_BROWSERPANE_H
 
 #include <juce_gui_basics/juce_gui_basics.h>
+#include <sst/jucegui/components/NamedPanel.h>
 
-namespace scxt::ui
+namespace scxt::ui::browser
 {
-struct PlayScreen : juce::Component
+struct BrowserPane : public sst::jucegui::components::NamedPanel
 {
-    void paint(juce::Graphics &g)
+    struct CL : juce::Component
     {
-        g.setColour(juce::Colours::white);
-        g.setFont(juce::Font(60, juce::Font::plain));
-        g.drawText("Play Mode", getLocalBounds().withTrimmedBottom(40),
-                   juce::Justification::centred);
-        g.setFont(juce::Font(20, juce::Font::plain));
-        g.drawText("Coming A Bit Less Soon", getLocalBounds().withTrimmedTop(40),
-                   juce::Justification::centred);
+        juce::Colour color;
+        std::string label;
+        void paint(juce::Graphics &g) override
+        {
+            g.setFont(juce::Font("Comic Sans MS", 40, juce::Font::plain));
+
+            g.setColour(color);
+            g.drawText(label, getLocalBounds(), juce::Justification::centred);
+        }
+    };
+    std::unique_ptr<CL> cl;
+    BrowserPane() : sst::jucegui::components::NamedPanel("Browser")
+    {
+        cl = std::make_unique<CL>();
+        cl->color = juce::Colours::cyan;
+        cl->label = "BROWSER";
+        addAndMakeVisible(*cl);
+        hasHamburger = true;
     }
+    void resized() override { cl->setBounds(getContentArea()); }
 };
-} // namespace scxt::ui
-#endif // SHORTCIRCUITXT_PLAYSCREEN_H
+} // namespace scxt::ui::browser
+
+#endif // SHORTCIRCUITXT_BROWSERPANE_H

--- a/src-ui/components/mixer/BusPane.h
+++ b/src-ui/components/mixer/BusPane.h
@@ -25,31 +25,39 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#include <random>
-#include <chrono>
+#ifndef SCXT_SRC_UI_COMPONENTS_MIXER_BUSPANE_H
+#define SCXT_SRC_UI_COMPONENTS_MIXER_BUSPANE_H
 
-#ifndef SCXT_SRC_INFRASTRUCTURE_RNG_GEN_H
-#define SCXT_SRC_INFRASTRUCTURE_RNG_GEN_H
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <sst/jucegui/components/NamedPanel.h>
 
-namespace scxt::infrastructure
+namespace scxt::ui::mixer
 {
-struct RNGGen
+struct BusPane : public sst::jucegui::components::NamedPanel
 {
-    RNGGen()
-        : g(std::chrono::system_clock::now().time_since_epoch().count()), pm1(-1.f, 1.f),
-          z1(0.f, 1.f), u32(0, 0xFFFFFFFF)
+    struct CL : juce::Component
     {
+        juce::Colour color;
+        std::string label;
+        void paint(juce::Graphics &g) override
+        {
+            g.setFont(juce::Font("Comic Sans MS", 40, juce::Font::plain));
+
+            g.setColour(color);
+            g.drawText(label, getLocalBounds(), juce::Justification::centred);
+        }
+    };
+    std::unique_ptr<CL> cl;
+    BusPane() : sst::jucegui::components::NamedPanel("BUSSES")
+    {
+        cl = std::make_unique<CL>();
+        cl->color = juce::Colours::cyan;
+        cl->label = "BUSSES";
+        addAndMakeVisible(*cl);
+        hasHamburger = true;
     }
-
-    inline float rand01() { return z1(g); }
-    inline float randPM1() { return pm1(g); }
-    inline uint32_t randU32() { return u32(g); }
-
-  private:
-    std::minstd_rand g;
-    std::uniform_real_distribution<float> pm1, z1;
-    std::uniform_int_distribution<uint32_t> u32;
+    void resized() override { cl->setBounds(getContentArea()); }
 };
-} // namespace scxt::infrastructure
+} // namespace scxt::ui::mixer
 
-#endif // SHORTCIRCUITXT_RNG_GEN_H
+#endif // SHORTCIRCUITXT_BUSPANEL_H

--- a/src-ui/components/mixer/PartEffectsPane.cpp
+++ b/src-ui/components/mixer/PartEffectsPane.cpp
@@ -1,0 +1,290 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2023, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "connectors/Connectors.h"
+#include "PartEffectsPane.h"
+#include "components/SCXTEditor.h"
+#include "components/MixerScreen.h"
+
+#include "sst/jucegui/components/Knob.h"
+#include "sst/jucegui/components/Label.h"
+#include "sst/jucegui/components/MenuButton.h"
+
+namespace scxt::ui::mixer
+{
+namespace cmsg = scxt::messaging::client;
+namespace jcmp = sst::jucegui::components;
+void PartEffectsPane::showHamburger()
+{
+    auto p = juce::PopupMenu();
+    p.addSectionHeader("Effects");
+    p.addSeparator();
+    auto go = [w = juce::Component::SafePointer(this)](auto q) {
+        return [w, q]() {
+            if (w)
+            {
+                cmsg::clientSendToSerialization(
+                    cmsg::SetBusEffectToType({w->busAddress, w->fxSlot, q}), w->editor->msgCont);
+            }
+        };
+    };
+    auto add = [this, &go, &p](auto q) { p.addItem(effectDisplayName(q, true), go(q)); };
+    add(engine::AvailableBusEffects::none);
+    add(engine::AvailableBusEffects::reverb1);
+    add(engine::AvailableBusEffects::delay);
+    add(engine::AvailableBusEffects::flanger);
+    p.showMenuAsync(editor->defaultPopupMenuOptions());
+}
+
+PartEffectsPane::~PartEffectsPane()
+{
+    removeAllChildren();
+    // order matters here
+    components.clear();
+    floatAttachments.clear();
+}
+
+void PartEffectsPane::paintMetadata(juce::Graphics &g, const juce::Rectangle<int> &into)
+{
+    auto &b = mixer->busEffectsData[busAddress][fxSlot];
+
+    auto r = into.withHeight(20);
+    int idx{0};
+    for (const auto &p : b.first)
+    {
+        if (p.type != sst::basic_blocks::params::ParamMetaData::NONE)
+        {
+            g.setColour(juce::Colours::white);
+            g.drawText(p.name, r, juce::Justification::left);
+
+            auto s = p.valueToString(b.second.params[idx]);
+            if (s.has_value())
+                g.drawText(*s, r, juce::Justification::right);
+        }
+        r = r.translated(0, 20);
+        idx++;
+    }
+}
+
+void PartEffectsPane::rebuild()
+{
+    auto &b = mixer->busEffectsData[busAddress][fxSlot];
+    auto &params = b.first;
+    auto &data = b.second;
+    auto t = data.type;
+    name = effectDisplayName(t, false);
+
+    removeAllChildren();
+    components.clear();
+    // intAttachments.clear();
+    // floatAttachments.clear();
+
+    if (getHeight() < 10)
+        return;
+
+    switch (t)
+    {
+    default:
+        rebuildDefaultLayout();
+        break;
+    }
+
+    repaint();
+}
+
+std::string PartEffectsPane::effectDisplayName(engine::AvailableBusEffects t, bool forMenu)
+{
+    switch (t)
+    {
+    case engine::none:
+        return forMenu ? "None" : "FX";
+    case engine::flanger:
+        return forMenu ? "Flanger" : "FLANGER";
+    case engine::delay:
+        return forMenu ? "Delay" : "DELAY";
+    case engine::reverb1:
+        return forMenu ? "Reverb 1" : "REVERB 1";
+    }
+}
+
+template <typename T> T *PartEffectsPane::attachWidgetToFloat(int pidx)
+{
+    auto &data = mixer->busEffectsData[busAddress][fxSlot];
+    auto &pmd = data.first[pidx];
+    auto onGuiChange = [w = juce::Component::SafePointer(this), pidx](auto &a) {
+        if (w)
+            w->floatParameterChangedFromGui(a, pidx);
+    };
+
+    auto at = std::make_unique<attachment_t>(
+        this, pmd, onGuiChange,
+        [w = juce::Component::SafePointer(this), pidx](const typename attachment_t::payload_t &pl) {
+            if (w)
+                return w->mixer->busEffectsData[w->busAddress][w->fxSlot].second.params[pidx];
+            return 0.f;
+        },
+        mixer->busEffectsData[busAddress][fxSlot].second.params[pidx]);
+    auto w = std::make_unique<T>();
+    w->setSource(at.get());
+
+    w->onBeginEdit = [this, q = juce::Component::SafePointer(w.get()), atPtr = at.get()]() {
+        if (q)
+            editor->showTooltip(*q);
+        updateTooltip(*atPtr);
+    };
+    w->onEndEdit = [this]() { editor->hideTooltip(); };
+
+    addAndMakeVisible(*w);
+
+    auto retVal = w.get();
+    components.insert(std::move(w));
+    floatAttachments.insert(std::move(at));
+
+    return retVal;
+}
+
+juce::Component *PartEffectsPane::attachMenuButtonToInt(int index)
+{
+    // TODO - this really needs some contemplation. I bet it wil lbe a pretty
+    // common pattern. Where to put it?
+    auto &b = mixer->busEffectsData[busAddress][fxSlot];
+    auto &pmd = b.first;
+    auto &bes = b.second;
+
+    auto r = std::make_unique<jcmp::MenuButton>();
+    auto sv = pmd[index].valueToString(bes.params[index]);
+    if (sv.has_value())
+        r->setLabel(*sv);
+    r->setOnCallback([r = juce::Component::SafePointer(r.get()),
+                      w = juce::Component::SafePointer(this), index]() {
+        if (!w)
+            return;
+        auto &b = w->mixer->busEffectsData[w->busAddress][w->fxSlot];
+        auto &pmd = b.first[index];
+        auto &bes = b.second;
+
+        auto p = juce::PopupMenu();
+        p.addSectionHeader(pmd.name);
+        p.addSeparator();
+        for (int i = pmd.minVal; i <= pmd.maxVal; ++i)
+        {
+            auto sv = pmd.valueToString(i);
+            if (sv.has_value())
+                p.addItem(*sv, [w, r, sv, i, index]() {
+                    if (w)
+                    {
+                        auto &bes = w->mixer->busEffectsData[w->busAddress][w->fxSlot].second;
+                        bes.params[index] = i;
+                        if (r)
+                        {
+                            r->setLabel(*sv);
+                            r->repaint();
+                        }
+
+                        cmsg::clientSendToSerialization(
+                            cmsg::SetBusEffectStorage({w->busAddress, w->fxSlot, bes}),
+                            w->editor->msgCont);
+                    }
+                });
+        }
+        p.showMenuAsync(w->editor->defaultPopupMenuOptions());
+    });
+    addAndMakeVisible(*r);
+    auto retVal = r.get();
+    components.insert(std::move(r));
+    return retVal;
+}
+
+void PartEffectsPane::rebuildDefaultLayout()
+{
+    namespace jcmp = sst::jucegui::components;
+    // Just a stack of modulation style hsliders with labels
+    int labht{15};
+    static_assert(engine::BusEffectStorage::maxBusEffectParams <= 12,
+                  "If this is false, this 3x4 grid will be bad");
+    auto bx = std::min((getHeight() / 4.f + labht), getWidth() / 3.f) * 0.9f;
+    auto &b = mixer->busEffectsData[busAddress][fxSlot];
+
+    auto into = getContentArea();
+    auto r =
+        into.withHeight(bx + labht).withWidth(bx).translated((into.getWidth() - bx * 3) * 0.5, 0);
+    int idx{0};
+    for (const auto &p : b.first)
+    {
+        if (p.type != sst::basic_blocks::params::ParamMetaData::NONE)
+        {
+            auto l = std::make_unique<jcmp::Label>();
+            l->setText(p.name);
+            l->setBounds(r);
+            l->setJustification(juce::Justification::centredBottom);
+            addAndMakeVisible(*l);
+            components.insert(std::move(l));
+
+            if (p.type == sst::basic_blocks::params::ParamMetaData::FLOAT)
+            {
+                // make slidera
+                auto w = attachWidgetToFloat<jcmp::Knob>(idx);
+                w->setBounds(r.withHeight(bx).reduced(2));
+            }
+            else if (p.type == sst::basic_blocks::params::ParamMetaData::INT)
+            {
+                // make menu
+                auto w = attachMenuButtonToInt(idx);
+                w->setBounds(r.withHeight(bx).withSizeKeepingCentre(r.getWidth(), 24));
+            }
+            else
+            {
+                SCDBGCOUT << "No widget for type " << p.type << " / " << p.name << std::endl;
+            }
+
+            r = r.translated(bx, 0);
+            if (!into.contains(r))
+            {
+                r = r.withX(into.getX()).translated((into.getWidth() - bx * 3) * 0.5, bx + labht);
+            }
+        }
+        idx++;
+    }
+}
+
+void PartEffectsPane::floatParameterChangedFromGui(
+    const scxt::ui::mixer::PartEffectsPane::attachment_t &at, int idx)
+{
+    updateTooltip(at);
+    auto &data = mixer->busEffectsData[busAddress][fxSlot];
+
+    cmsg::clientSendToSerialization(cmsg::SetBusEffectStorage({busAddress, fxSlot, data.second}),
+                                    editor->msgCont);
+}
+
+void PartEffectsPane::updateTooltip(const attachment_t &at)
+{
+    editor->setTooltipContents(at.label + " = " +
+                               at.description.valueToString(at.value).value_or("Error"));
+}
+
+} // namespace scxt::ui::mixer

--- a/src-ui/components/mixer/PartEffectsPane.h
+++ b/src-ui/components/mixer/PartEffectsPane.h
@@ -1,0 +1,102 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2023, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_UI_COMPONENTS_MIXER_PARTEFFECTSPANE_H
+#define SCXT_SRC_UI_COMPONENTS_MIXER_PARTEFFECTSPANE_H
+
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <sst/jucegui/components/NamedPanel.h>
+#include <unordered_set>
+
+#include "components/HasEditor.h"
+#include "connectors/PayloadDataAttachment.h"
+#include "engine/bus.h"
+
+namespace scxt::ui
+{
+struct MixerScreen;
+}
+namespace scxt::ui::mixer
+{
+struct PartEffectsPane : public HasEditor, sst::jucegui::components::NamedPanel
+{
+
+    int fxSlot{0}, busAddress{0};
+    MixerScreen *mixer{nullptr};
+    PartEffectsPane(SCXTEditor *e, MixerScreen *ms, int i)
+        : HasEditor(e), mixer(ms), fxSlot(i), sst::jucegui::components::NamedPanel("FX")
+    {
+        hasHamburger = true;
+        onHamburger = [w = juce::Component::SafePointer(this)] {
+            if (w)
+                w->showHamburger();
+        };
+        hasHamburger = true;
+    }
+    ~PartEffectsPane();
+
+    void setBusAddress(int ba)
+    {
+        busAddress = ba;
+        if (isVisible())
+            rebuild();
+    }
+    void resized() override { rebuild(); }
+
+    // The effects have names like 'flanger' and 'delay' internally but we
+    // want alternate display names here.
+    std::string effectDisplayName(engine::AvailableBusEffects, bool forMenu);
+
+    void rebuild();
+    void showHamburger();
+
+    void paintMetadata(juce::Graphics &g, const juce::Rectangle<int> &into);
+
+    std::unordered_set<std::unique_ptr<juce::Component>> components;
+    typedef connectors::PayloadDataAttachment<PartEffectsPane, engine::BusEffectStorage>
+        attachment_t;
+    // typedef connectors::PayloadDataAttachment<PartEffectsPane, engine::BusEffectStorage>
+    //     attachment_t;
+    std::unordered_set<std::unique_ptr<attachment_t>> floatAttachments;
+
+  protected:
+    // This returns a pointer which is owned by the class; do not delete it or
+    // move it.
+    template <typename T> T *attachWidgetToFloat(int index);
+    juce::Component *attachMenuButtonToInt(int index);
+
+    // Generic
+    void rebuildDefaultLayout();
+    void floatParameterChangedFromGui(const attachment_t &at, int idx);
+    void updateTooltip(const attachment_t &at);
+
+    // Specific
+    // void rebuildDelayLayout();
+};
+} // namespace scxt::ui::mixer
+
+#endif // SHORTCIRCUITXT_PARTEFFECTSPANEL_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(${PROJECT_NAME} STATIC
         engine/zone.cpp
         engine/group.cpp
         engine/part.cpp
+        engine/patch.cpp
         engine/memory_pool.cpp
         engine/bus.cpp
 

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -36,8 +36,9 @@ namespace scxt
 static constexpr uint16_t blockSize{16};
 static constexpr uint16_t blockSizeQuad{16 >> 2};
 static constexpr uint16_t numParts{16};
-static constexpr uint16_t numAux{16};
+static constexpr uint16_t numAux{4};
 static constexpr uint16_t maxOutputs{1 + numParts + numAux}; // 16 parts, 4 aux, a main
+static constexpr uint16_t maxBusses{maxOutputs};
 static constexpr uint16_t mainOutput{0};
 static constexpr uint16_t firstPartOutput{1};
 static constexpr uint16_t firstAuxOutput{firstPartOutput + numParts};

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -73,26 +73,6 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
 
     EngineID id;
 
-    struct Busses
-    {
-        Busses()
-        {
-            std::fill(partToVSTRouting.begin(), partToVSTRouting.end(), 0);
-            std::fill(auxToVSTRouting.begin(), auxToVSTRouting.end(), 0);
-        }
-
-        static constexpr int busCount{numParts + numAux + 1};
-
-        Bus mainBus;
-
-        std::array<Bus, numParts> partBusses;
-        // here '0' means main bus
-        std::array<int16_t, numParts> partToVSTRouting{};
-
-        std::array<Bus, numAux> auxBusses;
-        std::array<int16_t, numParts> auxToVSTRouting{};
-    } busses;
-
     const std::unique_ptr<Patch> &getPatch() const { return patch; }
     const std::unique_ptr<sample::SampleManager> &getSampleManager() const { return sampleManager; }
 
@@ -241,7 +221,7 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
      */
     struct SharedUIMemoryState
     {
-        std::array<std::array<std::atomic<float>, 2>, Busses::busCount> busVULevels;
+        std::array<std::array<std::atomic<float>, 2>, Patch::Busses::busCount> busVULevels;
 
         std::atomic<int64_t> voiceDisplayStateWriteCounter{0};
 

--- a/src/engine/part.cpp
+++ b/src/engine/part.cpp
@@ -68,8 +68,10 @@ void Part::process(Engine &e)
             {
                 bi = (BusAddress)(MAIN_0 + partNumber);
             }
-            blk::accumulate_from_to<blockSize>(g->output[0], e.busses.partBusses[bi].output[0]);
-            blk::accumulate_from_to<blockSize>(g->output[1], e.busses.partBusses[bi].output[1]);
+            blk::accumulate_from_to<blockSize>(g->output[0],
+                                               e.getPatch()->busses.partBusses[bi].output[0]);
+            blk::accumulate_from_to<blockSize>(g->output[1],
+                                               e.getPatch()->busses.partBusses[bi].output[1]);
         }
     }
 }

--- a/src/engine/patch.cpp
+++ b/src/engine/patch.cpp
@@ -1,0 +1,97 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2023, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "patch.h"
+#include "sst/basic-blocks/mechanics/block-ops.h"
+
+namespace scxt::engine
+{
+void Patch::process(Engine &e)
+{
+    namespace mech = sst::basic_blocks::mechanics;
+    // Run each of the parts, accumulating onto the engine busses
+    for (const auto &part : parts)
+    {
+        if (part->isActive())
+        {
+            part->process(e);
+        }
+    }
+
+    // Then process the part busses
+    for (auto &b : busses.partBusses)
+    {
+        b.process();
+        if (b.supportsSends && b.hasSends)
+        {
+            // TOD accumulate my sends
+        }
+    }
+
+    // Process my send busses
+    for (auto &b : busses.auxBusses)
+        b.process();
+
+    // And finally push onto the main bus
+    for (auto [bi, br] : sst::cpputils::enumerate(busses.partToVSTRouting))
+    {
+        if (br == 0)
+        {
+            // accumulate onto main
+            mech::accumulate_from_to<blockSize>(busses.partBusses[bi].output[0],
+                                                busses.mainBus.output[0]);
+            mech::accumulate_from_to<blockSize>(busses.partBusses[bi].output[1],
+                                                busses.mainBus.output[1]);
+        }
+    }
+
+    for (auto [bi, br] : sst::cpputils::enumerate(busses.auxToVSTRouting))
+    {
+        if (br == 0)
+        {
+            // accumulate onto main
+            mech::accumulate_from_to<blockSize>(busses.auxBusses[bi].output[0],
+                                                busses.mainBus.output[0]);
+            mech::accumulate_from_to<blockSize>(busses.auxBusses[bi].output[1],
+                                                busses.mainBus.output[1]);
+        }
+    }
+
+    // And run the main bus
+    busses.mainBus.process();
+}
+
+void Patch::setupBussesOnUnstream(Engine &e)
+{
+    // Assume the bus storage is correct
+    busses.mainBus.initializeAfterUnstream(e);
+    for (auto &p : busses.partBusses)
+        p.initializeAfterUnstream(e);
+    for (auto &a : busses.auxBusses)
+        a.initializeAfterUnstream(e);
+}
+} // namespace scxt::engine

--- a/src/messaging/client/client_messages.h
+++ b/src/messaging/client/client_messages.h
@@ -37,5 +37,6 @@
 #include "group_messages.h"
 #include "part_messages.h"
 #include "interaction_messages.h"
+#include "mixer_messages.h"
 
 #endif // SHORTCIRCUIT_CLIENT_MESSAGE_IMPLS_H

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -64,6 +64,10 @@ enum ClientToSerializationMessagesIds
 
     c2s_noteonoff,
 
+    c2s_initialize_mixer,
+    c2s_set_mixer_effect,
+    c2s_set_mixer_effect_storage,
+
     num_clientToSerializationMessages
 };
 
@@ -85,6 +89,9 @@ enum SerializationToClientMessageIds
 
     s2c_send_selected_group_zone_mapping_summary,
     s2c_send_selection_state,
+
+    s2c_initialize_mixer,
+    s2c_bus_effect_full_data,
 
     num_serializationToClientMessages
 };

--- a/src/messaging/client/mixer_messages.h
+++ b/src/messaging/client/mixer_messages.h
@@ -1,0 +1,81 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2023, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_MESSAGING_CLIENT_MIXER_MESSAGES_H
+#define SCXT_SRC_MESSAGING_CLIENT_MIXER_MESSAGES_H
+
+#include "client_macros.h"
+#include "engine/bus.h"
+#include "engine/part.h"
+
+namespace scxt::messaging::client
+{
+
+using busEffectFullData_t =
+    std::tuple<int, int,
+               std::pair<std::array<sst::basic_blocks::params::ParamMetaData,
+                                    engine::BusEffectStorage::maxBusEffectParams>,
+                         engine::BusEffectStorage>>;
+
+SERIAL_TO_CLIENT(SendBusEffectFullData, s2c_bus_effect_full_data, busEffectFullData_t,
+                 onMixerBusEffectFullData);
+
+using setBusEffectToType_t = std::tuple<int, int, int>; // bus, fx, type
+inline void setBusEffectToType(const setBusEffectToType_t &payload,
+                               messaging::MessageController &cont)
+{
+    cont.scheduleAudioThreadCallbackUnderStructureLock(
+        [p = payload](auto &e) {
+            auto [bus, fxslot, type] = p;
+            e.getPatch()
+                ->busses.busByAddress((engine::BusAddress)bus)
+                .setBusEffectType(e, fxslot, (engine::AvailableBusEffects)type);
+        },
+        [p = payload, &cont](auto &e) {
+            auto [bus, fxslot, type] = p;
+            // ToDo: Send Metadata Blast back
+            e.getPatch()
+                ->busses.busByAddress((engine::BusAddress)bus)
+                .sendBusEffectInfoToClient(e, fxslot);
+        });
+}
+CLIENT_TO_SERIAL(SetBusEffectToType, c2s_set_mixer_effect, setBusEffectToType_t,
+                 setBusEffectToType(payload, cont));
+
+using setBusEffectStorage_t = std::tuple<int, int, engine::BusEffectStorage>; // bus, fx, type
+inline void setBusEffectStorage(const setBusEffectStorage_t &payload,
+                                messaging::MessageController &cont)
+{
+    cont.scheduleAudioThreadCallbackUnderStructureLock([p = payload](auto &e) {
+        auto [bus, fxslot, bes] = p;
+        e.getPatch()->busses.busByAddress((engine::BusAddress)bus).busEffectStorage[fxslot] = bes;
+    });
+}
+CLIENT_TO_SERIAL(SetBusEffectStorage, c2s_set_mixer_effect_storage, setBusEffectStorage_t,
+                 setBusEffectStorage(payload, cont));
+} // namespace scxt::messaging::client
+#endif // SHORTCIRCUITXT_MIXER_MESSAGES_H

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -246,10 +246,13 @@ bool Voice::process()
     // At the end of the voice we have to produce stereo
     if (chainIsMono)
     {
+        mech::scale_by<blockSize>(aeg.outputCache, output[0]);
         mech::copy_from_to<blockSize>(output[0], output[1]);
     }
-
-    mech::scale_by<blockSize>(aeg.outputCache, output[0], output[1]);
+    else
+    {
+        mech::scale_by<blockSize>(aeg.outputCache, output[0], output[1]);
+    }
 
     /*
      * Finally do voice state update


### PR DESCRIPTION
This substantial commit makes a few core changes

1. Implements a full bus model with aux, send, etc... all in the code, but not editable
2. Introduce properly working bus effects which can live on those buses
3. Create a UI which allows you to edit the effects on the main bus (and main bus only so far)
4. Activates R1, Flanger, and Delay as effects
5. Implements a default UI for those effects