### PR TITLE
Make sure Bus Floats are init to 0 in arrays

### DIFF
--- a/src/engine/bus.h
+++ b/src/engine/bus.h
@@ -76,9 +76,10 @@ enum AvailableBusEffects
 
 struct BusEffectStorage
 {
+    BusEffectStorage() { std::fill(params.begin(), params.end(), 0.f); }
     static constexpr int maxBusEffectParams{12};
-    AvailableBusEffects type;
-    std::array<float, maxBusEffectParams> params;
+    AvailableBusEffects type{AvailableBusEffects::none};
+    std::array<float, maxBusEffectParams> params{};
 };
 struct BusEffect
 {
@@ -131,6 +132,7 @@ struct Bus : MoveableOnly<Bus>, SampleRateSupport
 
     struct BusSendStorage
     {
+        BusSendStorage() { std::fill(sendLevels.begin(), sendLevels.end(), 0.f); }
         bool hasSends{false};
         bool supportsSends{false};
 


### PR DESCRIPTION
Without these initis, you could send an occasional NaN down the pipe, which crashed out the toStream.

Also make it so a json serailization error doesn't crash the entire system but instead attempts to report the error to the host.

Closes #566