### PR TITLE
MIDI note formatting

### DIFF
--- a/src-ui/components/SCXTEditor.cpp
+++ b/src-ui/components/SCXTEditor.cpp
@@ -54,6 +54,9 @@ SCXTEditor::SCXTEditor(messaging::MessageController &e, infrastructure::Defaults
 {
     sst::jucegui::style::StyleSheet::initializeStyleSheets([]() {});
 
+    sst::basic_blocks::params::ParamMetaData::defaultMidiNoteOctaveOffset =
+        defaultsProvider.getUserDefaultValue(infrastructure::octave0, 0);
+
     // TODO: Obviously expand this
     auto sn = defaultsProvider.getUserDefaultValue(infrastructure::skinName, "builtin.DARK");
     if (sn == "builtin.LIGHT")

--- a/src-ui/components/SCXTEditorMenus.cpp
+++ b/src-ui/components/SCXTEditorMenus.cpp
@@ -63,7 +63,7 @@ void SCXTEditor::showMainMenu()
 
     juce::PopupMenu skin;
     addUIThemesMenu(skin);
-    m.addSubMenu("UI Themes", skin);
+    m.addSubMenu("UI Behavior", skin);
 
     m.addSeparator();
     m.addItem(juce::String("Copy ") + scxt::build::FullVersionStr,
@@ -140,9 +140,10 @@ void SCXTEditor::addUIThemesMenu(juce::PopupMenu &p, bool addTitle)
 {
     if (addTitle)
     {
-        p.addSectionHeader("UI Themes");
+        p.addSectionHeader("UI Behavior");
         p.addSeparator();
     }
+    p.addSectionHeader("Themes");
     p.addItem("Dark", [w = juce::Component::SafePointer(this)]() {
         if (w)
         {
@@ -157,9 +158,22 @@ void SCXTEditor::addUIThemesMenu(juce::PopupMenu &p, bool addTitle)
         {
             w->setStyle(scxt::ui::connectors::SCXTStyleSheetCreator::setup(
                 sst::jucegui::style::StyleSheet::LIGHT));
-            w->defaultsProvider.updateUserDefaultPath(infrastructure::skinName, "builtin.LIGHT");
+            w->defaultsProvider.updateUserDefaultValue(infrastructure::skinName, "builtin.LIGHT");
         }
     });
+
+    p.addSeparator();
+    p.addSectionHeader("MIDI Octave");
+    for (int i = -1; i <= 1; ++i)
+    {
+        p.addItem(fmt::format("C{} is MIDI 60", 4 + i),
+                  [w = juce::Component::SafePointer(this), i]() {
+                      if (w)
+                      {
+                          w->defaultsProvider.updateUserDefaultValue(infrastructure::octave0, i);
+                      }
+                  });
+    }
 }
 
 } // namespace scxt::ui

--- a/src-ui/components/multi/MappingPane.cpp
+++ b/src-ui/components/multi/MappingPane.cpp
@@ -219,50 +219,46 @@ struct MappingDisplay : juce::Component, HasEditor
         attachEditor(Ctrl::RootKey, datamodel::pmd().asMIDINote().withName("RootKey"),
                      mappingView.rootKey);
         addLabel(Ctrl::RootKey, "Root Key");
-        attachments[Ctrl::RootKey]->setAsMidiNote();
 
         attachEditor(Ctrl::KeyStart,
                      datamodel::pmd().asMIDINote().withName("Key Start").withDefault(60 - 12),
                      mappingView.keyboardRange.keyStart);
-        attachments[Ctrl::KeyStart]->setAsMidiNote();
+
         attachEditor(Ctrl::KeyEnd,
                      datamodel::pmd().asMIDINote().withName("Key End").withDefault(60 + 12),
                      mappingView.keyboardRange.keyEnd);
-        attachments[Ctrl::KeyEnd]->setAsMidiNote();
         addLabel(Ctrl::KeyStart, "Key Range");
 
-        auto mDist = []() { return datamodel::pmd().asMIDINote(); };
+        auto mDist = []() { return datamodel::pmd().asMIDIPitch().withUnit(""); };
 
         attachEditor(Ctrl::FadeStart, mDist().withName("Fade Start").withDefault(0),
                      mappingView.keyboardRange.fadeStart);
-        attachments[Ctrl::FadeStart]->setAsInteger();
+        // attachments[Ctrl::FadeStart]->setAsInteger();
         attachEditor(Ctrl::FadeEnd, mDist().withName("Fade End").withDefault(0),
                      mappingView.keyboardRange.fadeEnd);
-        attachments[Ctrl::FadeEnd]->setAsInteger();
+        // attachments[Ctrl::FadeEnd]->setAsInteger();
         addLabel(Ctrl::FadeStart, "Crossfade");
 
-        attachEditor(Ctrl::VelStart,
-                     datamodel::pmd().asMIDINote().withName("Vel Start").withDefault(0),
+        attachEditor(Ctrl::VelStart, mDist().withName("Vel Start").withDefault(0),
                      mappingView.velocityRange.velStart);
-        attachments[Ctrl::VelStart]->setAsInteger();
-        attachEditor(Ctrl::VelEnd,
-                     datamodel::pmd().asMIDINote().withName("Vel End").withDefault(127),
+        // attachments[Ctrl::VelStart]->setAsInteger();
+        attachEditor(Ctrl::VelEnd, mDist().withName("Vel End").withDefault(127),
                      mappingView.velocityRange.velEnd);
-        attachments[Ctrl::VelEnd]->setAsInteger();
+        // attachments[Ctrl::VelEnd]->setAsInteger();
         addLabel(Ctrl::VelStart, "Vel Range");
 
         attachEditor(Ctrl::VelFadeStart, mDist().withName("Vel Fade Start").withDefault(0),
                      mappingView.velocityRange.fadeStart);
-        attachments[Ctrl::VelFadeStart]->setAsInteger();
+        // attachments[Ctrl::VelFadeStart]->setAsInteger();
         attachEditor(Ctrl::VelFadeEnd, mDist().withName("Vel Fade End").withDefault(0),
                      mappingView.velocityRange.fadeEnd);
-        attachments[Ctrl::VelFadeEnd]->setAsInteger();
+        // attachments[Ctrl::VelFadeEnd]->setAsInteger();
         addLabel(Ctrl::VelFadeStart, "Crossfade");
 
         attachEditor(Ctrl::PBDown, mDist().withName("PBDown").withDefault(2), mappingView.pbDown);
-        attachments[Ctrl::PBDown]->setAsInteger();
+        // attachments[Ctrl::PBDown]->setAsInteger();
         attachEditor(Ctrl::PBUp, mDist().withName("PBUp").withDefault(2), mappingView.pbUp);
-        attachments[Ctrl::PBUp]->setAsInteger();
+        // attachments[Ctrl::PBUp]->setAsInteger();
         addLabel(Ctrl::PBDown, "Pitch Bend");
 
         attachFloatEditor(Ctrl::Level,

--- a/src/infrastructure/user_defaults.h
+++ b/src/infrastructure/user_defaults.h
@@ -36,6 +36,7 @@ enum DefaultKeys
 {
     zoomLevel,
     skinName,
+    octave0,
     nKeys
 };
 inline std::string defaultKeyToString(DefaultKeys k)
@@ -46,6 +47,8 @@ inline std::string defaultKeyToString(DefaultKeys k)
         return "zoomLevel";
     case skinName:
         return "skinName";
+    case octave0:
+        return "octave0";
     case nKeys:
         return "nKeys";
     default:


### PR DESCRIPTION
1. Fix a bug with A2/A3 mis-calculation in MIDI
2. Move MIDI calculation all to ParamMetaDat
3. Support custom octave 0 offsets, but still require a UI restart when toggling.

Closes #596