### PR TITLE
Compile with ghc::filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@
 cmake_minimum_required(VERSION 3.20)
 cmake_policy(SET CMP0091 NEW)
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+# https://github.com/taocpp/PEGTL/issues/347 would let us go to 13
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15 CACHE STRING "Minimum macOS version")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -3,13 +3,15 @@ add_subdirectory(JUCE)
 add_subdirectory(clap-juce-extensions clap-extensions EXCLUDE_FROM_ALL)
 
 add_subdirectory(fmt)
+# Modify this basedon the outcome of https://github.com/taocpp/PEGTL/issues/347
+set(PEGTL_NO_STD_FILESYSTEM ON CACHE BOOL "Skip PEGTL FileSystem")
 add_subdirectory(taocpp_json)
 
 add_subdirectory(xiph)
 
 add_subdirectory(sst/sst-cpputils)
 
-set(SST_PLUGININFRA_FILESYSTEM_FORCE_PLATFORM ON CACHE BOOL "Force platform filesystem")
+# set(SST_PLUGININFRA_FILESYSTEM_FORCE_PLATFORM ON CACHE BOOL "Force platform filesystem")
 set(SST_PLUGININFRA_PROVIDE_TINYXML ON CACHE BOOL "Skip TinyXML")  # need this for UserDefaults
 add_subdirectory(sst/sst-basic-blocks)
 add_subdirectory(sst/sst-plugininfra)

--- a/src-ui/components/browser/BrowserPane.cpp
+++ b/src-ui/components/browser/BrowserPane.cpp
@@ -179,7 +179,7 @@ struct DriveFSArea : juce::Component, HasEditor
         contents.clear();
         try
         {
-            for (auto const &dir_entry : std::filesystem::directory_iterator{currentPath})
+            for (auto const &dir_entry : fs::directory_iterator{currentPath})
             {
                 // Who to skip? Well
                 bool include = false;

--- a/src/infrastructure/filesystem_import.h
+++ b/src/infrastructure/filesystem_import.h
@@ -28,7 +28,6 @@
 #ifndef SCXT_SRC_INFRASTRUCTURE_FILESYSTEM_IMPORT_H
 #define SCXT_SRC_INFRASTRUCTURE_FILESYSTEM_IMPORT_H
 
-#include <filesystem>
-namespace fs = std::filesystem;
+#include "filesystem/import.h"
 
 #endif // SHORTCIRCUIT_FILESYSTEM_IMPORT_H

--- a/src/json/stream.cpp
+++ b/src/json/stream.cpp
@@ -29,7 +29,6 @@
 
 #include <tao/json/to_string.hpp>
 #include <tao/json/from_string.hpp>
-#include <tao/json/from_file.hpp>
 #include <tao/json/contrib/traits.hpp>
 
 #include "scxt_traits.h"
@@ -69,14 +68,6 @@ std::string streamPatch(const engine::Patch &p, bool pretty)
 std::string streamEngineState(const engine::Engine &e, bool pretty)
 {
     return streamValue(json::scxt_value(e), pretty);
-}
-
-void unstreamEngineState(engine::Engine &e, const fs::path &path)
-{
-    tao::json::events::transformer<tao::json::events::to_basic_value<scxt_traits>> consumer;
-    tao::json::events::from_file(consumer, path);
-    auto jv = std::move(consumer.value);
-    jv.to(e);
 }
 
 void unstreamEngineState(engine::Engine &e, const std::string &xml)

--- a/src/json/stream.h
+++ b/src/json/stream.h
@@ -39,8 +39,6 @@ static constexpr uint64_t currentStreamingVersion{0x20230201};
 std::string streamPatch(const engine::Patch &p, bool pretty = false);
 std::string streamEngineState(const engine::Engine &e, bool pretty = false);
 void unstreamEngineState(engine::Engine &e, const std::string &jsonData);
-void unstreamEngineState(engine::Engine &e, const fs::path &path);
-
 } // namespace scxt::json
 
 #endif // SHORTCIRCUIT_STREAM_H

--- a/src/messaging/client/detail/client_serial_impl.h
+++ b/src/messaging/client/detail/client_serial_impl.h
@@ -30,7 +30,15 @@
 
 #include "tao/json/to_string.hpp"
 #include "tao/json/from_string.hpp"
-#include "tao/json/msgpack.hpp"
+
+#include "tao/json/msgpack/consume_string.hpp"
+#include "tao/json/msgpack/from_binary.hpp"
+#include "tao/json/msgpack/from_input.hpp"
+#include "tao/json/msgpack/from_string.hpp"
+#include "tao/json/msgpack/parts_parser.hpp"
+#include "tao/json/msgpack/to_stream.hpp"
+#include "tao/json/msgpack/to_string.hpp"
+
 #include "messaging/client/detail/client_json_details.h"
 
 // This is a 'details only' file which you can safely ignore

--- a/src/sfz_support/sfz_import.cpp
+++ b/src/sfz_support/sfz_import.cpp
@@ -42,7 +42,7 @@ int parseMidiNote(const std::string &s)
     return std::atol(s.c_str());
 }
 
-bool importSFZ(const std::filesystem::path &f, engine::Engine &e)
+bool importSFZ(const fs::path &f, engine::Engine &e)
 {
     assert(e.getMessageController()->threadingChecker.isSerialThread());
 
@@ -101,7 +101,7 @@ bool importSFZ(const std::filesystem::path &f, engine::Engine &e)
                     sampleFile = oc.value;
                 }
             }
-            // std::filesystem always works with / and on windows also works with back
+            // fs always works with / and on windows also works with back
             std::replace(sampleFile.begin(), sampleFile.end(), '\\', '/');
             if (!fs::exists(sampleDir / sampleFile) && !fs::exists(sampleFile))
             {

--- a/src/sfz_support/sfz_import.h
+++ b/src/sfz_support/sfz_import.h
@@ -28,11 +28,12 @@
 #ifndef SCXT_SRC_SFZ_SUPPORT_SFZ_IMPORT_H
 #define SCXT_SRC_SFZ_SUPPORT_SFZ_IMPORT_H
 
-#include <filesystem>
+#include "filesystem/import.h"
 #include <engine/engine.h>
+
 namespace scxt::sfz_support
 {
-bool importSFZ(const std::filesystem::path &, engine::Engine &);
+bool importSFZ(const fs::path &, engine::Engine &);
 }
 
 #endif // SHORTCIRCUITXT_SFZ_IMPORT_H

--- a/src/sfz_support/sfz_parse.cpp
+++ b/src/sfz_support/sfz_parse.cpp
@@ -418,7 +418,7 @@ SFZParser::document_t SFZParser::parse(const std::string &s)
 }
 #endif
 
-SFZParser::document_t SFZParser::parse(const std::filesystem::path &f)
+SFZParser::document_t SFZParser::parse(const fs::path &f)
 {
     std::ifstream ifs;
     ifs.open(f);

--- a/src/sfz_support/sfz_parse.h
+++ b/src/sfz_support/sfz_parse.h
@@ -32,6 +32,7 @@
 #include <variant>
 #include <vector>
 #include <filesystem>
+#include "filesystem/import.h"
 
 namespace scxt::sfz_support
 {
@@ -66,7 +67,7 @@ struct SFZParser
     typedef std::vector<section_t> document_t;
 
     document_t parse(const std::string &contents);
-    document_t parse(const std::filesystem::path &file);
+    document_t parse(const fs::path &file);
 };
 } // namespace scxt::sfz_support
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -39,6 +39,7 @@
 #include <map>
 #include <thread>
 #include "unordered_map"
+#include "filesystem/import.h"
 
 namespace scxt
 {
@@ -263,7 +264,7 @@ inline std::unordered_map<std::string, E> makeEnumInverse(const E &from, const E
 
 void printStackTrace(int frameDepth = -1);
 
-inline bool extensionMatches(const std::filesystem::path &p, const std::string &s)
+inline bool extensionMatches(const fs::path &p, const std::string &s)
 {
     auto pes = p.extension().u8string();
     if (pes.size() != s.size())


### PR DESCRIPTION
This change allows us to compile with ghc::filesystem. If we eiterh merge or branch PEGTL as described in https://github.com/taocpp/PEGTL/issues/347#issuecomment-1615949742 we can also set OSX version back to 10.13. If we did that today macos would get an accidentaly boost dependency which we don't want.

Addresses #598