### PR TITLE
Group Features Continued

### DIFF
--- a/src-ui/components/MultiScreen.h
+++ b/src-ui/components/MultiScreen.h
@@ -61,14 +61,39 @@ struct MultiScreen : juce::Component, HasEditor
     static constexpr int envHeight = 160, modHeight = 160, fxHeight = 176;
     static constexpr int pad = 0;
 
-    std::unique_ptr<multi::OutputPane> output;
     std::unique_ptr<browser::BrowserPane> browser;
-    std::unique_ptr<multi::LfoPane> lfo;
     std::unique_ptr<multi::MappingPane> sample;
     std::unique_ptr<multi::PartGroupSidebar> parts;
-    std::unique_ptr<multi::AdsrPane> eg[2];
-    std::unique_ptr<multi::ModPane> mod;
-    std::unique_ptr<multi::ProcessorPane> processors[numProcessorDisplays];
+
+    enum class ZoneGroupIndex
+    {
+        ZONE = 0,
+        GROUP = 1
+    };
+    struct ZoneOrGroupElements
+    {
+        ZoneGroupIndex index;
+        ZoneOrGroupElements(ZoneGroupIndex z);
+        ~ZoneOrGroupElements();
+        std::unique_ptr<multi::OutputPane> output;
+        std::unique_ptr<multi::LfoPane> lfo;
+        std::unique_ptr<multi::AdsrPane> eg[2];
+        std::unique_ptr<multi::ModPane> mod;
+        std::unique_ptr<multi::ProcessorPane> processors[numProcessorDisplays];
+
+        void setVisible(bool b);
+    };
+
+    std::unique_ptr<ZoneOrGroupElements> zoneGroupElements[2];
+    const std::unique_ptr<ZoneOrGroupElements> &getZoneElements()
+    {
+        return zoneGroupElements[(int)ZoneGroupIndex::ZONE];
+    }
+    const std::unique_ptr<ZoneOrGroupElements> &getGroupElements()
+    {
+        return zoneGroupElements[(int)ZoneGroupIndex::GROUP];
+    }
+
     MultiScreen(SCXTEditor *e);
     ~MultiScreen();
     void resized() override { layout(); }

--- a/src-ui/components/SCXTEditor.h
+++ b/src-ui/components/SCXTEditor.h
@@ -158,12 +158,12 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel,
     // Serialization to Client Messages
     void onErrorFromEngine(const scxt::messaging::client::s2cError_t &);
     void onEngineStatus(const engine::Engine::EngineStatusMessage &e);
-    void onEnvelopeUpdated(const scxt::messaging::client::adsrViewResponsePayload_t &);
     void onMappingUpdated(const scxt::messaging::client::mappingSelectedZoneViewResposne_t &);
     void onSamplesUpdated(const scxt::messaging::client::sampleSelectedZoneViewResposne_t &);
     void onStructureUpdated(const engine::Engine::pgzStructure_t &);
+    void onZoneEnvelopeUpdated(const scxt::messaging::client::adsrViewResponsePayload_t &);
     void
-    onProcessorDataAndMetadata(const scxt::messaging::client::processorDataResponsePayload_t &);
+    onZoneProcessorDataAndMetadata(const scxt::messaging::client::processorDataResponsePayload_t &);
     void onZoneVoiceMatrixMetadata(const scxt::modulation::voiceModMatrixMetadata_t &);
     void onZoneVoiceMatrix(const scxt::modulation::VoiceModMatrix::routingTable_t &);
     void onZoneLfoUpdated(const scxt::messaging::client::indexedLfoUpdate_t &);

--- a/src-ui/components/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/components/SCXTEditorResponseHandlers.cpp
@@ -41,18 +41,18 @@
 
 namespace scxt::ui
 {
-void SCXTEditor::onEnvelopeUpdated(
+void SCXTEditor::onZoneEnvelopeUpdated(
     const scxt::messaging::client::adsrViewResponsePayload_t &payload)
 {
     const auto &[which, active, env] = payload;
     if (active)
     {
         // TODO - do I want a multiScreen->onEnvelopeUpdated or just
-        multiScreen->eg[which]->adsrChangedFromModel(env);
+        multiScreen->getZoneElements()->eg[which]->adsrChangedFromModel(env);
     }
     else
     {
-        multiScreen->eg[which]->adsrDeactivated();
+        multiScreen->getZoneElements()->eg[which]->adsrDeactivated();
     }
 }
 
@@ -93,48 +93,50 @@ void SCXTEditor::onStructureUpdated(const engine::Engine::pgzStructure_t &s)
         multiScreen->parts->setPartGroupZoneStructure(s);
 }
 
-void SCXTEditor::onProcessorDataAndMetadata(
+void SCXTEditor::onZoneProcessorDataAndMetadata(
     const scxt::messaging::client::processorDataResponsePayload_t &d)
 {
     const auto &[which, enabled, control, storage] = d;
 
     assert(which >= 0 && which < MultiScreen::numProcessorDisplays);
-    multiScreen->processors[which]->setEnabled(enabled);
-    multiScreen->processors[which]->setProcessorControlDescriptionAndStorage(control, storage);
+    multiScreen->getZoneElements()->processors[which]->setEnabled(enabled);
+    multiScreen->getZoneElements()->processors[which]->setProcessorControlDescriptionAndStorage(
+        control, storage);
 }
 
 void SCXTEditor::onZoneVoiceMatrixMetadata(const scxt::modulation::voiceModMatrixMetadata_t &d)
 {
     const auto &[active, sinf, dinf, cinf] = d;
-    multiScreen->mod->setActive(active);
+    multiScreen->getZoneElements()->mod->setActive(active);
     if (active)
     {
-        multiScreen->mod->matrixMetadata = d;
-        multiScreen->mod->rebuildMatrix();
+        multiScreen->getZoneElements()->mod->matrixMetadata = d;
+        multiScreen->getZoneElements()->mod->rebuildMatrix();
     }
 }
 
 void SCXTEditor::onZoneVoiceMatrix(const scxt::modulation::VoiceModMatrix::routingTable_t &t)
 {
-    assert(multiScreen->mod->isEnabled()); // we shouldn't send a matrix to a non-enabled pane
-    multiScreen->mod->routingTable = t;
-    multiScreen->mod->refreshMatrix();
+    assert(multiScreen->getZoneElements()
+               ->mod->isEnabled()); // we shouldn't send a matrix to a non-enabled pane
+    multiScreen->getZoneElements()->mod->routingTable = t;
+    multiScreen->getZoneElements()->mod->refreshMatrix();
 }
 
 void SCXTEditor::onZoneLfoUpdated(const scxt::messaging::client::indexedLfoUpdate_t &payload)
 {
     const auto &[active, i, r] = payload;
-    multiScreen->lfo->setActive(i, active);
-    multiScreen->lfo->setLfo(i, r);
+    multiScreen->getZoneElements()->lfo->setActive(i, active);
+    multiScreen->getZoneElements()->lfo->setLfo(i, r);
 }
 
 void SCXTEditor::onZoneOutputInfoUpdated(const scxt::messaging::client::zoneOutputInfoUpdate_t &p)
 {
     auto [active, inf] = p;
-    multiScreen->output->setActive(active);
+    multiScreen->getZoneElements()->output->setActive(active);
     if (active)
     {
-        multiScreen->output->setOutputData(inf);
+        multiScreen->getZoneElements()->output->setOutputData(inf);
     }
 }
 

--- a/src/messaging/client/processor_messages.h
+++ b/src/messaging/client/processor_messages.h
@@ -40,7 +40,7 @@ typedef std::tuple<int, bool, dsp::processor::ProcessorControlDescription,
     processorDataResponsePayload_t;
 
 SERIAL_TO_CLIENT(ProcessorMetadataAndData, s2c_respond_single_processor_metadata_and_data,
-                 processorDataResponsePayload_t, onProcessorDataAndMetadata);
+                 processorDataResponsePayload_t, onZoneProcessorDataAndMetadata);
 
 // C2S set processor type (sends back data and metadata)
 typedef std::pair<int32_t, int32_t> setProcessorPayload_t;

--- a/src/messaging/client/zone_messages.h
+++ b/src/messaging/client/zone_messages.h
@@ -37,7 +37,7 @@ namespace scxt::messaging::client
 {
 typedef std::tuple<int, bool, datamodel::AdsrStorage> adsrViewResponsePayload_t;
 SERIAL_TO_CLIENT(AdsrSelectedZoneView, s2c_respond_zone_adsr_view, adsrViewResponsePayload_t,
-                 onEnvelopeUpdated);
+                 onZoneEnvelopeUpdated);
 
 typedef std::tuple<int, datamodel::AdsrStorage> adsrSelectedZoneC2SPayload_t;
 inline void adsrSelectedZoneUpdate(const adsrSelectedZoneC2SPayload_t &payload,

--- a/src/selection/selection_manager.h
+++ b/src/selection/selection_manager.h
@@ -146,7 +146,10 @@ struct SelectionManager
     std::pair<int, int> bestPartGroupForNewSample(const engine::Engine &e);
 
     void sendSelectedZonesToClient();
-    void sendClientDataForSelectionState();
+    void sendClientDataForLeadSelectionState();
+    void sendDisplayDataForSingleZone(int part, int group, int zone);
+    void sendDisplayDataForNoZoneSelected();
+    void sendDisplayDataForSingleGroup(int part, int group);
 
   public:
     std::unordered_map<std::string, std::string> otherTabSelection;


### PR DESCRIPTION
- Clean up selection maanger a bit with better names and a few more helper functions
- Fix the UI so the group components are distinct components from the zone components in the data structure to make edit group toggle way easier

Next is to modify all the zone messages to have a 'group or zone' key but I want to lock this change in first.