### PR TITLE
Zone Selection Mouse Gestures

### DIFF
--- a/src-ui/components/SCXTEditor.cpp
+++ b/src-ui/components/SCXTEditor.cpp
@@ -248,6 +248,12 @@ void SCXTEditor::doSelectionAction(const selection::SelectionManager::ZoneAddres
     repaint();
 }
 
+void SCXTEditor::doSelectionAction(const selection::SelectionManager::SelectActionContents &p)
+{
+    namespace cmsg = scxt::messaging::client;
+    sendToSerialization(cmsg::DoSelectAction(p));
+    repaint();
+}
 void SCXTEditor::doMultiSelectionAction(
     const std::vector<selection::SelectionManager::SelectActionContents> &p)
 {

--- a/src-ui/components/SCXTEditor.h
+++ b/src-ui/components/SCXTEditor.h
@@ -187,6 +187,7 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel,
     // Originate client to serialization messages
     void doSelectionAction(const selection::SelectionManager::ZoneAddress &, bool selecting,
                            bool distinct, bool asLead);
+    void doSelectionAction(const selection::SelectionManager::SelectActionContents &);
     void
     doMultiSelectionAction(const std::vector<selection::SelectionManager::SelectActionContents> &);
     std::optional<selection::SelectionManager::ZoneAddress> currentLeadZoneSelection;

--- a/src-ui/components/multi/MappingPane.cpp
+++ b/src-ui/components/multi/MappingPane.cpp
@@ -578,9 +578,9 @@ void MappingZonesAndKeyboard::mouseDown(const juce::MouseEvent &e)
                 // command click a selected zone deselects it
                 display->editor->doSelectionAction(nextZone, false, false, false);
             }
-            else if (e.mods.isCtrlDown())
+            else if (e.mods.isAltDown())
             {
-                // ctrl click promotes it to lead
+                // alt click promotes it to lead
                 display->editor->doSelectionAction(nextZone, true, false, true);
             }
             else
@@ -592,7 +592,8 @@ void MappingZonesAndKeyboard::mouseDown(const juce::MouseEvent &e)
         else
         {
             SCLOG("About to select " << SCD(nextZone));
-            display->editor->doSelectionAction(nextZone, true, !e.mods.isCommandDown(), true);
+            display->editor->doSelectionAction(
+                nextZone, true, !(e.mods.isCommandDown() || e.mods.isAltDown()), true);
         }
     }
 }

--- a/src/json/selection_traits.h
+++ b/src/json/selection_traits.h
@@ -48,10 +48,15 @@ template <> struct scxt_traits<scxt::selection::SelectionManager::SelectActionCo
     template <template <typename...> class Traits>
     static void assign(tao::json::basic_value<Traits> &v, const za_t &e)
     {
-        v = {{"part", e.part},         {"group", e.group},
-             {"zone", e.zone},         {"selecting", e.selecting},
-             {"distinct", e.distinct}, {"selectingAsLead", e.selectingAsLead},
-             {"forZone", e.forZone}};
+        v = {{"part", e.part},
+             {"group", e.group},
+             {"zone", e.zone},
+             {"selecting", e.selecting},
+             {"distinct", e.distinct},
+             {"selectingAsLead", e.selectingAsLead},
+             {"forZone", e.forZone},
+             {"isContiguous", e.isContiguous},
+             {"contiguousFrom", e.contiguousFrom}};
     }
 
     template <template <typename...> class Traits>
@@ -64,6 +69,8 @@ template <> struct scxt_traits<scxt::selection::SelectionManager::SelectActionCo
         findIf(v, "distinct", z.distinct);
         findIf(v, "selectingAsLead", z.selectingAsLead);
         findIf(v, "forZone", z.forZone);
+        findIf(v, "isContiguous", z.isContiguous);
+        findIf(v, "contiguousFrom", z.contiguousFrom);
     }
 };
 

--- a/src/selection/selection_manager.h
+++ b/src/selection/selection_manager.h
@@ -72,7 +72,21 @@ struct SelectionManager
             return part == other.part && group == other.group && zone == other.zone;
         }
 
+        bool operator<(const ZoneAddress &other) const
+        {
+            if (part != other.part)
+                return part < other.part;
+            if (group != other.group)
+                return group < other.group;
+            if (zone != other.zone)
+                return zone < other.zone;
+            return false;
+        }
+
+        // PGZ is in the engine
         bool isIn(const engine::Engine &e);
+        // PGZ is in the engine or G and-or Z are -1
+        bool isInWithPartials(const engine::Engine &e);
 
         friend std::ostream &operator<<(std::ostream &os, const ZoneAddress &z)
         {
@@ -115,6 +129,9 @@ struct SelectionManager
         bool selectingAsLead{true};
 
         bool forZone{true};
+
+        bool isContiguous{false};
+        ZoneAddress contiguousFrom{};
 
         friend std::ostream &operator<<(std::ostream &os, const SelectActionContents &z)
         {


### PR DESCRIPTION
Zone Mode Sidebar
  - click zone is select distinct as lead everywhere
  - click group is select entire groups zones
  - shift click is contiguous select
  - cmd/ctrl click is non-contiguous toggle select zone
  - alt-click is move lead or add and make lead

Mapping Area
   - click zone is select disctinct as lead
   - cmd/ctrl click toggles in or out of set
   - alt click selects as lead adding if needs be

No rubber band with shift yet