### PR TITLE
Handle mixed-select processor types

### DIFF
--- a/src-ui/components/SCXTEditor.h
+++ b/src-ui/components/SCXTEditor.h
@@ -165,6 +165,7 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel,
     onGroupOrZoneEnvelopeUpdated(const scxt::messaging::client::adsrViewResponsePayload_t &payload);
     void
     onZoneProcessorDataAndMetadata(const scxt::messaging::client::processorDataResponsePayload_t &);
+    void onZoneProcessorDataMismatch(const scxt::messaging::client::processorMismatchPayload_t &);
     void onZoneVoiceMatrixMetadata(const scxt::modulation::voiceModMatrixMetadata_t &);
     void onZoneVoiceMatrix(const scxt::modulation::VoiceModMatrix::routingTable_t &);
     void onZoneLfoUpdated(const scxt::messaging::client::indexedLfoUpdate_t &);

--- a/src-ui/components/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/components/SCXTEditorResponseHandlers.cpp
@@ -119,6 +119,14 @@ void SCXTEditor::onZoneProcessorDataAndMetadata(
         control, storage);
 }
 
+void SCXTEditor::onZoneProcessorDataMismatch(
+    const scxt::messaging::client::processorMismatchPayload_t &pl)
+{
+    const auto &[idx, leadType, otherTypes] = pl;
+    SCLOG_UNIMPL("Processor Data Mismatch " << SCD(idx) << SCD(leadType) << SCD(otherTypes.size()));
+    multiScreen->getZoneElements()->processors[idx]->setAsMultiZone(leadType, otherTypes);
+}
+
 void SCXTEditor::onZoneVoiceMatrixMetadata(const scxt::modulation::voiceModMatrixMetadata_t &d)
 {
     const auto &[active, sinf, dinf, cinf] = d;

--- a/src-ui/components/SCXTJuceLookAndFeel.h
+++ b/src-ui/components/SCXTJuceLookAndFeel.h
@@ -41,6 +41,10 @@ struct SCXTJuceLookAndFeel : juce::LookAndFeel_V4
         interMedTF = juce::Typeface::createSystemTypefaceFor(scxt::ui::binary::InterMedium_ttf,
                                                              scxt::ui::binary::InterMedium_ttfSize);
         setColour(juce::PopupMenu::ColourIds::backgroundColourId, juce::Colour(0x15, 0x15, 0x15));
+        setColour(juce::PopupMenu::ColourIds::highlightedBackgroundColourId,
+                  juce::Colour(0x35, 0x35, 0x45));
+        setColour(juce::PopupMenu::ColourIds::highlightedTextColourId,
+                  juce::Colour(0xFF, 0xFF, 0x80));
     }
 
     juce::Font getPopupMenuFont() override { return juce::Font(interMedTF).withHeight(13); }

--- a/src-ui/components/multi/OutputPane.cpp
+++ b/src-ui/components/multi/OutputPane.cpp
@@ -81,7 +81,13 @@ void OutputPane::resized()
     proc->setBounds(getContentArea());
 }
 
-void OutputPane::setActive(bool b) { SCLOG_UNIMPL("Output Pane setActive " << (b ? "ON" : "OFF")); }
+void OutputPane::setActive(bool b)
+{
+    static bool warned{false};
+    if (!warned)
+        SCLOG_UNIMPL("Output Pane setActive " << (b ? "ON" : "OFF"));
+    warned = true;
+}
 
 void OutputPane::setOutputData(const engine::Zone::ZoneOutputInfo &d)
 {

--- a/src-ui/components/multi/ProcessorPane.cpp
+++ b/src-ui/components/multi/ProcessorPane.cpp
@@ -105,6 +105,18 @@ void ProcessorPane::rebuildControlsFromDescription()
         return;
     }
 
+    if (multiZone)
+    {
+        SCLOG("Rebuild for MultiZone");
+        // it's a bit hacky to do this inline but I"m sure it will change
+        multiLabel = std::make_unique<sst::jucegui::components::Label>();
+        multiLabel->setText("Multiple Types Selected");
+        auto b = getContentAreaComponent()->getLocalBounds();
+        multiLabel->setBounds(b);
+        getContentAreaComponent()->addAndMakeVisible(*multiLabel[0]);
+        return;
+    }
+
     setName(processorControlDescription.typeDisplayName);
 
     if (processorControlDescription.type == dsp::processor::proct_none)
@@ -342,6 +354,17 @@ void ProcessorPane::mouseUp(const juce::MouseEvent &e)
 {
     isDragging = false;
     sst::jucegui::components::NamedPanel::mouseUp(e);
+}
+
+void ProcessorPane::setAsMultiZone(int32_t primaryType, const std::set<int32_t> &otherTypes)
+{
+    multiZone = true;
+    setEnabled(true);
+    setName("Multiple");
+    resetControls();
+    setToggleDataSource(nullptr);
+    resized();
+    repaint();
 }
 
 } // namespace scxt::ui::multi

--- a/src-ui/components/multi/ProcessorPane.h
+++ b/src-ui/components/multi/ProcessorPane.h
@@ -62,15 +62,19 @@ struct ProcessorPane : sst::jucegui::components::NamedPanel, HasEditor, juce::Dr
     setProcessorControlDescriptionAndStorage(const dsp::processor::ProcessorControlDescription &pcd,
                                              const dsp::processor::ProcessorStorage &ps)
     {
+        multiZone = false;
         processorControlDescription = pcd;
         processorView = ps;
         rebuildControlsFromDescription();
     }
     void setProcessorStorage(const dsp::processor::ProcessorStorage &p)
     {
+        multiZone = false;
         processorView = p;
         repaint();
     }
+
+    void setAsMultiZone(int32_t primaryType, const std::set<int32_t> &otherTypes);
 
     void processorChangedFromGui(const attachment_t &at);
     void processorChangedFromGui(const int_attachment_t &at);
@@ -96,7 +100,7 @@ struct ProcessorPane : sst::jucegui::components::NamedPanel, HasEditor, juce::Dr
     bool isInterestedInDragSource(const SourceDetails &dragSourceDetails) override;
     void itemDropped(const SourceDetails &dragSourceDetails) override;
 
-    std::unique_ptr<juce::Component> processorRegion;
+    bool multiZone{false};
 
     std::array<std::unique_ptr<sst::jucegui::components::ContinuousParamEditor>,
                dsp::processor::maxProcessorFloatParams>
@@ -120,6 +124,8 @@ struct ProcessorPane : sst::jucegui::components::NamedPanel, HasEditor, juce::Dr
     std::unique_ptr<sst::jucegui::components::Knob> mixEditor;
     std::unique_ptr<sst::jucegui::components::Label> mixLabel;
     std::unique_ptr<attachment_t> mixAttachment;
+
+    std::unique_ptr<sst::jucegui::components::Label> multiLabel;
 };
 } // namespace scxt::ui::multi
 

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -96,6 +96,7 @@ enum SerializationToClientMessageIds
     s2c_update_zone_output_info,
 
     s2c_respond_single_processor_metadata_and_data,
+    s2c_notify_mismatched_processors_for_zone,
 
     s2c_send_selected_group_zone_mapping_summary,
     s2c_send_selection_state,

--- a/src/messaging/client/processor_messages.h
+++ b/src/messaging/client/processor_messages.h
@@ -42,6 +42,11 @@ typedef std::tuple<int, bool, dsp::processor::ProcessorControlDescription,
 SERIAL_TO_CLIENT(ProcessorMetadataAndData, s2c_respond_single_processor_metadata_and_data,
                  processorDataResponsePayload_t, onZoneProcessorDataAndMetadata);
 
+// zone, lead type, all types
+typedef std::tuple<int, int, std::set<int32_t>> processorMismatchPayload_t;
+SERIAL_TO_CLIENT(ProcessorsMismatched, s2c_notify_mismatched_processors_for_zone,
+                 processorMismatchPayload_t, onZoneProcessorDataMismatch);
+
 // C2S set processor type (sends back data and metadata)
 typedef std::pair<int32_t, int32_t> setProcessorPayload_t;
 inline void setProcessorType(const setProcessorPayload_t &whichToType, const engine::Engine &engine,

--- a/src/selection/selection_manager.h
+++ b/src/selection/selection_manager.h
@@ -37,6 +37,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include "utils.h"
+#include "dsp/processor/processor.h"
 
 namespace scxt::engine
 {
@@ -84,9 +85,9 @@ struct SelectionManager
         }
 
         // PGZ is in the engine
-        bool isIn(const engine::Engine &e);
+        bool isIn(const engine::Engine &e) const;
         // PGZ is in the engine or G and-or Z are -1
-        bool isInWithPartials(const engine::Engine &e);
+        bool isInWithPartials(const engine::Engine &e) const;
 
         friend std::ostream &operator<<(std::ostream &os, const ZoneAddress &z)
         {
@@ -124,14 +125,14 @@ struct SelectionManager
         int32_t part{-1};
         int32_t group{-1};
         int32_t zone{-1};
-        bool selecting{true}; // am i selecting (T) or deselecting (F) this zone
-        bool distinct{true};  // Is this a single selection or a multi-selection gesture
-        bool selectingAsLead{true};
+        bool selecting{true};       // am i selecting (T) or deselecting (F) this zone
+        bool distinct{true};        // Is this a single selection or a multi-selection gesture
+        bool selectingAsLead{true}; // Should I force this selection to be lead?
 
-        bool forZone{true};
+        bool forZone{true}; // does this target the zone selection set (T) or group (F)
 
-        bool isContiguous{false};
-        ZoneAddress contiguousFrom{};
+        bool isContiguous{false};     // Is this a gesture which implies a contiguous selection
+        ZoneAddress contiguousFrom{}; // and if so, starting from where?
 
         friend std::ostream &operator<<(std::ostream &os, const SelectActionContents &z)
         {
@@ -168,10 +169,12 @@ struct SelectionManager
 
     void sendSelectedZonesToClient();
     void sendClientDataForLeadSelectionState();
-    void sendDisplayDataForSingleZone(int part, int group, int zone);
+    void sendDisplayDataForZonesBasedOnLead(int part, int group, int zone);
     void sendDisplayDataForNoZoneSelected();
     void sendDisplayDataForSingleGroup(int part, int group);
     void sendDisplayDataForNoGroupSelected();
+
+    std::set<dsp::processor::ProcessorType> processorTypesForSelectedZones(int pidx);
 
   public:
     std::unordered_map<std::string, std::string> otherTabSelection;


### PR DESCRIPTION
Detect mixed select types. Show them in the UI. Calculate but don't display the away types and local type. Zones only but basically working. Didn't test DnD