### PR TITLE
Group Processors Continue, but not done

### DIFF
--- a/src-ui/components/MultiScreen.cpp
+++ b/src-ui/components/MultiScreen.cpp
@@ -40,7 +40,7 @@
 namespace scxt::ui
 {
 
-static_assert(engine::processorsPerZone == MultiScreen::numProcessorDisplays);
+static_assert(engine::processorCount == MultiScreen::numProcessorDisplays);
 
 struct DebugRect : public sst::jucegui::components::NamedPanel
 {
@@ -85,7 +85,8 @@ MultiScreen::MultiScreen(SCXTEditor *e) : HasEditor(e)
     {
         for (int i = 0; i < 4; ++i)
         {
-            auto ff = std::make_unique<multi::ProcessorPane>(editor, i);
+            auto ff = std::make_unique<multi::ProcessorPane>(editor, i,
+                                                             ctr->index == ZoneGroupIndex::ZONE);
             ff->hasHamburger = true;
             ctr->processors[i] = std::move(ff);
             addChildComponent(*(ctr->processors[i]));

--- a/src-ui/components/SCXTEditor.h
+++ b/src-ui/components/SCXTEditor.h
@@ -163,8 +163,8 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel,
     void onStructureUpdated(const engine::Engine::pgzStructure_t &);
     void
     onGroupOrZoneEnvelopeUpdated(const scxt::messaging::client::adsrViewResponsePayload_t &payload);
-    void
-    onZoneProcessorDataAndMetadata(const scxt::messaging::client::processorDataResponsePayload_t &);
+    void onGroupOrZoneProcessorDataAndMetadata(
+        const scxt::messaging::client::processorDataResponsePayload_t &d);
     void onZoneProcessorDataMismatch(const scxt::messaging::client::processorMismatchPayload_t &);
     void onZoneVoiceMatrixMetadata(const scxt::modulation::voiceModMatrixMetadata_t &);
     void onZoneVoiceMatrix(const scxt::modulation::VoiceModMatrix::routingTable_t &);

--- a/src-ui/components/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/components/SCXTEditorResponseHandlers.cpp
@@ -108,15 +108,25 @@ void SCXTEditor::onStructureUpdated(const engine::Engine::pgzStructure_t &s)
         multiScreen->parts->setPartGroupZoneStructure(s);
 }
 
-void SCXTEditor::onZoneProcessorDataAndMetadata(
+void SCXTEditor::onGroupOrZoneProcessorDataAndMetadata(
     const scxt::messaging::client::processorDataResponsePayload_t &d)
 {
-    const auto &[which, enabled, control, storage] = d;
+    const auto &[forZone, which, enabled, control, storage] = d;
 
     assert(which >= 0 && which < MultiScreen::numProcessorDisplays);
-    multiScreen->getZoneElements()->processors[which]->setEnabled(enabled);
-    multiScreen->getZoneElements()->processors[which]->setProcessorControlDescriptionAndStorage(
-        control, storage);
+    if (forZone)
+    {
+        multiScreen->getZoneElements()->processors[which]->setEnabled(enabled);
+        multiScreen->getZoneElements()->processors[which]->setProcessorControlDescriptionAndStorage(
+            control, storage);
+    }
+    else
+    {
+        multiScreen->getGroupElements()->processors[which]->setEnabled(enabled);
+        multiScreen->getGroupElements()
+            ->processors[which]
+            ->setProcessorControlDescriptionAndStorage(control, storage);
+    }
 }
 
 void SCXTEditor::onZoneProcessorDataMismatch(

--- a/src-ui/components/multi/ProcessorPane.cpp
+++ b/src-ui/components/multi/ProcessorPane.cpp
@@ -37,9 +37,9 @@ namespace scxt::ui::multi
 {
 namespace cmsg = scxt::messaging::client;
 
-ProcessorPane::ProcessorPane(SCXTEditor *e, int index)
+ProcessorPane::ProcessorPane(SCXTEditor *e, int index, bool fz)
     : HasEditor(e), sst::jucegui::components::NamedPanel("PROCESSOR " + std::to_string(index + 1)),
-      index(index)
+      index(index), forZone(fz)
 {
     setContentAreaComponent(std::make_unique<juce::Component>());
     hasHamburger = true;
@@ -65,6 +65,8 @@ void ProcessorPane::showHamburgerMenu()
     if (!isEnabled())
         return;
 
+    SCLOG("Creating processor hamburger menu " << SCD(forZone) << " " << SCD(index));
+
     juce::PopupMenu p;
     p.addSectionHeader("Processors");
     for (const auto &pd : editor->allProcessors)
@@ -72,7 +74,8 @@ void ProcessorPane::showHamburgerMenu()
         p.addItem(pd.displayName, [wt = juce::Component::SafePointer(this), type = pd.id]() {
             if (wt)
             {
-                wt->sendToSerialization(cmsg::SetSelectedProcessorType({wt->index, type}));
+                wt->sendToSerialization(
+                    cmsg::SetSelectedProcessorType({wt->forZone, wt->index, type}));
             }
         });
     }
@@ -342,7 +345,6 @@ void ProcessorPane::itemDropped(const juce::DragAndDropTarget::SourceDetails &dr
     if (!pp)
         return;
 
-    SCLOG("Swapping processors " << SCD(index) << SCD(pp->index));
     sendToSerialization(cmsg::SwapZoneProcessors({index, pp->index}));
 }
 

--- a/src-ui/components/multi/ProcessorPane.h
+++ b/src-ui/components/multi/ProcessorPane.h
@@ -56,7 +56,8 @@ struct ProcessorPane : sst::jucegui::components::NamedPanel, HasEditor, juce::Dr
     dsp::processor::ProcessorStorage processorView;
     dsp::processor::ProcessorControlDescription processorControlDescription;
     int index{0};
-    ProcessorPane(SCXTEditor *, int index);
+    bool forZone{true};
+    ProcessorPane(SCXTEditor *, int index, bool);
     ~ProcessorPane();
 
     void

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -384,7 +384,7 @@ Engine::getProcessorStorage(const processorAddress_t &addr) const
     if (!zref || which < 0)
         return {};
 
-    if (which < processorsPerZone)
+    if (which < processorCount)
         return zref->processorStorage[which];
 
     return {};
@@ -650,60 +650,48 @@ void Engine::loadSf2MultiSampleIntoSelectedPart(const fs::path &p)
                     znSD.endLoop = reg->LoopEnd;
                 }
 
-#if 0
-                std::cout << "STUFF I HAVEN'T DEALT WITH YET" << std::endl;
-                cout << "\t\t    Modulation Envelope Generator" << endl;
-                cout << "\t\t\tPitch=" << GetValue(reg->modEnvToPitch) << "cents, Cutoff=";
-                cout << GetValue(reg->modEnvToFilterFc) << "cents" << endl << endl;
+                SCLOG("Unimplemented SF2 Features Follow:")
+                SCLOG("\tModulation Envelope Generator Pitch="
+                      << GetValue(reg->modEnvToPitch)
+                      << "cents, Cutoff=" << GetValue(reg->modEnvToFilterFc) << "cents");
 
-                cout << "\t\t    Modulation LFO: Delay=" << ::sf2::ToSeconds(reg->delayModLfo)
-                     << "s, Frequency=";
-                cout << ::sf2::ToHz(reg->freqModLfo)
-                     << "Hz, LFO to Volume=" << (reg->modLfoToVolume / 10) << "dB";
-                cout << ", LFO to Filter Cutoff=" << reg->modLfoToFilterFc;
-                cout << ", LFO to Pitch=" << reg->modLfoToPitch << endl;
+                SCLOG("\tModulation LFO: Delay="
+                      << ::sf2::ToSeconds(reg->delayModLfo)
+                      << "s, Frequency=" << ::sf2::ToHz(reg->freqModLfo)
+                      << "Hz, LFO to Volume=" << (reg->modLfoToVolume / 10) << "dB"
+                      << ", LFO to Filter Cutoff=" << reg->modLfoToFilterFc
+                      << ", LFO to Pitch=" << reg->modLfoToPitch);
 
-                cout << "\t\t    Vibrato LFO:    Delay=" << ::sf2::ToSeconds(reg->delayVibLfo)
-                     << "s, Frequency=";
-                cout << ::sf2::ToHz(reg->freqVibLfo) << "Hz, LFO to Pitch=" << reg->vibLfoToPitch
-                     << endl;
+                SCLOG("\tVibrato LFO:    Delay=" << ::sf2::ToSeconds(reg->delayVibLfo)
+                                                 << "s, Frequency=" << ::sf2::ToHz(reg->freqVibLfo)
+                                                 << "Hz, LFO to Pitch=" << reg->vibLfoToPitch);
 
-                cout << "\t\t\tModulators (" << reg->modulators.size() << ")" << endl;
+                SCLOG("\tModulators Ignored. Count =(" << reg->modulators.size() << ")");
 
                 for (int i = 0; i < reg->modulators.size(); i++)
                 {
-                    cout << "\t\t\tModulator " << i << endl;
                     // PrintModulatorItem(&reg->modulators[i]);
                 }
 
-                cout << "\t" << s->Name
-                     << " (Depth: " << ((s->GetFrameSize() / s->GetChannelCount()) * 8);
-                cout << ", SampleRate: " << s->SampleRate;
-                cout << ", Pitch: " << ((int)s->OriginalPitch);
-                cout << ", Pitch Correction: " << ((int)s->PitchCorrection) << endl;
-                cout << "\t\tStart: " << s->Start << ", End: " << s->End;
-                cout << "\t\tSample Type: " << s->SampleType << ", Sample Link: " << s->SampleLink
-                     << ")" << endl;
-
-                cout << ", Start Loop: " << s->StartLoop << ", End Loop: " << s->EndLoop << endl;
-                cout << "\t\t    Key range=";
-
-                cout << "\t\t    Initial cutoff frequency=";
                 if (reg->initialFilterFc == ::sf2::NONE)
-                    cout << "None" << endl;
+                {
+                    SCLOG("\tFilter Cutoff: None");
+                }
                 else
-                    cout << reg->initialFilterFc << "cents" << endl;
+                {
+                    SCLOG("\tFilter Cutoff " << reg->initialFilterFc << "cents");
+                }
 
-                cout << "\t\t    Initial resonance=";
                 if (reg->initialFilterQ == ::sf2::NONE)
-                    cout << "None" << endl;
+                {
+                    SCLOG("\tFilter Q: None");
+                }
                 else
-                    cout << (reg->initialFilterQ / 10.0) << "dB" << endl;
+                {
+                    SCLOG("\tFilter Q " << reg->initialFilterQ / 10.0 << "dB");
+                }
 
-                if (reg->exclusiveClass)
-                    cout << ", Exclusive group=" << reg->exclusiveClass;
-                cout << endl;
-#endif
+                SCLOG("\tExclusive Class : " << reg->exclusiveClass);
 
                 grp->addZone(zn);
             }

--- a/src/engine/group.cpp
+++ b/src/engine/group.cpp
@@ -35,6 +35,11 @@
 
 #include <cassert>
 
+#include "messaging/messaging.h"
+#include "patch.h"
+#include "engine.h"
+#include "group_and_zone_impl.h"
+
 namespace scxt::engine
 {
 
@@ -82,4 +87,21 @@ void Group::removeActiveZone()
     }
 }
 
+engine::Engine *Group::getEngine()
+{
+    if (parentPart && parentPart->parentPatch)
+        return parentPart->parentPatch->parentEngine;
+    return nullptr;
+}
+
+void Group::setupOnUnstream(const engine::Engine &e)
+{
+    for (int p = 0; p < processorCount; ++p)
+    {
+        setupProcessorControlDescriptions(p, processorStorage[p].type);
+        onProcessorTypeChanged(p, processorStorage[p].type);
+    }
+}
+
+template struct HasGroupZoneProcessors<Group>;
 } // namespace scxt::engine

--- a/src/engine/group_and_zone.h
+++ b/src/engine/group_and_zone.h
@@ -1,0 +1,62 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2023, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_ENGINE_GROUP_AND_ZONE_H
+#define SCXT_SRC_ENGINE_GROUP_AND_ZONE_H
+
+#include <array>
+#include "dsp/processor/processor.h"
+
+/*
+ * Base classes which provide functions shared by
+ * groups and zones. This is a template class but it
+ * needs to be explicitly instantiated since it has too
+ * much stuff in the innards. So there's a group_and_zone_impl
+ * which you should include in group and zone and explicitly
+ * instantiate. Which we do.
+ */
+
+namespace scxt::engine
+{
+struct Engine;
+
+template <typename T> struct HasGroupZoneProcessors
+{
+    T *asT() { return static_cast<T *>(this); }
+    static constexpr int processorCount{4};
+    void setProcessorType(int whichProcessor, dsp::processor::ProcessorType type);
+    void setupProcessorControlDescriptions(int whichProcessor, dsp::processor::ProcessorType type,
+                                           dsp::processor::Processor *tmpProcessor = nullptr);
+
+    std::array<dsp::processor::ProcessorStorage, processorCount> processorStorage;
+    std::array<dsp::processor::ProcessorControlDescription, processorCount> processorDescription;
+};
+
+constexpr int processorCount{HasGroupZoneProcessors<Zone>::processorCount};
+
+} // namespace scxt::engine
+#endif // SHORTCIRCUITXT_GROUP_AND_ZONE_H

--- a/src/engine/group_and_zone_impl.h
+++ b/src/engine/group_and_zone_impl.h
@@ -1,0 +1,117 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2023, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "group_and_zone.h"
+
+/*
+ * For why this is a .h, see the comment in group_and_zone.h
+ */
+
+namespace scxt::engine
+{
+
+template <typename T>
+void HasGroupZoneProcessors<T>::setProcessorType(int whichProcessor,
+                                                 dsp::processor::ProcessorType type)
+{
+    assert(asT()->getEngine() &&
+           asT()->getEngine()->getMessageController()->threadingChecker.isAudioThread());
+
+    auto &ps = processorStorage[whichProcessor];
+    ps.type = type;
+    ps.mix = 1.0;
+
+    uint8_t memory[dsp::processor::processorMemoryBufferSize];
+    dsp::processor::Processor *tmpProcessor{nullptr};
+    float pfp[dsp::processor::maxProcessorFloatParams];
+    int ifp[dsp::processor::maxProcessorIntParams];
+
+    tmpProcessor = dsp::processor::spawnProcessorInPlace(
+        type, asT()->getEngine()->getMemoryPool().get(), memory,
+        dsp::processor::processorMemoryBufferSize, pfp, ifp);
+
+    if (type != dsp::processor::proct_none)
+    {
+        assert(tmpProcessor);
+        assert(asT()->getEngine());
+        tmpProcessor->setSampleRate(asT()->getEngine()->getSampleRate());
+        tmpProcessor->init();
+        tmpProcessor->init_params();
+
+        memcpy(&(ps.floatParams[0]), pfp, sizeof(ps.floatParams));
+        memcpy(&(ps.intParams[0]), ifp, sizeof(ps.intParams));
+        setupProcessorControlDescriptions(whichProcessor, type, tmpProcessor);
+
+        // TODO: The control descriptions get populated now also
+        dsp::processor::unspawnProcessor(tmpProcessor);
+    }
+    else
+    {
+        assert(!tmpProcessor);
+        setupProcessorControlDescriptions(whichProcessor, type, tmpProcessor);
+    }
+
+    asT()->onProcessorTypeChanged(whichProcessor, type);
+}
+
+template <typename T>
+void HasGroupZoneProcessors<T>::setupProcessorControlDescriptions(
+    int whichProcessor, dsp::processor::ProcessorType type,
+    dsp::processor::Processor *tmpProcessorFromAfar)
+{
+    if (type == dsp::processor::proct_none)
+    {
+        processorDescription[whichProcessor] = {};
+        processorDescription[whichProcessor].typeDisplayName = "Off";
+        return;
+    }
+
+    auto *tmpProcessor = tmpProcessorFromAfar;
+
+    assert(asT()->getEngine() &&
+           asT()->getEngine()->getMessageController()->threadingChecker.isAudioThread());
+
+    uint8_t memory[dsp::processor::processorMemoryBufferSize];
+    float pfp[dsp::processor::maxProcessorFloatParams];
+    int ifp[dsp::processor::maxProcessorIntParams];
+
+    if (!tmpProcessor)
+    {
+        tmpProcessor = dsp::processor::spawnProcessorInPlace(
+            type, asT()->getEngine()->getMemoryPool().get(), memory,
+            dsp::processor::processorMemoryBufferSize, pfp, ifp);
+    }
+
+    assert(tmpProcessor);
+
+    processorDescription[whichProcessor] = tmpProcessor->getControlDescription();
+
+    if (!tmpProcessorFromAfar)
+        dsp::processor::unspawnProcessor(tmpProcessor);
+}
+
+} // namespace scxt::engine

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -139,7 +139,10 @@ template <> struct scxt_traits<scxt::engine::Group>
     template <template <typename...> class Traits>
     static void assign(tao::json::basic_value<Traits> &v, const scxt::engine::Group &t)
     {
-        v = {{"zones", t.getZones()}, {"name", t.getName()}, {"gegStorage", t.gegStorage}};
+        v = {{"zones", t.getZones()},
+             {"name", t.getName()},
+             {"gegStorage", t.gegStorage},
+             {"processorStorage", t.processorStorage}};
     }
 
     template <template <typename...> class Traits>
@@ -147,6 +150,7 @@ template <> struct scxt_traits<scxt::engine::Group>
     {
         findIf(v, "name", group.name);
         findIf(v, "gegStorage", group.gegStorage);
+        findIf(v, "processorStorage", group.processorStorage);
         group.clearZones();
 
         auto vzones = v.at("zones").get_array();
@@ -161,6 +165,7 @@ template <> struct scxt_traits<scxt::engine::Group>
                 group.getZone(idx)->setupOnUnstream(*(group.parentPart->parentPatch->parentEngine));
             }
         }
+        group.setupOnUnstream(*(group.parentPart->parentPatch->parentEngine));
     }
 };
 

--- a/src/modulation/voice_matrix.cpp
+++ b/src/modulation/voice_matrix.cpp
@@ -66,7 +66,7 @@ void VoiceModMatrix::snapDepthScalesFromZone(engine::Zone *z)
     depthScales[destIndex(vmd_Sample_Pitch_Offset, 0)] = 60;
 
     // Processor Depth is by-processor
-    for (int idx = 0; idx < engine::processorsPerZone; ++idx)
+    for (int idx = 0; idx < engine::processorCount; ++idx)
     {
         for (int q = vmd_Processor_FP1; q <= vmd_Processor_FP9; ++q)
         {
@@ -80,7 +80,7 @@ void VoiceModMatrix::snapDepthScalesFromZone(engine::Zone *z)
 
 void VoiceModMatrix::copyBaseValuesFromZone(engine::Zone *z)
 {
-    for (int i = 0; i < engine::processorsPerZone; ++i)
+    for (int i = 0; i < engine::processorCount; ++i)
     {
         // TODO - skip off
         baseValues[destIndex(vmd_Processor_Mix, i)] = z->processorStorage[i].mix;
@@ -370,7 +370,7 @@ int getVoiceModMatrixDestIndexCount(const VoiceModMatrixDestinationType &t)
     case vmd_Processor_FP7:
     case vmd_Processor_FP8:
     case vmd_Processor_FP9:
-        return engine::processorsPerZone;
+        return engine::processorCount;
     case vmd_eg_A:
     case vmd_eg_H:
     case vmd_eg_D:
@@ -488,7 +488,7 @@ voiceModMatrixDestinationNames_t getVoiceModulationDestinationNames(const engine
 {
     voiceModMatrixDestinationNames_t res;
     // TODO code this way better - index on the 'outside' sorts but is inefficient
-    int maxIndex = std::max({2, engine::processorsPerZone, engine::lfosPerZone});
+    int maxIndex = std::max({2, engine::processorCount, engine::lfosPerZone});
     for (int idx = 0; idx < maxIndex; ++idx)
     {
         for (int i = vmd_none; i < numVoiceMatrixDestinations; ++i)

--- a/src/selection/selection_manager.h
+++ b/src/selection/selection_manager.h
@@ -165,6 +165,12 @@ struct SelectionManager
             return leadZone;
         return {};
     }
+    std::optional<ZoneAddress> currentLeadGroup(const engine::Engine &e)
+    {
+        if (leadGroup.isInWithPartials(e))
+            return leadGroup;
+        return {};
+    }
     std::pair<int, int> bestPartGroupForNewSample(const engine::Engine &e);
 
     void sendSelectedZonesToClient();
@@ -182,7 +188,7 @@ struct SelectionManager
   public:
     std::unordered_map<std::string, std::string> otherTabSelection;
     selectedZones_t allSelectedZones, allSelectedGroups;
-    ZoneAddress leadZone;
+    ZoneAddress leadZone, leadGroup;
 
   protected:
     std::map<size_t, std::set<size_t>> selectedGroupByPart;

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -47,7 +47,7 @@ Voice::Voice(engine::Engine *e, engine::Zone *z)
 
 Voice::~Voice()
 {
-    for (auto i = 0; i < engine::processorsPerZone; ++i)
+    for (auto i = 0; i < engine::processorCount; ++i)
     {
         dsp::processor::unspawnProcessor(processors[i]);
     }
@@ -198,7 +198,7 @@ bool Voice::process()
         sampleAmp.multiply_2_blocks(output[0], output[1]);
     }
 
-    for (auto i = 0; i < engine::processorsPerZone; ++i)
+    for (auto i = 0; i < engine::processorCount; ++i)
     {
         if (processors[i])
         {
@@ -418,7 +418,7 @@ void Voice::initializeProcessors()
     sampleAmp.set_target_instant(modMatrix.getValue(modulation::vmd_Zone_Sample_Amplitude, 0));
     outputPan.set_target_instant(modMatrix.getValue(modulation::vmd_Zone_Output_Pan, 0));
     outputAmp.set_target_instant(modMatrix.getValue(modulation::vmd_Zone_Output_Amplitude, 0));
-    for (auto i = 0; i < engine::processorsPerZone; ++i)
+    for (auto i = 0; i < engine::processorCount; ++i)
     {
         processorIsActive[i] = zone->processorStorage[i].isActive;
         processorMix[i].set_target_instant(modMatrix.getValue(modulation::vmd_Processor_Mix, i));

--- a/src/voice/voice.h
+++ b/src/voice/voice.h
@@ -119,16 +119,16 @@ struct alignas(16) Voice : MoveableOnly<Voice>, SampleRateSupport
     /**
      * Processors: Storage, memory blocks, types, and more
      */
-    dsp::processor::Processor *processors[engine::processorsPerZone]{nullptr, nullptr};
-    dsp::processor::ProcessorType processorType[engine::processorsPerZone]{
-        dsp::processor::proct_none, dsp::processor::proct_none};
+    dsp::processor::Processor *processors[engine::processorCount]{nullptr, nullptr};
+    dsp::processor::ProcessorType processorType[engine::processorCount]{dsp::processor::proct_none,
+                                                                        dsp::processor::proct_none};
     uint8_t processorPlacementStorage alignas(
-        16)[engine::processorsPerZone][dsp::processor::processorMemoryBufferSize];
+        16)[engine::processorCount][dsp::processor::processorMemoryBufferSize];
     int32_t processorIntParams alignas(
-        16)[engine::processorsPerZone][dsp::processor::maxProcessorIntParams];
-    bool processorIsActive[engine::processorsPerZone]{false, false, false, false};
-    bool processorConsumesMono[engine::processorsPerZone]{false, false, false, false};
-    bool processorProducesStereo[engine::processorsPerZone]{false, false, false, false};
+        16)[engine::processorCount][dsp::processor::maxProcessorIntParams];
+    bool processorIsActive[engine::processorCount]{false, false, false, false};
+    bool processorConsumesMono[engine::processorCount]{false, false, false, false};
+    bool processorProducesStereo[engine::processorCount]{false, false, false, false};
 
     void initializeProcessors();
 
@@ -138,7 +138,7 @@ struct alignas(16) Voice : MoveableOnly<Voice>, SampleRateSupport
     void panOutputsBy(bool inputIsMono, const lipol &pv);
 
     // TODO - this should be more carefully structured for modulation onto the entire filter
-    lipol processorMix[engine::processorsPerZone];
+    lipol processorMix[engine::processorCount];
 
     /*
      * Voice State on Creation


### PR DESCRIPTION
- Factor out shared group/zone features
- Add group processor support with messages for setting type
- Add leadgroup as well as selected groups (but retain single select)
- Stream and API for setting up processors on groups
- Change 'processorsPerZone' to 'processorCount' everywhere
- Fix drag-and-drop processor with multi-select zone
- At least show the single select processor data for group
- Make SF2 more chatty about whats not done to the log