### PR TITLE
Group Matrix More; Group ADSR, LFO and Matrix Data

### DIFF
--- a/src-ui/components/MultiScreen.h
+++ b/src-ui/components/MultiScreen.h
@@ -42,7 +42,10 @@ struct AdsrPane;
 struct OutputPane;
 struct PartGroupSidebar;
 struct MappingPane;
-struct ModPane;
+
+struct ModPaneZoneTraits;
+struct ModPaneGroupTraits;
+template <typename T> struct ModPane;
 struct ProcessorPane;
 struct LfoPane;
 } // namespace multi
@@ -78,7 +81,22 @@ struct MultiScreen : juce::Component, HasEditor
         std::unique_ptr<multi::OutputPane> output;
         std::unique_ptr<multi::LfoPane> lfo;
         std::unique_ptr<multi::AdsrPane> eg[2];
-        std::unique_ptr<multi::ModPane> mod;
+        std::variant<std::unique_ptr<multi::ModPane<multi::ModPaneZoneTraits>>,
+                     std::unique_ptr<multi::ModPane<multi::ModPaneGroupTraits>>>
+            modvariant;
+
+        juce::Component *modComponent();
+        const std::unique_ptr<multi::ModPane<multi::ModPaneZoneTraits>> &zoneMod()
+        {
+            assert(index == ZoneGroupIndex::ZONE);
+            return std::get<0>(modvariant);
+        }
+
+        const std::unique_ptr<multi::ModPane<multi::ModPaneGroupTraits>> &groupMod()
+        {
+            assert(index == ZoneGroupIndex::GROUP);
+            return std::get<1>(modvariant);
+        }
         std::unique_ptr<multi::ProcessorPane> processors[numProcessorDisplays];
 
         void setVisible(bool b);

--- a/src-ui/components/MultiScreen.h
+++ b/src-ui/components/MultiScreen.h
@@ -30,6 +30,7 @@
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <memory>
+#include <variant>
 #include "HasEditor.h"
 #include "browser/BrowserPane.h"
 #include "sst/jucegui/components/NamedPanel.h"

--- a/src-ui/components/SCXTEditor.h
+++ b/src-ui/components/SCXTEditor.h
@@ -166,9 +166,13 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel,
     void onGroupOrZoneProcessorDataAndMetadata(
         const scxt::messaging::client::processorDataResponsePayload_t &d);
     void onZoneProcessorDataMismatch(const scxt::messaging::client::processorMismatchPayload_t &);
+
     void onZoneVoiceMatrixMetadata(const scxt::modulation::voiceModMatrixMetadata_t &);
     void onZoneVoiceMatrix(const scxt::modulation::VoiceModMatrix::routingTable_t &);
-    void onZoneLfoUpdated(const scxt::messaging::client::indexedLfoUpdate_t &);
+    void onGroupMatrixMetadata(const scxt::modulation::groupModMatrixMetadata_t &);
+    void onGroupMatrix(const scxt::modulation::GroupModMatrix::routingTable_t &);
+
+    void onGroupOrZoneLfoUpdated(const scxt::messaging::client::indexedLfoUpdate_t &);
     void onZoneOutputInfoUpdated(const scxt::messaging::client::zoneOutputInfoUpdate_t &p);
 
     void onGroupZoneMappingSummary(const scxt::engine::Part::zoneMappingSummary_t &);

--- a/src-ui/components/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/components/SCXTEditorResponseHandlers.cpp
@@ -139,27 +139,56 @@ void SCXTEditor::onZoneProcessorDataMismatch(
 void SCXTEditor::onZoneVoiceMatrixMetadata(const scxt::modulation::voiceModMatrixMetadata_t &d)
 {
     const auto &[active, sinf, dinf, cinf] = d;
-    multiScreen->getZoneElements()->mod->setActive(active);
+    multiScreen->getZoneElements()->zoneMod()->setActive(active);
     if (active)
     {
-        multiScreen->getZoneElements()->mod->matrixMetadata = d;
-        multiScreen->getZoneElements()->mod->rebuildMatrix();
+        multiScreen->getZoneElements()->zoneMod()->matrixMetadata = d;
+        multiScreen->getZoneElements()->zoneMod()->rebuildMatrix();
     }
 }
 
 void SCXTEditor::onZoneVoiceMatrix(const scxt::modulation::VoiceModMatrix::routingTable_t &t)
 {
     assert(multiScreen->getZoneElements()
-               ->mod->isEnabled()); // we shouldn't send a matrix to a non-enabled pane
-    multiScreen->getZoneElements()->mod->routingTable = t;
-    multiScreen->getZoneElements()->mod->refreshMatrix();
+               ->zoneMod()
+               ->isEnabled()); // we shouldn't send a matrix to a non-enabled pane
+    multiScreen->getZoneElements()->zoneMod()->routingTable = t;
+    multiScreen->getZoneElements()->zoneMod()->refreshMatrix();
 }
 
-void SCXTEditor::onZoneLfoUpdated(const scxt::messaging::client::indexedLfoUpdate_t &payload)
+void SCXTEditor::onGroupMatrixMetadata(const scxt::modulation::groupModMatrixMetadata_t &d)
 {
-    const auto &[active, i, r] = payload;
-    multiScreen->getZoneElements()->lfo->setActive(i, active);
-    multiScreen->getZoneElements()->lfo->setLfo(i, r);
+    const auto &[active, sinf, dinf, cinf] = d;
+    multiScreen->getGroupElements()->groupMod()->setActive(active);
+    if (active)
+    {
+        multiScreen->getGroupElements()->groupMod()->matrixMetadata = d;
+        multiScreen->getGroupElements()->groupMod()->rebuildMatrix();
+    }
+}
+
+void SCXTEditor::onGroupMatrix(const scxt::modulation::GroupModMatrix::routingTable_t &t)
+{
+    assert(multiScreen->getGroupElements()
+               ->groupMod()
+               ->isEnabled()); // we shouldn't send a matrix to a non-enabled pane
+    multiScreen->getGroupElements()->groupMod()->routingTable = t;
+    multiScreen->getGroupElements()->groupMod()->refreshMatrix();
+}
+
+void SCXTEditor::onGroupOrZoneLfoUpdated(const scxt::messaging::client::indexedLfoUpdate_t &payload)
+{
+    const auto &[forZone, active, i, r] = payload;
+    if (forZone)
+    {
+        multiScreen->getZoneElements()->lfo->setActive(i, active);
+        multiScreen->getZoneElements()->lfo->setLfo(i, r);
+    }
+    else
+    {
+        multiScreen->getGroupElements()->lfo->setActive(i, active);
+        multiScreen->getGroupElements()->lfo->setLfo(i, r);
+    }
 }
 
 void SCXTEditor::onZoneOutputInfoUpdated(const scxt::messaging::client::zoneOutputInfoUpdate_t &p)

--- a/src-ui/components/multi/LFOPane.cpp
+++ b/src-ui/components/multi/LFOPane.cpp
@@ -152,7 +152,8 @@ struct LfoDataRender : juce::Component
     }
 }; // namespace juce::Component
 
-LfoPane::LfoPane(SCXTEditor *e) : sst::jucegui::components::NamedPanel(""), HasEditor(e)
+LfoPane::LfoPane(SCXTEditor *e, bool fz)
+    : sst::jucegui::components::NamedPanel(""), HasEditor(e), forZone(fz)
 {
     setCustomClass(connectors::SCXTStyleSheetCreator::ModulationTabs);
     hasHamburger = true;
@@ -370,7 +371,8 @@ namespace cmsg = scxt::messaging::client;
 
 void LfoPane::pushCurrentLfoUpdate()
 {
-    sendToSerialization(cmsg::IndexedLfoUpdated({true, selectedTab, lfoData[selectedTab]}));
+    sendToSerialization(
+        cmsg::IndexedLfoUpdated({forZone, true, selectedTab, lfoData[selectedTab]}));
     repaint();
 }
 

--- a/src-ui/components/multi/LFOPane.h
+++ b/src-ui/components/multi/LFOPane.h
@@ -53,8 +53,10 @@ struct LfoPane : sst::jucegui::components::NamedPanel, HasEditor
     typedef connectors::BooleanPayloadDataAttachment<modulation::modulators::StepLFOStorage>
         boolAttachment_t;
 
-    LfoPane(SCXTEditor *);
+    LfoPane(SCXTEditor *, bool forZone);
     ~LfoPane();
+
+    bool forZone{true};
 
     void tabChanged(int i);
 

--- a/src-ui/components/multi/ModPane.h
+++ b/src-ui/components/multi/ModPane.h
@@ -31,15 +31,32 @@
 #include "sst/jucegui/components/NamedPanel.h"
 #include "components/HasEditor.h"
 #include "modulation/voice_matrix.h"
+#include "modulation/group_matrix.h"
 
 namespace scxt::ui::multi
 {
-struct ModRow;
 
-struct ModPane : sst::jucegui::components::NamedPanel, HasEditor
+struct ModPaneZoneTraits
+{
+    static constexpr bool forZone{true};
+    using metadata = scxt::modulation::voiceModMatrixMetadata_t;
+    using routing = scxt::modulation::VoiceModMatrix::routingTable_t;
+};
+
+struct ModPaneGroupTraits
+{
+    static constexpr bool forZone{false};
+    using metadata = scxt::modulation::groupModMatrixMetadata_t;
+    using routing = scxt::modulation::GroupModMatrix::routingTable_t;
+};
+
+template <typename GZTrait> struct ModRow;
+
+// We will explicity instantiate these on the trait in ModPane.cpp
+template <typename GZTrait> struct ModPane : sst::jucegui::components::NamedPanel, HasEditor
 {
     static constexpr int numRowsOnScreen{6};
-    ModPane(SCXTEditor *e);
+    ModPane(SCXTEditor *e, bool forZone);
     ~ModPane();
 
     void resized() override;
@@ -48,11 +65,12 @@ struct ModPane : sst::jucegui::components::NamedPanel, HasEditor
     void refreshMatrix(); // new routing table, no new components
     void setActive(bool b);
 
-    std::array<std::unique_ptr<ModRow>, numRowsOnScreen> rows;
+    std::array<std::unique_ptr<ModRow<GZTrait>>, numRowsOnScreen> rows;
 
-    scxt::modulation::voiceModMatrixMetadata_t matrixMetadata;
-    scxt::modulation::VoiceModMatrix::routingTable_t routingTable;
+    typename GZTrait::metadata matrixMetadata;
+    typename GZTrait::routing routingTable;
 
+    bool forZone{GZTrait::forZone};
     int tabRange{0};
 };
 } // namespace scxt::ui::multi

--- a/src/engine/group.h
+++ b/src/engine/group.h
@@ -32,6 +32,7 @@
 #include <memory>
 #include <vector>
 #include <cassert>
+#include <cmath>
 
 #include <sst/cpputils.h>
 #include <sst/basic-blocks/modulators/AHDSRShapedSC.h>

--- a/src/engine/part.h
+++ b/src/engine/part.h
@@ -76,6 +76,7 @@ struct Part : MoveableOnly<Part>, SampleRateSupport
     {
         auto g = std::make_unique<Group>();
         g->parentPart = this;
+        g->setSampleRate(getSampleRate());
         groups.push_back(std::move(g));
         return groups.size();
     }
@@ -123,6 +124,8 @@ struct Part : MoveableOnly<Part>, SampleRateSupport
         pitchBendSmoother.setSampleRate(samplerate);
         for (auto &mcc : midiCCSmoothers)
             mcc.setSampleRate(samplerate);
+        for (auto &g : groups)
+            g->setSampleRate(samplerate);
     }
 
     // TODO: A group by ID which throws an SCXTError

--- a/src/engine/zone.cpp
+++ b/src/engine/zone.cpp
@@ -47,6 +47,7 @@ void Zone::process(Engine &e)
 
     std::array<voice::Voice *, maxVoices> toCleanUp;
     size_t cleanupIdx{0};
+    gatedVoiceCount = 0;
     for (auto &v : voiceWeakPointers)
     {
         if (v && v->isVoiceAssigned)
@@ -70,6 +71,11 @@ void Zone::process(Engine &e)
             if (!v->isVoicePlaying)
             {
                 toCleanUp[cleanupIdx++] = v;
+            }
+
+            if (v->isGated)
+            {
+                gatedVoiceCount++;
             }
         }
     }

--- a/src/engine/zone.h
+++ b/src/engine/zone.h
@@ -173,6 +173,8 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>
     bool isActive() { return activeVoices != 0; }
     uint32_t activeVoices{0};
     std::array<voice::Voice *, maxVoices> voiceWeakPointers;
+    int gatedVoiceCount{0};
+
     void initialize();
     // Just a weak ref - don't take ownership. engine manages lifetime
     void addVoice(voice::Voice *);

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -139,11 +139,9 @@ template <> struct scxt_traits<scxt::engine::Group>
     template <template <typename...> class Traits>
     static void assign(tao::json::basic_value<Traits> &v, const scxt::engine::Group &t)
     {
-        v = {{"zones", t.getZones()},
-             {"name", t.getName()},
-             {"routingTable", t.routingTable},
-             {"gegStorage", t.gegStorage},
-             {"processorStorage", t.processorStorage}};
+        v = {{"zones", t.getZones()},          {"name", t.getName()},
+             {"routingTable", t.routingTable}, {"gegStorage", t.gegStorage},
+             {"lfoStorage", t.lfoStorage},     {"processorStorage", t.processorStorage}};
     }
 
     template <template <typename...> class Traits>
@@ -153,6 +151,7 @@ template <> struct scxt_traits<scxt::engine::Group>
         findIf(v, "gegStorage", group.gegStorage);
         findIf(v, "processorStorage", group.processorStorage);
         findIf(v, "routingTable", group.routingTable);
+        findIf(v, "lfoStorage", group.lfoStorage);
         group.clearZones();
 
         auto vzones = v.at("zones").get_array();

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -50,8 +50,9 @@ enum ClientToSerializationMessagesIds
     c2s_update_zone_mapping,
     c2s_update_zone_samples,
     c2s_update_zone_routing_row,
+    c2s_update_group_routing_row,
 
-    c2s_update_individual_lfo,
+    c2s_update_group_or_zone_individual_lfo,
 
     c2s_request_pgz_structure,
 
@@ -91,9 +92,11 @@ enum SerializationToClientMessageIds
     s2c_respond_zone_samples,
     s2c_send_pgz_structure,
     s2c_send_all_processor_descriptions,
-    s2c_update_zone_voice_matrix_metadata,
-    s2c_update_zone_voice_matrix,
-    s2c_update_zone_individual_lfo,
+    s2c_update_zone_matrix_metadata,
+    s2c_update_zone_matrix,
+    s2c_update_group_matrix_metadata,
+    s2c_update_group_matrix,
+    s2c_update_group_or_zone_individual_lfo,
     s2c_update_zone_output_info,
 
     s2c_respond_single_processor_metadata_and_data,

--- a/src/messaging/client/detail/client_serial_impl.h
+++ b/src/messaging/client/detail/client_serial_impl.h
@@ -131,6 +131,8 @@ void doExecOnClient(tao::json::basic_value<Traits> &o, Client *c)
     typedef typename SerializationToClientType<(SerializationToClientMessageIds)I>::T handler_t;
     if constexpr (std::is_same<handler_t, unimpl_t>::value)
     {
+        // If you hit this assert, it means you have not defined a handler type, probably
+        // skipping the SERIAL_TO_CLIENT
         assert(false);
         return;
     }

--- a/src/messaging/client/processor_messages.h
+++ b/src/messaging/client/processor_messages.h
@@ -81,7 +81,7 @@ inline void setProcessorType(const setProcessorPayload_t &whichToType, const eng
                         *(engine.getMessageController()));
                     /*
                     serializationSendToClient(
-                        messaging::client::s2c_update_zone_voice_matrix_metadata,
+                        messaging::client::s2c_update_zone_matrix_metadata,
                         modulation::getVoiceModMatrixMetadata(*z),
                         *(engine.getMessageController()));*/
                 });
@@ -115,10 +115,9 @@ inline void setProcessorType(const setProcessorPayload_t &whichToType, const eng
                             true, which, true, z->processorDescription[which],
                             z->processorStorage[which]},
                         *(engine.getMessageController()));
-                    serializationSendToClient(
-                        messaging::client::s2c_update_zone_voice_matrix_metadata,
-                        modulation::getVoiceModMatrixMetadata(*z),
-                        *(engine.getMessageController()));
+                    serializationSendToClient(messaging::client::s2c_update_zone_matrix_metadata,
+                                              modulation::getVoiceModMatrixMetadata(*z),
+                                              *(engine.getMessageController()));
                 });
         }
     }

--- a/src/modulation/group_matrix.h
+++ b/src/modulation/group_matrix.h
@@ -44,6 +44,11 @@ namespace scxt::modulation
 enum GroupModMatrixSource
 {
     gms_none,
+    gms_EG1,
+    gms_EG2,
+    gms_LFO1,
+    gms_LFO2,
+    gms_LFO3,
 
     numGroupMatrixSources
 };
@@ -51,6 +56,7 @@ enum GroupModMatrixSource
 enum GroupModMatrixDestinationType
 {
     gmd_none,
+    gmd_grouplevel,
 
     numGroupMatrixDestinations
 };
@@ -82,6 +88,22 @@ struct GroupModMatrixDestinationAddress
         return other.type == type && other.index == index;
     }
 };
+
+typedef std::vector<std::pair<GroupModMatrixDestinationAddress, std::string>>
+    groupModMatrixDestinationNames_t;
+groupModMatrixDestinationNames_t getGroupModulationDestinationNames(const engine::Group &);
+typedef std::vector<std::pair<GroupModMatrixSource, std::string>> groupModMatrixSourceNames_t;
+groupModMatrixSourceNames_t getGroupModMatrixSourceNames(const engine::Group &);
+
+typedef std::tuple<bool, groupModMatrixSourceNames_t, groupModMatrixDestinationNames_t,
+                   modMatrixCurveNames_t>
+    groupModMatrixMetadata_t;
+inline groupModMatrixMetadata_t getGroupModMatrixMetadata(const engine::Group &g)
+{
+    return {true, getGroupModMatrixSourceNames(g), getGroupModulationDestinationNames(g),
+            getModMatrixCurveNames()};
+}
+
 struct GroupModMatrixTraits
 {
     static constexpr int numModMatrixSlots{6};
@@ -94,6 +116,9 @@ struct GroupModMatrixTraits
 struct GroupModMatrix : public MoveableOnly<GroupModMatrix>, ModMatrix<GroupModMatrixTraits>
 {
     GroupModMatrix() { clear(); }
+
+    void copyBaseValuesFromGroup(engine::Group &);
+    void updateModulatorUsed(engine::Group &) const;
 };
 } // namespace scxt::modulation
 #endif // SHORTCIRCUITXT_GROUP_MATRIX_H

--- a/src/voice/voice.h
+++ b/src/voice/voice.h
@@ -77,7 +77,7 @@ struct alignas(16) Voice : MoveableOnly<Voice>, SampleRateSupport
         ahdsrenv_t;
     ahdsrenv_t aeg, eg2;
 
-    // TODO obviously this sucks move to a table
+    // TODO obviously this sucks move to a table. Also its copied in group
     inline float envelope_rate_linear_nowrap(float f)
     {
         return blockSize * sampleRateInv * pow(2.f, -f);


### PR DESCRIPTION
Basically last push to make this work

- Group gets a level property
- Group gets ADSR and LFO evaluators
- Add, stream, and make editable group lfo storage
- geg evaluators in place
- group becomes a sample rate support to allow above
- Group and Zone Matrix messages split (since different types)
- ModPane gets a template and variant to deal with above
- Communicate edits back to the mod matrix
- Have the group matrix UI be untabbed