### PR TITLE
More Chipping Away at Modulation and So ON

### DIFF
--- a/clients/juce-plugin/SCXTProcessor.cpp
+++ b/clients/juce-plugin/SCXTProcessor.cpp
@@ -304,6 +304,7 @@ juce::AudioProcessorEditor *SCXTProcessor::createEditor()
 //==============================================================================
 void SCXTProcessor::getStateInformation(juce::MemoryBlock &destData)
 {
+    engine->getSampleManager()->purgeUnreferencedSamples();
     auto xml = scxt::json::streamEngineState(*engine);
     destData.replaceAll(xml.c_str(), xml.size() + 1);
 }

--- a/src-ui/components/multi/PartGroupSidebar.cpp
+++ b/src-ui/components/multi/PartGroupSidebar.cpp
@@ -341,6 +341,7 @@ void PartGroupSidebar::resized()
 void PartGroupSidebar::setPartGroupZoneStructure(const engine::Engine::pgzStructure_t &p)
 {
     pgzStructure = p;
+#if LOG_PART_GROUP_SIDEBAR
     SCLOG("PartGroupZone in Sidebar: Showing Part0 Entries");
     for (const auto &a : pgzStructure)
     {
@@ -354,6 +355,7 @@ void PartGroupSidebar::setPartGroupZoneStructure(const engine::Engine::pgzStruct
             SCLOG("  " << pad << " " << a.second << " -> " << a.first);
         }
     }
+#endif
     groupSidebar->listBoxModel->rebuild();
     groupSidebar->listBox->updateContent();
     zoneSidebar->listBoxModel->rebuild();

--- a/src/engine/group.cpp
+++ b/src/engine/group.cpp
@@ -55,7 +55,6 @@ void Group::process(Engine &e)
     float *lOut = output[0];
     float *rOut = output[1];
 
-    modMatrix.updateModulatorUsed(*this);
     modMatrix.copyBaseValuesFromGroup(*this);
     modMatrix.initializeModulationValues();
 
@@ -140,6 +139,8 @@ void Group::setupOnUnstream(const engine::Engine &e)
         setupProcessorControlDescriptions(p, processorStorage[p].type);
         onProcessorTypeChanged(p, processorStorage[p].type);
     }
+
+    modMatrix.updateModulatorUsed(*this);
 }
 
 template struct HasGroupZoneProcessors<Group>;

--- a/src/messaging/client/modulation_messages.h
+++ b/src/messaging/client/modulation_messages.h
@@ -93,7 +93,11 @@ inline void indexedGroupRoutingRowUpdated(const indexedGroupRowUpdate_t &payload
         cont.scheduleAudioThreadCallback(
             [index = i, row = r, gs = sg](auto &eng) {
                 for (const auto &z : gs)
-                    eng.getPatch()->getPart(z.part)->getGroup(z.group)->routingTable[index] = row;
+                {
+                    auto &grp = eng.getPatch()->getPart(z.part)->getGroup(z.group);
+                    grp->routingTable[index] = row;
+                    grp->modMatrix.updateModulatorUsed(*grp);
+                }
             },
             [doUpdate = b](auto &eng) {
                 if (doUpdate)

--- a/src/messaging/client/structure_messages.h
+++ b/src/messaging/client/structure_messages.h
@@ -133,6 +133,7 @@ inline void removeZone(const selection::SelectionManager::ZoneAddress &a, engine
             auto z = e.getPatch()->getPart(s.part)->getGroup(s.group)->removeZone(zid);
         },
         [t = a](auto &engine) {
+            engine.getSampleManager()->purgeUnreferencedSamples();
             serializationSendToClient(s2c_send_pgz_structure,
                                       engine.getPartGroupZoneStructure(t.part),
                                       *(engine.getMessageController()));
@@ -162,6 +163,8 @@ inline void removeSelectedZones(const bool &, engine::Engine &engine, MessageCon
                 auto z = e.getPatch()->getPart(p)->getGroup(g)->removeZone(zid);
         },
         [t = part](auto &engine) {
+            engine.getSampleManager()->purgeUnreferencedSamples();
+
             serializationSendToClient(s2c_send_pgz_structure, engine.getPartGroupZoneStructure(t),
                                       *(engine.getMessageController()));
             serializationSendToClient(s2c_send_selected_group_zone_mapping_summary,
@@ -181,6 +184,8 @@ inline void removeGroup(const selection::SelectionManager::ZoneAddress &a, engin
             auto g = e.getPatch()->getPart(s.part)->removeGroup(gid);
         },
         [t = a](auto &engine) {
+            engine.getSampleManager()->purgeUnreferencedSamples();
+
             serializationSendToClient(s2c_send_pgz_structure,
                                       engine.getPartGroupZoneStructure(t.part),
                                       *(engine.getMessageController()));

--- a/src/modulation/group_matrix.cpp
+++ b/src/modulation/group_matrix.cpp
@@ -104,13 +104,17 @@ void GroupModMatrix::copyBaseValuesFromGroup(engine::Group &g)
 void GroupModMatrix::updateModulatorUsed(engine::Group &g) const
 {
     // TODO: Call this only when the mod matrix morphs. For now run them all
-    g.gegUsed[0] = true;
-    g.gegUsed[1] = true;
-    g.lfoUsed[0] = false;
-    g.lfoUsed[1] = false;
-    g.lfoUsed[2] = false;
+    for (const auto &r : routingTable)
+    {
+        g.gegUsed[0] = g.gegUsed[0] || r.src == gms_EG1 || r.srcVia == gms_EG1;
+        g.gegUsed[1] = g.gegUsed[1] || r.src == gms_EG2 || r.srcVia == gms_EG2;
+        g.lfoUsed[0] = g.lfoUsed[0] || r.src == gms_LFO1 || r.srcVia == gms_LFO1;
+        g.lfoUsed[1] = g.lfoUsed[1] || r.src == gms_LFO2 || r.srcVia == gms_LFO2;
+        g.lfoUsed[2] = g.lfoUsed[2] || r.src == gms_LFO3 || r.srcVia == gms_LFO3;
+    }
 
-    g.anyModulatorUsed = true;
+    g.anyModulatorUsed =
+        g.gegUsed[0] || g.gegUsed[1] || g.lfoUsed[0] || g.lfoUsed[1] || g.lfoUsed[2];
 }
 
 std::string getGroupModMatrixSourceDisplayName(const GroupModMatrixSource &dest)

--- a/src/sample/sample_manager.cpp
+++ b/src/sample/sample_manager.cpp
@@ -139,4 +139,21 @@ std::optional<SampleID> SampleManager::loadSampleFromSF2ToID(const fs::path &p, 
     samples[sp->id] = sp;
     return sp->id;
 }
+
+void SampleManager::purgeUnreferencedSamples()
+{
+    SCLOG_WFUNC("PrePurge Sample Count is " << samples.size());
+    for (auto b = samples.begin(); b != samples.end(); ++b)
+    {
+        auto ct = b->second.use_count();
+        if (ct <= 1)
+        {
+            SCLOG("Purging sample " << b->first.to_string() << " from "
+                                    << b->second->mFileName.u8string())
+            b = samples.erase(b);
+        }
+    }
+
+    SCLOG_WFUNC("PostPurge Sample Count is " << samples.size());
+}
 } // namespace scxt::sample

--- a/src/sample/sample_manager.h
+++ b/src/sample/sample_manager.h
@@ -81,6 +81,8 @@ struct SampleManager : MoveableOnly<SampleManager>
     }
     void restoreFromSampleAddressesAndIDs(const sampleAddressesAndIds_t &);
 
+    void purgeUnreferencedSamples();
+
     void reset()
     {
         samples.clear();


### PR DESCRIPTION
- SampleManager has a purge action for when you delete
- The calculation of modulators-used happens only when the routing table morphs