### PR TITLE
Mono Pan Scaling Fix

### DIFF
--- a/src/dsp/generator.cpp
+++ b/src/dsp/generator.cpp
@@ -264,6 +264,27 @@ void GeneratorSample(GeneratorState *__restrict GD, GeneratorIO *__restrict IO)
             _mm_store_ss(&OutputL[i], fL);
             if (stereo)
                 _mm_store_ss(&OutputR[i], fR);
+
+#define DEBUG_OUTPUT_MINMAX 0
+#if DEBUG_OUTPUT_MINMAX
+            {
+                // Please don't remove this in some cleanup. It is handly
+                static int printEvery{0};
+                static float mxOut = std::numeric_limits<float>::min();
+                static float mnOut = std::numeric_limits<float>::max();
+
+                mxOut = std::max(OutputL[i], mxOut);
+                mnOut = std::min(OutputL[i], mnOut);
+                if (printEvery == 1000)
+                {
+                    SCLOG("GENERATOR " << SCD(mxOut) << " " << SCD(mnOut));
+                    printEvery = 0;
+                    mxOut = std::numeric_limits<float>::min();
+                    mnOut = std::numeric_limits<float>::max();
+                }
+                printEvery++;
+            }
+#endif
         }
 
         // 3. Forward sample position

--- a/src/sample/sample.cpp
+++ b/src/sample/sample.cpp
@@ -348,4 +348,58 @@ bool Sample::SetMeta(unsigned int Channels, unsigned int SampleRate, unsigned in
 
     return true;
 }
+
+void Sample::dumpInformationToLog()
+{
+    SCLOG("Sample Dump for " << getDisplayName());
+    switch (type)
+    {
+    case WAV_FILE:
+        SCLOG("WAV File : " << getPath().u8string());
+        break;
+    case FLAC_FILE:
+        SCLOG("FLAC File : " << getPath().u8string());
+        break;
+    case AIFF_FILE:
+        SCLOG("AIFF File : " << getPath().u8string());
+        break;
+    case SF2_FILE:
+        SCLOG("SF2 File : " << getPath().u8string() << " Instrument=" << getCompoundInstrument()
+                            << " Region=" << getCompoundRegion());
+        break;
+    }
+
+    SCLOG("BitDepth=" << bitDepthByteSize(bitDepth) * 8 << " Channels=" << (int)channels);
+    SCLOG("SampleRate=" << sample_rate << " sample_length=" << sample_length);
+
+    switch (bitDepth)
+    {
+    case BD_I16:
+    {
+        for (int c = 0; c < channels; ++c)
+        {
+            auto *dat = GetSamplePtrI16(c);
+            auto mxv = std::numeric_limits<int16_t>::min();
+            auto mnv = std::numeric_limits<int16_t>::max();
+            for (int i = 0; i < sample_length; ++i)
+            {
+                mxv = std::max(mxv, dat[i]);
+                mnv = std::min(mnv, dat[i]);
+            }
+            SCLOG("Min/Max = " << mxv << " " << mnv);
+
+            const float I16InvScale = (1.f / (16384.f * 32768.f));
+            SCLOG("Min/Max Float Scaled = " << mxv / 32768.f << " " << mnv / 32768.f);
+            SCLOG("Min/Max Generator Scaled = " << mxv * I16InvScale << " " << mnv * I16InvScale);
+        }
+    }
+    break;
+    case BD_F32:
+    {
+        SCLOG("TODO: Implement Sapmle Scan for F32");
+    }
+    break;
+    }
+}
+
 } // namespace scxt::sample

--- a/src/sample/sample.h
+++ b/src/sample/sample.h
@@ -48,6 +48,8 @@ struct alignas(16) Sample : MoveableOnly<Sample>
     Sample(const SampleID &sid) : id(sid), displayName(sid.to_string()) {}
     virtual ~Sample() = default;
 
+    void dumpInformationToLog();
+
     std::string displayName{};
     std::string getDisplayName() const { return displayName; }
     bool load(const fs::path &path);

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -186,6 +186,12 @@ bool Voice::process()
         panOutputsBy(chainIsMono, samplePan);
         chainIsMono = false;
     }
+    else if (chainIsMono)
+    {
+        // panning drops us by a root 2, so no panning needs to also
+        constexpr float invsqrt2{1.f / 1.414213562373095};
+        mech::mul_block<blockSize>(output[0], invsqrt2);
+    }
 
     auto pva = modMatrix.getValue(modulation::vmd_Zone_Sample_Amplitude, 0);
     sampleAmp.set_target(pva);
@@ -296,7 +302,7 @@ void Voice::panOutputsBy(bool chainIsMono, const lipol &plip)
     if (chainIsMono)
     {
         chainIsMono = false;
-        pl::monoEqualPower(pv, pmat);
+        pl::monoEqualPowerUnityGainAtExtrema(pv, pmat);
         for (int i = 0; i < blockSize; ++i)
         {
             output[1][i] = output[0][i] * pmat[3];


### PR DESCRIPTION
The mono pan law was set up so a center pan retained amplitude in both channels and an extram added a root 2. So a pan left was L = root 2 * mono. Replace this with a pan law that has the extrema at unity so L = mono which means in center, then L = mono / root 2. Finally make it so if unpanned that scale comes out also.

This basically addresses the SF2 overdrive/clipping problems since that root 2 was on every stereo side.