### PR TITLE
SF2 Preset Structure

### DIFF
--- a/src-ui/components/multi/detail/GroupZoneTreeControl.h
+++ b/src-ui/components/multi/detail/GroupZoneTreeControl.h
@@ -201,6 +201,15 @@ template <typename SidebarParent> struct GroupZoneListBoxModel : juce::ListBoxMo
                         w->gsb->sendToSerialization(cmsg::DeleteGroup(za));
                     });
                 }
+
+                p.addItem("Delete All Zones and Groups",
+                          [w = juce::Component::SafePointer(this)]() {
+                              if (!w)
+                                  return;
+                              auto za = w->getZoneAddress();
+
+                              w->gsb->sendToSerialization(cmsg::ClearPart(za.part));
+                          });
                 isPopup = true;
                 p.showMenuAsync(gsb->editor->defaultPopupMenuOptions());
             }

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -68,6 +68,7 @@ enum ClientToSerializationMessagesIds
     c2s_delete_zone,
     c2s_delete_selected_zones,
     c2s_delete_group,
+    c2s_clear_part,
 
     c2s_set_tuning_mode,
 


### PR DESCRIPTION
SF2 has a preset/instrument structure which we ignored meaning multi-instrument presets loaded improperly. Now they dont. which is great.

But

1. In the future SF2 presets should show as browser sub-elements in the browser. Requires a parse so a bit tricky

2. In the nearer future, SF2 presets > 1 could load into a muted group once we have group mute