### PR TITLE
Tweak the SF2 group strategy

### DIFF
--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -544,14 +544,15 @@ void Engine::loadSf2MultiSampleIntoSelectedPart(const fs::path &p)
             auto *preset = sf->GetPreset(pc);
             auto pnm = std::string(preset->GetName());
 
+            auto grpnum = part->addGroup() - 1;
+            auto &grp = part->getGroup(grpnum);
+
+            grp->name = pnm;
+
             for (int i = 0; i < preset->GetRegionCount(); ++i)
             {
                 auto *presetRegion = preset->GetRegion(i);
                 sf2::Instrument *instr = presetRegion->pInstrument;
-
-                auto grpnum = part->addGroup() - 1;
-                auto &grp = part->getGroup(grpnum);
-                grp->name = pnm + " - " + instr->GetName();
 
                 if (instr->pGlobalRegion)
                 {

--- a/src/sample/sample.cpp
+++ b/src/sample/sample.cpp
@@ -108,7 +108,8 @@ bool Sample::loadFromSF2(const fs::path &p, sf2::File *f, int inst, int reg)
     auto s = sfsample;
 
     auto fnp = fs::path{f->GetRiffFile()->GetFileName()};
-    displayName = fmt::format("{} ({}/{}/{})", s->Name, fnp.filename().u8string(), inst, region);
+    displayName = fmt::format("{} - {} ({} @ {}.{})", f->GetInstrument(inst)->GetName(), s->Name,
+                              fnp.filename().u8string(), inst, region);
 
     if (frameSize == 2 && channels == 1 && sfsample->SampleType == sf2::Sample::MONO_SAMPLE)
     {


### PR DESCRIPTION
You have a group per PRESET not per INSTRUMENT
This makes it seem more natural compared to other
samplers we tried