### PR TITLE
A bunch more work towards output editing and routing

### DIFF
--- a/src-ui/components/MultiScreen.cpp
+++ b/src-ui/components/MultiScreen.cpp
@@ -95,15 +95,18 @@ MultiScreen::MultiScreen(SCXTEditor *e) : HasEditor(e)
         {
             ctr->modvariant =
                 std::make_unique<multi::ModPane<multi::ModPaneZoneTraits>>(editor, forZone);
+            ctr->outputvariant =
+                std::make_unique<multi::OutputPane<multi::OutPaneZoneTraits>>(editor);
         }
         else
         {
             ctr->modvariant =
                 std::make_unique<multi::ModPane<multi::ModPaneGroupTraits>>(editor, forZone);
+            ctr->outputvariant =
+                std::make_unique<multi::OutputPane<multi::OutPaneGroupTraits>>(editor);
         }
         addChildComponent(*ctr->modComponent());
-        ctr->output = std::make_unique<multi::OutputPane>(editor);
-        addChildComponent(*ctr->output);
+        addChildComponent(*ctr->outputComponent());
 
         for (int i = 0; i < 2; ++i)
         {
@@ -115,7 +118,8 @@ MultiScreen::MultiScreen(SCXTEditor *e) : HasEditor(e)
 
         if (!forZone)
         {
-            ctr->output->setCustomClass(connectors::SCXTStyleSheetCreator::GroupMultiNamedPanel);
+            ctr->groupOut()->setCustomClass(
+                connectors::SCXTStyleSheetCreator::GroupMultiNamedPanel);
             ctr->groupMod()->setCustomClass(
                 connectors::SCXTStyleSheetCreator::GroupMultiNamedPanel);
             ctr->lfo->setCustomClass(connectors::SCXTStyleSheetCreator::GroupMultiNamedPanel);
@@ -164,7 +168,7 @@ void MultiScreen::layout()
         auto mw = modRect.getWidth() * 0.750;
         ctr->modComponent()->setBounds(modRect.withWidth(mw));
         auto xw = modRect.getWidth() * 0.250;
-        ctr->output->setBounds(modRect.withWidth(xw).translated(mw, 0));
+        ctr->outputComponent()->setBounds(modRect.withWidth(xw).translated(mw, 0));
 
         auto envRect =
             mainRect.withTrimmedTop(wavHeight + fxHeight + modHeight).withHeight(envHeight);
@@ -213,7 +217,7 @@ MultiScreen::ZoneOrGroupElements::~ZoneOrGroupElements() = default;
 
 void MultiScreen::ZoneOrGroupElements::setVisible(bool b)
 {
-    output->setVisible(b);
+    outputComponent()->setVisible(b);
     lfo->setVisible(b);
     modComponent()->setVisible(b);
     for (auto &e : eg)
@@ -229,6 +233,16 @@ juce::Component *MultiScreen::ZoneOrGroupElements::modComponent()
         return std::get<0>(modvariant).get();
     if (index == ZoneGroupIndex::GROUP)
         return std::get<1>(modvariant).get();
+    return nullptr;
+}
+
+juce::Component *MultiScreen::ZoneOrGroupElements::outputComponent()
+
+{
+    if (index == ZoneGroupIndex::ZONE)
+        return std::get<0>(outputvariant).get();
+    if (index == ZoneGroupIndex::GROUP)
+        return std::get<1>(outputvariant).get();
     return nullptr;
 }
 } // namespace scxt::ui

--- a/src-ui/components/MultiScreen.h
+++ b/src-ui/components/MultiScreen.h
@@ -40,7 +40,11 @@ namespace scxt::ui
 namespace multi
 {
 struct AdsrPane;
-struct OutputPane;
+
+struct OutPaneZoneTraits;
+struct OutPaneGroupTraits;
+template <typename T> struct OutputPane;
+
 struct PartGroupSidebar;
 struct MappingPane;
 
@@ -79,7 +83,9 @@ struct MultiScreen : juce::Component, HasEditor
         ZoneGroupIndex index;
         ZoneOrGroupElements(ZoneGroupIndex z);
         ~ZoneOrGroupElements();
-        std::unique_ptr<multi::OutputPane> output;
+        std::variant<std::unique_ptr<multi::OutputPane<multi::OutPaneZoneTraits>>,
+                     std::unique_ptr<multi::OutputPane<multi::OutPaneGroupTraits>>>
+            outputvariant;
         std::unique_ptr<multi::LfoPane> lfo;
         std::unique_ptr<multi::AdsrPane> eg[2];
         std::variant<std::unique_ptr<multi::ModPane<multi::ModPaneZoneTraits>>,
@@ -87,6 +93,7 @@ struct MultiScreen : juce::Component, HasEditor
             modvariant;
 
         juce::Component *modComponent();
+        juce::Component *outputComponent();
         const std::unique_ptr<multi::ModPane<multi::ModPaneZoneTraits>> &zoneMod()
         {
             assert(index == ZoneGroupIndex::ZONE);
@@ -98,6 +105,19 @@ struct MultiScreen : juce::Component, HasEditor
             assert(index == ZoneGroupIndex::GROUP);
             return std::get<1>(modvariant);
         }
+
+        const std::unique_ptr<multi::OutputPane<multi::OutPaneZoneTraits>> &zoneOut()
+        {
+            assert(index == ZoneGroupIndex::ZONE);
+            return std::get<0>(outputvariant);
+        }
+
+        const std::unique_ptr<multi::OutputPane<multi::OutPaneGroupTraits>> &groupOut()
+        {
+            assert(index == ZoneGroupIndex::GROUP);
+            return std::get<1>(outputvariant);
+        }
+
         std::unique_ptr<multi::ProcessorPane> processors[numProcessorDisplays];
 
         void setVisible(bool b);

--- a/src-ui/components/SCXTEditor.h
+++ b/src-ui/components/SCXTEditor.h
@@ -174,6 +174,7 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel,
 
     void onGroupOrZoneLfoUpdated(const scxt::messaging::client::indexedLfoUpdate_t &);
     void onZoneOutputInfoUpdated(const scxt::messaging::client::zoneOutputInfoUpdate_t &p);
+    void onGroupOutputInfoUpdated(const scxt::messaging::client::groupOutputInfoUpdate_t &p);
 
     void onGroupZoneMappingSummary(const scxt::engine::Part::zoneMappingSummary_t &);
     void onSelectionState(const scxt::messaging::client::selectedStateMessage_t &);

--- a/src-ui/components/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/components/SCXTEditorResponseHandlers.cpp
@@ -194,10 +194,20 @@ void SCXTEditor::onGroupOrZoneLfoUpdated(const scxt::messaging::client::indexedL
 void SCXTEditor::onZoneOutputInfoUpdated(const scxt::messaging::client::zoneOutputInfoUpdate_t &p)
 {
     auto [active, inf] = p;
-    multiScreen->getZoneElements()->output->setActive(active);
+    multiScreen->getZoneElements()->zoneOut()->setActive(active);
     if (active)
     {
-        multiScreen->getZoneElements()->output->setOutputData(inf);
+        multiScreen->getZoneElements()->zoneOut()->setOutputData(inf);
+    }
+}
+
+void SCXTEditor::onGroupOutputInfoUpdated(const scxt::messaging::client::groupOutputInfoUpdate_t &p)
+{
+    auto [active, inf] = p;
+    multiScreen->getGroupElements()->groupOut()->setActive(active);
+    if (active)
+    {
+        multiScreen->getGroupElements()->groupOut()->setOutputData(inf);
     }
 }
 

--- a/src-ui/components/multi/OutputPane.h
+++ b/src-ui/components/multi/OutputPane.h
@@ -31,20 +31,34 @@
 #include "sst/jucegui/components/NamedPanel.h"
 #include "components/HasEditor.h"
 #include "engine/zone.h"
+#include "engine/group.h"
 
 namespace scxt::ui::multi
 {
-struct OutputTab;
-struct OutputPane : sst::jucegui::components::NamedPanel, HasEditor
+
+struct OutPaneZoneTraits
+{
+    static constexpr bool forZone{true};
+    using info_t = engine::Zone::ZoneOutputInfo;
+};
+
+struct OutPaneGroupTraits
+{
+    static constexpr bool forZone{false};
+    using info_t = engine::Group::GroupOutputInfo;
+};
+template <typename OTTraits> struct OutputTab;
+
+template <typename OTTraits> struct OutputPane : sst::jucegui::components::NamedPanel, HasEditor
 {
     OutputPane(SCXTEditor *e);
     ~OutputPane();
 
     void resized() override;
     void setActive(bool);
-    void setOutputData(const engine::Zone::ZoneOutputInfo &);
+    void setOutputData(const typename OTTraits::info_t &);
 
-    std::unique_ptr<OutputTab> output;
+    std::unique_ptr<OutputTab<OTTraits>> output;
     std::unique_ptr<juce::Component> proc;
 };
 } // namespace scxt::ui::multi

--- a/src/engine/group.h
+++ b/src/engine/group.h
@@ -65,6 +65,7 @@ struct Group : MoveableOnly<Group>, HasGroupZoneProcessors<Group>, SampleRateSup
     {
         float amplitude{1.f}, pan{0.f};
         bool muted{false};
+        ProcRoutingPath procRouting{procRoute_linear};
         BusAddress routeTo{DEFAULT_BUS};
     } outputInfo;
 

--- a/src/engine/group_and_zone.h
+++ b/src/engine/group_and_zone.h
@@ -46,6 +46,18 @@ struct Engine;
 
 template <typename T> struct HasGroupZoneProcessors
 {
+    /*
+     * This enum is here but we put it in the output info structure of
+     * group and zone separately
+     */
+    enum ProcRoutingPath
+    {
+        procRoute_linear,
+        procRoute_bypass
+    };
+    DECLARE_ENUM_STRING(ProcRoutingPath);
+    std::string getProcRoutingPathDisplayName(ProcRoutingPath p);
+
     T *asT() { return static_cast<T *>(this); }
     static constexpr int processorCount{4};
     void setProcessorType(int whichProcessor, dsp::processor::ProcessorType type);

--- a/src/engine/group_and_zone_impl.h
+++ b/src/engine/group_and_zone_impl.h
@@ -114,4 +114,44 @@ void HasGroupZoneProcessors<T>::setupProcessorControlDescriptions(
         dsp::processor::unspawnProcessor(tmpProcessor);
 }
 
+template <typename T>
+std::string HasGroupZoneProcessors<T>::toStringProcRoutingPath(
+    const scxt::engine::HasGroupZoneProcessors<T>::ProcRoutingPath &p)
+{
+    switch (p)
+    {
+    case procRoute_linear:
+        return "procRoute_linear";
+    case procRoute_bypass:
+        return "procRoute_bypass";
+    }
+    return "procRoute_linear";
+}
+
+template <typename T>
+typename HasGroupZoneProcessors<T>::ProcRoutingPath
+HasGroupZoneProcessors<T>::fromStringProcRoutingPath(const std::string &s)
+{
+    static auto inverse =
+        makeEnumInverse<ProcRoutingPath, HasGroupZoneProcessors<T>::toStringProcRoutingPath>(
+            procRoute_linear, procRoute_bypass);
+    auto p = inverse.find(s);
+    if (p == inverse.end())
+        return procRoute_linear;
+    return p->second;
+}
+
+template <typename T>
+std::string HasGroupZoneProcessors<T>::getProcRoutingPathDisplayName(
+    scxt::engine::HasGroupZoneProcessors<T>::ProcRoutingPath p)
+{
+    switch (p)
+    {
+    case procRoute_linear:
+        return "Linear";
+    case procRoute_bypass:
+        return "Bypass";
+    }
+    return "ERROR";
+}
 } // namespace scxt::engine

--- a/src/engine/zone.h
+++ b/src/engine/zone.h
@@ -125,6 +125,7 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>
     {
         float amplitude{1.f}, pan{0.f};
         bool muted{false};
+        ProcRoutingPath procRouting{procRoute_linear};
         BusAddress routeTo{DEFAULT_BUS};
     } outputInfo;
 

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -143,6 +143,7 @@ template <> struct scxt_traits<scxt::engine::Group::GroupOutputInfo>
         v = {{"amplitude", t.amplitude},
              {"pan", t.pan},
              {"muted", t.muted},
+             {"procRouting", scxt::engine::Group::toStringProcRoutingPath(t.procRouting)},
              {"routeTo", (int)t.routeTo}};
     }
 
@@ -155,6 +156,9 @@ template <> struct scxt_traits<scxt::engine::Group::GroupOutputInfo>
         findIf(v, "pan", zo.pan);
         findIf(v, "muted", zo.muted);
         findIf(v, "routeTo", rt);
+        std::string tp;
+        findIf(v, "procRouting", tp);
+        zo.procRouting = scxt::engine::Group::fromStringProcRoutingPath(tp);
         zo.routeTo = (engine::BusAddress)(rt);
     }
 };
@@ -209,6 +213,7 @@ template <> struct scxt_traits<scxt::engine::Zone::ZoneOutputInfo>
         v = {{"amplitude", t.amplitude},
              {"pan", t.pan},
              {"muted", t.muted},
+             {"procRouting", scxt::engine::Zone::toStringProcRoutingPath(t.procRouting)},
              {"routeTo", (int)t.routeTo}};
     }
 
@@ -220,6 +225,10 @@ template <> struct scxt_traits<scxt::engine::Zone::ZoneOutputInfo>
         findIf(v, "pan", zo.pan);
         findIf(v, "muted", zo.muted);
         findIf(v, "routeTo", rt);
+        std::string tp;
+        findIf(v, "procRouting", tp);
+        zo.procRouting = scxt::engine::Zone::fromStringProcRoutingPath(tp);
+
         zo.routeTo = (engine::BusAddress)(rt);
     }
 };

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -100,6 +100,7 @@ enum SerializationToClientMessageIds
     s2c_update_group_matrix,
     s2c_update_group_or_zone_individual_lfo,
     s2c_update_zone_output_info,
+    s2c_update_group_output_info,
 
     s2c_respond_single_processor_metadata_and_data,
     s2c_notify_mismatched_processors_for_zone,

--- a/src/messaging/client/group_messages.h
+++ b/src/messaging/client/group_messages.h
@@ -34,5 +34,10 @@
 
 namespace scxt::messaging::client
 {
+
+using groupOutputInfoUpdate_t = std::pair<bool, engine::Group::GroupOutputInfo>;
+SERIAL_TO_CLIENT(GroupOutputInfoUpdated, s2c_update_group_output_info, groupOutputInfoUpdate_t,
+                 onGroupOutputInfoUpdated);
+
 } // namespace scxt::messaging::client
 #endif // SHORTCIRCUIT_GROUP_MESSAGES_H

--- a/src/messaging/client/zone_messages.h
+++ b/src/messaging/client/zone_messages.h
@@ -89,7 +89,6 @@ CLIENT_TO_SERIAL(SamplesSelectedZoneUpdateRequest, c2s_update_zone_samples,
 using zoneOutputInfoUpdate_t = std::pair<bool, engine::Zone::ZoneOutputInfo>;
 SERIAL_TO_CLIENT(ZoneOutputInfoUpdated, s2c_update_zone_output_info, zoneOutputInfoUpdate_t,
                  onZoneOutputInfoUpdated);
-
 } // namespace scxt::messaging::client
 
 #endif // SHORTCIRCUIT_ZONE_MESSAGES_H

--- a/src/selection/selection_manager.cpp
+++ b/src/selection/selection_manager.cpp
@@ -494,6 +494,10 @@ void SelectionManager::sendDisplayDataForNoZoneSelected()
 void SelectionManager::sendDisplayDataForSingleGroup(int part, int group)
 {
     const auto &g = engine.getPatch()->getPart(part)->getGroup(group);
+    serializationSendToClient(cms::s2c_update_group_output_info,
+                              cms::groupOutputInfoUpdate_t{true, g->outputInfo},
+                              *(engine.getMessageController()));
+
     for (int i = 0; i < engine::Group::egPerGroup; ++i)
     {
         serializationSendToClient(


### PR DESCRIPTION
Didn't quite get the knob on the screen but managed to get group and zone output info up to the client and the proper object model for both. Merge it just to keep current. Put the controls on the screen tomorrow (and maybe add a proc routing dropdown while i'm there)

Also add proc routing enum to the output infos
but don't use it for anything yet. Will get that tomorrow or saturday