### PR TITLE
Move Zone, Group and Bus output attenuators do db

### DIFF
--- a/src-ui/components/mixer/ChannelStrip.cpp
+++ b/src-ui/components/mixer/ChannelStrip.cpp
@@ -126,7 +126,7 @@ ChannelStrip::ChannelStrip(scxt::ui::SCXTEditor *e, MixerScreen *m, int bi, BusT
     setupWidgetForValueTooltip(panKnob, panAttachment);
 
     vcaAttachment = std::make_unique<attachment_t>(
-        datamodel::pmd().asPercent().withName("Level").withDefault(1.0), onChange,
+        datamodel::pmd().asCubicDecibelAttenuation().withName("Level").withDefault(1.0), onChange,
         mixer->busSendData[busIndex].level);
     vcaSlider = std::make_unique<jcmp::VSlider>();
     vcaSlider->setSource(vcaAttachment.get());

--- a/src-ui/components/multi/OutputPane.cpp
+++ b/src-ui/components/multi/OutputPane.cpp
@@ -79,7 +79,7 @@ template <typename OTTraits> struct OutputTab : juce::Component, HasEditor
     OutputTab(SCXTEditor *e, OutputPane<OTTraits> *p) : HasEditor(e), parent(p)
     {
         outputAttachment = std::make_unique<attachment_t>(
-            datamodel::pmd().asPercent().withName("Amplitude"), // FIXME - move to decibel
+            datamodel::pmd().asCubicDecibelAttenuation().withName("Amplitude"),
             [w = juce::Component::SafePointer(this)](const auto &at) {
                 if (w && w->parent)
                     w->outputChangedFromGUI(at);

--- a/src/engine/bus.cpp
+++ b/src/engine/bus.cpp
@@ -228,7 +228,8 @@ void Bus::process()
     }
     if (busSendStorage.level != 1.f)
     {
-        mech::scale_by<blockSize>(busSendStorage.level, output[0], output[1]);
+        auto lv = busSendStorage.level * busSendStorage.level * busSendStorage.level;
+        mech::scale_by<blockSize>(lv, output[0], output[1]);
     }
 
     if (busSendStorage.supportsSends && busSendStorage.hasSends &&

--- a/src/engine/group.cpp
+++ b/src/engine/group.cpp
@@ -137,7 +137,7 @@ void Group::process(Engine &e)
 
     // multiply by vca level from matrix
     auto mlev = modMatrix.getValue(modulation::gmd_grouplevel, 0);
-    outputAmp.set_target(mlev);
+    outputAmp.set_target(mlev * mlev * mlev);
     outputAmp.multiply_2_blocks(lOut, rOut);
 }
 

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -261,7 +261,7 @@ bool Voice::process()
     }
 
     auto pao = modMatrix.getValue(modulation::vmd_Zone_Output_Amplitude, 0);
-    outputAmp.set_target(pao);
+    outputAmp.set_target(pao * pao * pao);
     if (chainIsMono)
     {
         outputAmp.multiply_block(output[0]);


### PR DESCRIPTION
using the cubic-feels-like-a-good-db-distribution trick