### PR TITLE
Increase macos deployment target to 10.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_policy(SET CMP0091 NEW)
 cmake_policy(SET CMP0063 NEW)
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 # https://github.com/taocpp/PEGTL/issues/347 would let us go to 13
-set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13 CACHE STRING "Minimum macOS version")
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14 CACHE STRING "Minimum macOS version")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 


### PR DESCRIPTION
Required by the use of std::variant in ComponentBase.h (in sst::jucegui::components)