### PR TITLE
Restore the Channel Strip UI selection highlight

### DIFF
--- a/src-ui/components/MixerScreen.cpp
+++ b/src-ui/components/MixerScreen.cpp
@@ -110,7 +110,9 @@ void MixerScreen::selectBus(int index)
         p->rebuild();
     }
     for (const auto &b : busPane->channelStrips)
-        b->selected = false;
+    {
+        b->setSelected(false);
+    }
     busPane->channelStrips[index]->selected = true;
     repaint();
 }


### PR DESCRIPTION
This got lost in the buig stylesheet shuffle I did before breaking for surge 1.3