### PR TITLE
Group output routing now works also

### DIFF
--- a/src-ui/components/mixer/ChannelStrip.h
+++ b/src-ui/components/mixer/ChannelStrip.h
@@ -48,6 +48,8 @@ namespace scxt::ui::mixer
 struct ChannelStrip : public HasEditor, sst::jucegui::components::NamedPanel
 {
     using attachment_t = scxt::ui::connectors::PayloadDataAttachment<engine::Bus::BusSendStorage>;
+    using boolattachment_t =
+        scxt::ui::connectors::BooleanPayloadDataAttachment<engine::Bus::BusSendStorage>;
 
     MixerScreen *mixer{nullptr};
     int16_t busIndex{-1};
@@ -69,6 +71,7 @@ struct ChannelStrip : public HasEditor, sst::jucegui::components::NamedPanel
     std::array<std::unique_ptr<sst::jucegui::components::ToggleButton>,
                scxt::engine::Bus::maxEffectsPerBus>
         fxToggle;
+    std::array<std::unique_ptr<boolattachment_t>, scxt::engine::Bus::maxEffectsPerBus> fxToggleAtt;
 
     std::array<std::unique_ptr<sst::jucegui::components::HSlider>, scxt::numAux> auxSlider;
     std::array<std::unique_ptr<attachment_t>, scxt::numAux> auxAttachments;

--- a/src/engine/bus.cpp
+++ b/src/engine/bus.cpp
@@ -201,12 +201,14 @@ void Bus::process()
         busSendStorage.auxLocation == BusSendStorage::PRE_FX)
         memcpy(auxoutput, output, sizeof(output));
 
+    int idx{0};
     for (auto &fx : busEffects)
     {
-        if (fx)
+        if (fx && busEffectStorage[idx].isActive)
         {
             fx->process(output[0], output[1]);
         }
+        idx++;
     }
 
     if (busSendStorage.supportsSends && busSendStorage.hasSends &&

--- a/src/engine/bus.h
+++ b/src/engine/bus.h
@@ -80,6 +80,7 @@ struct BusEffectStorage
     BusEffectStorage() { std::fill(params.begin(), params.end(), 0.f); }
     static constexpr int maxBusEffectParams{12};
     AvailableBusEffects type{AvailableBusEffects::none};
+    bool isActive{true};
     std::array<float, maxBusEffectParams> params{};
 };
 struct BusEffect

--- a/src/engine/group.cpp
+++ b/src/engine/group.cpp
@@ -65,7 +65,6 @@ void Group::process(Engine &e)
     memset(output, 0, sizeof(output));
 
     // When we have alternate group routing we change these pointers
-    assert(outputInfo.routeTo == DEFAULT_BUS);
     float *lOut = output[0];
     float *rOut = output[1];
 
@@ -110,8 +109,16 @@ void Group::process(Engine &e)
         if (z->isActive())
         {
             z->process(e);
-            blk::accumulate_from_to<blockSize>(z->output[0], lOut);
-            blk::accumulate_from_to<blockSize>(z->output[1], rOut);
+            /*
+             * This is just an optimization to not accumulate. The zone will
+             * have already routed to the approprite other bus and output will
+             * be empty.
+             */
+            if (z->outputInfo.routeTo == DEFAULT_BUS)
+            {
+                blk::accumulate_from_to<blockSize>(z->output[0], lOut);
+                blk::accumulate_from_to<blockSize>(z->output[1], rOut);
+            }
         }
     }
 

--- a/src/engine/part.cpp
+++ b/src/engine/part.cpp
@@ -57,10 +57,10 @@ void Part::process(Engine &e)
             {
                 bi = (BusAddress)(MAIN_0 + partNumber);
             }
-            blk::accumulate_from_to<blockSize>(g->output[0],
-                                               e.getPatch()->busses.partBusses[bi].output[0]);
-            blk::accumulate_from_to<blockSize>(g->output[1],
-                                               e.getPatch()->busses.partBusses[bi].output[1]);
+            auto &obus = e.getPatch()->busses.busByAddress(bi);
+
+            blk::accumulate_from_to<blockSize>(g->output[0], obus.output[0]);
+            blk::accumulate_from_to<blockSize>(g->output[1], obus.output[1]);
         }
     }
 }

--- a/src/engine/part.cpp
+++ b/src/engine/part.cpp
@@ -55,7 +55,7 @@ void Part::process(Engine &e)
             auto bi = g->outputInfo.routeTo;
             if (bi == DEFAULT_BUS)
             {
-                bi = (BusAddress)(MAIN_0 + partNumber);
+                bi = (BusAddress)(PART_0 + partNumber);
             }
             auto &obus = e.getPatch()->busses.busByAddress(bi);
 

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -469,7 +469,9 @@ template <> struct scxt_traits<engine::BusEffectStorage>
     template <template <typename...> class Traits>
     static void assign(tao::json::basic_value<Traits> &v, const engine::BusEffectStorage &t)
     {
-        v = {{"type", scxt::engine::toStringAvailableBusEffects(t.type)}, {"params", t.params}};
+        v = {{"type", scxt::engine::toStringAvailableBusEffects(t.type)},
+             {"isActive", t.isActive},
+             {"params", t.params}};
     }
 
     template <template <typename...> class Traits>
@@ -479,6 +481,7 @@ template <> struct scxt_traits<engine::BusEffectStorage>
         findIf(v, "type", tp);
         r.type = scxt::engine::fromStringAvailableBusEffects(tp);
         findIf(v, "params", r.params);
+        findOrSet(v, "isActive", true, r.isActive);
     }
 };
 

--- a/src/messaging/client/mixer_messages.h
+++ b/src/messaging/client/mixer_messages.h
@@ -74,7 +74,7 @@ inline void setBusEffectStorage(const setBusEffectStorage_t &payload,
                                 messaging::MessageController &cont)
 {
     cont.scheduleAudioThreadCallback([p = payload](auto &e) {
-        auto [bus, fxslot, bes] = p;
+        const auto &[bus, fxslot, bes] = p;
         e.getPatch()->busses.busByAddress((engine::BusAddress)bus).busEffectStorage[fxslot] = bes;
     });
 }


### PR DESCRIPTION
So now zones and groups can be sent to any of the internal busses or still up their default hierarchy