### PR TITLE
Use the sst::basic_blocks 2^x table consistently

### DIFF
--- a/src/dsp/data_tables.cpp
+++ b/src/dsp/data_tables.cpp
@@ -32,4 +32,5 @@ namespace scxt::dsp
 {
 SincTable sincTable;
 DbTable dbTable;
+TwoToTheXTable twoToTheXTable;
 } // namespace scxt::dsp

--- a/src/dsp/data_tables.h
+++ b/src/dsp/data_tables.h
@@ -34,6 +34,7 @@
 
 #include "sst/basic-blocks/tables/SincTableProvider.h"
 #include "sst/basic-blocks/tables/DbToLinearProvider.h"
+#include "sst/basic-blocks/tables/TwoToTheXProvider.h"
 #include "resampling.h"
 
 namespace scxt::dsp
@@ -46,6 +47,9 @@ static_assert(dsp::FIRipolI16_N == SincTable::FIRipolI16_N);
 
 using DbTable = sst::basic_blocks::tables::DbToLinearProvider;
 extern DbTable dbTable;
+
+using TwoToTheXTable = sst::basic_blocks::tables::TwoToTheXProvider;
+extern TwoToTheXTable twoToTheXTable;
 } // namespace scxt::dsp
 
 #endif // __SCXT_DSP_SINC_TABLES_H

--- a/src/engine/bus.cpp
+++ b/src/engine/bus.cpp
@@ -86,7 +86,7 @@ struct Config
 
     static inline float envelopeRateLinear(GlobalStorage *s, float f)
     {
-        return s->getSampleRateInv() * pow(2.0, -f);
+        return blockSize * s->getSampleRateInv() * dsp::twoToTheXTable.twoToThe(-f);
     }
 
     static inline float temposyncRatio(GlobalStorage *s, EffectStorage *e, int idx) { return 1; }

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -62,6 +62,7 @@ Engine::Engine()
     messageController = std::make_unique<messaging::MessageController>(*this);
     dsp::sincTable.init();
     dsp::dbTable.init();
+    dsp::twoToTheXTable.init();
     tuning::equalTuning.init();
 
     sampleManager = std::make_unique<sample::SampleManager>(messageController->threadingChecker);

--- a/src/engine/group.h
+++ b/src/engine/group.h
@@ -163,10 +163,9 @@ struct Group : MoveableOnly<Group>, HasGroupZoneProcessors<Group>, SampleRateSup
     modulation::GroupModMatrix modMatrix;
     modulation::GroupModMatrix::routingTable_t &routingTable;
 
-    // TODO obviously this sucks move to a table. Also its copied in voice
     inline float envelope_rate_linear_nowrap(float f)
     {
-        return blockSize * sampleRateInv * pow(2.f, -f);
+        return blockSize * sampleRateInv * dsp::twoToTheXTable.twoToThe(-f);
     }
 
     bool anyModulatorUsed{false};

--- a/src/voice/voice.h
+++ b/src/voice/voice.h
@@ -77,10 +77,9 @@ struct alignas(16) Voice : MoveableOnly<Voice>, SampleRateSupport
         ahdsrenv_t;
     ahdsrenv_t aeg, eg2;
 
-    // TODO obviously this sucks move to a table. Also its copied in group
     inline float envelope_rate_linear_nowrap(float f)
     {
-        return blockSize * sampleRateInv * pow(2.f, -f);
+        return blockSize * sampleRateInv * dsp::twoToTheXTable.twoToThe(-f);
     }
 
     template <typename ET, int EB, typename ER>


### PR DESCRIPTION
to avoid all those pow calls. Closes #641