### PR TITLE
Mixer Aux Routing

### DIFF
--- a/src-ui/components/mixer/ChannelStrip.h
+++ b/src-ui/components/mixer/ChannelStrip.h
@@ -89,6 +89,7 @@ struct ChannelStrip : public HasEditor, sst::jucegui::components::NamedPanel
     std::unique_ptr<sst::jucegui::components::MenuButton> outputMenu;
 
     void mouseDown(const juce::MouseEvent &) override;
+    void showAuxRouting(int idx);
 
     void effectsChanged();
     float vuL{0.f}, vuR{0.f};

--- a/src/engine/bus.h
+++ b/src/engine/bus.h
@@ -107,7 +107,9 @@ struct Bus : MoveableOnly<Bus>, SampleRateSupport
     Bus(BusAddress a) : address(a) { assert(address != DEFAULT_BUS && address != ERROR_BUS); }
 
     float output alignas(16)[2][blockSize];
-    float auxoutput alignas(16)[2][blockSize];
+    float auxoutputPreFX alignas(16)[2][blockSize];
+    float auxoutputPreVCA alignas(16)[2][blockSize];
+    float auxoutputPostVCA alignas(16)[2][blockSize];
     float vuLevel[2]{0.f, 0.f}, vuFalloff{0.f};
 
     inline void clear() { memset(output, 0, sizeof(output)); }
@@ -143,7 +145,11 @@ struct Bus : MoveableOnly<Bus>, SampleRateSupport
 
     struct BusSendStorage
     {
-        BusSendStorage() { std::fill(sendLevels.begin(), sendLevels.end(), 0.f); }
+        BusSendStorage()
+        {
+            std::fill(sendLevels.begin(), sendLevels.end(), 0.f);
+            std::fill(auxLocation.begin(), auxLocation.end(), POST_VCA);
+        }
         bool hasSends{false};
         bool supportsSends{false};
 
@@ -152,7 +158,9 @@ struct Bus : MoveableOnly<Bus>, SampleRateSupport
             PRE_FX,
             POST_FX_PRE_VCA,
             POST_VCA
-        } auxLocation{POST_FX_PRE_VCA};
+        };
+        std::array<AuxLocation, maxSendsPerBus> auxLocation;
+        DECLARE_ENUM_STRING(AuxLocation);
 
         // Send levels in 0...1 scale to each bus
         std::array<float, maxSendsPerBus> sendLevels{};

--- a/src/engine/patch.cpp
+++ b/src/engine/patch.cpp
@@ -59,9 +59,27 @@ void Patch::process(Engine &e)
             {
                 if (b.busSendStorage.sendLevels[i] != 0.f)
                 {
-                    mech::scale_accumulate_from_to<blockSize>(
-                        b.auxoutput[0], b.auxoutput[1], b.busSendStorage.sendLevels[i],
-                        busses.auxBusses[i].output[0], busses.auxBusses[i].output[1]);
+                    switch (b.busSendStorage.auxLocation[i])
+                    {
+                    case Bus::BusSendStorage::PRE_FX:
+                        mech::scale_accumulate_from_to<blockSize>(
+                            b.auxoutputPreFX[0], b.auxoutputPreFX[1],
+                            b.busSendStorage.sendLevels[i], busses.auxBusses[i].output[0],
+                            busses.auxBusses[i].output[1]);
+                        break;
+                    case Bus::BusSendStorage::POST_FX_PRE_VCA:
+                        mech::scale_accumulate_from_to<blockSize>(
+                            b.auxoutputPreVCA[0], b.auxoutputPreVCA[1],
+                            b.busSendStorage.sendLevels[i], busses.auxBusses[i].output[0],
+                            busses.auxBusses[i].output[1]);
+                        break;
+                    case Bus::BusSendStorage::POST_VCA:
+                        mech::scale_accumulate_from_to<blockSize>(
+                            b.auxoutputPostVCA[0], b.auxoutputPostVCA[1],
+                            b.busSendStorage.sendLevels[i], busses.auxBusses[i].output[0],
+                            busses.auxBusses[i].output[1]);
+                        break;
+                    }
                 }
             }
         }

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -430,19 +430,18 @@ template <> struct scxt_traits<engine::Bus>
     }
 };
 
+STREAM_ENUM(engine::Bus::BusSendStorage::AuxLocation,
+            engine::Bus::BusSendStorage::toStringAuxLocation,
+            engine::Bus::BusSendStorage::fromStringAuxLocation)
+
 template <> struct scxt_traits<engine::Bus::BusSendStorage>
 {
     template <template <typename...> class Traits>
     static void assign(tao::json::basic_value<Traits> &v, const engine::Bus::BusSendStorage &t)
     {
-        // TODO
-        if (t.auxLocation != engine::Bus::BusSendStorage::POST_FX_PRE_VCA)
-        {
-            SCLOG("Stream Aux Location as String please");
-        }
         v = {
             {"supportsSends", t.supportsSends},
-            {"auxLocation", (int)t.auxLocation},
+            {"auxLocation", t.auxLocation},
             {"sendLevels", t.sendLevels},
             {"level", t.level},
             {"mute", t.mute},
@@ -455,7 +454,7 @@ template <> struct scxt_traits<engine::Bus::BusSendStorage>
     static void to(const tao::json::basic_value<Traits> &v, engine::Bus::BusSendStorage &r)
     {
         findIf(v, "supportsSends", r.supportsSends);
-        findEnumIf(v, "auxLocation", r.auxLocation);
+        findIf(v, "auxLocation", r.auxLocation);
         findIf(v, "sendLevels", r.sendLevels);
         findIf(v, "level", r.level);
         findIf(v, "mute", r.mute);


### PR DESCRIPTION
Mixer Aux Routing can be pre-fx, post-fx-pre-vca or post-vca. Implement the engine andui to allow this choice in the mixer.

Addresses #462