### PR TITLE
Towards full plugin output usage. Stereo fix

### DIFF
--- a/clients/clap-first/scxt-plugin/scxt-plugin.cpp
+++ b/clients/clap-first/scxt-plugin/scxt-plugin.cpp
@@ -122,7 +122,7 @@ uint32_t SCXTPlugin::audioPortsCount(bool isInput) const noexcept
     if (isInput)
         return 0;
     else
-        return maxOutputs;
+        return numPluginOutputs;
 }
 bool SCXTPlugin::audioPortsInfo(uint32_t index, bool isInput,
                                 clap_audio_port_info *info) const noexcept
@@ -139,20 +139,11 @@ bool SCXTPlugin::audioPortsInfo(uint32_t index, bool isInput,
         info->channel_count = 2;
         info->port_type = CLAP_PORT_STEREO;
     }
-    else if (index < numParts + 1)
+    else if (index < numPluginOutputs)
     {
         info->id = 1000 + index - 1;
         info->in_place_pair = CLAP_INVALID_ID;
         snprintf(info->name, sizeof(info->name) - 1, "Output %02d", index);
-        info->flags = 0;
-        info->channel_count = 2;
-        info->port_type = CLAP_PORT_STEREO;
-    }
-    else
-    {
-        info->id = 2000 + index - numParts - 1;
-        info->in_place_pair = CLAP_INVALID_ID;
-        snprintf(info->name, sizeof(info->name) - 1, "Aux %02d", index - numParts - 1);
         info->flags = 0;
         info->channel_count = 2;
         info->port_type = CLAP_PORT_STEREO;

--- a/clients/juce-plugin/SCXTProcessor.cpp
+++ b/clients/juce-plugin/SCXTProcessor.cpp
@@ -195,10 +195,6 @@ void SCXTProcessor::processBlock(juce::AudioBuffer<float> &buffer, juce::MidiBuf
     if (activeBusCount == 0)
         return;
 
-    // assert(activeBusCount == 1);
-    if (activeBusCount > 1)
-        activeBusCount = 1;
-
     for (int i = 0; i < buffer.getNumSamples(); i++)
     {
         while (i == nextMidi)
@@ -220,6 +216,9 @@ void SCXTProcessor::processBlock(juce::AudioBuffer<float> &buffer, juce::MidiBuf
 
         for (int bus = 0; bus < activeBusCount; bus++)
         {
+            if (!engine->getPatch()->usesOutputBus(bus))
+                continue;
+
             auto iob = getBusBuffer(buffer, false, bus);
 
             auto outL = iob.getWritePointer(0, i);
@@ -227,15 +226,8 @@ void SCXTProcessor::processBlock(juce::AudioBuffer<float> &buffer, juce::MidiBuf
 
             if (outL && outR)
             {
-                if (bus == 0)
-                {
-                    *outL = engine->getPatch()->busses.mainBus.output[0][blockPos];
-                    *outR = engine->getPatch()->busses.mainBus.output[1][blockPos];
-                }
-                else
-                {
-                    assert(false);
-                }
+                *outL = engine->getPatch()->busses.mainBus.output[0][blockPos];
+                *outR = engine->getPatch()->busses.mainBus.output[1][blockPos];
             }
         }
 

--- a/src-ui/components/mixer/ChannelStrip.cpp
+++ b/src-ui/components/mixer/ChannelStrip.cpp
@@ -169,11 +169,11 @@ ChannelStrip::ChannelStrip(scxt::ui::SCXTEditor *e, MixerScreen *m, int bi, BusT
 
         addAndMakeVisible(*muteButton);
         addAndMakeVisible(*soloButton);
-    }
 
-    outputMenu = std::make_unique<jcmp::MenuButton>();
-    outputMenu->setLabel("OUTPUT");
-    addAndMakeVisible(*outputMenu);
+        outputMenu = std::make_unique<jcmp::MenuButton>();
+        outputMenu->setLabel("MAIN");
+        addAndMakeVisible(*outputMenu);
+    }
 
     vuMeter = std::make_unique<jcmp::VUMeter>();
     addAndMakeVisible(*vuMeter);
@@ -251,8 +251,11 @@ void ChannelStrip::resized()
                   .reduced(1);
     vuMeter->setBounds(vs);
 
-    fx = fx.translated(0, sliderVUHeight + fxheight / 2);
-    outputMenu->setBounds(fx);
+    if (type != BusType::MAIN)
+    {
+        fx = fx.translated(0, sliderVUHeight + fxheight / 2);
+        outputMenu->setBounds(fx);
+    }
 }
 
 void ChannelStrip::effectsChanged()

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -43,6 +43,9 @@ static constexpr uint16_t mainOutput{0};
 static constexpr uint16_t firstPartOutput{1};
 static constexpr uint16_t firstAuxOutput{firstPartOutput + numParts};
 
+static constexpr uint16_t numNonMainPluginOutputs{20};
+static constexpr uint16_t numPluginOutputs{numNonMainPluginOutputs + 1};
+
 static constexpr uint16_t maxVoices{256};
 
 // some battles are not worth it

--- a/src/engine/bus.h
+++ b/src/engine/bus.h
@@ -170,6 +170,8 @@ struct Bus : MoveableOnly<Bus>, SampleRateSupport
         bool solo{false};
         float pan{0.f};
         float level{1.f};
+
+        uint16_t pluginOutputBus{0};
     } busSendStorage;
 
     bool mutedDueToSoloAway{false};

--- a/src/engine/patch.h
+++ b/src/engine/patch.h
@@ -60,6 +60,8 @@ struct Patch : MoveableOnly<Patch>, SampleRateSupport
                 p.address = (BusAddress)adr;
                 adr++;
             }
+            reconfigureSolo();
+            reconfigureOutputBusses();
         }
 
         inline void clear()
@@ -133,6 +135,14 @@ struct Patch : MoveableOnly<Patch>, SampleRateSupport
                 b.mutedDueToSoloAway = anySolo && !b.busSendStorage.solo;
             }
         }
+
+        void reconfigureOutputBusses()
+        {
+            for (auto &u : usesOutput)
+                u = false;
+            usesOutput[0] = true;
+        }
+        std::array<bool, numPluginOutputs> usesOutput{};
     } busses;
 
     void process(Engine &e);
@@ -150,6 +160,7 @@ struct Patch : MoveableOnly<Patch>, SampleRateSupport
         }
     }
 
+    bool usesOutputBus(int bus) { return busses.usesOutput[bus]; }
     void setupBussesOnUnstream(Engine &e);
     PatchID id;
     uint64_t streamingVersion{0}; // we use hex dates for these

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -439,15 +439,14 @@ template <> struct scxt_traits<engine::Bus::BusSendStorage>
     template <template <typename...> class Traits>
     static void assign(tao::json::basic_value<Traits> &v, const engine::Bus::BusSendStorage &t)
     {
-        v = {
-            {"supportsSends", t.supportsSends},
-            {"auxLocation", t.auxLocation},
-            {"sendLevels", t.sendLevels},
-            {"level", t.level},
-            {"mute", t.mute},
-            {"solo", t.solo},
-            {"pan", t.pan},
-        };
+        v = {{"supportsSends", t.supportsSends},
+             {"auxLocation", t.auxLocation},
+             {"sendLevels", t.sendLevels},
+             {"level", t.level},
+             {"mute", t.mute},
+             {"solo", t.solo},
+             {"pan", t.pan},
+             {"pluginOutputBus", t.pluginOutputBus}};
     }
 
     template <template <typename...> class Traits>
@@ -460,6 +459,7 @@ template <> struct scxt_traits<engine::Bus::BusSendStorage>
         findIf(v, "mute", r.mute);
         findIf(v, "solo", r.solo);
         findIf(v, "pan", r.pan);
+        findIf(v, "pluginOutputBus", r.pluginOutputBus);
     }
 };
 
@@ -507,6 +507,7 @@ template <> struct scxt_traits<engine::Patch::Busses>
         findIf(v, "auxToVSTRouting", r.auxToVSTRouting);
 
         r.reconfigureSolo();
+        r.reconfigureOutputBusses();
     }
 };
 } // namespace scxt::json

--- a/src/utils.h
+++ b/src/utils.h
@@ -241,9 +241,9 @@ std::string logTimestamp();
 #define SCLOG(...)                                                                                 \
     {                                                                                              \
         std::ostringstream oss_macr;                                                               \
-        oss_macr << __FILE__ << ":" << __LINE__ << " [" << logTimestamp() << "] " << __VA_ARGS__   \
-                 << "\n";                                                                          \
-        postToLog(oss_macr.str());                                                                 \
+        oss_macr << __FILE__ << ":" << __LINE__ << " [" << scxt::logTimestamp() << "] "            \
+                 << __VA_ARGS__ << "\n";                                                           \
+        scxt::postToLog(oss_macr.str());                                                           \
     }
 
 #define SCLOG_ONCE(...)                                                                            \
@@ -252,9 +252,9 @@ std::string logTimestamp();
         if (!x842132)                                                                              \
         {                                                                                          \
             std::ostringstream oss_macr;                                                           \
-            oss_macr << __FILE__ << ":" << __LINE__ << " [" << logTimestamp() << "] "              \
+            oss_macr << __FILE__ << ":" << __LINE__ << " [" << scxt::logTimestamp() << "] "        \
                      << __VA_ARGS__ << " (Message will only appear once)\n";                       \
-            postToLog(oss_macr.str());                                                             \
+            scxt::postToLog(oss_macr.str());                                                       \
         }                                                                                          \
         x842132 = true;                                                                            \
     }


### PR DESCRIPTION
The aux and part channels can optionally route to
non-main output. This is the start of that code but since it fixes a silly stereo bug, I want to commit it ahead of the full feature.