### PR TITLE
Misc Processor, Pipeline, Juce Bus fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,28 @@ variables:
   - group: mac-signing
 
 jobs:
+  - job: BuildCodeQuality
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    pool:
+      vmImage: 'ubuntu-20.04'
+
+    steps:
+      - checkout: self
+        fetchDepth: 1
+        # submodules: recursive # can't do submodules here b'cuz depth=1 fails with Github
+
+      - bash: |
+          mkdir ignore
+          pushd ignore
+          git clone https://github.com/jidicula/clang-format-action
+          popd
+          ./ignore/clang-format-action/check.sh 16 src llvm
+          ./ignore/clang-format-action/check.sh 16 src-ui llvm
+          ./ignore/clang-format-action/check.sh 16 tests llvm
+          ./ignore/clang-format-action/check.sh 16 clients llvm
+
+        displayName: Do Codequal
+
   - job: PRBuild
     condition: eq(variables['Build.Reason'], 'PullRequest')
     strategy:
@@ -50,7 +72,6 @@ jobs:
         lin:
           imageName: 'ubuntu-latest'
           isLinux: True
-          isCodeQual: True
           scxtTarget: scxt_plugin_Standalone
           cmakeArgs:
         lin-clap-first:
@@ -117,11 +138,6 @@ jobs:
           echo cmake -Bbuild -DCMAKE_BUILD_TYPE=Debug $(cmakeArgs)
           cmake -Bbuild -DAZURE_PIPELINE=1 -DCMAKE_BUILD_TYPE=Debug -DSCXT_COPY_PLUGIN_AFTER_BUILD=FALSE $(cmakeArgs)
         displayName: Run CMake (Debug)
-
-      - bash: |
-          cmake --build build --config Debug --target scxt-code-checks --parallel 4
-        displayName: Code Checks
-        condition: variables.isCodeQual
 
       - bash: |
           cmake --build build --config Debug --target $(scxtTarget) --parallel 4

--- a/clients/juce-plugin/SCXTProcessor.cpp
+++ b/clients/juce-plugin/SCXTProcessor.cpp
@@ -228,9 +228,6 @@ void SCXTProcessor::processBlock(juce::AudioBuffer<float> &buffer, juce::MidiBuf
         }
         for (int bus = 1; bus < activeBusCount; bus++)
         {
-            if (!engine->getPatch()->usesOutputBus(bus))
-                continue;
-
             auto iob = getBusBuffer(buffer, false, bus);
 
             auto outL = iob.getWritePointer(0, i);
@@ -238,8 +235,16 @@ void SCXTProcessor::processBlock(juce::AudioBuffer<float> &buffer, juce::MidiBuf
 
             if (outL && outR)
             {
-                *outL = engine->getPatch()->busses.pluginNonMainOutputs[bus - 1][0][blockPos];
-                *outR = engine->getPatch()->busses.pluginNonMainOutputs[bus - 1][1][blockPos];
+                if (!engine->getPatch()->usesOutputBus(bus))
+                {
+                    *outL = 0.f;
+                    *outR = 0.f;
+                }
+                else
+                {
+                    *outL = engine->getPatch()->busses.pluginNonMainOutputs[bus - 1][0][blockPos];
+                    *outR = engine->getPatch()->busses.pluginNonMainOutputs[bus - 1][1][blockPos];
+                }
             }
         }
 


### PR DESCRIPTION
1. Init extra busses to 0 if unused in juce too
2. Don't mono mono it's not right. Closes #678
3. either monoStereo or monoMono or neither but not both
4. Update sst-effects to init values into waveshaper
5. Move clang format job to CLF docker / 16