### PR TITLE
Don't stream blank zones samples, processors, or effects

### DIFF
--- a/src/json/dsp_traits.h
+++ b/src/json/dsp_traits.h
@@ -44,11 +44,18 @@ template <> struct scxt_traits<scxt::dsp::processor::ProcessorStorage>
     static void assign(tao::json::basic_value<Traits> &v,
                        const scxt::dsp::processor::ProcessorStorage &t)
     {
-        v = {{"type", scxt::dsp::processor::getProcessorStreamingName(t.type)},
-             {"mix", t.mix},
-             {"floatParams", t.floatParams},
-             {"intParams", t.intParams},
-             {"isActive", t.isActive}};
+        if (t.type == dsp::processor::proct_none)
+        {
+            v = {{"type", scxt::dsp::processor::getProcessorStreamingName(t.type)}};
+        }
+        else
+        {
+            v = {{"type", scxt::dsp::processor::getProcessorStreamingName(t.type)},
+                 {"mix", t.mix},
+                 {"floatParams", t.floatParams},
+                 {"intParams", t.intParams},
+                 {"isActive", t.isActive}};
+        }
     }
 
     template <template <typename...> class Traits>
@@ -65,10 +72,18 @@ template <> struct scxt_traits<scxt::dsp::processor::ProcessorStorage>
         else
             result.type = scxt::dsp::processor::proct_none;
 
-        findIf(v, "mix", result.mix);
-        findIf(v, "floatParams", result.floatParams);
-        findIf(v, "intParams", result.intParams);
-        findOrSet(v, "isActive", false, result.isActive);
+        if (result.type == dsp::processor::proct_none)
+        {
+            result = scxt::dsp::processor::ProcessorStorage();
+            result.type = dsp::processor::proct_none;
+        }
+        else
+        {
+            findIf(v, "mix", result.mix);
+            findIf(v, "floatParams", result.floatParams);
+            findIf(v, "intParams", result.intParams);
+            findOrSet(v, "isActive", false, result.isActive);
+        }
     }
 };
 

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -282,37 +282,53 @@ template <> struct scxt_traits<scxt::engine::Zone::AssociatedSample>
     static void assign(tao::json::basic_value<Traits> &v,
                        const scxt::engine::Zone::AssociatedSample &s)
     {
-        v = {{"active", s.active},
-             {"id", s.sampleID},
-             {"startSample", s.startSample},
-             {"endSample", s.endSample},
-             {"startLoop", s.startLoop},
-             {"endLoop", s.endLoop},
-             {"playMode", s.playMode},
-             {"loopActive", s.loopActive},
-             {"playReverse", s.playReverse},
-             {"loopMode", s.loopMode},
-             {"loopDirection", s.loopDirection},
-             {"loopCountWhenCounted", s.loopCountWhenCounted},
-             {"loopFade", s.loopFade}};
+        if (s.active)
+        {
+            v = {{"active", s.active},
+                 {"id", s.sampleID},
+                 {"startSample", s.startSample},
+                 {"endSample", s.endSample},
+                 {"startLoop", s.startLoop},
+                 {"endLoop", s.endLoop},
+                 {"playMode", s.playMode},
+                 {"loopActive", s.loopActive},
+                 {"playReverse", s.playReverse},
+                 {"loopMode", s.loopMode},
+                 {"loopDirection", s.loopDirection},
+                 {"loopCountWhenCounted", s.loopCountWhenCounted},
+                 {"loopFade", s.loopFade}};
+        }
+        else
+        {
+            v = {{"active", s.active}};
+        }
     }
 
     template <template <typename...> class Traits>
     static void to(const tao::json::basic_value<Traits> &v, scxt::engine::Zone::AssociatedSample &s)
     {
         findOrSet(v, "active", false, s.active);
-        findIf(v, "id", s.sampleID);
-        findOrSet(v, "startSample", -1, s.startSample);
-        findOrSet(v, "endSample", -1, s.endSample);
-        findOrSet(v, "startLoop", -1, s.startLoop);
-        findOrSet(v, "endLoop", -1, s.endLoop);
-        findOrSet(v, "playMode", engine::Zone::PlayMode::NORMAL, s.playMode);
-        findOrSet(v, "loopActive", false, s.loopActive);
-        findOrSet(v, "playReverse", false, s.playReverse);
-        findOrSet(v, "loopMode", engine::Zone::LoopMode::LOOP_DURING_VOICE, s.loopMode);
-        findOrSet(v, "loopDirection", engine::Zone::LoopDirection::FORWARD_ONLY, s.loopDirection);
-        findOrSet(v, "loopFade", 0, s.loopFade);
-        findOrSet(v, "loopCountWhenCounted", 0, s.loopCountWhenCounted);
+        if (s.active)
+        {
+            findIf(v, "id", s.sampleID);
+            findOrSet(v, "startSample", -1, s.startSample);
+            findOrSet(v, "endSample", -1, s.endSample);
+            findOrSet(v, "startLoop", -1, s.startLoop);
+            findOrSet(v, "endLoop", -1, s.endLoop);
+            findOrSet(v, "playMode", engine::Zone::PlayMode::NORMAL, s.playMode);
+            findOrSet(v, "loopActive", false, s.loopActive);
+            findOrSet(v, "playReverse", false, s.playReverse);
+            findOrSet(v, "loopMode", engine::Zone::LoopMode::LOOP_DURING_VOICE, s.loopMode);
+            findOrSet(v, "loopDirection", engine::Zone::LoopDirection::FORWARD_ONLY,
+                      s.loopDirection);
+            findOrSet(v, "loopFade", 0, s.loopFade);
+            findOrSet(v, "loopCountWhenCounted", 0, s.loopCountWhenCounted);
+        }
+        else
+        {
+            s = scxt::engine::Zone::AssociatedSample();
+            assert(!s.active);
+        }
     }
 };
 
@@ -468,9 +484,16 @@ template <> struct scxt_traits<engine::BusEffectStorage>
     template <template <typename...> class Traits>
     static void assign(tao::json::basic_value<Traits> &v, const engine::BusEffectStorage &t)
     {
-        v = {{"type", scxt::engine::toStringAvailableBusEffects(t.type)},
-             {"isActive", t.isActive},
-             {"params", t.params}};
+        if (t.type == scxt::engine::AvailableBusEffects::none)
+        {
+            v = {{"type", scxt::engine::toStringAvailableBusEffects(t.type)}};
+        }
+        else
+        {
+            v = {{"type", scxt::engine::toStringAvailableBusEffects(t.type)},
+                 {"isActive", t.isActive},
+                 {"params", t.params}};
+        }
     }
 
     template <template <typename...> class Traits>
@@ -479,8 +502,16 @@ template <> struct scxt_traits<engine::BusEffectStorage>
         std::string tp;
         findIf(v, "type", tp);
         r.type = scxt::engine::fromStringAvailableBusEffects(tp);
-        findIf(v, "params", r.params);
-        findOrSet(v, "isActive", true, r.isActive);
+        if (r.type == engine::AvailableBusEffects::none)
+        {
+            r = engine::BusEffectStorage();
+            r.type = engine::AvailableBusEffects::none;
+        }
+        else
+        {
+            findIf(v, "params", r.params);
+            findOrSet(v, "isActive", true, r.isActive);
+        }
     }
 };
 


### PR DESCRIPTION
A zone sample with no sample assigned, a processor with type proct_none or an effect with type AvailableBusEffects::none don't need to stream their parameters and so forth since they are unused. From looking at the json, and having fixed length data structures for these elements, this resulted in us havnig a lot of streaming we didn't need. So remediate

Closes #682