### PR TITLE
Make selection state consistent on delete

### DIFF
--- a/src/selection/selection_manager.h
+++ b/src/selection/selection_manager.h
@@ -150,6 +150,7 @@ struct SelectionManager
 
     void selectAction(const SelectActionContents &z);
     void multiSelectAction(const std::vector<SelectActionContents> &v);
+    void guaranteeConsistencyAfterDeletes(const engine::Engine &);
 
   protected:
     void adjustInternalStateForAction(const SelectActionContents &);


### PR DESCRIPTION
If you deleted a selected item, the selection manager was not consistent. That would make things seem very wonky. So fix that up some.

Closes #677