### PR TITLE
OneShot moves to correct storage location

### DIFF
--- a/src-ui/components/multi/LFOPane.cpp
+++ b/src-ui/components/multi/LFOPane.cpp
@@ -207,6 +207,13 @@ struct StepLFOPane : juce::Component
         cycleB->setCustomClass(connectors::SCXTStyleSheetCreator::ModulationMatrixToggle);
         addAndMakeVisible(*cycleB);
 
+        oneshotA = std::make_unique<LfoPane::boolAttachment_t>("OneShot", update(), ls.oneShot);
+        oneshotB = std::make_unique<jcmp::ToggleButton>();
+        oneshotB->setSource(oneshotA.get());
+        oneshotB->setCustomClass(connectors::SCXTStyleSheetCreator::ModulationMatrixToggle);
+        oneshotB->setLabel("ONE SHOT");
+        addAndMakeVisible(*oneshotB);
+
         rateA = std::make_unique<attachment_t>(datamodel::lfoModulationRate().withName("Rate"),
                                                update(), ms.rate);
         auto mk = [this](auto &a, auto b) {
@@ -307,7 +314,8 @@ struct StepLFOPane : juce::Component
     std::unique_ptr<jcmp::JogUpDownButton> stepsJ;
 
     std::unique_ptr<LfoPane::boolBaseAttachment_t> cycleA;
-    std::unique_ptr<jcmp::ToggleButton> cycleB;
+    std::unique_ptr<LfoPane::boolAttachment_t> oneshotA;
+    std::unique_ptr<jcmp::ToggleButton> cycleB, oneshotB;
 
     std::array<std::unique_ptr<sst::jucegui::components::GlyphButton>, 4> jog;
 
@@ -321,11 +329,15 @@ struct StepLFOPane : juce::Component
         auto knobw = knobReg - 16;
         auto bot = b.withTrimmedTop(b.getHeight() - knobReg);
 
-        auto jx = bot.withWidth(knobw * 2 - mg).withHeight(20);
+        auto menht = 17;
+        auto jx = bot.withWidth(knobw * 2 - mg).withHeight(menht);
         stepsJ->setBounds(jx);
 
-        jx = jx.translated(0, 20 + mg);
+        jx = jx.translated(0, menht + mg);
         cycleB->setBounds(jx);
+
+        jx = jx.translated(0, menht + mg);
+        oneshotB->setBounds(jx);
 
         auto bx = bot.withWidth(knobw).translated(knobw * 2 + mg, 0);
         rateK->setBounds(bx.withHeight(knobw));
@@ -505,13 +517,12 @@ void LfoPane::rebuildPanelComponents()
             .asInt()
             .withName("Trigger")
             .withRange(modulation::ModulatorStorage::KEYTRIGGER,
-                       modulation::ModulatorStorage::ONESHOT)
+                       modulation::ModulatorStorage::RELEASE)
             .withUnorderedMapFormatting({
                 {modulation::ModulatorStorage::KEYTRIGGER, "KEYTRIG"},
                 {modulation::ModulatorStorage::FREERUN, "FREERUN"},
                 {modulation::ModulatorStorage::RANDOM, "RANDOM"},
                 {modulation::ModulatorStorage::RELEASE, "RELEASE"},
-                {modulation::ModulatorStorage::ONESHOT, "ONESHOT"},
             }),
         updateNoTT(), ms.triggerMode);
     triggerMode = std::make_unique<jcmp::MultiSwitch>();
@@ -572,7 +583,7 @@ void LfoPane::repositionContentAreaComponents()
     auto mg = 5;
 
     modulatorShape->setBounds(0, 0, wd, ht);
-    triggerMode->setBounds(0, ht + mg, wd, 5 * ht);
+    triggerMode->setBounds(0, ht + mg, wd, 4 * ht);
     auto paneArea = getContentArea().withX(0).withTrimmedLeft(wd + mg).withY(0);
     stepLfoPane->setBounds(paneArea);
     msegLfoPane->setBounds(paneArea);

--- a/src-ui/components/multi/LFOPane.h
+++ b/src-ui/components/multi/LFOPane.h
@@ -62,6 +62,7 @@ struct LfoPane : sst::jucegui::components::NamedPanel, HasEditor
     typedef connectors::DiscretePayloadDataAttachment<modulation::ModulatorStorage> intAttachment_t;
     typedef connectors::DiscretePayloadDataAttachment<modulation::ModulatorStorage, bool>
         boolBaseAttachment_t;
+    typedef connectors::BooleanPayloadDataAttachment<modulation::ModulatorStorage> boolAttachment_t;
 
     LfoPane(SCXTEditor *, bool forZone);
     ~LfoPane();

--- a/src-ui/connectors/SCXTStyleSheetCreator.cpp
+++ b/src-ui/connectors/SCXTStyleSheetCreator.cpp
@@ -76,6 +76,8 @@ void SCXTStyleSheetCreator::makeDarkColors(const sheet_t::ptr_t &base)
 
     base->setColour(ModulationMatrixToggle, comp::ToggleButton::Styles::value,
                     juce::Colour(0x27, 0x88, 0xD6));
+    base->setColour(ModulationMatrixToggle, comp::ToggleButton::Styles::value_hover,
+                    juce::Colour(0x27, 0x88, 0xD6).brighter(0.4));
 
     // TODO - do hvoer
     base->setColour(InformationLabel, comp::base_styles::BaseLabel::labelcolor,

--- a/src/json/modulation_traits.h
+++ b/src/json/modulation_traits.h
@@ -200,6 +200,7 @@ template <> struct scxt_traits<scxt::modulation::modulators::StepLFOStorage>
         v = {{"data", t.data},
              {"repeat", t.repeat},
              {"rateIsEntireCycle", t.rateIsEntireCycle},
+             {"oneShot", t.oneShot},
              {"smooth", t.smooth}};
     }
 
@@ -210,6 +211,7 @@ template <> struct scxt_traits<scxt::modulation::modulators::StepLFOStorage>
         findIf(v, "data", result.data);
         findIf(v, "repeat", result.repeat);
         findIf(v, "smooth", result.smooth);
+        findIf(v, "oneShot", result.oneShot);
         findIf(v, "rateIsEntireCycle", result.rateIsEntireCycle);
     }
 };

--- a/src/modulation/modulator_storage.cpp
+++ b/src/modulation/modulator_storage.cpp
@@ -77,8 +77,6 @@ ModulatorStorage::toStringTriggerMode(const scxt::modulation::ModulatorStorage::
         return "rnd";
     case RELEASE:
         return "rel";
-    case ONESHOT:
-        return "one";
     }
     return "ERROR";
 }
@@ -87,7 +85,7 @@ ModulatorStorage::TriggerMode ModulatorStorage::fromStringTriggerMode(const std:
 {
     static auto inverse =
         makeEnumInverse<ModulatorStorage::TriggerMode, ModulatorStorage::toStringTriggerMode>(
-            TriggerMode::KEYTRIGGER, TriggerMode::ONESHOT);
+            TriggerMode::KEYTRIGGER, TriggerMode::RELEASE);
     auto p = inverse.find(s);
     if (p == inverse.end())
         return KEYTRIGGER;

--- a/src/modulation/modulator_storage.h
+++ b/src/modulation/modulator_storage.h
@@ -48,6 +48,7 @@ struct StepLFOStorage
 
     float smooth{0.f};
     bool rateIsEntireCycle{false};
+    bool oneShot{false};
 };
 
 struct CurveLFOStorage
@@ -79,8 +80,7 @@ struct ModulatorStorage
         KEYTRIGGER,
         FREERUN,
         RANDOM,
-        RELEASE,
-        ONESHOT
+        RELEASE
     } triggerMode{TriggerMode::KEYTRIGGER};
     DECLARE_ENUM_STRING(TriggerMode);
 

--- a/src/modulation/modulators/steplfo.cpp
+++ b/src/modulation/modulators/steplfo.cpp
@@ -242,7 +242,7 @@ void StepLFO::process(int)
 
         state++;
 
-        if (settings->triggerMode == ModulatorStorage::ONESHOT)
+        if (settings->stepLfoStorage.oneShot)
             state = std::min((long)(ls.repeat - 1), state);
         else if (state >= ls.repeat)
             state = 0;


### PR DESCRIPTION
Curves don't have a 'oneshot' - it is a feature of steps and msegs. Also it is distinct from trigger mode. You could ahve a release oneshot for instance. So move it back to the Step storage and move the button from the mutliswitch

Oh also make sure it works. It does!