### PR TITLE
disable warning shorten-64-to-32

### DIFF
--- a/cmake/compiler-and-git.cmake
+++ b/cmake/compiler-and-git.cmake
@@ -38,6 +38,7 @@ if (APPLE)
     set(OS_COMPILE_OPTIONS
             -Werror
             -Wno-multichar
+            -Wno-shorten-64-to-32
             )
     set(OS_COMPILE_DEFINITIONS MAC=1)
 


### PR DESCRIPTION
Needed to compile on Xcode 15.2