### PR TITLE
Step LFO: cycle rate name and draw the curve

### DIFF
--- a/src-ui/components/SCXTEditor.cpp
+++ b/src-ui/components/SCXTEditor.cpp
@@ -260,9 +260,12 @@ void SCXTEditor::drainCallbackQueue()
             assert(msgCont.threadingChecker.isClientThread());
             cmsg::clientThreadExecuteSerializationMessage(qmsg, this);
             inboundMessageCount++;
+            inboundMessageBytes += qmsg.size();
             if (inboundMessageCount % 100 == 0)
             {
-                SCLOG("Serial -> Client Message Count: " << inboundMessageCount);
+                SCLOG("Serial -> Client Message Count: "
+                      << inboundMessageCount << " size: " << inboundMessageBytes
+                      << " avgmsg: " << inboundMessageBytes / inboundMessageCount);
             }
         }
     }

--- a/src-ui/components/SCXTEditor.h
+++ b/src-ui/components/SCXTEditor.h
@@ -150,6 +150,7 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel,
     void idle();
     void drainCallbackQueue();
     uint64_t inboundMessageCount{0};
+    uint64_t inboundMessageBytes{0};
 
     // Popup Menu Options
     juce::PopupMenu::Options defaultPopupMenuOptions()

--- a/src-ui/components/multi/LFOPane.cpp
+++ b/src-ui/components/multi/LFOPane.cpp
@@ -26,6 +26,9 @@
  */
 
 #include "LFOPane.h"
+
+#include <cmath>
+
 #include "connectors/SCXTStyleSheetCreator.h"
 #include "datamodel/parameter.h"
 #include "juce_gui_basics/juce_gui_basics.h"

--- a/src-ui/components/multi/LFOPane.cpp
+++ b/src-ui/components/multi/LFOPane.cpp
@@ -197,7 +197,7 @@ struct StepLFOPane : juce::Component
             float renderSR{48000};
             so->setSampleRate(renderSR);
             float rate{3.f}; // 8 steps a second
-            float stepSamples{renderSR / std::powf(2.0f, rate) /
+            float stepSamples{renderSR / std::pow(2.0f, rate) /
                               blockSize}; // how manu samples in a step
             int captureEvery{(int)(stepSamples / (ms.stepLfoStorage.repeat * 10))};
             scxt::datamodel::TimeData td{};

--- a/src-ui/components/multi/LFOPane.cpp
+++ b/src-ui/components/multi/LFOPane.cpp
@@ -678,7 +678,9 @@ void LfoPane::rebuildPanelComponents()
         datamodel::pmd()
             .asInt()
             .withName("Modulator Shape")
-            .withRange(modulation::ModulatorStorage::STEP, modulation::ModulatorStorage::MSEG)
+            .withRange(modulation::ModulatorStorage::STEP,
+                       modulation::ModulatorStorage::MSEG -
+                           1) /* This -1 turns off MSEG in the menu */
             .withUnorderedMapFormatting({
                 {modulation::ModulatorStorage::STEP, "STEP"},
                 {modulation::ModulatorStorage::MSEG, "MSEG"},

--- a/src/json/modulation_traits.h
+++ b/src/json/modulation_traits.h
@@ -133,7 +133,7 @@ template <> struct scxt_traits<scxt::modulation::modulators::StepLFOStorage>
     {
         v = {{"data", t.data},
              {"repeat", t.repeat},
-             {"rateIsEntireCycle", t.rateIsEntireCycle},
+             {"rateIsForSingleStep", t.rateIsForSingleStep},
              {"smooth", t.smooth}};
     }
 
@@ -144,7 +144,7 @@ template <> struct scxt_traits<scxt::modulation::modulators::StepLFOStorage>
         findIf(v, "data", result.data);
         findIf(v, "repeat", result.repeat);
         findIf(v, "smooth", result.smooth);
-        findIf(v, "rateIsEntireCycle", result.rateIsEntireCycle);
+        findIf(v, "rateIsForSingleStep", result.rateIsForSingleStep);
     }
 };
 

--- a/src/modulation/modulator_storage.h
+++ b/src/modulation/modulator_storage.h
@@ -73,7 +73,7 @@ struct ModulatorStorage
         LFO_SH_NOISE,
         LFO_ENV,
 
-        MSEG,
+        MSEG, // for a variety of reasons, if this isn't last some menus and stuff will be wonky.
     } modulatorShape{ModulatorShape::STEP};
     DECLARE_ENUM_STRING(ModulatorShape);
 

--- a/src/modulation/modulator_storage.h
+++ b/src/modulation/modulator_storage.h
@@ -47,7 +47,7 @@ struct StepLFOStorage
     int repeat{16};
 
     float smooth{0.f};
-    bool rateIsEntireCycle{false};
+    bool rateIsForSingleStep{false};
 };
 
 struct CurveLFOStorage

--- a/src/modulation/modulators/steplfo.cpp
+++ b/src/modulation/modulators/steplfo.cpp
@@ -226,7 +226,7 @@ void StepLFO::UpdatePhaseIncrement()
 {
     auto &ls = settings->stepLfoStorage;
     phaseInc = BLOCK_SIZE * tuning::equalTuning.note_to_pitch(12 * (*rate)) * samplerate_inv *
-               (ls.rateIsEntireCycle ? 1 : ls.repeat) *
+               (ls.rateIsForSingleStep ? 1 : ls.repeat) *
                (settings->temposync ? (td->tempo * (1.f / 120.f)) : 1);
 }
 

--- a/src/modulation/modulators/steplfo.h
+++ b/src/modulation/modulators/steplfo.h
@@ -110,10 +110,12 @@ struct StepLFO : MoveableOnly<StepLFO>, SampleRateSupport
 
     void UpdatePhaseIncrement();
 
+    float phase{0};
+
   protected:
     long state;
     long state_tminus1;
-    float phase, phaseInc;
+    float phaseInc;
     float wf_history[4];
     float ratemult;
     int shuffle_id;


### PR DESCRIPTION
1. The rate cycle variable name was "backwards". Fix, but this will break streaming
2. Draw the Step LFO curve in the UI, as a preface of how we will draw the other curves