### PR TITLE
A single update pattern (Zone Only so far)

### DIFF
--- a/src-ui/components/HasEditor.h
+++ b/src-ui/components/HasEditor.h
@@ -41,6 +41,16 @@ struct HasEditor
     virtual ~HasEditor() = default;
 
     template <typename T> void sendToSerialization(const T &msg);
+    template <typename T, typename P, typename V>
+    void sendSingleToSerialization(const P &payload, const V &value)
+    {
+        auto pdiff = (uint8_t *)&value - (uint8_t *)&payload;
+        static_assert(std::is_standard_layout_v<P>);
+        assert(pdiff >= 0);
+        assert(pdiff <= sizeof(payload) - sizeof(value));
+        this->sendToSerialization(T({pdiff, value}));
+    }
+
     template <typename T> void updateValueTooltip(const T &attachment);
     template <typename W, typename A>
     void setupWidgetForValueTooltip(const W &widget, const A &attachment);

--- a/src-ui/components/MultiScreen.h
+++ b/src-ui/components/MultiScreen.h
@@ -39,7 +39,10 @@ namespace scxt::ui
 {
 namespace multi
 {
-struct AdsrPane;
+
+struct AdsrZoneTraits;
+struct AdsrGroupTraits;
+template <typename T> struct AdsrPane;
 
 struct OutPaneZoneTraits;
 struct OutPaneGroupTraits;
@@ -87,7 +90,10 @@ struct MultiScreen : juce::Component, HasEditor
                      std::unique_ptr<multi::OutputPane<multi::OutPaneGroupTraits>>>
             outputvariant;
         std::unique_ptr<multi::LfoPane> lfo;
-        std::unique_ptr<multi::AdsrPane> eg[2];
+        std::variant<std::unique_ptr<multi::AdsrPane<multi::AdsrZoneTraits>>,
+                     std::unique_ptr<multi::AdsrPane<multi::AdsrGroupTraits>>>
+
+            eg[2];
         std::variant<std::unique_ptr<multi::ModPane<multi::ModPaneZoneTraits>>,
                      std::unique_ptr<juce::Component>
                      /*std::unique_ptr<multi::ModPane<multi::ModPaneGroupTraits>>*/>
@@ -95,6 +101,7 @@ struct MultiScreen : juce::Component, HasEditor
 
         juce::Component *modComponent();
         juce::Component *outputComponent();
+        juce::Component *adsrComponent(int);
         const std::unique_ptr<multi::ModPane<multi::ModPaneZoneTraits>> &zoneMod()
         {
             assert(index == ZoneGroupIndex::ZONE);

--- a/src-ui/components/SCXTEditor.h
+++ b/src-ui/components/SCXTEditor.h
@@ -30,6 +30,7 @@
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <memory>
+#include <type_traits>
 
 #include "SCXTJuceLookAndFeel.h"
 #include "engine/engine.h"

--- a/src-ui/components/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/components/SCXTEditorResponseHandlers.cpp
@@ -50,11 +50,11 @@ void SCXTEditor::onGroupOrZoneEnvelopeUpdated(
         if (active)
         {
             // TODO - do I want a multiScreen->onEnvelopeUpdated or just
-            multiScreen->getZoneElements()->eg[which]->adsrChangedFromModel(env);
+            std::get<0>(multiScreen->getZoneElements()->eg[which])->adsrChangedFromModel(env);
         }
         else
         {
-            multiScreen->getZoneElements()->eg[which]->adsrDeactivated();
+            std::get<0>(multiScreen->getZoneElements()->eg[which])->adsrDeactivated();
         }
     }
     else
@@ -62,11 +62,11 @@ void SCXTEditor::onGroupOrZoneEnvelopeUpdated(
         if (active)
         {
             // TODO - do I want a multiScreen->onEnvelopeUpdated or just
-            multiScreen->getGroupElements()->eg[which]->adsrChangedFromModel(env);
+            std::get<1>(multiScreen->getGroupElements()->eg[which])->adsrChangedFromModel(env);
         }
         else
         {
-            multiScreen->getGroupElements()->eg[which]->adsrDeactivated();
+            std::get<1>(multiScreen->getGroupElements()->eg[which])->adsrDeactivated();
         }
     }
 }

--- a/src-ui/components/multi/AdsrPane.cpp
+++ b/src-ui/components/multi/AdsrPane.cpp
@@ -39,95 +39,81 @@ namespace cmsg = scxt::messaging::client;
 using dma = datamodel::AdsrStorage;
 namespace comp = sst::jucegui::components;
 
-AdsrPane::AdsrPane(SCXTEditor *e, int index, bool fz)
-    : HasEditor(e), sst::jucegui::components::NamedPanel(index == 0 ? "AMP EG" : "EG 2"),
-      index(index), forZone(fz)
+template <typename GZTrait>
+AdsrPane<GZTrait>::AdsrPane(SCXTEditor *e, int idx, bool fz)
+    : HasEditor(e), sst::jucegui::components::NamedPanel(idx == 0 ? "AMP EG" : "EG 2"), index(idx),
+      forZone(fz)
 {
     hasHamburger = true;
 
-    auto stowOnto = [this](auto &tgt, auto c, auto pair, bool slider = true) {
-        auto &[a, s] = pair;
-        attachments[c] = std::move(a);
-        tgt[c] = std::move(s);
+    using fac = connectors::SingleValueIndexedFactory<attachment_t, typename GZTrait::floatMsg_t>;
 
-        if (slider)
-            tgt[c]->setCustomClass(connectors::SCXTStyleSheetCreator::ModulationEditorVSlider);
-        else
-            tgt[c]->setCustomClass(connectors::SCXTStyleSheetCreator::ModulationEditorKnob);
+    fac::attachAndAdd(dma::paramAHD.withName("Attack"), adsrView, index, adsrView.a, this,
+                      attachments.A, sliders.A);
+    fac::attachAndAdd(dma::paramAHD.withName("Hold"), adsrView, index, adsrView.h, this,
+                      attachments.H, sliders.H);
+    fac::attachAndAdd(dma::paramAHD.withName("Decay"), adsrView, index, adsrView.d, this,
+                      attachments.D, sliders.D);
+    fac::attachAndAdd(dma::paramS.withName("Sustain"), adsrView, index, adsrView.s, this,
+                      attachments.S, sliders.S);
+    fac::attachAndAdd(dma::paramR.withName("Release"), adsrView, index, adsrView.r, this,
+                      attachments.R, sliders.R);
 
-        setupWidgetForValueTooltip(tgt[c], attachments[c]);
+    fac::attachAndAdd(dma::paramShape.withName("A Shape"), adsrView, index, adsrView.aShape, this,
+                      attachments.Ash, knobs.Ash);
+    fac::attachAndAdd(dma::paramShape.withName("D Shape"), adsrView, index, adsrView.dShape, this,
+                      attachments.Dsh, knobs.Dsh);
+    fac::attachAndAdd(dma::paramShape.withName("R Shape"), adsrView, index, adsrView.rShape, this,
+                      attachments.Rsh, knobs.Rsh);
 
-        addAndMakeVisible(*tgt[c]);
-    };
-    auto makeLabel = [this](auto c, const std::string &l) {
-        auto lb = std::make_unique<sst::jucegui::components::Label>();
+    auto makeLabel = [this](auto &lb, const std::string &l) {
+        lb = std::make_unique<sst::jucegui::components::Label>();
         lb->setText(l);
         addAndMakeVisible(*lb);
-        labels[c] = std::move(lb);
     };
+    makeLabel(labels.A, "A");
+    makeLabel(labels.H, "H");
+    makeLabel(labels.D, "D");
+    makeLabel(labels.S, "S");
+    makeLabel(labels.R, "R");
 
-    connectors::ConnectorFactory<attachment_t, comp::VSlider> sliderFactory(
-        [this](auto &a) { this->adsrChangedFromGui(a); }, adsrView);
-    connectors::ConnectorFactory<attachment_t, comp::Knob> knobFactory(
-        [this](auto &a) { this->adsrChangedFromGui(a); }, adsrView);
-
-    stowOnto(sliders, Ctrl::A, sliderFactory.attach("Attack", dma::paramAHD, &dma::a));
-    makeLabel(Ctrl::A, "A");
-
-    stowOnto(sliders, Ctrl::H, sliderFactory.attach("Hold", dma::paramAHD, &dma::h));
-    makeLabel(Ctrl::H, "H");
-
-    stowOnto(sliders, Ctrl::D, sliderFactory.attach("Decay", dma::paramAHD, &dma::d));
-    makeLabel(Ctrl::D, "D");
-
-    stowOnto(sliders, Ctrl::S, sliderFactory.attach("Sustain", dma::paramS, &dma::s));
-    makeLabel(Ctrl::S, "S");
-
-    stowOnto(sliders, Ctrl::R, sliderFactory.attach("Release", dma::paramR, &dma::r));
-    makeLabel(Ctrl::R, "R");
-
-    stowOnto(knobs, Ctrl::Ash, knobFactory.attach("A Shape", dma::paramShape, &dma::aShape), false);
-    stowOnto(knobs, Ctrl::Dsh, knobFactory.attach("D Shape", dma::paramShape, &dma::dShape), false);
-    stowOnto(knobs, Ctrl::Rsh, knobFactory.attach("R Shape", dma::paramShape, &dma::rShape), false);
-
-    onHamburger = [safeThis = juce::Component::SafePointer(this)]() {
-        if (safeThis)
-            safeThis->showHamburgerMenu();
-    };
-
-    adsrDeactivated();
+    for (const auto &k : knobs.members)
+        if (k)
+            k->setCustomClass(connectors::SCXTStyleSheetCreator::ModulationEditorKnob);
+    for (const auto &k : sliders.members)
+        if (k)
+            k->setCustomClass(connectors::SCXTStyleSheetCreator::ModulationEditorKnob);
 }
 
-void AdsrPane::adsrChangedFromModel(const datamodel::AdsrStorage &d)
+template <typename GZTrait>
+void AdsrPane<GZTrait>::adsrChangedFromModel(const datamodel::AdsrStorage &d)
 {
     adsrView = d;
-    for (const auto &[c, sl] : sliders)
-        sl->setEnabled(true);
+    for (const auto &sl : sliders.members)
+        if (sl)
+            sl->setEnabled(true);
 
-    for (const auto &[c, sl] : knobs)
-        sl->setEnabled(true);
-
-    repaint();
-}
-
-void AdsrPane::adsrChangedFromGui(const attachment_t &at)
-{
-    updateValueTooltip(at);
-    sendToSerialization(cmsg::AdsrSelectedGroupOrZoneUpdateRequest({forZone, index, adsrView}));
-}
-
-void AdsrPane::adsrDeactivated()
-{
-    for (const auto &[c, sl] : sliders)
-        sl->setEnabled(false);
-
-    for (const auto &[c, sl] : knobs)
-        sl->setEnabled(false);
+    for (const auto &sl : knobs.members)
+        if (sl)
+            sl->setEnabled(true);
 
     repaint();
 }
 
-void AdsrPane::resized()
+template <typename GZTrait> void AdsrPane<GZTrait>::adsrDeactivated()
+{
+    for (const auto &sl : sliders.members)
+        if (sl)
+            sl->setEnabled(false);
+
+    for (const auto &sl : knobs.members)
+        if (sl)
+            sl->setEnabled(false);
+
+    repaint();
+}
+
+template <typename GZTrait> void AdsrPane<GZTrait>::resized()
 {
     auto r = getContentArea();
     auto lh = 16.f;
@@ -138,29 +124,27 @@ void AdsrPane::resized()
     auto w = 34.f;
     x = x + (r.getWidth() - w * 5) * 0.5;
 
-    for (const auto &c : {Ctrl::A, H, D, S, R})
-    {
-        switch (c)
-        {
-        case A:
-            knobs[Ash]->setBounds(x + (w - kh) * 0.5, y - lh, kh, kh);
-            break;
-        case D:
-            knobs[Dsh]->setBounds(x + (w - kh) * 0.5, y - lh, kh, kh);
-            break;
-        case R:
-            knobs[Rsh]->setBounds(x + (w - kh) * 0.5, y - lh, kh, kh);
-            break;
-        default:
-            break;
-        }
-        sliders[c]->setBounds(x, y, w, h);
-        labels[c]->setBounds(x, y + h, w, lh);
-        x += w;
-    }
+    sliders.A->setBounds(x, y, w, h);
+    labels.A->setBounds(x, y + h, w, lh);
+    knobs.Ash->setBounds(x + (w - kh) * 0.5, y - lh, kh, kh);
+    x += w;
+    sliders.H->setBounds(x, y, w, h);
+    labels.H->setBounds(x, y + h, w, lh);
+    x += w;
+    sliders.D->setBounds(x, y, w, h);
+    labels.D->setBounds(x, y + h, w, lh);
+    knobs.Dsh->setBounds(x + (w - kh) * 0.5, y - lh, kh, kh);
+    x += w;
+    sliders.S->setBounds(x, y, w, h);
+    labels.S->setBounds(x, y + h, w, lh);
+    x += w;
+    sliders.R->setBounds(x, y, w, h);
+    labels.R->setBounds(x, y + h, w, lh);
+    knobs.Rsh->setBounds(x + (w - kh) * 0.5, y - lh, kh, kh);
+    x += w;
 }
 
-void AdsrPane::showHamburgerMenu()
+template <typename GZTrait> void AdsrPane<GZTrait>::showHamburgerMenu()
 {
     juce::PopupMenu p;
     p.addSectionHeader("Menu");
@@ -170,4 +154,6 @@ void AdsrPane::showHamburgerMenu()
     p.showMenuAsync(editor->defaultPopupMenuOptions());
 }
 
+template struct AdsrPane<AdsrGroupTraits>;
+template struct AdsrPane<AdsrZoneTraits>;
 } // namespace scxt::ui::multi

--- a/src-ui/components/multi/OutputPane.h
+++ b/src-ui/components/multi/OutputPane.h
@@ -32,6 +32,7 @@
 #include "components/HasEditor.h"
 #include "engine/zone.h"
 #include "engine/group.h"
+#include "messaging/messaging.h"
 
 namespace scxt::ui::multi
 {
@@ -41,6 +42,9 @@ struct OutPaneZoneTraits
     static constexpr bool forZone{true};
     static constexpr const char *defaultRoutingLocationName{"Group Output"};
     using info_t = engine::Zone::ZoneOutputInfo;
+
+    using floatMsg_t = scxt::messaging::client::UpdateZoneOutputFloatValue;
+    using int16Msg_t = scxt::messaging::client::UpdateZoneOutputInt16TValue;
 };
 
 struct OutPaneGroupTraits
@@ -48,6 +52,9 @@ struct OutPaneGroupTraits
     static constexpr bool forZone{false};
     static constexpr const char *defaultRoutingLocationName{"Part Output"};
     using info_t = engine::Group::GroupOutputInfo;
+
+    using floatMsg_t = scxt::messaging::client::UpdateGroupOutputFloatValue;
+    using int16Msg_t = scxt::messaging::client::UpdateGroupOutputInt16TValue;
 };
 template <typename OTTraits> struct OutputTab;
 

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -589,11 +589,11 @@ void Engine::loadSf2MultiSampleIntoSelectedPart(const fs::path &p)
                         return pow(10.0, db * 0.05);
                     };
 
-                    zn->aegStorage.a = s2a(reg->GetEG1Attack(presetRegion));
-                    zn->aegStorage.h = s2a(reg->GetEG1Hold(presetRegion));
-                    zn->aegStorage.d = s2a(reg->GetEG1Decay(presetRegion));
-                    zn->aegStorage.s = sus2l(reg->GetEG1Sustain(presetRegion));
-                    zn->aegStorage.r = s2a(reg->GetEG1Release(presetRegion));
+                    zn->egStorage[0].a = s2a(reg->GetEG1Attack(presetRegion));
+                    zn->egStorage[0].h = s2a(reg->GetEG1Hold(presetRegion));
+                    zn->egStorage[0].d = s2a(reg->GetEG1Decay(presetRegion));
+                    zn->egStorage[0].s = sus2l(reg->GetEG1Sustain(presetRegion));
+                    zn->egStorage[0].r = s2a(reg->GetEG1Release(presetRegion));
 
                     auto GetValue = [](const auto &val) {
                         if (val == sf2::NONE)
@@ -601,11 +601,11 @@ void Engine::loadSf2MultiSampleIntoSelectedPart(const fs::path &p)
                         return ToString(val);
                     };
 
-                    zn->eg2Storage.a = s2a(reg->GetEG2Attack(presetRegion));
-                    zn->eg2Storage.h = s2a(reg->GetEG2Hold(presetRegion));
-                    zn->eg2Storage.d = s2a(reg->GetEG2Decay(presetRegion));
-                    zn->eg2Storage.s = sus2l(reg->GetEG2Sustain(presetRegion));
-                    zn->eg2Storage.r = s2a(reg->GetEG2Release(presetRegion));
+                    zn->egStorage[1].a = s2a(reg->GetEG2Attack(presetRegion));
+                    zn->egStorage[1].h = s2a(reg->GetEG2Hold(presetRegion));
+                    zn->egStorage[1].d = s2a(reg->GetEG2Decay(presetRegion));
+                    zn->egStorage[1].s = sus2l(reg->GetEG2Sustain(presetRegion));
+                    zn->egStorage[1].r = s2a(reg->GetEG2Release(presetRegion));
 
                     if (reg->HasLoop)
                     {

--- a/src/engine/group_and_zone.h
+++ b/src/engine/group_and_zone.h
@@ -50,7 +50,7 @@ template <typename T> struct HasGroupZoneProcessors
      * This enum is here but we put it in the output info structure of
      * group and zone separately
      */
-    enum ProcRoutingPath
+    enum ProcRoutingPath : int16_t
     {
         procRoute_linear,
         procRoute_bypass

--- a/src/engine/zone.h
+++ b/src/engine/zone.h
@@ -129,6 +129,7 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
         ProcRoutingPath procRouting{procRoute_linear};
         BusAddress routeTo{DEFAULT_BUS};
     } outputInfo;
+    static_assert(std::is_standard_layout<ZoneOutputInfo>::value);
 
     float output alignas(16)[2][blockSize];
     void process(Engine &onto);
@@ -186,7 +187,8 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
     voice::modulation::Matrix::RoutingTable routingTable;
     std::array<modulation::ModulatorStorage, lfosPerZone> modulatorStorage;
 
-    datamodel::AdsrStorage aegStorage, eg2Storage;
+    // 0 is the AEG, 1 is EG2
+    std::array<datamodel::AdsrStorage, 2> egStorage;
 
     void onProcessorTypeChanged(int, dsp::processor::ProcessorType) {}
 

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -348,7 +348,7 @@ template <> struct scxt_traits<scxt::engine::Zone>
         v = {{"sampleData", t.sampleData},     {"mappingData", t.mapping},
              {"outputInfo", t.outputInfo},     {"processorStorage", t.processorStorage},
              {"routingTable", t.routingTable}, {"modulatorStorage", t.modulatorStorage},
-             {"aegStorage", t.aegStorage},     {"eg2Storage", t.eg2Storage}};
+             {"aegStorage", t.egStorage[0]},   {"eg2Storage", t.egStorage[1]}};
     }
 
     template <template <typename...> class Traits>
@@ -361,8 +361,8 @@ template <> struct scxt_traits<scxt::engine::Zone>
 
         findIf(v, "routingTable", zone.routingTable);
         findIf(v, "modulatorStorage", zone.modulatorStorage);
-        findOrDefault(v, "aegStorage", zone.aegStorage);
-        findOrDefault(v, "eg2Storage", zone.eg2Storage);
+        findOrDefault(v, "aegStorage", zone.egStorage[0]);
+        findOrDefault(v, "eg2Storage", zone.egStorage[1]);
     }
 };
 

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -46,13 +46,19 @@ enum ClientToSerializationMessagesIds
     c2s_do_multi_select_action,
 
     c2s_update_group_or_zone_adsr_view,
+    c2s_update_zone_adsr_value,
+    c2s_update_group_adsr_value,
 
     c2s_update_zone_mapping,
     c2s_update_zone_samples,
     c2s_update_zone_routing_row,
-    c2s_update_zone_output_info,
+
+    c2s_update_zone_output_float_value,
+    c2s_update_zone_output_int16_t_value,
+
     c2s_update_group_routing_row,
-    c2s_update_group_output_info,
+    c2s_update_group_output_float_value,
+    c2s_update_group_output_int16_t_value,
 
     c2s_update_group_or_zone_individual_modulator_storage,
 

--- a/src/messaging/client/detail/client_serial_impl.h
+++ b/src/messaging/client/detail/client_serial_impl.h
@@ -78,8 +78,11 @@ template <typename T> struct client_message_traits<MessageWrapper<T>>
 template <typename T> struct ResponseWrapper
 {
     const T &msg;
-    SerializationToClientMessageIds id;
-    ResponseWrapper(const T &m, SerializationToClientMessageIds i) : msg(m), id(i) {}
+    scxt::messaging::client::SerializationToClientMessageIds id;
+    ResponseWrapper(const T &m, scxt::messaging::client::SerializationToClientMessageIds i)
+        : msg(m), id(i)
+    {
+    }
 };
 template <typename T> struct client_message_traits<ResponseWrapper<T>>
 {

--- a/src/messaging/client/detail/message_helpers.h
+++ b/src/messaging/client/detail/message_helpers.h
@@ -1,0 +1,190 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_MESSAGING_CLIENT_DETAIL_MESSAGE_HELPERS_H
+#define SCXT_SRC_MESSAGING_CLIENT_DETAIL_MESSAGE_HELPERS_H
+
+#include <tuple>
+
+namespace scxt::messaging::client::detail
+{
+
+template <typename VT> using diffMsg_t = std::tuple<ptrdiff_t, VT>;
+
+template <typename VT, typename M>
+inline void updateZoneMemberValue(M m, const diffMsg_t<VT> &payload, const engine::Engine &engine,
+                                  MessageController &cont,
+                                  std::function<void(const engine::Engine &)> responseCB = nullptr)
+{
+    auto sz = engine.getSelectionManager()->currentlySelectedZones();
+    if (!sz.empty())
+    {
+        cont.scheduleAudioThreadCallback(
+            [zs = sz, payload, m](auto &eng) {
+                auto [d, v] = payload;
+                for (const auto &[p, g, z] : zs)
+                {
+                    auto &zn = eng.getPatch()->getPart(p)->getGroup(g)->getZone(z);
+                    auto &dat = *zn.*m;
+                    static_assert(
+                        std::is_standard_layout_v<std::remove_reference_t<decltype(dat)>>);
+                    assert(d <= sizeof(dat) - sizeof(v));
+                    assert(d >= 0);
+                    if constexpr (std::is_same_v<VT, float>)
+                    {
+                        if (!zn->isActive())
+                        {
+                            *(VT *)(((uint8_t *)&dat) + d) = v;
+                        }
+                        else
+                        {
+                            zn->mUILag.setNewDestination((VT *)(((uint8_t *)&dat) + d), v);
+                        }
+                    }
+                    else
+                    {
+                        *(VT *)(((uint8_t *)&dat) + d) = v;
+                    }
+                }
+            },
+            responseCB);
+    }
+}
+
+template <typename VT, typename M>
+inline void updateGroupMemberValue(M m, const diffMsg_t<VT> &payload, const engine::Engine &engine,
+                                   MessageController &cont,
+                                   std::function<void(const engine::Engine &)> responseCB = nullptr)
+{
+    auto sg = engine.getSelectionManager()->currentlySelectedGroups();
+    if (!sg.empty())
+    {
+        cont.scheduleAudioThreadCallback(
+            [gs = sg, payload, m](auto &eng) {
+                auto [d, v] = payload;
+                for (const auto &[p, g, z] : gs)
+                {
+                    auto &grp = eng.getPatch()->getPart(p)->getGroup(g);
+                    auto &dat = *grp.*m;
+                    static_assert(
+                        std::is_standard_layout_v<std::remove_reference_t<decltype(dat)>>);
+                    assert(d <= sizeof(dat) - sizeof(v));
+                    assert(d >= 0);
+                    if constexpr (std::is_same_v<VT, float>)
+                    {
+                        // TODO: Group UI Lag
+                        *(VT *)(((uint8_t *)&dat) + d) = v;
+                    }
+                    else
+                    {
+                        *(VT *)(((uint8_t *)&dat) + d) = v;
+                    }
+                }
+            },
+            responseCB);
+    }
+}
+
+template <typename VT> using indexedDiffMsg_t = std::tuple<size_t, ptrdiff_t, VT>;
+
+template <typename VT, typename M>
+inline void
+updateZoneIndexedMemberValue(M m, const indexedDiffMsg_t<VT> &payload, const engine::Engine &engine,
+                             MessageController &cont,
+                             std::function<void(const engine::Engine &)> responseCB = nullptr)
+{
+    auto sz = engine.getSelectionManager()->currentlySelectedZones();
+    if (!sz.empty())
+    {
+        cont.scheduleAudioThreadCallback(
+            [zs = sz, payload, m](auto &eng) {
+                auto [idx, d, v] = payload;
+                for (const auto &[p, g, z] : zs)
+                {
+                    auto &zn = eng.getPatch()->getPart(p)->getGroup(g)->getZone(z);
+                    auto &dat = (*zn.*m)[idx];
+                    static_assert(
+                        std::is_standard_layout_v<std::remove_reference_t<decltype(dat)>>);
+                    assert(d <= sizeof(dat) - sizeof(v));
+                    assert(d >= 0);
+                    if constexpr (std::is_same_v<VT, float>)
+                    {
+                        if (!zn->isActive())
+                        {
+                            *(VT *)(((uint8_t *)&dat) + d) = v;
+                        }
+                        else
+                        {
+                            zn->mUILag.setNewDestination((VT *)(((uint8_t *)&dat) + d), v);
+                        }
+                    }
+                    else
+                    {
+                        *(VT *)(((uint8_t *)&dat) + d) = v;
+                    }
+                }
+            },
+            responseCB);
+    }
+}
+
+template <typename VT, typename M>
+inline void
+updateGroupIndexedMemberValue(M m, const indexedDiffMsg_t<VT> &payload,
+                              const engine::Engine &engine, MessageController &cont,
+                              std::function<void(const engine::Engine &)> responseCB = nullptr)
+{
+    auto sg = engine.getSelectionManager()->currentlySelectedGroups();
+    if (!sg.empty())
+    {
+        cont.scheduleAudioThreadCallback(
+            [gs = sg, payload, m](auto &eng) {
+                auto [idx, d, v] = payload;
+                for (const auto &[p, g, z] : gs)
+                {
+                    auto &grp = eng.getPatch()->getPart(p)->getGroup(g);
+                    auto &dat = (*grp.*m)[idx];
+                    static_assert(
+                        std::is_standard_layout_v<std::remove_reference_t<decltype(dat)>>);
+                    assert(d <= sizeof(dat) - sizeof(v));
+                    assert(d >= 0);
+                    if constexpr (std::is_same_v<VT, float>)
+                    {
+                        // TODO: Group UI Lag
+                        *(VT *)(((uint8_t *)&dat) + d) = v;
+                    }
+                    else
+                    {
+                        *(VT *)(((uint8_t *)&dat) + d) = v;
+                    }
+                }
+            },
+            responseCB);
+    }
+}
+} // namespace scxt::messaging::client::detail
+#endif // SHORTCIRCUITXT_MESSAGE_HELPERS_H

--- a/src/messaging/client/group_or_zone_messages.h
+++ b/src/messaging/client/group_or_zone_messages.h
@@ -50,10 +50,7 @@ inline void adsrSelectedGroupOrZoneUpdate(const adsrSelectedGroupOrZoneC2SPayloa
             cont.scheduleAudioThreadCallback([zs = sz, ew = e, adsrv = adsr](auto &eng) {
                 for (const auto &[p, g, z] : zs)
                 {
-                    if (ew == 0)
-                        eng.getPatch()->getPart(p)->getGroup(g)->getZone(z)->aegStorage = adsrv;
-                    if (ew == 1)
-                        eng.getPatch()->getPart(p)->getGroup(g)->getZone(z)->eg2Storage = adsrv;
+                    eng.getPatch()->getPart(p)->getGroup(g)->getZone(z)->egStorage[ew] = adsrv;
                 }
             });
         }
@@ -75,6 +72,16 @@ inline void adsrSelectedGroupOrZoneUpdate(const adsrSelectedGroupOrZoneC2SPayloa
 CLIENT_TO_SERIAL(AdsrSelectedGroupOrZoneUpdateRequest, c2s_update_group_or_zone_adsr_view,
                  adsrSelectedGroupOrZoneC2SPayload_t,
                  adsrSelectedGroupOrZoneUpdate(payload, engine, cont));
+
+CLIENT_TO_SERIAL(UpdateZoneEGFloatValue, c2s_update_zone_adsr_value,
+                 detail::indexedDiffMsg_t<float>,
+                 detail::updateZoneIndexedMemberValue(&engine::Zone::egStorage, payload, engine,
+                                                      cont));
+
+CLIENT_TO_SERIAL(UpdateGroupEGFloatValue, c2s_update_group_adsr_value,
+                 detail::indexedDiffMsg_t<float>,
+                 detail::updateGroupIndexedMemberValue(&engine::Group::gegStorage, payload, engine,
+                                                       cont));
 
 } // namespace scxt::messaging::client
 #endif // SHORTCIRCUITXT_GROUP_OR_ZONE_MESSAGES_H

--- a/src/messaging/client/zone_messages.h
+++ b/src/messaging/client/zone_messages.h
@@ -29,6 +29,7 @@
 #define SCXT_SRC_MESSAGING_CLIENT_ZONE_MESSAGES_H
 
 #include "messaging/client/detail/client_json_details.h"
+#include "messaging/client/detail/message_helpers.h"
 #include "json/engine_traits.h"
 #include "json/datamodel_traits.h"
 #include "selection/selection_manager.h"
@@ -90,23 +91,13 @@ using zoneOutputInfoUpdate_t = std::pair<bool, engine::Zone::ZoneOutputInfo>;
 SERIAL_TO_CLIENT(ZoneOutputInfoUpdated, s2c_update_zone_output_info, zoneOutputInfoUpdate_t,
                  onZoneOutputInfoUpdated);
 
-inline void updateZoneOutputInfo(const engine::Zone::ZoneOutputInfo &payload,
-                                 const engine::Engine &engine, MessageController &cont)
-{
-    // TODO Selected Zone State
-    auto sz = engine.getSelectionManager()->currentlySelectedZones();
-    if (!sz.empty())
-    {
-        cont.scheduleAudioThreadCallback([zs = sz, info = payload](auto &eng) {
-            for (const auto &[p, g, z] : zs)
-            {
-                eng.getPatch()->getPart(p)->getGroup(g)->getZone(z)->outputInfo = info;
-            }
-        });
-    }
-}
-CLIENT_TO_SERIAL(UpdateZoneOutputInfo, c2s_update_zone_output_info, engine::Zone::ZoneOutputInfo,
-                 updateZoneOutputInfo(payload, engine, cont));
+CLIENT_TO_SERIAL(UpdateZoneOutputFloatValue, c2s_update_zone_output_float_value,
+                 detail::diffMsg_t<float>,
+                 detail::updateZoneMemberValue(&engine::Zone::outputInfo, payload, engine, cont));
+
+CLIENT_TO_SERIAL(UpdateZoneOutputInt16TValue, c2s_update_zone_output_int16_t_value,
+                 detail::diffMsg_t<int16_t>,
+                 detail::updateZoneMemberValue(&engine::Zone::outputInfo, payload, engine, cont));
 
 } // namespace scxt::messaging::client
 

--- a/src/modulation/voice_matrix.cpp
+++ b/src/modulation/voice_matrix.cpp
@@ -94,18 +94,8 @@ void MatrixEndpoints::EGTarget::bind(scxt::voice::modulation::Matrix &m, engine:
         bindEl(m, rsT, eg.rShape, rsP);
     };
 
-    if (index == 0)
-    {
-        doBind(z.aegStorage);
-    }
-    else if (index == 1)
-    {
-        doBind(z.eg2Storage);
-    }
-    else
-    {
-        assert(false);
-    }
+    assert(index >= 0 && index < z.egStorage.size());
+    doBind(z.egStorage[index]);
 }
 
 void MatrixEndpoints::MappingTarget::bind(scxt::voice::modulation::Matrix &m, engine::Zone &z)

--- a/src/selection/selection_manager.cpp
+++ b/src/selection/selection_manager.cpp
@@ -416,11 +416,11 @@ void SelectionManager::sendDisplayDataForZonesBasedOnLead(int p, int g, int z)
                               *(engine.getMessageController()));
     serializationSendToClient(
         cms::s2c_update_group_or_zone_adsr_view,
-        cms::AdsrGroupOrZoneUpdate::s2c_payload_t{true, 0, true, zp->aegStorage},
+        cms::AdsrGroupOrZoneUpdate::s2c_payload_t{true, 0, true, zp->egStorage[0]},
         *(engine.getMessageController()));
     serializationSendToClient(
         cms::s2c_update_group_or_zone_adsr_view,
-        cms::AdsrGroupOrZoneUpdate::s2c_payload_t{true, 1, true, zp->eg2Storage},
+        cms::AdsrGroupOrZoneUpdate::s2c_payload_t{true, 1, true, zp->egStorage[1]},
         *(engine.getMessageController()));
 
     for (int i = 0; i < engine::lfosPerZone; ++i)


### PR DESCRIPTION
- A single item udpate pattern
- Implemented for zone output and AEG in this commit.
- Zone gets eg[2] as opposed to two variables like group
- SingleValueFactory makes float binding soooooo much easier
- Remove the ancient ConnectorFactory which kinda didnt work
- Rip apart ADSR to nothing again with traits variant
- So that's a good checkpoint commit for a thursday night