### PR TITLE
C2S/S2C message stats symmetric; Debug only

### DIFF
--- a/src-ui/components/SCXTEditor.cpp
+++ b/src-ui/components/SCXTEditor.cpp
@@ -259,6 +259,7 @@ void SCXTEditor::drainCallbackQueue()
         {
             assert(msgCont.threadingChecker.isClientThread());
             cmsg::clientThreadExecuteSerializationMessage(qmsg, this);
+#if BUILD_IS_DEBUG
             inboundMessageCount++;
             inboundMessageBytes += qmsg.size();
             if (inboundMessageCount % 100 == 0)
@@ -267,6 +268,7 @@ void SCXTEditor::drainCallbackQueue()
                       << inboundMessageCount << " size: " << inboundMessageBytes
                       << " avgmsg: " << inboundMessageBytes / inboundMessageCount);
             }
+#endif
         }
     }
 }

--- a/src/messaging/client/detail/client_serial_impl.h
+++ b/src/messaging/client/detail/client_serial_impl.h
@@ -166,6 +166,16 @@ inline void clientSendToSerialization(const T &msg, messaging::MessageController
     auto mw = detail::MessageWrapper(msg);
     detail::client_message_value v = mw;
     auto res = encoder::to_string(v);
+#if BUILD_IS_DEBUG
+    mc.c2sMessageCount++;
+    mc.c2sMessageBytes += res.size();
+    if (mc.c2sMessageCount % 100 == 0)
+    {
+        SCLOG("Client -> Serial Message Count : " << mc.c2sMessageCount << " size "
+                                                  << mc.c2sMessageBytes << " avgmsg: "
+                                                  << 1.f * mc.c2sMessageBytes / mc.c2sMessageCount);
+    }
+#endif
     mc.sendRawFromClient(res);
 }
 

--- a/src/messaging/messaging.h
+++ b/src/messaging/messaging.h
@@ -305,6 +305,11 @@ struct MessageController : MoveableOnly<MessageController>
      */
     void reportErrorToClient(const std::string &title, const std::string &body);
 
+    /*
+     * Some stats on messages back
+     */
+    uint64_t c2sMessageCount{0}, c2sMessageBytes{0};
+
   private:
     uint64_t inboundClientMessageCount{0};
     void runSerialization();


### PR DESCRIPTION
Also lets me see how much smaller the messages are now for float idnex items!