### PR TITLE
Zone-Or-Group float message; varags on factories

### DIFF
--- a/src-ui/components/MultiScreen.cpp
+++ b/src-ui/components/MultiScreen.cpp
@@ -154,8 +154,7 @@ MultiScreen::ZoneOrGroupElements<ZGTrait>::ZoneOrGroupElements(MultiScreen *pare
 
     for (int i = 0; i < scxt::egPerGroup; ++i)
     {
-        auto egt = std::make_unique<multi::AdsrPane<typename ZGTrait::AdsrTraits>>(parent->editor,
-                                                                                   i, forZone);
+        auto egt = std::make_unique<multi::AdsrPane>(parent->editor, i, forZone);
         eg[i] = std::move(egt);
         parent->addChildComponent(*eg[i]);
     }

--- a/src-ui/components/MultiScreen.h
+++ b/src-ui/components/MultiScreen.h
@@ -39,10 +39,7 @@ namespace scxt::ui
 {
 namespace multi
 {
-
-struct AdsrZoneTraits;
-struct AdsrGroupTraits;
-template <typename T> struct AdsrPane;
+struct AdsrPane;
 
 struct OutPaneZoneTraits;
 struct OutPaneGroupTraits;
@@ -79,14 +76,12 @@ struct MultiScreen : juce::Component, HasEditor
     struct ZoneTraits
     {
         using OutPaneTraits = multi::OutPaneZoneTraits;
-        using AdsrTraits = multi::AdsrZoneTraits;
         using ModPaneTraits = multi::ModPaneZoneTraits;
         static constexpr bool forZone{true};
     };
     struct GroupTraits
     {
         using OutPaneTraits = multi::OutPaneGroupTraits;
-        using AdsrTraits = multi::AdsrGroupTraits;
         using ModPaneTraits = multi::ModPaneGroupTraits;
         static constexpr bool forZone{false};
     };
@@ -99,7 +94,7 @@ struct MultiScreen : juce::Component, HasEditor
         ~ZoneOrGroupElements();
         std::unique_ptr<multi::OutputPane<typename ZGTrait::OutPaneTraits>> outPane;
         std::unique_ptr<multi::LfoPane> lfo;
-        std::array<std::unique_ptr<multi::AdsrPane<typename ZGTrait::AdsrTraits>>, 2> eg;
+        std::array<std::unique_ptr<multi::AdsrPane>, 2> eg;
 
         std::unique_ptr<multi::ModPane<typename ZGTrait::ModPaneTraits>> modPane;
 

--- a/src-ui/components/multi/AdsrPane.cpp
+++ b/src-ui/components/multi/AdsrPane.cpp
@@ -39,32 +39,31 @@ namespace cmsg = scxt::messaging::client;
 using dma = datamodel::AdsrStorage;
 namespace comp = sst::jucegui::components;
 
-template <typename GZTrait>
-AdsrPane<GZTrait>::AdsrPane(SCXTEditor *e, int idx, bool fz)
+AdsrPane::AdsrPane(SCXTEditor *e, int idx, bool fz)
     : HasEditor(e), sst::jucegui::components::NamedPanel(idx == 0 ? "AMP EG" : "EG 2"), index(idx),
       forZone(fz)
 {
     hasHamburger = true;
 
-    using fac = connectors::SingleValueIndexedFactory<attachment_t, typename GZTrait::floatMsg_t>;
+    using fac = connectors::SingleValueFactory<attachment_t, cmsg::UpdateZoneGroupEGFloatValue>;
 
-    fac::attachAndAdd(dma::paramAHD.withName("Attack"), adsrView, index, adsrView.a, this,
-                      attachments.A, sliders.A);
-    fac::attachAndAdd(dma::paramAHD.withName("Hold"), adsrView, index, adsrView.h, this,
-                      attachments.H, sliders.H);
-    fac::attachAndAdd(dma::paramAHD.withName("Decay"), adsrView, index, adsrView.d, this,
-                      attachments.D, sliders.D);
-    fac::attachAndAdd(dma::paramS.withName("Sustain"), adsrView, index, adsrView.s, this,
-                      attachments.S, sliders.S);
-    fac::attachAndAdd(dma::paramR.withName("Release"), adsrView, index, adsrView.r, this,
-                      attachments.R, sliders.R);
+    fac::attachAndAdd(dma::paramAHD.withName("Attack"), adsrView, adsrView.a, this, attachments.A,
+                      sliders.A, forZone, index);
+    fac::attachAndAdd(dma::paramAHD.withName("Hold"), adsrView, adsrView.h, this, attachments.H,
+                      sliders.H, forZone, index);
+    fac::attachAndAdd(dma::paramAHD.withName("Decay"), adsrView, adsrView.d, this, attachments.D,
+                      sliders.D, forZone, index);
+    fac::attachAndAdd(dma::paramS.withName("Sustain"), adsrView, adsrView.s, this, attachments.S,
+                      sliders.S, forZone, index);
+    fac::attachAndAdd(dma::paramR.withName("Release"), adsrView, adsrView.r, this, attachments.R,
+                      sliders.R, forZone, index);
 
-    fac::attachAndAdd(dma::paramShape.withName("A Shape"), adsrView, index, adsrView.aShape, this,
-                      attachments.Ash, knobs.Ash);
-    fac::attachAndAdd(dma::paramShape.withName("D Shape"), adsrView, index, adsrView.dShape, this,
-                      attachments.Dsh, knobs.Dsh);
-    fac::attachAndAdd(dma::paramShape.withName("R Shape"), adsrView, index, adsrView.rShape, this,
-                      attachments.Rsh, knobs.Rsh);
+    fac::attachAndAdd(dma::paramShape.withName("A Shape"), adsrView, adsrView.aShape, this,
+                      attachments.Ash, knobs.Ash, forZone, index);
+    fac::attachAndAdd(dma::paramShape.withName("D Shape"), adsrView, adsrView.dShape, this,
+                      attachments.Dsh, knobs.Dsh, forZone, index);
+    fac::attachAndAdd(dma::paramShape.withName("R Shape"), adsrView, adsrView.rShape, this,
+                      attachments.Rsh, knobs.Rsh, forZone, index);
 
     auto makeLabel = [this](auto &lb, const std::string &l) {
         lb = std::make_unique<sst::jucegui::components::Label>();
@@ -85,8 +84,7 @@ AdsrPane<GZTrait>::AdsrPane(SCXTEditor *e, int idx, bool fz)
             k->setCustomClass(connectors::SCXTStyleSheetCreator::ModulationEditorKnob);
 }
 
-template <typename GZTrait>
-void AdsrPane<GZTrait>::adsrChangedFromModel(const datamodel::AdsrStorage &d)
+void AdsrPane::adsrChangedFromModel(const datamodel::AdsrStorage &d)
 {
     adsrView = d;
     for (const auto &sl : sliders.members)
@@ -100,7 +98,7 @@ void AdsrPane<GZTrait>::adsrChangedFromModel(const datamodel::AdsrStorage &d)
     repaint();
 }
 
-template <typename GZTrait> void AdsrPane<GZTrait>::adsrDeactivated()
+void AdsrPane::adsrDeactivated()
 {
     for (const auto &sl : sliders.members)
         if (sl)
@@ -113,7 +111,7 @@ template <typename GZTrait> void AdsrPane<GZTrait>::adsrDeactivated()
     repaint();
 }
 
-template <typename GZTrait> void AdsrPane<GZTrait>::resized()
+void AdsrPane::resized()
 {
     auto r = getContentArea();
     auto lh = 16.f;
@@ -144,7 +142,7 @@ template <typename GZTrait> void AdsrPane<GZTrait>::resized()
     x += w;
 }
 
-template <typename GZTrait> void AdsrPane<GZTrait>::showHamburgerMenu()
+void AdsrPane::showHamburgerMenu()
 {
     juce::PopupMenu p;
     p.addSectionHeader("Menu");
@@ -154,6 +152,4 @@ template <typename GZTrait> void AdsrPane<GZTrait>::showHamburgerMenu()
     p.showMenuAsync(editor->defaultPopupMenuOptions());
 }
 
-template struct AdsrPane<AdsrGroupTraits>;
-template struct AdsrPane<AdsrZoneTraits>;
 } // namespace scxt::ui::multi

--- a/src-ui/components/multi/AdsrPane.h
+++ b/src-ui/components/multi/AdsrPane.h
@@ -43,16 +43,7 @@
 
 namespace scxt::ui::multi
 {
-struct AdsrZoneTraits
-{
-    using floatMsg_t = scxt::messaging::client::UpdateZoneEGFloatValue;
-};
-struct AdsrGroupTraits
-{
-    using floatMsg_t = scxt::messaging::client::UpdateGroupEGFloatValue;
-};
-
-template <typename GZTrait> struct AdsrPane : sst::jucegui::components::NamedPanel, HasEditor
+struct AdsrPane : sst::jucegui::components::NamedPanel, HasEditor
 {
     typedef connectors::PayloadDataAttachment<datamodel::AdsrStorage> attachment_t;
 

--- a/src-ui/connectors/PayloadDataAttachment.h
+++ b/src-ui/connectors/PayloadDataAttachment.h
@@ -201,29 +201,6 @@ struct DiscretePayloadDataAttachment : sst::jucegui::data::Discrete
             return *r;
         return "";
     }
-
-    // bit bummed I have to ocpy this here. Lets think a bit
-    template <typename M>
-    void asSingleValueUpdate(const Payload &p, bool forZone, size_t &index, HasEditor *e)
-    {
-        static_assert(std::is_standard_layout_v<Payload>);
-
-        ptrdiff_t pdiff = (uint8_t *)&value - (uint8_t *)&p;
-        assert(pdiff >= 0);
-        assert(pdiff <= sizeof(p) - sizeof(value));
-
-        auto jc = dynamic_cast<juce::Component *>(e);
-        assert(jc);
-
-        onGuiValueChanged = [w = juce::Component::SafePointer(jc), e, forZone, &index,
-                             pdiff](const DiscretePayloadDataAttachment &a) {
-            if (w)
-            {
-                e->sendToSerialization(M({forZone, index, pdiff, a.value}));
-                e->updateValueTooltip(a);
-            }
-        };
-    }
 };
 
 template <typename Payload>

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -45,9 +45,11 @@ enum ClientToSerializationMessagesIds
     c2s_do_select_action,
     c2s_do_multi_select_action,
 
-    c2s_update_group_or_zone_adsr_view,
-    c2s_update_zone_adsr_value,
-    c2s_update_group_adsr_value,
+    c2s_update_zone_or_group_adsr_value,
+
+    c2s_update_zone_or_group_modstorage_float_value,
+    c2s_update_zone_or_group_modstorage_bool_value,
+    c2s_update_zone_or_group_modstorage_int16_t_value,
 
     c2s_update_zone_mapping,
     c2s_update_zone_samples,

--- a/src/messaging/client/detail/message_helpers.h
+++ b/src/messaging/client/detail/message_helpers.h
@@ -186,5 +186,25 @@ updateGroupIndexedMemberValue(M m, const indexedDiffMsg_t<VT> &payload,
             responseCB);
     }
 }
+
+template <typename VT> using indexedZoneOrGroupDiffMsg_t = std::tuple<bool, size_t, ptrdiff_t, VT>;
+
+template <typename VT, typename MZ, typename MG>
+inline void updateZoneOrGroupIndexedMemberValue(
+    MZ mz, MG mg, const indexedZoneOrGroupDiffMsg_t<VT> &payload, const engine::Engine &engine,
+    MessageController &cont, std::function<void(const engine::Engine &)> responseCB = nullptr)
+{
+    auto isZone = std::get<0>(payload);
+    auto underT =
+        indexedDiffMsg_t<VT>{std::get<1>(payload), std::get<2>(payload), std::get<3>(payload)};
+    if (isZone)
+    {
+        updateZoneIndexedMemberValue(mz, underT, engine, cont, responseCB);
+    }
+    else
+    {
+        updateGroupIndexedMemberValue(mg, underT, engine, cont, responseCB);
+    }
+}
 } // namespace scxt::messaging::client::detail
 #endif // SHORTCIRCUITXT_MESSAGE_HELPERS_H

--- a/src/messaging/client/modulation_messages.h
+++ b/src/messaging/client/modulation_messages.h
@@ -33,6 +33,7 @@
 #include "json/datamodel_traits.h"
 #include "selection/selection_manager.h"
 #include "voice/voice.h"
+#include "detail/message_helpers.h"
 
 namespace scxt::messaging::client
 {
@@ -187,6 +188,7 @@ CLIENT_TO_SERIAL(IndexedModulatorStorageUpdated,
                  c2s_update_group_or_zone_individual_modulator_storage,
                  indexedModulatorStorageUpdate_t,
                  indexedModulatorStorageUpdated(payload, engine, cont));
+
 SERIAL_TO_CLIENT(UpdateZoneLfo, s2c_update_group_or_zone_individual_modulator_storage,
                  indexedModulatorStorageUpdate_t, onGroupOrZoneModulatorStorageUpdated);
 


### PR DESCRIPTION
There's no reason we can't do 'zone or gorup' as the top of the tuple for a float message and stil lroute proerply. So do that.

Along the way
- detemplatize the ADSR again
- Make the LFO use float messages

Update the PayloadDataAttachment to hide the complexity in one spot also.