### PR TITLE
Type safe member updates

### DIFF
--- a/src-ui/components/multi/ProcessorPane.cpp
+++ b/src-ui/components/multi/ProcessorPane.cpp
@@ -175,7 +175,7 @@ void ProcessorPane::rebuildControlsFromDescription()
 
     auto at = std::make_unique<attachment_t>(
         datamodel::pmd().asPercent().withName("Mix").withDefault(1.0), processorView.mix);
-    connectors::configureUpdater<cmsg::UpdateZoneOrGroupModStorageFloatValue, attachment_t>(
+    connectors::configureUpdater<cmsg::UpdateZoneOrGroupProcessorFloatValue, attachment_t>(
         *at, processorView, this, forZone, index);
     mixAttachment = std::move(at);
 

--- a/src-ui/components/multi/detail/GroupZoneTreeControl.h
+++ b/src-ui/components/multi/detail/GroupZoneTreeControl.h
@@ -314,6 +314,8 @@ template <typename SidebarParent> struct GroupZoneListBoxModel : juce::ListBoxMo
             renameEditor->setVisible(false);
         }
         void textEditorFocusLost(juce::TextEditor &) override { renameEditor->setVisible(false); }
+
+        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(rowComponent);
     };
     struct rowAddComponent : juce::Component
     {
@@ -332,6 +334,8 @@ template <typename SidebarParent> struct GroupZoneListBoxModel : juce::ListBoxMo
             auto b = getLocalBounds().withSizeKeepingCentre(getHeight(), getHeight()).reduced(1);
             gBut->setBounds(b);
         }
+
+        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(rowAddComponent);
     };
 
     juce::Component *refreshComponentForRow(int rowNumber, bool isRowSelected,

--- a/src-ui/connectors/PayloadDataAttachment.h
+++ b/src-ui/connectors/PayloadDataAttachment.h
@@ -47,6 +47,12 @@ std::function<void(const ABase &)> makeUpdater(A &att, const typename A::payload
 {
     static_assert(std::is_standard_layout_v<typename A::payload_t>);
 
+    if constexpr (M::hasBoundPayload)
+    {
+        static_assert(std::is_same_v<typename M::bound_t, typename A::payload_t>,
+                      "This means you used a message for a member of a wrong payload type");
+    }
+
     ptrdiff_t pdiff = (uint8_t *)&att.value - (uint8_t *)&p;
     assert(pdiff >= 0);
     assert(pdiff <= sizeof(p) - sizeof(att.value));

--- a/src/messaging/client/client_macros.h
+++ b/src/messaging/client/client_macros.h
@@ -36,6 +36,27 @@
     struct className                                                                               \
     {                                                                                              \
         static constexpr ClientToSerializationMessagesIds c2s_id{id};                              \
+        static constexpr bool hasBoundPayload{false};                                              \
+        typedef payloadType c2s_payload_t;                                                         \
+        c2s_payload_t payload{};                                                                   \
+        explicit className(const c2s_payload_t &v) : payload(v) {}                                 \
+        static void executeOnSerialization(const c2s_payload_t &payload, engine::Engine &engine,   \
+                                           MessageController &cont)                                \
+        {                                                                                          \
+            executeBody;                                                                           \
+        }                                                                                          \
+    };                                                                                             \
+    template <> struct ClientToSerializationType<className::c2s_id>                                \
+    {                                                                                              \
+        typedef className T;                                                                       \
+    };
+
+#define CLIENT_TO_SERIAL_CONSTRAINED(className, id, payloadType, boundPayload, executeBody)        \
+    struct className                                                                               \
+    {                                                                                              \
+        static constexpr ClientToSerializationMessagesIds c2s_id{id};                              \
+        static constexpr bool hasBoundPayload{true};                                               \
+        typedef boundPayload bound_t;                                                              \
         typedef payloadType c2s_payload_t;                                                         \
         c2s_payload_t payload{};                                                                   \
         explicit className(const c2s_payload_t &v) : payload(v) {}                                 \
@@ -56,6 +77,8 @@
     {                                                                                              \
         static constexpr ClientToSerializationMessagesIds c2s_id{c2id};                            \
         static constexpr SerializationToClientMessageIds s2c_id{s2id};                             \
+        static constexpr bool hasBoundPayload{false};                                              \
+                                                                                                   \
         typedef c2payloadType c2s_payload_t;                                                       \
         typedef s2payloadType s2c_payload_t;                                                       \
         c2s_payload_t payload{};                                                                   \

--- a/src/messaging/client/group_messages.h
+++ b/src/messaging/client/group_messages.h
@@ -40,13 +40,15 @@ using groupOutputInfoUpdate_t = std::pair<bool, engine::Group::GroupOutputInfo>;
 SERIAL_TO_CLIENT(GroupOutputInfoUpdated, s2c_update_group_output_info, groupOutputInfoUpdate_t,
                  onGroupOutputInfoUpdated);
 
-CLIENT_TO_SERIAL(UpdateGroupOutputFloatValue, c2s_update_group_output_float_value,
-                 detail::diffMsg_t<float>,
-                 detail::updateGroupMemberValue(&engine::Group::outputInfo, payload, engine, cont));
+CLIENT_TO_SERIAL_CONSTRAINED(UpdateGroupOutputFloatValue, c2s_update_group_output_float_value,
+                             detail::diffMsg_t<float>, engine::Group::GroupOutputInfo,
+                             detail::updateGroupMemberValue(&engine::Group::outputInfo, payload,
+                                                            engine, cont));
 
-CLIENT_TO_SERIAL(UpdateGroupOutputInt16TValue, c2s_update_group_output_int16_t_value,
-                 detail::diffMsg_t<int16_t>,
-                 detail::updateGroupMemberValue(&engine::Group::outputInfo, payload, engine, cont));
+CLIENT_TO_SERIAL_CONSTRAINED(UpdateGroupOutputInt16TValue, c2s_update_group_output_int16_t_value,
+                             detail::diffMsg_t<int16_t>, engine::Group::GroupOutputInfo,
+                             detail::updateGroupMemberValue(&engine::Group::outputInfo, payload,
+                                                            engine, cont));
 
 using renameGroup_t = std::tuple<selection::SelectionManager::ZoneAddress, std::string>;
 inline void renameGroup(const renameGroup_t &payload, const engine::Engine &engine,

--- a/src/messaging/client/group_or_zone_messages.h
+++ b/src/messaging/client/group_or_zone_messages.h
@@ -35,32 +35,32 @@ typedef std::tuple<bool, int, bool, datamodel::AdsrStorage> adsrViewResponsePayl
 SERIAL_TO_CLIENT(AdsrGroupOrZoneUpdate, s2c_update_group_or_zone_adsr_view,
                  adsrViewResponsePayload_t, onGroupOrZoneEnvelopeUpdated);
 
-CLIENT_TO_SERIAL(UpdateZoneGroupEGFloatValue, c2s_update_zone_or_group_adsr_value,
-                 detail::indexedZoneOrGroupDiffMsg_t<float>,
-                 detail::updateZoneOrGroupIndexedMemberValue(&engine::Zone::egStorage,
-                                                             &engine::Group::gegStorage, payload,
-                                                             engine, cont));
+CLIENT_TO_SERIAL_CONSTRAINED(UpdateZoneGroupEGFloatValue, c2s_update_zone_or_group_adsr_value,
+                             detail::indexedZoneOrGroupDiffMsg_t<float>, datamodel::AdsrStorage,
+                             detail::updateZoneOrGroupIndexedMemberValue(&engine::Zone::egStorage,
+                                                                         &engine::Group::gegStorage,
+                                                                         payload, engine, cont));
 
-CLIENT_TO_SERIAL(UpdateZoneOrGroupModStorageFloatValue,
-                 c2s_update_zone_or_group_modstorage_float_value,
-                 detail::indexedZoneOrGroupDiffMsg_t<float>,
-                 detail::updateZoneOrGroupIndexedMemberValue(&engine::Zone::modulatorStorage,
-                                                             &engine::Group::modulatorStorage,
-                                                             payload, engine, cont));
+CLIENT_TO_SERIAL_CONSTRAINED(
+    UpdateZoneOrGroupModStorageFloatValue, c2s_update_zone_or_group_modstorage_float_value,
+    detail::indexedZoneOrGroupDiffMsg_t<float>, modulation::ModulatorStorage,
+    detail::updateZoneOrGroupIndexedMemberValue(&engine::Zone::modulatorStorage,
+                                                &engine::Group::modulatorStorage, payload, engine,
+                                                cont));
 
-CLIENT_TO_SERIAL(UpdateZoneOrGroupModStorageBoolValue,
-                 c2s_update_zone_or_group_modstorage_bool_value,
-                 detail::indexedZoneOrGroupDiffMsg_t<bool>,
-                 detail::updateZoneOrGroupIndexedMemberValue(&engine::Zone::modulatorStorage,
-                                                             &engine::Group::modulatorStorage,
-                                                             payload, engine, cont));
+CLIENT_TO_SERIAL_CONSTRAINED(
+    UpdateZoneOrGroupModStorageBoolValue, c2s_update_zone_or_group_modstorage_bool_value,
+    detail::indexedZoneOrGroupDiffMsg_t<bool>, modulation::ModulatorStorage,
+    detail::updateZoneOrGroupIndexedMemberValue(&engine::Zone::modulatorStorage,
+                                                &engine::Group::modulatorStorage, payload, engine,
+                                                cont));
 
-CLIENT_TO_SERIAL(UpdateZoneOrGroupModStorageInt16TValue,
-                 c2s_update_zone_or_group_modstorage_int16_t_value,
-                 detail::indexedZoneOrGroupDiffMsg_t<int16_t>,
-                 detail::updateZoneOrGroupIndexedMemberValue(&engine::Zone::modulatorStorage,
-                                                             &engine::Group::modulatorStorage,
-                                                             payload, engine, cont));
+CLIENT_TO_SERIAL_CONSTRAINED(
+    UpdateZoneOrGroupModStorageInt16TValue, c2s_update_zone_or_group_modstorage_int16_t_value,
+    detail::indexedZoneOrGroupDiffMsg_t<int16_t>, modulation::ModulatorStorage,
+    detail::updateZoneOrGroupIndexedMemberValue(&engine::Zone::modulatorStorage,
+                                                &engine::Group::modulatorStorage, payload, engine,
+                                                cont));
 
 } // namespace scxt::messaging::client
 #endif // SHORTCIRCUITXT_GROUP_OR_ZONE_MESSAGES_H

--- a/src/messaging/client/processor_messages.h
+++ b/src/messaging/client/processor_messages.h
@@ -128,23 +128,26 @@ CLIENT_TO_SERIAL(SetSelectedProcessorType, c2s_set_processor_type, setProcessorP
 CLIENT_TO_SERIAL(CopyProcessorLeadToAll, c2s_copy_processor_lead_to_all, int,
                  engine.getSelectionManager()->copyZoneProcessorLeadToAll(payload));
 
-CLIENT_TO_SERIAL(UpdateZoneOrGroupProcessorFloatValue, c2s_update_single_processor_float_value,
-                 detail::indexedZoneOrGroupDiffMsg_t<float>,
-                 detail::updateZoneOrGroupIndexedMemberValue(&engine::Zone::processorStorage,
-                                                             &engine::Group::processorStorage,
-                                                             payload, engine, cont));
+CLIENT_TO_SERIAL_CONSTRAINED(
+    UpdateZoneOrGroupProcessorFloatValue, c2s_update_single_processor_float_value,
+    detail::indexedZoneOrGroupDiffMsg_t<float>, dsp::processor::ProcessorStorage,
+    detail::updateZoneOrGroupIndexedMemberValue(&engine::Zone::processorStorage,
+                                                &engine::Group::processorStorage, payload, engine,
+                                                cont));
 
-CLIENT_TO_SERIAL(UpdateZoneOrGroupProcessorInt32TValue, c2s_update_single_processor_int32_t_value,
-                 detail::indexedZoneOrGroupDiffMsg_t<int32_t>,
-                 detail::updateZoneOrGroupIndexedMemberValue(&engine::Zone::processorStorage,
-                                                             &engine::Group::processorStorage,
-                                                             payload, engine, cont));
+CLIENT_TO_SERIAL_CONSTRAINED(
+    UpdateZoneOrGroupProcessorInt32TValue, c2s_update_single_processor_int32_t_value,
+    detail::indexedZoneOrGroupDiffMsg_t<int32_t>, dsp::processor::ProcessorStorage,
+    detail::updateZoneOrGroupIndexedMemberValue(&engine::Zone::processorStorage,
+                                                &engine::Group::processorStorage, payload, engine,
+                                                cont));
 
-CLIENT_TO_SERIAL(UpdateZoneOrGroupProcessorBoolValue, c2s_update_single_processor_bool_value,
-                 detail::indexedZoneOrGroupDiffMsg_t<bool>,
-                 detail::updateZoneOrGroupIndexedMemberValue(&engine::Zone::processorStorage,
-                                                             &engine::Group::processorStorage,
-                                                             payload, engine, cont));
+CLIENT_TO_SERIAL_CONSTRAINED(
+    UpdateZoneOrGroupProcessorBoolValue, c2s_update_single_processor_bool_value,
+    detail::indexedZoneOrGroupDiffMsg_t<bool>, dsp::processor::ProcessorStorage,
+    detail::updateZoneOrGroupIndexedMemberValue(&engine::Zone::processorStorage,
+                                                &engine::Group::processorStorage, payload, engine,
+                                                cont));
 
 // C2S set processor type (sends back data and metadata)
 typedef std::pair<int32_t, int32_t> processorPair_t;

--- a/src/messaging/client/zone_messages.h
+++ b/src/messaging/client/zone_messages.h
@@ -91,13 +91,15 @@ using zoneOutputInfoUpdate_t = std::pair<bool, engine::Zone::ZoneOutputInfo>;
 SERIAL_TO_CLIENT(ZoneOutputInfoUpdated, s2c_update_zone_output_info, zoneOutputInfoUpdate_t,
                  onZoneOutputInfoUpdated);
 
-CLIENT_TO_SERIAL(UpdateZoneOutputFloatValue, c2s_update_zone_output_float_value,
-                 detail::diffMsg_t<float>,
-                 detail::updateZoneMemberValue(&engine::Zone::outputInfo, payload, engine, cont));
+CLIENT_TO_SERIAL_CONSTRAINED(UpdateZoneOutputFloatValue, c2s_update_zone_output_float_value,
+                             detail::diffMsg_t<float>, engine::Zone::ZoneOutputInfo,
+                             detail::updateZoneMemberValue(&engine::Zone::outputInfo, payload,
+                                                           engine, cont));
 
-CLIENT_TO_SERIAL(UpdateZoneOutputInt16TValue, c2s_update_zone_output_int16_t_value,
-                 detail::diffMsg_t<int16_t>,
-                 detail::updateZoneMemberValue(&engine::Zone::outputInfo, payload, engine, cont));
+CLIENT_TO_SERIAL_CONSTRAINED(UpdateZoneOutputInt16TValue, c2s_update_zone_output_int16_t_value,
+                             detail::diffMsg_t<int16_t>, engine::Zone::ZoneOutputInfo,
+                             detail::updateZoneMemberValue(&engine::Zone::outputInfo, payload,
+                                                           engine, cont));
 
 } // namespace scxt::messaging::client
 

--- a/src/sample/sample.cpp
+++ b/src/sample/sample.cpp
@@ -39,7 +39,7 @@ using namespace sst::basic_blocks::mechanics;
 
 Sample::~Sample()
 {
-    SCLOG("Deleting sample '" << displayName << "'");
+    SCLOG("Deleting sample '" << displayName << "' at " << id.to_string());
     if (sampleData[0])
         free(sampleData[0]);
     if (sampleData[1])


### PR DESCRIPTION
Member updates were previously oblivious if the message matched the payload etc... this makes a complie error if you try to send a processor update to a mod row or some such