### PR TITLE
Fix a problem where shift-sel group with no zones ran away

### DIFF
--- a/src/selection/selection_manager.cpp
+++ b/src/selection/selection_manager.cpp
@@ -137,8 +137,8 @@ void SelectionManager::selectAction(
         for (auto gi = gs; gi <= ge; ++gi)
         {
             const auto &grp = engine.getPatch()->getPart(zf.part)->getGroup(gi);
-            auto sz = (gi == gs ? zf.zone : 0);
-            auto ez = (gi == ge ? zt.zone : grp->getZones().size() - 1);
+            auto sz = ((gi == gs && zf.zone >= 0) ? zf.zone : 0);
+            auto ez = ((gi == ge && zt.zone >= 0) ? zt.zone : grp->getZones().size() - 1);
             for (auto zi = sz; zi <= ez; ++zi)
             {
                 SelectActionContents se;


### PR DESCRIPTION
Shift-sel a group where no zones are selected and the zone in group of -1 would give the selection range the wrong end point, pushing 2^32 groups into the selection set and blowing out memory

Closes #756