### PR TITLE
Switch to the jucegui viewport subclass

### DIFF
--- a/src-ui/components/mixer/BusPane.cpp
+++ b/src-ui/components/mixer/BusPane.cpp
@@ -26,13 +26,16 @@
  */
 
 #include "BusPane.h"
+
+#include "sst/jucegui/components/Viewport.h"
+
 namespace scxt::ui::mixer
 {
 
 BusPane::BusPane(SCXTEditor *e, MixerScreen *m)
     : HasEditor(e), mixer(m), sst::jucegui::components::NamedPanel("BUSSES")
 {
-    partBusViewport = std::make_unique<juce::Viewport>();
+    partBusViewport = std::make_unique<sst::jucegui::components::Viewport>();
     partBusContainer = std::make_unique<juce::Component>();
 
     for (int i = 0; i < maxBusses; ++i)
@@ -82,14 +85,6 @@ void BusPane::resized()
         mb = mb.translated(busWidth, 0);
     }
     channelStrips[0]->setBounds(mb);
-}
-void BusPane::onStyleChanged()
-{
-    if (partBusViewport)
-    {
-        partBusViewport->getHorizontalScrollBar().setColour(
-            juce::ScrollBar::ColourIds::thumbColourId, getColour(Styles::outline));
-    }
 }
 
 } // namespace scxt::ui::mixer

--- a/src-ui/components/mixer/BusPane.h
+++ b/src-ui/components/mixer/BusPane.h
@@ -53,8 +53,6 @@ struct BusPane : public HasEditor, public sst::jucegui::components::NamedPanel
     MixerScreen *mixer{nullptr};
     BusPane(SCXTEditor *e, MixerScreen *m);
     void resized() override;
-
-    void onStyleChanged() override;
 };
 } // namespace scxt::ui::mixer
 

--- a/src-ui/components/multi/MappingPane.cpp
+++ b/src-ui/components/multi/MappingPane.cpp
@@ -39,6 +39,7 @@
 
 #include "connectors/SCXTStyleSheetCreator.h"
 #include "engine/part.h"
+#include "sst/jucegui/components/Viewport.h"
 
 namespace scxt::ui::multi
 {
@@ -201,7 +202,7 @@ struct Zoomable : public juce::Component
         : zoomX({1.f, 1, minMaxX.first, minMaxX.second}),
           zoomY({1.f, 1, minMaxY.first, minMaxY.second})
     {
-        viewport = std::make_unique<juce::Viewport>();
+        viewport = std::make_unique<sst::jucegui::components::Viewport>();
         viewport->setViewedComponent(attachedComponent, false);
         addAndMakeVisible(*viewport);
 


### PR DESCRIPTION
which styles and shapes our scrollbars consistently across usages. Move bus pane and mapping pane