### PR TITLE
On Zone Swap make sure mapping visibile matches tabs

### DIFF
--- a/src-ui/components/multi/MappingPane.cpp
+++ b/src-ui/components/multi/MappingPane.cpp
@@ -1933,7 +1933,9 @@ void MappingPane::setSampleData(const engine::Zone::AssociatedSampleArray &m)
 void MappingPane::setActive(bool b)
 {
     mappingDisplay->setActive(b);
+    mappingDisplay->setVisible(selectedTab == 0);
     sampleDisplay->setActive(b);
+    sampleDisplay->setVisible(selectedTab == 1);
 }
 
 void MappingPane::setGroupZoneMappingSummary(const engine::Part::zoneMappingSummary_t &d)


### PR DESCRIPTION
since we activate on zone swap that has an implicit visible in it which we need to override.

Closes #794