### PR TITLE
Fix a collection of structural changes

### DIFF
--- a/src-ui/components/multi/ProcessorPane.cpp
+++ b/src-ui/components/multi/ProcessorPane.cpp
@@ -452,7 +452,14 @@ void ProcessorPane::itemDropped(const juce::DragAndDropTarget::SourceDetails &dr
     if (!pp)
         return;
 
-    sendToSerialization(cmsg::SwapZoneProcessors({index, pp->index}));
+    if (forZone)
+    {
+        sendToSerialization(cmsg::SwapZoneProcessors({index, pp->index}));
+    }
+    else
+    {
+        sendToSerialization(cmsg::SwapGroupProcessors({index, pp->index}));
+    }
 }
 
 void ProcessorPane::mouseDrag(const juce::MouseEvent &e)

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -734,4 +734,13 @@ void Engine::registerGroupModSource(const modulation::GroupMatrixConfig::SourceI
     groupModSources.emplace(t, std::make_pair(pathFn, nameFn));
 }
 
+void Engine::terminateVoicesForZone(scxt::engine::Zone &z) { z.terminateAllVoices(); }
+
+void Engine::terminateVoicesForGroup(scxt::engine::Group &g)
+{
+    for (auto &z : g)
+    {
+        terminateVoicesForZone(*z);
+    }
+}
 } // namespace scxt::engine

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -412,6 +412,12 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     void registerGroupModSource(const modulation::GroupMatrixConfig::SourceIdentifier &,
                                 gmodSrcStrFn_t pathFn, gmodSrcStrFn_t nameFn);
 
+    /*
+     * Accelerated voice termination
+     */
+    void terminateVoicesForZone(Zone &z);
+    void terminateVoicesForGroup(Group &g);
+
   private:
     std::unique_ptr<Patch> patch;
     std::unique_ptr<MemoryPool> memoryPool;

--- a/src/engine/group.cpp
+++ b/src/engine/group.cpp
@@ -246,7 +246,10 @@ void Group::onProcessorTypeChanged(int w, dsp::processor::ProcessorType t)
 {
     if (t != dsp::processor::ProcessorType::proct_none)
     {
-        SCLOG("Group Processor Changed: " << w << " " << t);
+        if (processors[w])
+        {
+            dsp::processor::unspawnProcessor(processors[w]);
+        }
         // FIXME - replace the float params with something modulatable
         processors[w] = dsp::processor::spawnProcessorInPlace(
             t, asT()->getEngine()->getMemoryPool().get(), processorPlacementStorage[w],

--- a/src/engine/zone.cpp
+++ b/src/engine/zone.cpp
@@ -84,7 +84,6 @@ void Zone::process(Engine &e)
 
     for (int i = 0; i < cleanupIdx; ++i)
     {
-
 #if DEBUG_VOICE_LIFECYCLE
         SCLOG("Cleanup Voice at " << SCDBGV((int)toCleanUp[i]->key));
 #endif
@@ -279,6 +278,27 @@ Zone::LoopDirection Zone::fromStringLoopDirection(const std::string &s)
 }
 
 void Zone::onSampleRateChanged() { mUILag.setRate(120, blockSize, sampleRate); }
+
+void Zone::terminateAllVoices()
+{
+    std::array<voice::Voice *, maxVoices> toCleanUp{};
+    size_t cleanupIdx{0};
+    for (auto &v : voiceWeakPointers)
+    {
+        if (v && v->isVoiceAssigned)
+        {
+            toCleanUp[cleanupIdx++] = v;
+        }
+    }
+    if (cleanupIdx)
+    {
+        SCLOG("Early-terminating " << cleanupIdx << " voices");
+    }
+    for (int i = 0; i < cleanupIdx; ++i)
+    {
+        toCleanUp[i]->cleanupVoice();
+    }
+}
 
 template struct HasGroupZoneProcessors<Zone>;
 } // namespace scxt::engine

--- a/src/engine/zone.h
+++ b/src/engine/zone.h
@@ -171,6 +171,7 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
     uint32_t activeVoices{0};
     std::array<voice::Voice *, maxVoices> voiceWeakPointers;
     int gatedVoiceCount{0};
+    void terminateAllVoices();
 
     void initialize();
     // Just a weak ref - don't take ownership. engine manages lifetime

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -77,6 +77,7 @@ enum ClientToSerializationMessagesIds
     c2s_set_processor_type,
     c2s_copy_processor_lead_to_all,
     c2s_swap_zone_processors,
+    c2s_swap_group_processors,
 
     c2s_add_sample,
     c2s_add_sample_with_range,


### PR DESCRIPTION
1. Moving a zone, deleting a zone, deleting a group etc.. hard shuts down a voice. For now it just slams it to shut off with no fade.
2. Swapping group processors actually sends a group swap message.

I think this addresses #797 and #798 but will wait for some confirm before closing.