### PR TITLE
Start of a layout-style helper class set

### DIFF
--- a/src-ui/components/SCXTEditor.h
+++ b/src-ui/components/SCXTEditor.h
@@ -295,7 +295,7 @@ inline void HasEditor::setupWidgetForValueTooltip(const W &w, const A &a)
         editor->showTooltip(slRef);
         updateValueTooltip(atRef);
     };
-    w->onIdleHoverEnd = [this, &atRef = *a]() { editor->hideTooltip(); };
+    w->onIdleHoverEnd = [this]() { editor->hideTooltip(); };
 }
 } // namespace scxt::ui
 

--- a/src-ui/components/multi/ProcessorPaneEQNBandParametric.cpp
+++ b/src-ui/components/multi/ProcessorPaneEQNBandParametric.cpp
@@ -150,7 +150,7 @@ void ProcessorPane::layoutControlsEQNBandParm()
     getContentAreaComponent()->addAndMakeVisible(*eqdisp);
     otherEditors.push_back(std::move(eqdisp));
 
-    mixEditor = attachContinuousTo<sst::jucegui::components::VSlider>(mixAttachment);
-    mixEditor->setBounds(mx);
+    mixEditor = createWidgetAttachedTo<sst::jucegui::components::VSlider>(mixAttachment, "Mix");
+    mixEditor->item->setBounds(mx);
 }
 } // namespace scxt::ui::multi

--- a/src-ui/connectors/PayloadDataAttachment.h
+++ b/src-ui/connectors/PayloadDataAttachment.h
@@ -401,6 +401,37 @@ template <typename A, typename Msg, typename ABase = A> struct SingleValueFactor
         auto md = scxt::datamodel::describeValue(p, val);
         attachAndAdd(md, p, val, e, aRes, wRes, std::forward<Args>(args)...);
     }
+
+    template <typename W, typename... Args>
+    static void attachLabelAndAdd(const datamodel::pmd &md, const typename A::payload_t &p,
+                                  typename A::value_t &val, HasEditor *e, std::unique_ptr<A> &aRes,
+                                  std::unique_ptr<W> &wRes, const std::string &lab, Args... args)
+    {
+        assert(!wRes);
+        wRes = std::make_unique<W>();
+
+        attachAndAdd(md, p, val, e, aRes, wRes->item, std::forward<Args>(args)...);
+
+        using labUPType = decltype(W::label);
+        using labType = typename labUPType::element_type;
+        wRes->label = std::make_unique<labType>();
+        wRes->label->setText(lab);
+        auto jc = dynamic_cast<juce::Component *>(e);
+        assert(jc);
+        if (jc)
+        {
+            jc->addAndMakeVisible(*(wRes->label));
+        }
+    }
+
+    template <typename W, typename... Args>
+    static void attachLabelAndAdd(const typename A::payload_t &p, typename A::value_t &val,
+                                  HasEditor *e, std::unique_ptr<A> &aRes, std::unique_ptr<W> &wRes,
+                                  const std::string &lab, Args... args)
+    {
+        auto md = scxt::datamodel::describeValue(p, val);
+        attachLabelAndAdd(md, p, val, e, aRes, wRes, lab, std::forward<Args>(args)...);
+    }
 };
 
 template <typename A, typename Msg>

--- a/src-ui/theme/ColorMap.cpp
+++ b/src-ui/theme/ColorMap.cpp
@@ -1,6 +1,29 @@
-//
-// Created by Paul Walker on 2/25/24.
-//
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
 
 #include "ColorMap.h"
 

--- a/src-ui/theme/Layout.h
+++ b/src-ui/theme/Layout.h
@@ -1,0 +1,152 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_UI_THEME_LAYOUT_H
+#define SCXT_SRC_UI_THEME_LAYOUT_H
+
+#include <vector>
+#include <cassert>
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include "sst/jucegui/components/LabeledItem.h"
+
+namespace scxt::ui::theme::layout
+{
+namespace constants
+{
+static constexpr int labelHeight{12};
+static constexpr int labelMargin{2};
+static constexpr int extraLargeKnob{80};
+static constexpr int largeKnob{60};
+static constexpr int mediumKnob{40};
+} // namespace constants
+
+template <typename F> inline F centerOfColumnMofN(const juce::Rectangle<F> &r, int m, int N)
+{
+    assert(N > 0);
+    float w = r.getWidth() * 1.f / N;
+    return (F)(w * (m + 0.5));
+}
+
+template <typename F> inline std::vector<F> columnCenters(const juce::Rectangle<F> &r, int N)
+{
+    assert(N > 0);
+    float w = r.getWidth() * 1.f / N;
+    std::vector<F> res;
+    for (int i = 0; i < N; ++i)
+        res.push_back((F)(w * (i + 0.5)));
+    return res;
+}
+
+inline float centerOfColumnMofN(juce::Component *r, int m, int N)
+{
+    return centerOfColumnMofN(r->getLocalBounds().toFloat(), m, N);
+}
+
+inline float centerOfColumnMofN(const juce::Component &r, int m, int N)
+{
+    return centerOfColumnMofN(r.getLocalBounds().toFloat(), m, N);
+}
+
+template <typename F>
+inline juce::Rectangle<F> columnMofN(const juce::Rectangle<F> &r, int m, int N)
+{
+    auto w = r.getWidth() * 1.f / N;
+    return r.withTrimmedLeft((F)(w * m)).withWidth((F)w);
+}
+
+struct Layout
+{
+    struct Position : juce::Rectangle<float>
+    {
+        Position(float x, float y, float w, float h) : juce::Rectangle<float>(x, y, w, h) {}
+        Position(const juce::Rectangle<float> &other) : juce::Rectangle<float>(other) {}
+
+        Position belowWith(float withHeight) const
+        {
+            return {getX(), getY() + getHeight(), getWidth(), withHeight};
+        }
+
+        Position beneathLabel() const
+        {
+            return {getX(),
+                    getY() + getHeight() + constants::labelHeight + 2 * constants::labelMargin,
+                    getWidth(), getHeight()};
+        }
+
+        Position toRightOf() const
+        {
+            return {getX() + getWidth() + constants::labelMargin, getY(), getWidth(), getHeight()};
+        }
+
+        Position dX(float tx) const { return translated(tx, 0); }
+        Position dY(float ty) const { return translated(0, ty); }
+
+        Position labelBelow() const
+        {
+            return belowWith(constants::labelHeight).dY(constants::labelMargin);
+        }
+    };
+
+    Position add(juce::Component &c, float x, float y, float w, float h)
+    {
+        auto res = Position(x, y, w, h);
+        c.setBounds(res.toNearestIntEdges());
+        return res;
+    }
+
+    Position add(juce::Component &c, const Position &p)
+    {
+        c.setBounds(p.toNearestIntEdges());
+        return p;
+    }
+
+    template <typename T>
+    Position addLabeled(const sst::jucegui::components::Labeled<T> &lt, const Position &p)
+    {
+        add(*lt.item, p);
+        add(*lt.label, p.labelBelow());
+        return p;
+    }
+
+    template <int size, typename T>
+    Position knob(sst::jucegui::components::Labeled<T> &lt, float x, float y)
+    {
+        auto kc = Position(x, y, size, size);
+        return addLabeled(lt, kc);
+    }
+
+    template <int size, typename T>
+    Position knobCX(sst::jucegui::components::Labeled<T> &lt, float x, float y)
+    {
+        auto kc = Position(x - size / 2, y, size, size);
+        return addLabeled(lt, kc);
+    }
+};
+
+} // namespace scxt::ui::theme::layout
+#endif // SHORTCIRCUITXT_LAYOUT_H

--- a/src-ui/theme/ThemeApplier.cpp
+++ b/src-ui/theme/ThemeApplier.cpp
@@ -165,6 +165,7 @@ void populateSharedGroupZoneMultiModulation(jstl::CustomTypeMap &map)
 void ThemeApplier::applyZoneMultiScreenModulationTheme(juce::Component *toThis)
 {
     jstl::CustomTypeMap map;
+    map.addCustomClass<jcmp::NamedPanel>(detail::multi::zone::ModulationNamedPanel);
     map.addCustomClass<jcmp::MultiSwitch>(detail::multi::zone::ModulationMultiSwitch);
     map.addCustomClass<jcmp::VSlider>(detail::multi::zone::ModulationVSlider);
     map.addCustomClass<jcmp::Knob>(detail::multi::zone::ModulationKnob);


### PR DESCRIPTION
- LabeledWidget is a first classable thing
- A layout maanger with incipient constants for things like knobs
- An extension of juce::Rectangle with concepts like 'labelAreaBelow'
- Fixes to some color themeing code
- General functions to allow above, making clients more compact and readable