### PR TITLE
Implement a more rational memory pool

### DIFF
--- a/src/engine/memory_pool.h
+++ b/src/engine/memory_pool.h
@@ -32,6 +32,7 @@
 #include <cctype>
 #include <unordered_map>
 #include <unordered_set>
+#include <queue>
 
 #include "utils.h"
 
@@ -53,8 +54,10 @@ struct MemoryPool : MoveableOnly<MemoryPool>
     {
         return ((x >> N) + 1) * (1 << N);
     }
-    void growBlock(size_t blockSize);
-    std::unordered_map<size_t, std::unordered_set<data_t *>> cache;
+    void growBlock(size_t blockSize, size_t byEntries);
+    using pool_t = std::queue<data_t *>;
+    using cache_t = std::unordered_map<size_t, pool_t>;
+    cache_t cache;
 
     int64_t debugCheckouts{0}, debugReturns{0};
 };

--- a/src/voice/voice.h
+++ b/src/voice/voice.h
@@ -161,13 +161,7 @@ struct alignas(16) Voice : MoveableOnly<Voice>,
         voiceStarted();
     }
     void release() { isGated = false; }
-    void cleanupVoice()
-    {
-        zone->removeVoice(this);
-        zone = nullptr;
-        isVoiceAssigned = false;
-        engine->voiceManagerResponder.doVoiceEndCallback(this);
-    }
+    void cleanupVoice();
 };
 } // namespace scxt::voice
 


### PR DESCRIPTION
The memory pool pre-allocates chunks and grows available chunks on demand, cleaning up on exit, allowing minimal voice time allocation even for memory heavy effects like MicroGate.

Closes #385