### PR TITLE
Add transport based modulation phasors

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -47,6 +47,8 @@ static constexpr uint16_t firstAuxOutput{firstPartOutput + numParts};
 static constexpr uint16_t numNonMainPluginOutputs{20};
 static constexpr uint16_t numPluginOutputs{numNonMainPluginOutputs + 1};
 
+static constexpr size_t numTransportPhasors{7}; // double whole -> 32
+
 static constexpr uint16_t maxVoices{256};
 
 // some battles are not worth it

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -262,6 +262,8 @@ bool Engine::processAudio()
         return true;
     }
 
+    updateTransportPhasors();
+
     getPatch()->process(*this);
 
     auto &bl = sharedUIMemoryState.busVULevels;
@@ -751,5 +753,18 @@ void Engine::onTransportUpdated()
     sharedUIMemoryState.transportDisplay.tsnum = transport.signature.numerator;
     sharedUIMemoryState.transportDisplay.hostpos = transport.hostTimeInBeats;
     sharedUIMemoryState.transportDisplay.timepos = transport.timeInBeats;
+
+    updateTransportPhasors();
+}
+
+void Engine::updateTransportPhasors()
+{
+    float mul = 1 << ((numTransportPhasors - 1) / 2);
+    for (int i = 0; i < numTransportPhasors; ++i)
+    {
+        float rawBeat;
+        transportPhasors[i] = std::modf((float)(transport.timeInBeats) * mul, &rawBeat);
+        mul = mul / 2;
+    }
 }
 } // namespace scxt::engine

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -109,6 +109,8 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
 
     Transport transport;
     void onTransportUpdated();
+    float transportPhasors[numTransportPhasors]{};
+    void updateTransportPhasors();
 
     /**
      * Midi-style events. Each event is assumed to be at the top of the

--- a/src/modulation/group_matrix.cpp
+++ b/src/modulation/group_matrix.cpp
@@ -135,6 +135,11 @@ void GroupMatrixEndpoints::Sources::bind(scxt::modulation::GroupMatrix &m, engin
             break;
         }
     }
+
+    for (int i = 0; i < scxt::numTransportPhasors; ++i)
+    {
+        m.bindSourceValue(transportSources.phasors[i], g.getEngine()->transportPhasors[i]);
+    }
 }
 
 void GroupMatrixEndpoints::registerGroupModTarget(

--- a/src/modulation/group_matrix.h
+++ b/src/modulation/group_matrix.h
@@ -213,8 +213,7 @@ struct GroupMatrixEndpoints
     struct Sources
     {
         Sources(engine::Engine *e)
-            : lfoSources(e), egSource{{'greg', 'eg1 ', 0}, {'greg', 'eg2 ', 0}}
-
+            : lfoSources(e), egSource{{'greg', 'eg1 ', 0}, {'greg', 'eg2 ', 0}}, transportSources(e)
         {
             registerGroupModSource(e, egSource[0], "", "EG1");
             registerGroupModSource(e, egSource[1], "", "EG2");
@@ -233,6 +232,26 @@ struct GroupMatrixEndpoints
         } lfoSources;
 
         SR egSource[2];
+
+        struct TransportSources
+        {
+            TransportSources(engine::Engine *e)
+            {
+                auto ctr = (scxt::numTransportPhasors - 1) / 2;
+                for (uint32_t i = 0; i < scxt::numTransportPhasors; ++i)
+                {
+                    std::string name = "Beat";
+                    if (i < ctr)
+                        name = std::string("Beat / ") + std::to_string(1 << (ctr - i));
+                    if (i > ctr)
+                        name = std::string("Beat x ") + std::to_string(1 << (i - ctr));
+
+                    phasors[i] = SR{'gtsp', 'phsr', i};
+                    registerGroupModSource(e, phasors[i], "Transport", name);
+                }
+            }
+            SR phasors[scxt::numTransportPhasors];
+        } transportSources;
 
         float zeroSource{0.f};
 

--- a/src/modulation/voice_matrix.cpp
+++ b/src/modulation/voice_matrix.cpp
@@ -118,6 +118,11 @@ void MatrixEndpoints::Sources::bind(scxt::voice::modulation::Matrix &m, engine::
     m.bindSourceValue(midiSources.modWheelSource,
                       z.parentGroup->parentPart->midiCCSmoothers[1].output);
     m.bindSourceValue(midiSources.velocitySource, v.velocity);
+
+    for (int i = 0; i < scxt::numTransportPhasors; ++i)
+    {
+        m.bindSourceValue(transportSources.phasors[i], z.getEngine()->transportPhasors[i]);
+    }
 }
 
 void MatrixEndpoints::registerVoiceModTarget(

--- a/src/modulation/voice_matrix.h
+++ b/src/modulation/voice_matrix.h
@@ -202,7 +202,7 @@ struct MatrixEndpoints
     {
         Sources(engine::Engine *e)
             : lfoSources(e), midiSources(e), aegSource{'zneg', 'aeg ', 0},
-              eg2Source{'zneg', 'eg2 ', 0}
+              eg2Source{'zneg', 'eg2 ', 0}, transportSources(e)
         {
             registerVoiceModSource(e, aegSource, "", "AEG");
             registerVoiceModSource(e, eg2Source, "", "EG2");
@@ -230,6 +230,26 @@ struct MatrixEndpoints
             }
             SR modWheelSource, velocitySource;
         } midiSources;
+
+        struct TransportSources
+        {
+            TransportSources(engine::Engine *e)
+            {
+                auto ctr = (scxt::numTransportPhasors - 1) / 2;
+                for (uint32_t i = 0; i < scxt::numTransportPhasors; ++i)
+                {
+                    std::string name = "Beat";
+                    if (i < ctr)
+                        name = std::string("Beat / ") + std::to_string(1 << (ctr - i));
+                    if (i > ctr)
+                        name = std::string("Beat x ") + std::to_string(1 << (i - ctr));
+
+                    phasors[i] = SR{'ztsp', 'phsr', i};
+                    registerVoiceModSource(e, phasors[i], "Transport", name);
+                }
+            }
+            SR phasors[scxt::numTransportPhasors];
+        } transportSources;
 
         SR aegSource, eg2Source;
 


### PR DESCRIPTION
From Beat/4 -> Beat x 4 saw phasors based on the transport locked to songpos in the zone and group matrices.

Plus modify the source UI to allow submenus