### PR TITLE
Add Sample Variation round robin

### DIFF
--- a/src-ui/components/MultiScreen.cpp
+++ b/src-ui/components/MultiScreen.cpp
@@ -104,9 +104,9 @@ void MultiScreen::layout()
 
 void MultiScreen::onVoiceInfoChanged() { sample->repaint(); }
 
-void MultiScreen::updateSamplePlaybackPosition(int64_t samplePos)
+void MultiScreen::updateSamplePlaybackPosition(size_t sampleIndex, int64_t samplePos)
 {
-    sample->updateSamplePlaybackPosition(samplePos);
+    sample->updateSamplePlaybackPosition(sampleIndex, samplePos);
 }
 
 void MultiScreen::setSelectionMode(scxt::ui::MultiScreen::SelectionMode m)

--- a/src-ui/components/MultiScreen.h
+++ b/src-ui/components/MultiScreen.h
@@ -121,7 +121,7 @@ struct MultiScreen : juce::Component, HasEditor
 
     void layout();
     void onVoiceInfoChanged();
-    void updateSamplePlaybackPosition(int64_t samplePos);
+    void updateSamplePlaybackPosition(size_t sampleIndex, int64_t samplePos);
 
     enum class SelectionMode
     {

--- a/src-ui/components/SCXTEditor.cpp
+++ b/src-ui/components/SCXTEditor.cpp
@@ -216,17 +216,16 @@ void SCXTEditor::idle()
     {
         if (currentLeadZoneSelection.has_value())
         {
-            auto samplePos = -1;
             for (const auto &v : sharedUiMemoryState.voiceDisplayItems)
             {
+
                 if (v.active && v.group == currentLeadZoneSelection->group &&
                     v.part == currentLeadZoneSelection->part &&
                     v.zone == currentLeadZoneSelection->zone)
                 {
-                    samplePos = v.samplePos;
+                    multiScreen->updateSamplePlaybackPosition(v.sample, v.samplePos);
                 }
             }
-            multiScreen->updateSamplePlaybackPosition(samplePos);
         }
     }
 

--- a/src-ui/components/multi/MappingPane.h
+++ b/src-ui/components/multi/MappingPane.h
@@ -61,7 +61,7 @@ struct MappingPane : sst::jucegui::components::NamedPanel, HasEditor
     engine::Zone::ZoneMappingData mappingView;
     engine::Zone::AssociatedSampleArray sampleView;
 
-    void updateSamplePlaybackPosition(int64_t samplePos);
+    void updateSamplePlaybackPosition(size_t sampleIndex, int64_t samplePos);
 
     void invertScroll(bool invert);
     bool invertScroll() const;

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -403,7 +403,7 @@ void Engine::loadSampleIntoZone(const fs::path &p, int16_t partID, int16_t group
 
     // TODO: Deal with compound types more comprehensively
     // If you add a type here add it to Browser::isLoadableFile also
-    if (extensionMatches(p, ".sf2") or extensionMatches(p, ".sfz"))
+    if (extensionMatches(p, ".sf2") || extensionMatches(p, ".sfz"))
     {
         assert(false);
         return;

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -303,6 +303,7 @@ bool Engine::processAudio()
                 itm.part = v->zonePath.part;
                 itm.group = v->zonePath.group;
                 itm.zone = v->zonePath.zone;
+                itm.sample = v->sampleIndex;
                 itm.samplePos = v->GD.samplePos;
                 itm.midiNote = v->originalMidiKey;
                 itm.midiChannel = v->channel;
@@ -391,6 +392,57 @@ Engine::pgzStructure_t Engine::getPartGroupZoneStructure(int partFilter) const
         SCLOG( "   " << pg.first );;
         */
     return res;
+}
+
+void Engine::loadSampleIntoZone(const fs::path &p, int16_t partID, int16_t groupID, int16_t zoneID,
+                                int sampleID, int16_t rootKey, KeyboardRange krange,
+                                VelocityRange vrange)
+{
+    assert(messageController->threadingChecker.isSerialThread());
+    assert(sampleID < maxSamplesPerZone);
+
+    // TODO: Deal with compound types more comprehensively
+    // If you add a type here add it to Browser::isLoadableFile also
+    if (extensionMatches(p, ".sf2") or extensionMatches(p, ".sfz"))
+    {
+        assert(false);
+        return;
+    }
+
+    auto sz = getSelectionManager()->currentLeadZone(*this);
+
+    if (!sz.has_value())
+    {
+        messageController->reportErrorToClient("Unable to load Sample",
+                                               "There is no currentLeadZone");
+        return;
+    }
+
+    assert((*sz).part == partID);
+    assert((*sz).group == groupID);
+    assert((*sz).zone == zoneID);
+
+    // OK so what we want to do now is
+    // 1. Load this sample on this thread
+    auto sid = sampleManager->loadSampleByPath(p);
+
+    if (!sid.has_value())
+    {
+        messageController->reportErrorToClient(
+            "Unable to load Sample",
+            "Sample load failed:\n\n" + p.u8string() + "\n\n" +
+                "It is either an unsupported format or invalid file. "
+                "More information may be available in the log file (menu/log)");
+        return;
+    }
+
+    auto &part = getPatch()->getPart(partID);
+    auto &group = part->getGroup(groupID);
+    auto &zone = group->getZone(zoneID);
+    zone->sampleData[sampleID].sampleID = *sid;
+    zone->sampleData[sampleID].active = true;
+    zone->attachToSample(*sampleManager, sampleID);
+    selectionManager->selectAction({partID, groupID, zoneID, true, true, true});
 }
 
 void Engine::loadSampleIntoSelectedPartAndGroup(const fs::path &p, int16_t rootKey,

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -436,10 +436,6 @@ void Engine::loadSampleIntoZone(const fs::path &p, int16_t partID, int16_t group
         return;
     }
 
-    auto &part = getPatch()->getPart(partID);
-    auto &group = part->getGroup(groupID);
-    auto &zone = group->getZone(zoneID);
-
     messageController->scheduleAudioThreadCallbackUnderStructureLock(
         [p = partID, g = groupID, z = zoneID, sID = sampleID, sample = *sid](auto &e) {
             auto &zone = e.getPatch()->getPart(p)->getGroup(g)->getZone(z);

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -297,7 +297,7 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
         struct VoiceDisplayStateItem
         {
             std::atomic<bool> active{false};
-            std::atomic<size_t> part, group, zone;
+            std::atomic<size_t> part, group, zone, sample;
 
             std::atomic<int64_t> samplePos{}, midiNote{-1}, midiChannel{-1};
             std::atomic<bool> gated{false};
@@ -328,6 +328,13 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     void loadSampleIntoSelectedPartAndGroup(const fs::path &, int16_t rootKey = 60,
                                             KeyboardRange krange = {48, 72},
                                             VelocityRange vrange = {0, 127});
+
+    /*
+     * Serialization thread originated mutation apis
+     */
+    void loadSampleIntoZone(const fs::path &, int16_t part, int16_t group, int16_t zone,
+                            int sampleID, int16_t rootKey = 60, KeyboardRange krange = {48, 72},
+                            VelocityRange vrange = {0, 127});
 
     void loadSf2MultiSampleIntoSelectedPart(const fs::path &);
 

--- a/src/engine/engine_voice_responder.cpp
+++ b/src/engine/engine_voice_responder.cpp
@@ -51,8 +51,9 @@ int32_t Engine::VoiceManagerResponder::initializeMultipleVoices(
     for (const auto &path : nts)
     {
         const auto &z = engine.zoneByPath(path);
-
-        if (!z->samplePointers[0])
+        auto nbSampleLoadedInZone = z->getNumSampleLoaded();
+        z->sampleIndex = (z->sampleIndex + 1) % nbSampleLoadedInZone;
+        if (!z->samplePointers[z->sampleIndex])
         {
             // SCLOG( "Skipping voice with missing sample data" );
         }

--- a/src/engine/zone.cpp
+++ b/src/engine/zone.cpp
@@ -149,7 +149,11 @@ void Zone::initialize()
 void Zone::setupOnUnstream(const engine::Engine &e)
 {
     sampleLoadOverridesMapping = false;
-    attachToSample(*(e.getSampleManager()));
+    auto nbSampleLoaded{getNumSampleLoaded()};
+    for (auto i = 0; i < nbSampleLoaded; ++i)
+    {
+        attachToSample(*(e.getSampleManager()), i);
+    }
     for (int p = 0; p < processorCount; ++p)
     {
         setupProcessorControlDescriptions(p, processorStorage[p].type);

--- a/src/engine/zone.cpp
+++ b/src/engine/zone.cpp
@@ -189,23 +189,22 @@ bool Zone::attachToSample(const sample::SampleManager &manager, int index)
                 mapping.velocityRange = {m.vel_low, m.vel_high};
             }
         }
-
-        if (samplePointers[index])
+    }
+    if (samplePointers[index])
+    {
+        const auto &m = samplePointers[index]->meta;
+        s.startSample = 0;
+        s.endSample = samplePointers[index]->getSampleLength();
+        if (m.loop_present)
         {
-            const auto &m = samplePointers[index]->meta;
-            s.startSample = 0;
-            s.endSample = samplePointers[index]->getSampleLength();
-            if (m.loop_present)
-            {
-                s.startLoop = m.loop_start;
-                s.endLoop = m.loop_end;
-                s.loopActive = true;
-            }
-            else
-            {
-                s.startLoop = 0;
-                s.endLoop = s.endSample;
-            }
+            s.startLoop = m.loop_start;
+            s.endLoop = m.loop_end;
+            s.loopActive = true;
+        }
+        else
+        {
+            s.startLoop = 0;
+            s.endLoop = s.endSample;
         }
     }
     return samplePointers[index] != nullptr;

--- a/src/engine/zone.h
+++ b/src/engine/zone.h
@@ -120,6 +120,14 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
     typedef std::array<AssociatedSample, maxSamplesPerZone> AssociatedSampleArray;
     AssociatedSampleArray sampleData;
     std::array<std::shared_ptr<sample::Sample>, maxSamplesPerZone> samplePointers;
+    int8_t sampleIndex{-1};
+
+    auto getNumSampleLoaded() const
+    {
+        return std::distance(sampleData.begin(),
+                             std::find_if(sampleData.begin(), sampleData.end(),
+                                          [](const auto &s) { return s.active == false; }));
+    }
 
     struct ZoneOutputInfo
     {

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -81,6 +81,7 @@ enum ClientToSerializationMessagesIds
 
     c2s_add_sample,
     c2s_add_sample_with_range,
+    c2s_add_sample_in_zone,
     c2s_create_group,
     c2s_move_zone,
     c2s_delete_zone,

--- a/src/messaging/client/structure_messages.h
+++ b/src/messaging/client/structure_messages.h
@@ -100,6 +100,23 @@ inline void addSampleWithRange(const addSampleWithRange_t &payload, engine::Engi
 CLIENT_TO_SERIAL(AddSampleWithRange, c2s_add_sample_with_range, addSampleWithRange_t,
                  addSampleWithRange(payload, engine, cont);)
 
+// sample, part, group, wone, sampleid
+using addSampleInZone_t = std::tuple<std::string, int, int, int, int>;
+inline void addSampleInZone(const addSampleInZone_t &payload, engine::Engine &engine,
+                            MessageController &cont)
+{
+    assert(cont.threadingChecker.isSerialThread());
+    auto path = fs::path{std::get<0>(payload)};
+    auto part{std::get<1>(payload)};
+    auto group{std::get<2>(payload)};
+    auto zone{std::get<3>(payload)};
+    auto sampleID{std::get<4>(payload)};
+
+    engine.loadSampleIntoZone(path, part, group, zone, sampleID);
+}
+CLIENT_TO_SERIAL(AddSampleInZone, c2s_add_sample_in_zone, addSampleInZone_t,
+                 addSampleInZone(payload, engine, cont);)
+
 inline void createGroupIn(int partNumber, engine::Engine &engine, MessageController &cont)
 {
     if (partNumber < 0 || partNumber > numParts)

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -38,8 +38,8 @@ namespace scxt::voice
 {
 
 Voice::Voice(engine::Engine *e, engine::Zone *z)
-    : scxt::modulation::shared::HasModulators<Voice>(this), engine(e), zone(z), halfRate(6, true),
-      endpoints(nullptr) // see comment
+    : scxt::modulation::shared::HasModulators<Voice>(this), engine(e), zone(z),
+      sampleIndex(zone->sampleIndex), halfRate(6, true), endpoints(nullptr) // see comment
 {
     assert(zone);
     memset(output, 0, 2 * blockSize * sizeof(float));
@@ -138,8 +138,8 @@ bool Voice::process()
         return true;
     }
     // TODO round robin state
-    auto &s = zone->samplePointers[0];
-    auto &sdata = zone->sampleData[0];
+    auto &s = zone->samplePointers[sampleIndex];
+    auto &sdata = zone->sampleData[sampleIndex];
     assert(s);
 
     // Run Modulators
@@ -391,8 +391,8 @@ void Voice::panOutputsBy(bool chainIsMono, const lipol &plip)
 void Voice::initializeGenerator()
 {
     // TODO round robin
-    auto &s = zone->samplePointers[0];
-    auto &sampleData = zone->sampleData[0];
+    auto &s = zone->samplePointers[sampleIndex];
+    auto &sampleData = zone->sampleData[sampleIndex];
     assert(s);
 
     GDIO.outputL = output[0];
@@ -474,7 +474,7 @@ void Voice::calculateGeneratorRatio(float pitch)
     auto fac = tuning::equalTuning.note_to_pitch(ndiff);
 
     // TODO round robin
-    GD.ratio = (int32_t)((1 << 24) * fac * zone->samplePointers[0]->sample_rate * sampleRateInv *
+    GD.ratio = (int32_t)((1 << 24) * fac * zone->samplePointers[sampleIndex]->sample_rate * sampleRateInv *
                          (1.0 + modMatrix.getValue(modulation::vmd_Sample_Playback_Ratio, 0)));
 #endif
 
@@ -482,8 +482,8 @@ void Voice::calculateGeneratorRatio(float pitch)
     float ndiff = pitch - zone->mapping.rootKey;
     auto fac = tuning::equalTuning.note_to_pitch(ndiff);
     // TODO round robin
-    GD.ratio = (int32_t)((1 << 24) * fac * zone->samplePointers[0]->sample_rate * sampleRateInv *
-                         (1.0 + *endpoints->mappingTarget.playbackRatioP));
+    GD.ratio = (int32_t)((1 << 24) * fac * zone->samplePointers[sampleIndex]->sample_rate *
+                         sampleRateInv * (1.0 + *endpoints->mappingTarget.playbackRatioP));
 }
 
 void Voice::initializeProcessors()

--- a/src/voice/voice.h
+++ b/src/voice/voice.h
@@ -53,6 +53,7 @@ struct alignas(16) Voice : MoveableOnly<Voice>,
     engine::Zone *zone{nullptr};
     engine::Engine *engine{nullptr};
     engine::Engine::pathToZone_t zonePath{};
+    size_t sampleIndex{0};
 
     dsp::GeneratorState GD;
     dsp::GeneratorIO GDIO;


### PR DESCRIPTION
The thing to check is `Engine::loadSampleIntoZone`.

I'm also not a big fan of what I did in `SampleDisplay::rebuildForSelectedVariation`. There is probably a better way to do it.
It wouls also benefit from using the new way to manage Labels.