### PR TITLE
Handle state load threading issue

### DIFF
--- a/clients/clap-first/scxt-plugin/scxt-plugin.cpp
+++ b/clients/clap-first/scxt-plugin/scxt-plugin.cpp
@@ -110,18 +110,9 @@ bool SCXTPlugin::stateLoad(const clap_istream *istream) noexcept
     buffer[totalRd] = 0;
 
     auto xml = std::string(buffer.data());
-    try
-    {
-        engine->getMessageController()->threadingChecker.bypassThreadChecks = true;
-        std::lock_guard<std::mutex> g(engine->modifyStructureMutex);
-        scxt::json::unstreamEngineState(*engine, xml);
-    }
-    catch (std::exception &e)
-    {
-        std::cerr << "Unstream exception " << e.what() << std::endl;
-        return false;
-    }
-    engine->getMessageController()->threadingChecker.bypassThreadChecks = false;
+
+    scxt::messaging::client::clientSendToSerialization(
+        scxt::messaging::client::UnstreamIntoEngine{xml}, *engine->getMessageController());
     return true;
 }
 

--- a/clients/juce-plugin/SCXTProcessor.cpp
+++ b/clients/juce-plugin/SCXTProcessor.cpp
@@ -29,6 +29,7 @@
 #include "SCXTPluginEditor.h"
 #include "sst/plugininfra/cpufeatures.h"
 #include "sst/voicemanager/midi1_to_voicemanager.h"
+#include "messaging/client/client_messages.h"
 
 //==============================================================================
 SCXTProcessor::SCXTProcessor()
@@ -333,18 +334,8 @@ void SCXTProcessor::setStateInformation(const void *data, int sizeInBytes)
 
     auto xml = std::string(cd);
 
-    // TODO obviously fix this by pushing this xml to the serialization thread
-    try
-    {
-        engine->getMessageController()->threadingChecker.bypassThreadChecks = true;
-        std::lock_guard<std::mutex> g(engine->modifyStructureMutex);
-        scxt::json::unstreamEngineState(*engine, xml);
-    }
-    catch (std::exception &err)
-    {
-        SCLOG("Unable to unstream [" << err.what() << "]");
-    }
-    engine->getMessageController()->threadingChecker.bypassThreadChecks = false;
+    scxt::messaging::client::clientSendToSerialization(
+        scxt::messaging::client::UnstreamIntoEngine{xml}, *engine->getMessageController());
 }
 
 //==============================================================================

--- a/src-ui/theme/ThemeApplier.cpp
+++ b/src-ui/theme/ThemeApplier.cpp
@@ -70,7 +70,6 @@ static constexpr sheet_t::Class ModulationHSliderFilled{"multi.modulation.hslide
 void applyColors(const sheet_t::ptr_t &, const ColorMap &);
 void init()
 {
-    SCLOG("Initializing Group and Zone Multi Styles");
     sheet_t::addClass(ModulationJogButon).withBaseClass(jcmp::JogUpDownButton::Styles::styleClass);
     sheet_t::addClass(ModulationToggle).withBaseClass(jcmp::ToggleButton::Styles::styleClass);
     sheet_t::addClass(ModulationMenu).withBaseClass(jcmp::MenuButton::Styles::styleClass);
@@ -88,7 +87,6 @@ static constexpr sheet_t::Class ModulationKnob{"multi.zone.modulation.knob"};
 void applyColors(const sheet_t::ptr_t &, const ColorMap &);
 void init()
 {
-    SCLOG("Initializing Zone Multi Styles");
     sheet_t::addClass(ModulationMultiSwitch).withBaseClass(jcmp::MultiSwitch::Styles::styleClass);
     sheet_t::addClass(ModulationNamedPanel).withBaseClass(jcmp::NamedPanel::Styles::styleClass);
     sheet_t::addClass(ModulationVSlider).withBaseClass(jcmp::VSlider::Styles::styleClass);
@@ -111,7 +109,6 @@ static constexpr sheet_t::Class ModulationVSlider{"multi.group.modulation.vslide
 void applyColors(const sheet_t::ptr_t &, const ColorMap &);
 void init()
 {
-    SCLOG("Initializing Zone Multi Styles");
     sheet_t::addClass(NamedPanel).withBaseClass(jcmp::NamedPanel::Styles::styleClass);
     sheet_t::addClass(ModulationNamedPanel).withBaseClass(jcmp::NamedPanel::Styles::styleClass);
     sheet_t::addClass(MultiSwitch).withBaseClass(jcmp::MultiSwitch::Styles::styleClass);

--- a/src/engine/group_and_zone_impl.h
+++ b/src/engine/group_and_zone_impl.h
@@ -92,9 +92,6 @@ void HasGroupZoneProcessors<T>::setupProcessorControlDescriptions(
 
     auto *tmpProcessor = tmpProcessorFromAfar;
 
-    assert(asT()->getEngine() &&
-           asT()->getEngine()->getMessageController()->threadingChecker.isAudioThread());
-
     uint8_t memory[dsp::processor::processorMemoryBufferSize];
     float pfp[dsp::processor::maxProcessorFloatParams];
     int ifp[dsp::processor::maxProcessorIntParams];

--- a/src/engine/patch.h
+++ b/src/engine/patch.h
@@ -38,7 +38,7 @@ namespace scxt::engine
 struct Engine;
 struct Patch : MoveableOnly<Patch>, SampleRateSupport
 {
-    Patch() : id(PatchID::next()) { reset(); }
+    Patch() : id(PatchID::next()) { resetToBlankPatch(); }
 
     // TODO - does this really belong in the patch? I think it probably does
     struct Busses
@@ -161,7 +161,7 @@ struct Patch : MoveableOnly<Patch>, SampleRateSupport
 
     void process(Engine &e);
 
-    void reset()
+    void resetToBlankPatch()
     {
         // If it is the year 2112 and you just had a regtest fail because
         // this is earlier than the streaming version you just changed, then
@@ -172,6 +172,7 @@ struct Patch : MoveableOnly<Patch>, SampleRateSupport
             parts[i] = std::make_unique<Part>(i);
             parts[i]->parentPatch = this;
         }
+        setSampleRate(1);
     }
 
     bool usesOutputBus(int bus) { return busses.usesOutput[bus]; }

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -73,6 +73,9 @@ SC_STREAMDEF(scxt::engine::Engine, SC_FROM({
 
                  // Now we need to restore the bus effects
                  to.getPatch()->setupBussesOnUnstream(to);
+
+                 // and finally set the sample rate
+                 to.getPatch()->setSampleRate(to.getSampleRate());
              }))
 
 SC_STREAMDEF(scxt::engine::Patch, SC_FROM({
@@ -82,7 +85,7 @@ SC_STREAMDEF(scxt::engine::Patch, SC_FROM({
              }),
              SC_TO({
                  auto &patch = to;
-                 patch.reset();
+                 patch.resetToBlankPatch();
                  findIf(v, "streamingVersion", patch.streamingVersion);
 
                  // TODO: I could expose the array but I want to go to a limited stream in the

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -41,6 +41,8 @@ enum ClientToSerializationMessagesIds
 {
     c2s_on_register,
 
+    c2s_unstream_state,
+
     c2s_single_select_address,
     c2s_do_select_action,
     c2s_do_multi_select_action,


### PR DESCRIPTION
State load had always been a bit thread dicey. it turned off the thread checker for goodness sake! So lets do the right thing and actually use the message queue to load state, stopping audio, etc...

With this I can load a group processor project 10 times in reaper VST3 or in the clap or juce standalones and get it working no problem. So I think this addresses #824