### PR TITLE
Modify Zone Sample Data; Introduce Round Robin modes

### DIFF
--- a/src-ui/components/multi/MappingPane.h
+++ b/src-ui/components/multi/MappingPane.h
@@ -49,7 +49,7 @@ struct MappingPane : sst::jucegui::components::NamedPanel, HasEditor
     void resized() override;
 
     void setMappingData(const engine::Zone::ZoneMappingData &);
-    void setSampleData(const engine::Zone::AssociatedSampleArray &);
+    void setSampleData(const engine::Zone::AssociatedSampleSet &);
     void setGroupZoneMappingSummary(const engine::Part::zoneMappingSummary_t &);
     void editorSelectionChanged();
     void setActive(bool b);
@@ -59,7 +59,7 @@ struct MappingPane : sst::jucegui::components::NamedPanel, HasEditor
     std::unique_ptr<MacroDisplay> macroDisplay;
 
     engine::Zone::ZoneMappingData mappingView;
-    engine::Zone::AssociatedSampleArray sampleView;
+    engine::Zone::AssociatedSampleSet sampleView;
 
     void updateSamplePlaybackPosition(size_t sampleIndex, int64_t samplePos);
 

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -444,8 +444,8 @@ void Engine::loadSampleIntoZone(const fs::path &p, int16_t partID, int16_t group
         [p = partID, g = groupID, z = zoneID, sID = sampleID, sample = *sid](auto &e) {
             auto &zone = e.getPatch()->getPart(p)->getGroup(g)->getZone(z);
             zone->terminateAllVoices();
-            zone->sampleData[sID].sampleID = sample;
-            zone->sampleData[sID].active = true;
+            zone->sampleData.samples[sID].sampleID = sample;
+            zone->sampleData.samples[sID].active = true;
             zone->attachToSample(*e.getSampleManager(), sID);
         },
         [p = partID, g = groupID, z = zoneID](auto &e) {
@@ -641,7 +641,7 @@ void Engine::loadSf2MultiSampleIntoSelectedPart(const fs::path &p)
                         SCLOG("ERROR: Can't attach to sample");
                         return;
                     }
-                    auto &znSD = zn->sampleData[0];
+                    auto &znSD = zn->sampleData.samples[0];
 
                     auto p = region->GetPan(presetRegion);
                     // pan in SF2 is -64 to 63 so hackety hack a bit

--- a/src/engine/zone.cpp
+++ b/src/engine/zone.cpp
@@ -162,7 +162,7 @@ void Zone::setupOnUnstream(const engine::Engine &e)
 
 bool Zone::attachToSample(const sample::SampleManager &manager, int index)
 {
-    auto &s = sampleData[index];
+    auto &s = sampleData.samples[index];
     if (s.sampleID.isValid())
     {
         samplePointers[index] = manager.getSample(s.sampleID);
@@ -189,25 +189,52 @@ bool Zone::attachToSample(const sample::SampleManager &manager, int index)
                 mapping.velocityRange = {m.vel_low, m.vel_high};
             }
         }
-    }
-    if (samplePointers[index])
-    {
-        const auto &m = samplePointers[index]->meta;
-        s.startSample = 0;
-        s.endSample = samplePointers[index]->getSampleLength();
-        if (m.loop_present)
+        if (samplePointers[index])
         {
-            s.startLoop = m.loop_start;
-            s.endLoop = m.loop_end;
-            s.loopActive = true;
-        }
-        else
-        {
-            s.startLoop = 0;
-            s.endLoop = s.endSample;
+            const auto &m = samplePointers[index]->meta;
+            s.startSample = 0;
+            s.endSample = samplePointers[index]->getSampleLength();
+            if (m.loop_present)
+            {
+                s.startLoop = m.loop_start;
+                s.endLoop = m.loop_end;
+                s.loopActive = true;
+            }
+            else
+            {
+                s.startLoop = 0;
+                s.endLoop = s.endSample;
+            }
         }
     }
     return samplePointers[index] != nullptr;
+}
+
+std::string Zone::toStringVariantPlaybackMode(const Zone::VariantPlaybackMode &p)
+{
+    switch (p)
+    {
+    case FORWARD_RR:
+        return "frr";
+    case TRUE_RANDOM:
+        return "truerand";
+    case RANDOM_CYCLE:
+        return "randcyc";
+    case UNISON:
+        return "unison";
+    }
+    return "frr";
+}
+
+Zone::VariantPlaybackMode Zone::fromStringVariantPlaybackMode(const std::string &s)
+{
+    static auto inverse =
+        makeEnumInverse<Zone::VariantPlaybackMode, Zone::toStringVariantPlaybackMode>(
+            Zone::VariantPlaybackMode::FORWARD_RR, Zone::VariantPlaybackMode::UNISON);
+    auto p = inverse.find(s);
+    if (p == inverse.end())
+        return FORWARD_RR;
+    return p->second;
 }
 
 std::string Zone::toStringPlayMode(const PlayMode &p)

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -258,6 +258,8 @@ STREAM_ENUM(engine::Zone::ProcRoutingPath, engine::Zone::toStringProcRoutingPath
             engine::Zone::fromStringProcRoutingPath);
 STREAM_ENUM(engine::Group::ProcRoutingPath, engine::Group::toStringProcRoutingPath,
             engine::Group::fromStringProcRoutingPath);
+STREAM_ENUM(engine::Zone::VariantPlaybackMode, engine::Zone::toStringVariantPlaybackMode,
+            engine::Zone::fromStringVariantPlaybackMode);
 
 template <> struct scxt_traits<scxt::engine::Zone::AssociatedSample>
 {
@@ -315,6 +317,14 @@ template <> struct scxt_traits<scxt::engine::Zone::AssociatedSample>
         }
     }
 };
+
+SC_STREAMDEF(scxt::engine::Zone::AssociatedSampleSet, SC_FROM({
+                 v = {{"samples", t.samples}, {"variantPlaybackMode", t.variantPlaybackMode}};
+             }),
+             SC_TO({
+                 findIf(v, "samples", result.samples);
+                 findIf(v, "variantPlaybackMode", result.variantPlaybackMode);
+             }));
 
 template <> struct scxt_traits<scxt::engine::Zone>
 {

--- a/src/json/modulation_traits.h
+++ b/src/json/modulation_traits.h
@@ -48,7 +48,6 @@ SC_STREAMDEF(scxt::modulation::modulators::StepLFOStorage, SC_FROM({
                       {"smooth", t.smooth}};
              }),
              SC_TO({
-                 const auto &object = v.get_object();
                  findIf(v, "data", result.data);
                  findIf(v, "repeat", result.repeat);
                  findIf(v, "smooth", result.smooth);

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -60,6 +60,7 @@ enum ClientToSerializationMessagesIds
     c2s_update_zone_mapping_float,
     c2s_update_zone_mapping_int16_t,
     c2s_update_zone_samples,
+    c2s_update_zone_sampleset_int16_t,
     c2s_update_zone_routing_row,
 
     c2s_update_zone_output_float_value,

--- a/src/messaging/client/zone_messages.h
+++ b/src/messaging/client/zone_messages.h
@@ -89,7 +89,7 @@ CLIENT_TO_SERIAL_CONSTRAINED(
                 *(eng.getMessageController()));
         }));
 
-typedef std::tuple<bool, engine::Zone::AssociatedSampleArray> sampleSelectedZoneViewResposne_t;
+typedef std::tuple<bool, engine::Zone::AssociatedSampleSet> sampleSelectedZoneViewResposne_t;
 SERIAL_TO_CLIENT(SampleSelectedZoneView, s2c_respond_zone_samples, sampleSelectedZoneViewResposne_t,
                  onSamplesUpdated);
 
@@ -105,13 +105,19 @@ inline void samplesSelectedZoneUpdate(const associatedSampleVariationPayload_t &
         auto [ps, gs, zs] = *sz;
         cont.scheduleAudioThreadCallback([p = ps, g = gs, z = zs, sampv = samples](auto &eng) {
             auto &[idx, smp] = sampv;
-            eng.getPatch()->getPart(p)->getGroup(g)->getZone(z)->sampleData[idx] = smp;
+            eng.getPatch()->getPart(p)->getGroup(g)->getZone(z)->sampleData.samples[idx] = smp;
         });
     }
 }
 CLIENT_TO_SERIAL(SamplesSelectedZoneUpdateRequest, c2s_update_zone_samples,
                  associatedSampleVariationPayload_t,
                  samplesSelectedZoneUpdate(payload, engine, cont));
+
+CLIENT_TO_SERIAL_CONSTRAINED(UpdateZoneAssociatedSampleSetInt16TValue,
+                             c2s_update_zone_sampleset_int16_t, detail::diffMsg_t<int16_t>,
+                             engine::Zone::AssociatedSampleSet,
+                             detail::updateZoneMemberValue(&engine::Zone::sampleData, payload,
+                                                           engine, cont));
 
 using zoneOutputInfoUpdate_t = std::pair<bool, engine::Zone::ZoneOutputInfo>;
 SERIAL_TO_CLIENT(ZoneOutputInfoUpdated, s2c_update_zone_output_info, zoneOutputInfoUpdate_t,

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -142,7 +142,7 @@ bool Voice::process()
     }
     // TODO round robin state
     auto &s = zone->samplePointers[sampleIndex];
-    auto &sdata = zone->sampleData[sampleIndex];
+    auto &sdata = zone->sampleData.samples[sampleIndex];
     assert(s);
 
     // Run Modulators
@@ -397,7 +397,7 @@ void Voice::initializeGenerator()
 {
     // TODO round robin
     auto &s = zone->samplePointers[sampleIndex];
-    auto &sampleData = zone->sampleData[sampleIndex];
+    auto &sampleData = zone->sampleData.samples[sampleIndex];
     assert(s);
 
     GDIO.outputL = output[0];


### PR DESCRIPTION
the zone sample data was just an array of samples leaving no place to store collections of data edited by the sample view. So change it to a struct and add a variation playback mode enum to that struct.

Then support that enum and push it to the ui (with a new single field update sample message which we should use for other things like loops and stuff - I'll open an issue)

And then implement the four round robin modes.