### PR TITLE
Add a group-level velocity VCA scale

### DIFF
--- a/src-ui/components/multi/OutputPane.cpp
+++ b/src-ui/components/multi/OutputPane.cpp
@@ -29,6 +29,7 @@
 #include "components/SCXTEditor.h"
 #include "sst/jucegui/components/Label.h"
 #include "sst/jucegui/components/Knob.h"
+#include "sst/jucegui/components/HSliderFilled.h"
 #include "sst/jucegui/components/MenuButton.h"
 #include "sst/jucegui/components/LabeledItem.h"
 #include "connectors/PayloadDataAttachment.h"
@@ -64,10 +65,11 @@ template <typename OTTraits> struct OutputTab : juce::Component, HasEditor
 {
     typedef connectors::PayloadDataAttachment<typename OTTraits::info_t> attachment_t;
 
-    std::unique_ptr<attachment_t> outputAttachment, panAttachment;
+    std::unique_ptr<attachment_t> outputAttachment, panAttachment, velocitySensitivityAttachment;
     std::unique_ptr<jcmp::MenuButton> outputRouting;
     OutputPane<OTTraits> *parent{nullptr};
     std::unique_ptr<jcmp::Labeled<jcmp::Knob>> outputKnob, panKnob;
+    std::unique_ptr<jcmp::Labeled<jcmp::HSliderFilled>> velocitySensitivitySlider;
 
     OutputTab(SCXTEditor *e, OutputPane<OTTraits> *p) : HasEditor(e), parent(p)
     {
@@ -76,6 +78,12 @@ template <typename OTTraits> struct OutputTab : juce::Component, HasEditor
         fac::attachLabelAndAdd(info, info.amplitude, this, outputAttachment, outputKnob,
                                "Amplitude");
         fac::attachLabelAndAdd(info, info.pan, this, panAttachment, panKnob, "Pan");
+
+        if constexpr (!OTTraits::forZone)
+        {
+            fac::attachLabelAndAdd(info, info.velocitySensitivity, this,
+                                   velocitySensitivityAttachment, velocitySensitivitySlider, "Vel");
+        }
 
         outputRouting = std::make_unique<jcmp::MenuButton>();
         outputRouting->setLabel(OTTraits::defaultRoutingLocationName);
@@ -93,6 +101,14 @@ template <typename OTTraits> struct OutputTab : juce::Component, HasEditor
         auto cc = lo::columnCenterX(getLocalBounds(), 2);
         lo::knobCX<theme::layout::constants::largeKnob>(*outputKnob, cc[0], 10);
         lo::knobCX<theme::layout::constants::largeKnob>(*panKnob, cc[1], 10);
+
+        if (!OTTraits::forZone && velocitySensitivitySlider)
+        {
+            auto b = getLocalBounds();
+            auto op = b.withTop(b.getBottom() - 20).translated(0, -27).reduced(30, 4);
+            velocitySensitivitySlider->item->setBounds(op.withTrimmedLeft(30));
+            velocitySensitivitySlider->label->setBounds(op.withWidth(30));
+        }
 
         auto b = getLocalBounds();
         auto op = b.withTop(b.getBottom() - 20).translated(0, -5).reduced(10, 0);

--- a/src/engine/group.h
+++ b/src/engine/group.h
@@ -78,7 +78,7 @@ struct Group : MoveableOnly<Group>,
 
     struct GroupOutputInfo
     {
-        float amplitude{1.f}, pan{0.f};
+        float amplitude{1.f}, pan{0.f}, velocitySensitivity{0.6f};
         bool muted{false};
         ProcRoutingPath procRouting{procRoute_linear};
         BusAddress routeTo{DEFAULT_BUS};
@@ -216,5 +216,8 @@ struct Group : MoveableOnly<Group>,
 
 SC_DESCRIBE(scxt::engine::Group::GroupOutputInfo,
             SC_FIELD(amplitude, pmd().asCubicDecibelAttenuation().withName("Amplitude"));
-            SC_FIELD(pan, pmd().asPercentBipolar().withName("Pan"));)
+            SC_FIELD(pan, pmd().asPercentBipolar().withName("Pan"));
+            SC_FIELD(velocitySensitivity,
+                     pmd().asPercent().withName("Velocity Sensitivity").withDefault(0.6f));)
+
 #endif

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -118,32 +118,24 @@ SC_STREAMDEF(scxt::engine::Part, SC_FROM({
                  }
              }))
 
-template <> struct scxt_traits<scxt::engine::Group::GroupOutputInfo>
-{
-    template <template <typename...> class Traits>
-    static void assign(tao::json::basic_value<Traits> &v,
-                       const scxt::engine::Group::GroupOutputInfo &t)
-    {
-        v = {{"amplitude", t.amplitude},
-             {"pan", t.pan},
-             {"muted", t.muted},
-             {"procRouting", t.procRouting},
-             {"routeTo", (int)t.routeTo}};
-    }
-
-    template <template <typename...> class Traits>
-    static void to(const tao::json::basic_value<Traits> &v,
-                   scxt::engine::Group::GroupOutputInfo &zo)
-    {
-        int rt;
-        findIf(v, "amplitude", zo.amplitude);
-        findIf(v, "pan", zo.pan);
-        findIf(v, "muted", zo.muted);
-        findIf(v, "procRouting", zo.procRouting);
-        findIf(v, "routeTo", rt);
-        zo.routeTo = (engine::BusAddress)(rt);
-    }
-};
+SC_STREAMDEF(scxt::engine::Group::GroupOutputInfo, SC_FROM({
+                 v = {{"amplitude", t.amplitude},
+                      {"pan", t.pan},
+                      {"velocitySensitivity", t.velocitySensitivity},
+                      {"muted", t.muted},
+                      {"procRouting", t.procRouting},
+                      {"routeTo", (int)t.routeTo}};
+             }),
+             SC_TO({
+                 int rt;
+                 findIf(v, "amplitude", result.amplitude);
+                 findIf(v, "pan", result.pan);
+                 findIf(v, "muted", result.muted);
+                 findIf(v, "procRouting", result.procRouting);
+                 findIf(v, "velocitySensitivity", result.velocitySensitivity);
+                 findIf(v, "routeTo", rt);
+                 result.routeTo = (engine::BusAddress)(rt);
+             }));
 
 template <> struct scxt_traits<scxt::engine::Group>
 {

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -331,6 +331,12 @@ bool Voice::process()
     }
 
     auto pao = *endpoints->outputTarget.ampP;
+
+    auto velFac = zone->parentGroup->outputInfo.velocitySensitivity;
+    auto velMul = std ::clamp((1 - velFac) + velFac * velocity, 0.f, 1.f);
+
+    pao *= velMul;
+
     outputAmp.set_target(pao * pao * pao);
     if (chainIsMono)
     {


### PR DESCRIPTION
Add a group level velocity VCA scale which at 100% means full velocity to attenuation mapping and at 0% means none (so the opposite of the backwards surge slider!). Also replace the streaming template with the new macro version for group output info.