### PR TITLE
Oversample by Group

### DIFF
--- a/src-ui/components/multi/ProcessorPane.cpp
+++ b/src-ui/components/multi/ProcessorPane.cpp
@@ -323,7 +323,7 @@ void ProcessorPane::layoutControlsWaveshaper()
     // Drive/Bias/Gain in the floats
     // Type/OS in the ints
     assert(processorControlDescription.numFloatParams == 3);
-    assert(processorControlDescription.numIntParams == 2);
+    assert(processorControlDescription.numIntParams == 1);
 
     namespace lo = theme::layout;
     namespace locon = lo::constants;
@@ -338,12 +338,6 @@ void ProcessorPane::layoutControlsWaveshaper()
 
     mixEditor = createWidgetAttachedTo(mixAttachment, "Mix");
     lo::labeledAt(*mixEditor, lo::toRightOf(biasPos));
-
-    auto osl = createWidgetAttachedTo<jcmp::ToggleButton>(intAttachments[1]);
-    osl->setDrawMode(jcmp::ToggleButton::DrawMode::LABELED);
-    osl->setLabel("o/s");
-    osl->setBounds(lo::toRightOf(lo::belowLabel(biasPos)).reduced(2, 8));
-    intEditors[1] = std::make_unique<intEditor_t>(std::move(osl));
 
     auto ja = getContentAreaComponent()->getLocalBounds();
     ja = ja.withTop(ja.getBottom() - 22).translated(0, -3).reduced(3, 0);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,8 +8,6 @@ add_library(${PROJECT_NAME} STATIC
         dsp/data_tables.cpp
         dsp/processor/processor.cpp
 
-        dsp/processor/filter/supersvf.cpp
-
         engine/engine.cpp
         engine/engine_voice_responder.cpp
         engine/zone.cpp

--- a/src/dsp/processor/filter/supersvf.h
+++ b/src/dsp/processor/filter/supersvf.h
@@ -37,7 +37,7 @@ namespace scxt::dsp::processor
 namespace filter
 {
 
-struct alignas(16) SuperSVF : public Processor
+template <bool OS> struct alignas(16) SuperSVF : public Processor
 {
   private:
     __m128 Freq, dFreq, Q, dQ, MD, dMD, ClipDamp, dClipDamp, Gain, dGain, Reg[3], LastOutput;
@@ -72,10 +72,16 @@ struct alignas(16) SuperSVF : public Processor
 };
 
 } // namespace filter
+} // namespace scxt::dsp::processor
 
+#include "supersvf.cpp"
+
+namespace scxt::dsp::processor
+{
 template <> struct ProcessorImplementor<ProcessorType::proct_SuperSVF>
 {
-    typedef filter::SuperSVF T;
+    typedef filter::SuperSVF<false> T;
+    typedef filter::SuperSVF<true> TOS;
 };
 } // namespace scxt::dsp::processor
 #endif // SHORTCIRCUITXT_SUPERSVC_H

--- a/src/dsp/processor/processor.h
+++ b/src/dsp/processor/processor.h
@@ -293,7 +293,7 @@ class BiquadSupport
  * be a 16byte aligned block of at least size processorMemoryBufferSize.
  */
 Processor *spawnProcessorInPlace(ProcessorType id, engine::MemoryPool *mp, uint8_t *memory,
-                                 size_t memorySize, float *fp, int *ip);
+                                 size_t memorySize, float *fp, int *ip, bool oversample);
 
 /**
  * Whetner a processor is spawned in place or onto fresh memory, release it here.
@@ -305,6 +305,7 @@ typedef uint8_t unimpl_t;
 template <ProcessorType ft> struct ProcessorImplementor
 {
     typedef unimpl_t T;
+    typedef unimpl_t TOS;
 };
 
 } // namespace scxt::dsp::processor

--- a/src/dsp/processor/processor_defs.h
+++ b/src/dsp/processor/processor_defs.h
@@ -80,46 +80,62 @@
 namespace scxt::dsp::processor
 {
 // Just don't change the id or streaming name, basically
-DEFINE_PROC(MicroGate, sst::voice_effects::distortion::MicroGate<SCXTVFXConfig>, proct_fx_microgate,
+DEFINE_PROC(MicroGate, sst::voice_effects::distortion::MicroGate<SCXTVFXConfig<1>>,
+            sst::voice_effects::distortion::MicroGate<SCXTVFXConfig<2>>, proct_fx_microgate,
             "MicroGate", "Distortion", "micro-gate-fx");
-DEFINE_PROC(BitCrusher, sst::voice_effects::distortion::BitCrusher<SCXTVFXConfig>,
-            proct_fx_bitcrusher, "BitCrusher", "Distortion", "bit-crusher-fx");
-DEFINE_PROC(WaveShaper, sst::voice_effects::waveshaper::WaveShaper<SCXTVFXConfig>,
-            proct_fx_waveshaper, "WaveShaper", "Distortion", "waveshaper-fx");
+DEFINE_PROC(BitCrusher, sst::voice_effects::distortion::BitCrusher<SCXTVFXConfig<1>>,
+            sst::voice_effects::distortion::BitCrusher<SCXTVFXConfig<2>>, proct_fx_bitcrusher,
+            "BitCrusher", "Distortion", "bit-crusher-fx");
+DEFINE_PROC(WaveShaper, sst::voice_effects::waveshaper::WaveShaper<SCXTVFXConfig<1>>,
+            sst::voice_effects::waveshaper::WaveShaper<SCXTVFXConfig<2>>, proct_fx_waveshaper,
+            "WaveShaper", "Distortion", "waveshaper-fx");
 
 // Macros and commas don't get along
 namespace procimpl::detail
 {
-using eq1impl = sst::voice_effects::eq::EqNBandParametric<SCXTVFXConfig, 1>;
-using eq2impl = sst::voice_effects::eq::EqNBandParametric<SCXTVFXConfig, 2>;
-using eq3impl = sst::voice_effects::eq::EqNBandParametric<SCXTVFXConfig, 3>;
+using eq1impl = sst::voice_effects::eq::EqNBandParametric<SCXTVFXConfig<1>, 1>;
+using eq2impl = sst::voice_effects::eq::EqNBandParametric<SCXTVFXConfig<1>, 2>;
+using eq3impl = sst::voice_effects::eq::EqNBandParametric<SCXTVFXConfig<1>, 3>;
+
+using eq1impl_os = sst::voice_effects::eq::EqNBandParametric<SCXTVFXConfig<2>, 1>;
+using eq2impl_os = sst::voice_effects::eq::EqNBandParametric<SCXTVFXConfig<2>, 2>;
+using eq3impl_os = sst::voice_effects::eq::EqNBandParametric<SCXTVFXConfig<2>, 3>;
+
 } // namespace procimpl::detail
 
-DEFINE_PROC(EQ1Band, procimpl::detail::eq1impl, proct_eq_1band_parametric_A, "1 Band Parametric",
-            "EQ", "eq-parm-1band");
-DEFINE_PROC(EQ2Band, procimpl::detail::eq2impl, proct_eq_2band_parametric_A, "2 Band Parametric",
-            "EQ", "eq-parm-2band");
-DEFINE_PROC(EQ3Band, procimpl::detail::eq3impl, proct_eq_3band_parametric_A, "3 Band Parametric",
-            "EQ", "eq-parm-3band");
-DEFINE_PROC(EQGraphic6Band, sst::voice_effects::eq::EqGraphic6Band<SCXTVFXConfig>, proct_eq_6band,
+DEFINE_PROC(EQ1Band, procimpl::detail::eq1impl, procimpl::detail::eq1impl_os,
+            proct_eq_1band_parametric_A, "1 Band Parametric", "EQ", "eq-parm-1band");
+DEFINE_PROC(EQ2Band, procimpl::detail::eq2impl, procimpl::detail::eq2impl_os,
+            proct_eq_2band_parametric_A, "2 Band Parametric", "EQ", "eq-parm-2band");
+DEFINE_PROC(EQ3Band, procimpl::detail::eq3impl, procimpl::detail::eq3impl_os,
+            proct_eq_3band_parametric_A, "3 Band Parametric", "EQ", "eq-parm-3band");
+DEFINE_PROC(EQGraphic6Band, sst::voice_effects::eq::EqGraphic6Band<SCXTVFXConfig<1>>,
+            sst::voice_effects::eq::EqGraphic6Band<SCXTVFXConfig<2>>, proct_eq_6band,
             "6 Band Graphic", "EQ", "eq-grp-6");
 
-DEFINE_PROC(MorphEQ, sst::voice_effects::eq::MorphEQ<SCXTVFXConfig>, proct_eq_morph, "Morph", "EQ",
+DEFINE_PROC(MorphEQ, sst::voice_effects::eq::MorphEQ<SCXTVFXConfig<1>>,
+            sst::voice_effects::eq::MorphEQ<SCXTVFXConfig<2>>, proct_eq_morph, "Morph", "EQ",
             "eq-morph");
 
-DEFINE_PROC(GenSin, sst::voice_effects::generator::GenSin<SCXTVFXConfig>, proct_osc_sin, "Sin",
+DEFINE_PROC(GenSin, sst::voice_effects::generator::GenSin<SCXTVFXConfig<1>>,
+            sst::voice_effects::generator::GenSin<SCXTVFXConfig<2>>, proct_osc_sin, "Sin",
             "Generators", "osc-sin");
-DEFINE_PROC(GenSaw, sst::voice_effects::generator::GenSaw<SCXTVFXConfig>, proct_osc_saw, "Saw",
+DEFINE_PROC(GenSaw, sst::voice_effects::generator::GenSaw<SCXTVFXConfig<1>>,
+            sst::voice_effects::generator::GenSaw<SCXTVFXConfig<2>>, proct_osc_saw, "Saw",
             "Generators", "osc-saw");
-DEFINE_PROC(GenPulseSync, sst::voice_effects::generator::GenPulseSync<SCXTVFXConfig>,
-            proct_osc_pulse_sync, "Pulse Sync", "Generators", "osc-pulse-sync", dsp::sincTable);
-DEFINE_PROC(GenPhaseMod, sst::voice_effects::generator::GenPhaseMod<SCXTVFXConfig>,
-            proct_osc_phasemod, "Phase Mod", "Generators", "osc-phase-mod");
-DEFINE_PROC(GenCorrelatedNoise, sst::voice_effects::generator::GenCorrelatedNoise<SCXTVFXConfig>,
+DEFINE_PROC(GenPulseSync, sst::voice_effects::generator::GenPulseSync<SCXTVFXConfig<1>>,
+            sst::voice_effects::generator::GenPulseSync<SCXTVFXConfig<2>>, proct_osc_pulse_sync,
+            "Pulse Sync", "Generators", "osc-pulse-sync", dsp::sincTable);
+DEFINE_PROC(GenPhaseMod, sst::voice_effects::generator::GenPhaseMod<SCXTVFXConfig<1>>,
+            sst::voice_effects::generator::GenPhaseMod<SCXTVFXConfig<2>>, proct_osc_phasemod,
+            "Phase Mod", "Generators", "osc-phase-mod");
+DEFINE_PROC(GenCorrelatedNoise, sst::voice_effects::generator::GenCorrelatedNoise<SCXTVFXConfig<1>>,
+            sst::voice_effects::generator::GenCorrelatedNoise<SCXTVFXConfig<2>>,
             proct_osc_correlatednoise, "Correlated Noise", "Generators", "osc-correlated-noise");
 
-DEFINE_PROC(PitchRing, sst::voice_effects::pitch::PitchRing<SCXTVFXConfig>, proct_fx_pitchring,
-            "PitchRing", "Pitch and Frequency", "pitchring-fx");
+DEFINE_PROC(PitchRing, sst::voice_effects::pitch::PitchRing<SCXTVFXConfig<1>>,
+            sst::voice_effects::pitch::PitchRing<SCXTVFXConfig<2>>, proct_fx_pitchring, "PitchRing",
+            "Pitch and Frequency", "pitchring-fx");
 
 } // namespace scxt::dsp::processor
 

--- a/src/dsp/processor/processor_impl.h
+++ b/src/dsp/processor/processor_impl.h
@@ -34,10 +34,11 @@
 
 namespace scxt::dsp::processor
 {
-struct SCXTVFXConfig
+// oversample factor; 1, 2, 4 etc...
+template <int OSFactor> struct SCXTVFXConfig
 {
     using BaseClass = Processor;
-    static constexpr int blockSize{scxt::blockSize};
+    static constexpr int blockSize{scxt::blockSize * OSFactor};
 
     static void preReservePool(BaseClass *b, size_t s)
     {
@@ -70,6 +71,10 @@ struct SCXTVFXConfig
     static int getIntParam(const BaseClass *b, size_t index) { return b->iparam[index]; }
 
     static float dbToLinear(BaseClass *b, float db) { return dsp::dbTable.dbToLinear(db); }
+
+    // In voice.cpp and group.cpp we set the sample rate on the processor
+    // to a sample rate scaled by the oversample factor so here we can just
+    // return it.
     static float getSampleRate(const BaseClass *b) { return b->getSampleRate(); }
     static float getSampleRateInv(const BaseClass *b) { return b->getSampleRateInv(); }
     static float equalNoteToPitch(const BaseClass *b, float f)

--- a/src/engine/bus.cpp
+++ b/src/engine/bus.cpp
@@ -197,6 +197,17 @@ void Bus::initializeAfterUnstream(Engine &e)
 }
 void Bus::process()
 {
+    if (hasOSSignal)
+    {
+        if (!previousHadOSSignal)
+        {
+            downsampleFilter.reset();
+        }
+        downsampleFilter.process_block_D2(outputOS[0], outputOS[1], blockSize << 1);
+        mech::accumulate_from_to<blockSize>(outputOS[0], output[0]);
+        mech::accumulate_from_to<blockSize>(outputOS[1], output[1]);
+    }
+    previousHadOSSignal = hasOSSignal;
     // ToDo - we can skip these if theres no pre or at routing
     if (busSendStorage.supportsSends && busSendStorage.hasSends)
     {

--- a/src/engine/group_and_zone_impl.h
+++ b/src/engine/group_and_zone_impl.h
@@ -50,9 +50,11 @@ void HasGroupZoneProcessors<T>::setProcessorType(int whichProcessor,
     float pfp[dsp::processor::maxProcessorFloatParams];
     int ifp[dsp::processor::maxProcessorIntParams];
 
+    // this processor is just used for params and the like so we can always assume
+    // the non-oversampled case
     tmpProcessor = dsp::processor::spawnProcessorInPlace(
         type, asT()->getEngine()->getMemoryPool().get(), memory,
-        dsp::processor::processorMemoryBufferSize, pfp, ifp);
+        dsp::processor::processorMemoryBufferSize, pfp, ifp, false);
 
     if (type != dsp::processor::proct_none)
     {
@@ -96,11 +98,12 @@ void HasGroupZoneProcessors<T>::setupProcessorControlDescriptions(
     float pfp[dsp::processor::maxProcessorFloatParams];
     int ifp[dsp::processor::maxProcessorIntParams];
 
+    // this is just used for params and stuff so assume no oversample
     if (!tmpProcessor)
     {
         tmpProcessor = dsp::processor::spawnProcessorInPlace(
             type, asT()->getEngine()->getMemoryPool().get(), memory,
-            dsp::processor::processorMemoryBufferSize, pfp, ifp);
+            dsp::processor::processorMemoryBufferSize, pfp, ifp, false);
     }
 
     assert(tmpProcessor);

--- a/src/engine/zone.h
+++ b/src/engine/zone.h
@@ -157,8 +157,9 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
     } outputInfo;
     static_assert(std::is_standard_layout<ZoneOutputInfo>::value);
 
-    float output alignas(16)[2][blockSize];
+    float output alignas(16)[2][blockSize << 1];
     void process(Engine &onto);
+    template <bool OS> void processWithOS(Engine &onto);
 
     // TODO: editable name
     std::string getName() const

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -119,11 +119,9 @@ SC_STREAMDEF(scxt::engine::Part, SC_FROM({
              }))
 
 SC_STREAMDEF(scxt::engine::Group::GroupOutputInfo, SC_FROM({
-                 v = {{"amplitude", t.amplitude},
-                      {"pan", t.pan},
-                      {"velocitySensitivity", t.velocitySensitivity},
-                      {"muted", t.muted},
-                      {"procRouting", t.procRouting},
+                 v = {{"amplitude", t.amplitude},   {"pan", t.pan},
+                      {"oversample", t.oversample}, {"velocitySensitivity", t.velocitySensitivity},
+                      {"muted", t.muted},           {"procRouting", t.procRouting},
                       {"routeTo", (int)t.routeTo}};
              }),
              SC_TO({
@@ -133,6 +131,7 @@ SC_STREAMDEF(scxt::engine::Group::GroupOutputInfo, SC_FROM({
                  findIf(v, "muted", result.muted);
                  findIf(v, "procRouting", result.procRouting);
                  findIf(v, "velocitySensitivity", result.velocitySensitivity);
+                 findIf(v, "oversample", result.oversample);
                  findIf(v, "routeTo", rt);
                  result.routeTo = (engine::BusAddress)(rt);
              }));

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -69,6 +69,7 @@ enum ClientToSerializationMessagesIds
     c2s_update_group_routing_row,
     c2s_update_group_output_float_value,
     c2s_update_group_output_int16_t_value,
+    c2s_update_group_output_bool_value,
 
     c2s_update_group_or_zone_individual_modulator_storage,
 

--- a/src/messaging/client/group_messages.h
+++ b/src/messaging/client/group_messages.h
@@ -50,6 +50,11 @@ CLIENT_TO_SERIAL_CONSTRAINED(UpdateGroupOutputInt16TValue, c2s_update_group_outp
                              detail::updateGroupMemberValue(&engine::Group::outputInfo, payload,
                                                             engine, cont));
 
+CLIENT_TO_SERIAL_CONSTRAINED(UpdateGroupOutputBoolValue, c2s_update_group_output_bool_value,
+                             detail::diffMsg_t<bool>, engine::Group::GroupOutputInfo,
+                             detail::updateGroupMemberValue(&engine::Group::outputInfo, payload,
+                                                            engine, cont));
+
 using renameGroup_t = std::tuple<selection::SelectionManager::ZoneAddress, std::string>;
 inline void renameGroup(const renameGroup_t &payload, const engine::Engine &engine,
                         MessageController &cont)

--- a/src/modulation/has_modulators.h
+++ b/src/modulation/has_modulators.h
@@ -43,7 +43,7 @@ static_assert(lfosPerGroup == lfosPerZone,
               "If this is false you need to template out the count below");
 template <typename T> struct HasModulators
 {
-    HasModulators(T *that) : eg{that, that} {}
+    HasModulators(T *that) : eg{that, that}, egOS{that, that} {}
 
     static constexpr uint16_t lfosPerObject{lfosPerZone};
 
@@ -61,7 +61,13 @@ template <typename T> struct HasModulators
     typedef sst::basic_blocks::modulators::AHDSRShapedSC<
         T, blockSize, sst::basic_blocks::modulators::ThirtyTwoSecondRange>
         ahdsrenv_t;
+
+    typedef sst::basic_blocks::modulators::AHDSRShapedSC<
+        T, blockSize << 1, sst::basic_blocks::modulators::ThirtyTwoSecondRange>
+        ahdsrenvOS_t;
+
     ahdsrenv_t eg[2];
+    ahdsrenvOS_t egOS[2];
 };
 } // namespace scxt::modulation::shared
 #endif // SHORTCIRCUITXT_HAS_MODULATORS_H


### PR DESCRIPTION
Activate oversapmle by group as described in #837.

1. Add the oversample members to group and voice, connect to UI, stream, send to voice.

2. Modify the processors to allow creation of an oversampled effect, and to have the correct sapmle rate etc.. (including some submodule fixes)

3. Modify the voice and group processors to run oversampled or not, including envelopes and processors and pans and so on

4. Modify bus to allow an oversampled direct target from zone and as-needed downsampling at bus assembly time.

5. Variety of smaller workarounds and fixes and tweaks to deal with associated details that everything works

Closes #837