### PR TITLE
Add the "Faux-Stereo" effect; adjust Memory Pool

### DIFF
--- a/src/dsp/data_tables.cpp
+++ b/src/dsp/data_tables.cpp
@@ -31,6 +31,7 @@
 namespace scxt::dsp
 {
 SincTable sincTable;
+SurgeSincTable surgeSincTable;
 DbTable dbTable;
 TwoToTheXTable twoToTheXTable;
 } // namespace scxt::dsp

--- a/src/dsp/data_tables.h
+++ b/src/dsp/data_tables.h
@@ -41,6 +41,10 @@ namespace scxt::dsp
 {
 using SincTable = sst::basic_blocks::tables::ShortcircuitSincTableProvider;
 extern SincTable sincTable;
+
+using SurgeSincTable = sst::basic_blocks::tables::SurgeSincTableProvider;
+extern SurgeSincTable surgeSincTable;
+
 static_assert(dsp::FIRipol_M == SincTable::FIRipol_M);
 static_assert(dsp::FIRipol_N == SincTable::FIRipol_N);
 static_assert(dsp::FIRipolI16_N == SincTable::FIRipolI16_N);

--- a/src/dsp/processor/processor.h
+++ b/src/dsp/processor/processor.h
@@ -124,6 +124,7 @@ enum ProcessorType
     proct_fx_freqshift,
     proct_fx_waveshaper,
     proct_fx_pitchring,
+    proct_fx_fauxstereo,
     proct_osc_phasemod, // last part/fx
 
     proct_fx_treemonster,
@@ -214,7 +215,7 @@ struct Processor : MoveableOnly<Processor>, SampleRateSupport
     void setupProcessor(T *that, ProcessorType t, engine::MemoryPool *mp, float *fp, int *ip);
 
   public:
-    size_t preReserveSize{0};
+    size_t preReserveSize[16]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
     ProcessorType getType() const { return myType; }
     std::string getName() const { return getProcessorName(getType()); }

--- a/src/dsp/processor/processor_defs.h
+++ b/src/dsp/processor/processor_defs.h
@@ -77,6 +77,8 @@
 
 #include "sst/voice-effects/pitch/PitchRing.h"
 
+#include "sst/voice-effects/delay/FauxStereo.h"
+
 namespace scxt::dsp::processor
 {
 // Just don't change the id or streaming name, basically
@@ -137,6 +139,9 @@ DEFINE_PROC(PitchRing, sst::voice_effects::pitch::PitchRing<SCXTVFXConfig<1>>,
             sst::voice_effects::pitch::PitchRing<SCXTVFXConfig<2>>, proct_fx_pitchring, "PitchRing",
             "Pitch and Frequency", "pitchring-fx");
 
+DEFINE_PROC(FauxStereo, sst::voice_effects::delay::FauxStereo<SCXTVFXConfig<1>>,
+            sst::voice_effects::delay::FauxStereo<SCXTVFXConfig<2>>, proct_fx_fauxstereo,
+            "Faux Stereo", "Delay Based", "fxstereo-fx", dsp::surgeSincTable);
 } // namespace scxt::dsp::processor
 
 // port

--- a/src/dsp/processor/processor_impl.h
+++ b/src/dsp/processor/processor_impl.h
@@ -48,7 +48,14 @@ template <int OSFactor> struct SCXTVFXConfig
         }
         else
         {
-            b->preReserveSize = s;
+            for (int i = 0; i < 16; ++i)
+            {
+                if (b->preReserveSize[i] == 0)
+                {
+                    b->preReserveSize[i] = s;
+                    break;
+                }
+            }
         }
     }
 
@@ -217,10 +224,13 @@ void Processor::setupProcessor(T *that, ProcessorType t, engine::MemoryPool *mp,
     for (int i = 0; i < parameter_count; ++i)
         this->ctrlmode_desc[i] = that->paramAt(i);
 
-    if (preReserveSize > 0)
+    for (int i = 0; i < 16; ++i)
     {
-        assert(memoryPool);
-        memoryPool->preReservePool(preReserveSize);
+        if (preReserveSize[i] > 0)
+        {
+            assert(memoryPool);
+            memoryPool->preReservePool(preReserveSize[i]);
+        }
     }
 }
 


### PR DESCRIPTION
Faux Stereo is a V1 effect which is basically mid side into a comb. While at it, allow the memory pool pre-reserve to have up to 16 reserved sizes per effect
And also add the Surge as well as ShortCircuit sinc table (since the delay uses the surge one)

Addresses #836