### PR TITLE
Fix Fade Range Init; Add Surge Biquads; Fix BitCrusher

### DIFF
--- a/src-ui/components/multi/ProcessorPane.cpp
+++ b/src-ui/components/multi/ProcessorPane.cpp
@@ -204,7 +204,8 @@ void ProcessorPane::rebuildControlsFromDescription()
         break;
 
     case dsp::processor::proct_CytomicSVF:
-        layoutControlsCytomicSVF();
+    case dsp::processor::proct_SurgeBiquads:
+        layoutControlsCytomicSVFAndBiquads();
         break;
 
     case dsp::processor::proct_eq_1band_parametric_A:

--- a/src-ui/components/multi/ProcessorPane.h
+++ b/src-ui/components/multi/ProcessorPane.h
@@ -84,7 +84,7 @@ struct ProcessorPane : sst::jucegui::components::NamedPanel, HasEditor, juce::Dr
 
     void layoutControls();
     void layoutControlsSuperSVF();
-    void layoutControlsCytomicSVF();
+    void layoutControlsCytomicSVFAndBiquads();
     void layoutControlsWaveshaper();
     void layoutControlsEQNBandParm();
     void layoutControlsEQMorph();

--- a/src/dsp/processor/processor.h
+++ b/src/dsp/processor/processor.h
@@ -105,6 +105,7 @@ enum ProcessorType
     proct_biquadSBQ, // First zone
     proct_SuperSVF,
     proct_CytomicSVF,
+    proct_SurgeBiquads,
 
     proct_moogLP4sat,
     proct_eq_1band_parametric_A,

--- a/src/dsp/processor/processor_defs.h
+++ b/src/dsp/processor/processor_defs.h
@@ -80,6 +80,7 @@
 #include "sst/voice-effects/delay/FauxStereo.h"
 
 #include "sst/voice-effects/filter/CytomicSVF.h"
+#include "sst/voice-effects/filter/SurgeBiquads.h"
 
 namespace scxt::dsp::processor
 {
@@ -148,6 +149,10 @@ DEFINE_PROC(FauxStereo, sst::voice_effects::delay::FauxStereo<SCXTVFXConfig<1>>,
 DEFINE_PROC(CytomicSVF, sst::voice_effects::filter::CytomicSVF<SCXTVFXConfig<1>>,
             sst::voice_effects::filter::CytomicSVF<SCXTVFXConfig<2>>, proct_CytomicSVF, "Fast SVF",
             "Filters", "filt-cytomic");
+
+DEFINE_PROC(SurgeBiquads, sst::voice_effects::filter::SurgeBiquads<SCXTVFXConfig<1>>,
+            sst::voice_effects::filter::SurgeBiquads<SCXTVFXConfig<2>>, proct_SurgeBiquads,
+            "Surge Biquads", "Filters", "filt-sstbiquad");
 
 } // namespace scxt::dsp::processor
 

--- a/src/engine/keyboard.h
+++ b/src/engine/keyboard.h
@@ -43,12 +43,15 @@ struct KeyboardRange
     int16_t fadeStart{0}, fadeEnd{0};
 
     KeyboardRange() = default;
-    KeyboardRange(int s, int e) : keyStart(s), keyEnd(e) { normalize(); }
+    KeyboardRange(int s, int e) : keyStart(s), keyEnd(e), fadeStart(s), fadeEnd(e) { normalize(); }
 
     void normalize()
     {
         if (keyEnd < keyStart)
             std::swap(keyStart, keyEnd);
+        if (fadeEnd < fadeStart)
+            std::swap(fadeStart, fadeEnd);
+
         if (fadeStart + fadeEnd > keyEnd - keyStart)
         {
             // TODO: Handle this case
@@ -79,12 +82,15 @@ struct VelocityRange
     int16_t fadeStart{0}, fadeEnd{0};
 
     VelocityRange() = default;
-    VelocityRange(int s, int e) : velStart(s), velEnd(e) { normalize(); }
+    VelocityRange(int s, int e) : velStart(s), velEnd(e), fadeStart(s), fadeEnd(e) { normalize(); }
 
     void normalize()
     {
         if (velEnd < velStart)
             std::swap(velStart, velEnd);
+        if (fadeEnd < fadeStart)
+            std::swap(fadeStart, fadeEnd);
+        
         if (fadeStart + fadeEnd > velEnd - velStart)
         {
             // TODO: Handle this case


### PR DESCRIPTION
Three changes

1. The keyboardRange{s,e} constructor didn't set up fadeStart and fadeEnd properly nor did vel range, so draggin g asmaple in was incorrect.
2. Add the 'SurgeBiquads" filter type for comparison. This probalby won't survive to 1.0 but useful for now
3. Fix the filter in the BitCrusher