### PR TITLE
Fix sanitizer reference in group matrix

### DIFF
--- a/src/engine/group.cpp
+++ b/src/engine/group.cpp
@@ -48,7 +48,6 @@ Group::Group()
     : id(GroupID::next()), name(id.to_string()), endpoints{nullptr},
       modulation::shared::HasModulators<Group>(this), osDownFilter(6, true)
 {
-    rePrepareAndBindGroupMatrix();
 }
 
 void Group::rePrepareAndBindGroupMatrix()
@@ -259,6 +258,8 @@ engine::Engine *Group::getEngine()
 
 void Group::setupOnUnstream(const engine::Engine &e)
 {
+    rePrepareAndBindGroupMatrix();
+
     for (auto i = 0U; i < engine::lfosPerZone; ++i)
     {
         stepLfos[i].setSampleRate(sampleRate, sampleRateInv);

--- a/src/modulation/group_matrix.cpp
+++ b/src/modulation/group_matrix.cpp
@@ -138,6 +138,7 @@ void GroupMatrixEndpoints::Sources::bind(scxt::modulation::GroupMatrix &m, engin
 
     for (int i = 0; i < scxt::numTransportPhasors; ++i)
     {
+        assert(g.getEngine());
         m.bindSourceValue(transportSources.phasors[i], g.getEngine()->transportPhasors[i]);
     }
 }


### PR DESCRIPTION
We bound the group matrix before the engine was set up. This lead to a read of the null engine to bind so bound to random memory. Fix.

ASAN is clean now in a normal run.