### PR TITLE
Guard on Engine, not Processor sample rate; Led to fresh session defa…

### DIFF
--- a/src/engine/group_and_zone_impl.h
+++ b/src/engine/group_and_zone_impl.h
@@ -127,7 +127,7 @@ HasGroupZoneProcessors<T>::spawnTempProcessor(int whichProcessor,
     {
         assert(tmpProcessor);
         assert(asT()->getEngine());
-        if (asT()->isSampleRateSet())
+        if (asT()->getEngine()->isSampleRateSet())
         {
             tmpProcessor->setSampleRate(asT()->getEngine()->getSampleRate());
             tmpProcessor->init();


### PR DESCRIPTION
…ult issue

A fresh session would mis-default the sample rate of a processor in setProcessorType leading to defaults being ignored. The correct check was for the engine.

Addresses most of #876