### PR TITLE
Change the meaning of 'fadeStart/fadeEnd'; adjust

### DIFF
--- a/src-ui/connectors/PayloadDataAttachment.h
+++ b/src-ui/connectors/PayloadDataAttachment.h
@@ -102,6 +102,14 @@ inline void configureUpdater(A &att, const typename A::payload_t &p, HasEditor *
     att.onGuiValueChanged = makeUpdater<M, A, ABase>(att, p, e, std::forward<Args>(args)...);
 }
 
+template <typename A, typename F> inline void addGuiStepBeforeSend(A &att, F preStep)
+{
+    auto orig = att.onGuiValueChanged;
+    att.onGuiValueChanged = [orig, preStep](const auto &a) {
+        preStep(a);
+        orig(a);
+    };
+}
 template <typename A, typename F> inline void addGuiStep(A &att, F andThen)
 {
     auto orig = att.onGuiValueChanged;

--- a/src/engine/engine_voice_responder.cpp
+++ b/src/engine/engine_voice_responder.cpp
@@ -131,44 +131,10 @@ int32_t Engine::VoiceManagerResponder::initializeMultipleVoices(
                 if (v)
                 {
                     v->velocity = velocity;
-                    if (z->mapping.keyboardRange.fadeStart != z->mapping.keyboardRange.keyStart &&
-                        key < z->mapping.keyboardRange.fadeStart)
-                    {
-                        auto keyFade{((float)(key - z->mapping.keyboardRange.keyStart)) /
-                                     (z->mapping.keyboardRange.fadeStart -
-                                      z->mapping.keyboardRange.keyStart)};
-                        keyFade = std ::clamp(keyFade, 0.f, 1.f);
-                        v->velKeyFade *= keyFade;
-                    }
-                    if (z->mapping.keyboardRange.fadeEnd != z->mapping.keyboardRange.keyEnd &&
-                        key > z->mapping.keyboardRange.fadeEnd)
-                    {
-                        auto keyFade{
-                            ((float)(z->mapping.keyboardRange.keyEnd - key)) /
-                            (z->mapping.keyboardRange.keyEnd - z->mapping.keyboardRange.fadeEnd)};
-                        keyFade = std ::clamp(keyFade, 0.f, 1.f);
-                        v->velKeyFade *= keyFade;
-                    }
-                    uint8_t midiVel = velocity * 127;
-                    if (z->mapping.velocityRange.fadeStart != z->mapping.velocityRange.velStart &&
-                        midiVel < z->mapping.velocityRange.fadeStart)
-                    {
-                        auto velFade{((float)(midiVel - z->mapping.velocityRange.velStart)) /
-                                     (z->mapping.velocityRange.fadeStart -
-                                      z->mapping.velocityRange.velStart)};
-                        velFade = std ::clamp(velFade, 0.f, 1.f);
-                        v->velKeyFade *= velFade;
-                    }
-                    if (z->mapping.velocityRange.fadeEnd != z->mapping.velocityRange.velEnd &&
-                        midiVel > z->mapping.velocityRange.fadeEnd)
-                    {
-                        uint8_t midiVel = velocity * 127;
-                        auto velFade{
-                            ((float)(z->mapping.velocityRange.velEnd - midiVel)) /
-                            (z->mapping.velocityRange.velEnd - z->mapping.velocityRange.fadeEnd)};
-                        velFade = std ::clamp(velFade, 0.f, 1.f);
-                        v->velKeyFade *= velFade;
-                    }
+                    v->velKeyFade = z->mapping.keyboardRange.fadeAmpltiudeAt(key);
+                    v->velKeyFade *= z->mapping.velocityRange.fadeAmpltiudeAt(
+                        (int16_t)std::clamp(velocity * 127.0, 0., 127.));
+
                     v->originalMidiKey = key;
                     v->attack();
                 }


### PR DESCRIPTION
Previous versions had fadeStart and fadeEnd be the midi note of the fade regions. This led to lots of complexity lots of spaces, including not making '0' a good default.

So change the internal meaning so fadeStart and fadeEnd are the distance from start and end of the fade zone. Once you do this lots of stuff gets simpler

- ui constraints are easier to calculate
- initialization is fine at 0
- you can move the fade calculation onto the range objects easily
- etc...

While in there also add an 'addGuiStepPreSend' to the connectors so you can do constrained guis more easily.