### PR TITLE
Make processor mix defaultable per-type

### DIFF
--- a/src/datamodel/metadata.h
+++ b/src/datamodel/metadata.h
@@ -43,7 +43,7 @@ using pmd = sst::basic_blocks::params::ParamMetaData;
 template <typename P, typename V> pmd describeValue(const P &p, const V &l)
 {
     auto pd = detail::offV(p, l);
-    return detail::descFor<P>(pd);
+    return detail::descFor<P>(p, pd);
 }
 } // namespace scxt::datamodel
 

--- a/src/datamodel/metadata_detail.h
+++ b/src/datamodel/metadata_detail.h
@@ -42,7 +42,7 @@ template <typename P, typename V> ptrdiff_t offV(const P &p, const V &l)
     auto pd = (uint8_t *)&(l) - (uint8_t *)&p;
     return pd;
 }
-template <typename P> sst::basic_blocks::params::ParamMetaData descFor(ptrdiff_t pd)
+template <typename P> sst::basic_blocks::params::ParamMetaData descFor(const P &, ptrdiff_t pd)
 {
     assert(false);
     return sst::basic_blocks::params::ParamMetaData()
@@ -55,7 +55,7 @@ template <typename P> sst::basic_blocks::params::ParamMetaData descFor(ptrdiff_t
 #define SC_DESCRIBE(T, ...)                                                                        \
     template <>                                                                                    \
     inline sst::basic_blocks::params::ParamMetaData scxt::datamodel::detail::descFor<T>(           \
-        ptrdiff_t(pd))                                                                             \
+        const T &payload, ptrdiff_t(pd))                                                           \
     {                                                                                              \
         using data = T;                                                                            \
         static_assert(std::is_standard_layout_v<T>);                                               \
@@ -70,6 +70,12 @@ template <typename P> sst::basic_blocks::params::ParamMetaData descFor(ptrdiff_t
     if (pd == offsetof(data, x))                                                                   \
     {                                                                                              \
         return __VA_ARGS__;                                                                        \
+    }
+
+#define SC_FIELD_COMPUTED(x, ...)                                                                  \
+    if (pd == offsetof(data, x))                                                                   \
+    {                                                                                              \
+        __VA_ARGS__;                                                                               \
     }
 
 #endif // SHORTCIRCUITXT_METADATA_DETAIL_H

--- a/src/dsp/processor/definition_helpers.h
+++ b/src/dsp/processor/definition_helpers.h
@@ -47,4 +47,10 @@
         static_assert(sizeof(TOS) < processorMemoryBufferSize);                                    \
     };
 
+#define PROC_DEFAULT_MIX(proct, mix)                                                               \
+    template <> struct ProcessorDefaultMix<proct>                                                  \
+    {                                                                                              \
+        static constexpr float defaultMix{mix};                                                    \
+    };
+
 #endif // SHORTCIRCUITXT_DEFINITION_HELPERS_H

--- a/src/dsp/processor/processor.cpp
+++ b/src/dsp/processor/processor.cpp
@@ -50,6 +50,7 @@ namespace detail
 
 using boolOp_t = bool (*)();
 using constCharOp_t = const char *(*)();
+using floatOp_t = float (*)();
 
 template <size_t I> bool implIsProcessorImplemented()
 {
@@ -115,9 +116,20 @@ template <size_t I> const char *implGetProcessorDisplayGroup()
         return ProcessorImplementor<(ProcessorType)I>::T::processorDisplayGroup;
 }
 
+template <size_t I> float implGetProcessorDefaultMix()
+{
+    return ProcessorDefaultMix<(ProcessorType)I>::defaultMix;
+}
+
 template <size_t... Is> auto getProcessorDisplayGroup(size_t ft, std::index_sequence<Is...>)
 {
     constexpr constCharOp_t fnc[] = {detail::implGetProcessorDisplayGroup<Is>...};
+    return fnc[ft]();
+}
+
+template <size_t... Is> auto getProcessorDefaultMix(size_t ft, std::index_sequence<Is...>)
+{
+    constexpr floatOp_t fnc[] = {detail::implGetProcessorDefaultMix<Is>...};
     return fnc[ft]();
 }
 template <size_t I>
@@ -201,6 +213,12 @@ const char *getProcessorStreamingName(ProcessorType id)
 const char *getProcessorDisplayGroup(ProcessorType id)
 {
     return detail::getProcessorDisplayGroup(
+        id, std::make_index_sequence<(size_t)ProcessorType::proct_num_types>());
+}
+
+float getProcessorDefaultMix(ProcessorType id)
+{
+    return detail::getProcessorDefaultMix(
         id, std::make_index_sequence<(size_t)ProcessorType::proct_num_types>());
 }
 

--- a/src/dsp/processor/processor.h
+++ b/src/dsp/processor/processor.h
@@ -148,6 +148,7 @@ bool isProcessorImplemented(ProcessorType id); // choice: return 'true' for none
 const char *getProcessorName(ProcessorType id);
 const char *getProcessorStreamingName(ProcessorType id);
 const char *getProcessorDisplayGroup(ProcessorType id);
+float getProcessorDefaultMix(ProcessorType id);
 std::optional<ProcessorType> fromProcessorStreamingName(const std::string &s);
 
 struct ProcessorDescription
@@ -316,8 +317,16 @@ template <ProcessorType ft> struct ProcessorImplementor
     typedef unimpl_t TOS;
 };
 
+template <ProcessorType ft> struct ProcessorDefaultMix
+{
+    static constexpr float defaultMix{1.0};
+};
+
 } // namespace scxt::dsp::processor
 
-SC_DESCRIBE(scxt::dsp::processor::ProcessorStorage,
-            SC_FIELD(mix, datamodel::pmd().asPercent().withName("Mix")));
+SC_DESCRIBE(scxt::dsp::processor::ProcessorStorage, SC_FIELD_COMPUTED(mix, {
+                auto dr = dsp::processor::getProcessorDefaultMix(payload.type);
+                return datamodel::pmd().asPercent().withName("Mix").withDefault(dr);
+            }));
+
 #endif // __SCXT_DSP_PROCESSOR_PROCESSOR_H

--- a/src/dsp/processor/processor_defs.h
+++ b/src/dsp/processor/processor_defs.h
@@ -128,9 +128,13 @@ DEFINE_PROC(MorphEQ, sst::voice_effects::eq::MorphEQ<SCXTVFXConfig<1>>,
 DEFINE_PROC(GenSin, sst::voice_effects::generator::GenSin<SCXTVFXConfig<1>>,
             sst::voice_effects::generator::GenSin<SCXTVFXConfig<2>>, proct_osc_sin, "Sin",
             "Generators", "osc-sin");
+PROC_DEFAULT_MIX(proct_osc_sin, 0.5);
+
 DEFINE_PROC(GenSaw, sst::voice_effects::generator::GenSaw<SCXTVFXConfig<1>>,
             sst::voice_effects::generator::GenSaw<SCXTVFXConfig<2>>, proct_osc_saw, "Saw",
             "Generators", "osc-saw");
+PROC_DEFAULT_MIX(proct_osc_saw, 0.5);
+
 DEFINE_PROC(GenPulseSync, sst::voice_effects::generator::GenPulseSync<SCXTVFXConfig<1>>,
             sst::voice_effects::generator::GenPulseSync<SCXTVFXConfig<2>>, proct_osc_pulse_sync,
             "Pulse Sync", "Generators", "osc-pulse-sync", dsp::sincTable);

--- a/src/engine/group_and_zone_impl.h
+++ b/src/engine/group_and_zone_impl.h
@@ -44,7 +44,8 @@ void HasGroupZoneProcessors<T>::setProcessorType(int whichProcessor,
     auto &ps = processorStorage[whichProcessor];
     auto &pd = processorDescription[whichProcessor];
     ps.type = type;
-    ps.mix = 1.0;
+
+    ps.mix = dsp::processor::getProcessorDefaultMix(type);
 
     uint8_t memory[dsp::processor::processorMemoryBufferSize];
     float pfp[dsp::processor::maxProcessorFloatParams];


### PR DESCRIPTION
Basically add a default mix customization based on type; use that to generate the metadata (so the metadat agenerator can inspect the payload which is useful anyway) and template type vary it. Then add a base class and specialization macro. Then set a couple to make sure it works and turn it over to andreya to set them all.

Closes #888