### PR TITLE
Finish lags when group.zones go unactive

### DIFF
--- a/src/engine/group.cpp
+++ b/src/engine/group.cpp
@@ -245,6 +245,7 @@ void Group::removeActiveZone()
     activeZones--;
     if (activeZones == 0)
     {
+        mUILag.instantlySnap();
         parentPart->removeActiveGroup();
     }
 }

--- a/src/engine/zone.cpp
+++ b/src/engine/zone.cpp
@@ -145,6 +145,7 @@ void Zone::removeVoice(voice::Voice *v)
             activeVoices--;
             if (activeVoices == 0)
             {
+                mUILag.instantlySnap();
                 parentGroup->removeActiveZone();
             }
             return;


### PR DESCRIPTION
I think this will fix some of the non-responsive or dropped-seeming UI messages we see, #878 for instance