### PR TITLE
Mono->Mono or Mono->Stereo is a runtime feature

### DIFF
--- a/src/dsp/processor/processor.h
+++ b/src/dsp/processor/processor.h
@@ -267,7 +267,8 @@ struct Processor : MoveableOnly<Processor>, SampleRateSupport
      */
     virtual bool canProcessMono() { return false; }
     virtual bool monoInputCreatesStereoOutput() { return false; }
-    virtual void process_mono(float *datain, float *dataoutL, float *dataoutR, float pitch)
+    virtual void process_monoToMono(float *datain, float *dataoutL, float pitch) { assert(false); }
+    virtual void process_monoToStereo(float *datain, float *dataoutL, float *dataoutR, float pitch)
     {
         assert(false);
     }

--- a/src/voice/voice.h
+++ b/src/voice/voice.h
@@ -138,7 +138,6 @@ struct alignas(16) Voice : MoveableOnly<Voice>,
         16)[engine::processorCount][dsp::processor::maxProcessorIntParams];
     bool processorIsActive[engine::processorCount]{false, false, false, false};
     bool processorConsumesMono[engine::processorCount]{false, false, false, false};
-    bool processorProducesStereo[engine::processorCount]{false, false, false, false};
 
     void initializeProcessors();
 


### PR DESCRIPTION
not a build time feature, if you want. If you dnt want it still works the old way. Yay, templates.

Addresses #887