### PR TITLE
LFOPane UI Improvement

### DIFF
--- a/src-ui/components/multi/LFOPane.cpp
+++ b/src-ui/components/multi/LFOPane.cpp
@@ -366,10 +366,6 @@ struct StepLFOPane : juce::Component, HasEditor
         auto jogBox = knobBounds.withHeight(buttonH).withY(knobBounds.getHeight() - buttonH).withWidth(knobBounds.getWidth()/2);
         jog[2]->setBounds(jogBox);
         jog[3]->setBounds(jogBox.withX(jogBox.getX() + jogBox.getWidth()));
-        std::cout<<2*jogBox.getWidth() << std::endl;
-        std::cout<<knobBounds.getWidth() << std::endl;
-        std::cout<<jogBox.getX() + 2*jogBox.getWidth() << std::endl;
-        std::cout<<b.getX() + b.getWidth() << std::endl;
     }
 };
 

--- a/src-ui/components/multi/LFOPane.cpp
+++ b/src-ui/components/multi/LFOPane.cpp
@@ -47,7 +47,8 @@ namespace scxt::ui::multi
 namespace jcmp = sst::jucegui::components;
 namespace cmsg = scxt::messaging::client;
 
-const int MG = 3;
+const int MG = 5;
+const int BUTTON_H = 18;
 
 struct StepLFOPane : juce::Component, HasEditor
 {
@@ -326,42 +327,49 @@ struct StepLFOPane : juce::Component, HasEditor
     void resized() override
     {
         auto knobReg = 58;
-        auto mg = 3;
         auto b = getLocalBounds();
-        stepRender->setBounds(b.withTrimmedBottom(knobReg + mg));
 
+        stepRender->setBounds(b.withTrimmedTop(b.getHeight()/2));
         auto knobw = knobReg - 16;
         auto bot = b.withTrimmedTop(b.getHeight() - knobReg);
 
-        auto menht = 22;
-        auto jx = bot.withWidth(knobw * 2 - mg).withHeight(menht);
-        stepsJ->setBounds(jx);
+        auto buttonH = BUTTON_H;
+        cycleB->setBounds(0, b.getHeight()/2 - MG - buttonH, b.getWidth()/4, buttonH);
 
-        jx = jx.translated(0, menht + mg);
-        cycleB->setBounds(jx);
+        auto bx = bot.withWidth(knobw).translated(knobw * 2 + MG, 0);
+        
+        auto lbHt = 15;
+        // Knobs
+        auto nKnobs = 4;
+        auto allKnobsStartX = b.getWidth()/4 + MG*2;
+        auto allKnobsStartY = 0;
+        auto allKnobsWidth = b.getWidth() - allKnobsStartX;
+        auto allKnobsHeight = b.getHeight()/2 - MG;
 
-        auto bx = bot.withWidth(knobw).translated(knobw * 2 + mg, 0);
-        rateK->setBounds(bx.withHeight(knobw));
-        rateL->setBounds(bx.withTrimmedTop(knobw));
-        bx = bx.translated(knobw + mg, 0);
+        auto knobMg = 15;
+        auto knobWidth = (allKnobsWidth - knobMg * (nKnobs -1)) / nKnobs;
+        auto knobHeight = allKnobsHeight;
 
-        deformK->setBounds(bx.withHeight(knobw));
-        deformL->setBounds(bx.withTrimmedTop(knobw));
-        bx = bx.translated(knobw + mg, 0);
+        auto knobBounds = b.withWidth(knobWidth).withHeight(knobHeight).withX(allKnobsStartX).withY(allKnobsStartY);
+        auto makeKnobBounds = [](auto &knob, auto &label, auto &knobBounds, int lbHt, int knobWidth, int knobHeight, int knobMg){
+            knob->setBounds(knobBounds.withTrimmedBottom(23 - MG)); // remove modulator_storage label
+            label->setBounds(knobBounds.withTrimmedTop(knobHeight -lbHt));
+            knobBounds = knobBounds.translated(knobWidth + knobMg, 0);
+        };
+        makeKnobBounds(rateK, rateL, knobBounds, lbHt, knobWidth, knobHeight, knobMg);
+        makeKnobBounds(phaseK, phaseL, knobBounds, lbHt, knobWidth, knobHeight, knobMg);
+        makeKnobBounds(deformK, deformL, knobBounds, lbHt, knobWidth, knobHeight, knobMg);
+        // Knobs (END)
 
-        phaseK->setBounds(bx.withHeight(knobw));
-        phaseL->setBounds(bx.withTrimmedTop(knobw));
-
-        bx = bx.translated(knobw * 1.5 + mg, 0);
-        bx = bx.withWidth(bx.getWidth() * 1.2).reduced(0, mg);
-        auto bthrd = bx.getWidth() / 3;
-        auto rc = bx.toFloat().withWidth(bthrd);
-        jog[2]->setBounds(rc.withHeight(bthrd).withCentre(rc.getCentre()).toNearestInt());
-
-        rc = rc.translated(bthrd, 0);
-
-        rc = rc.translated(bthrd, 0);
-        jog[3]->setBounds(rc.withHeight(bthrd).withCentre(rc.getCentre()).toNearestInt());
+        // (use knobBounds to place this where the 4th knob would be)
+        stepsJ->setBounds(knobBounds.withHeight(buttonH));
+        auto jogBox = knobBounds.withHeight(buttonH).withY(knobBounds.getHeight() - buttonH).withWidth(knobBounds.getWidth()/2);
+        jog[2]->setBounds(jogBox);
+        jog[3]->setBounds(jogBox.withX(jogBox.getX() + jogBox.getWidth()));
+        std::cout<<2*jogBox.getWidth() << std::endl;
+        std::cout<<knobBounds.getWidth() << std::endl;
+        std::cout<<jogBox.getX() + 2*jogBox.getWidth() << std::endl;
+        std::cout<<b.getX() + b.getWidth() << std::endl;
     }
 };
 
@@ -443,10 +451,7 @@ struct CurveLFOPane : juce::Component, HasEditor
     void resized() override
     {
         auto lbHt = 15;
-
         auto b = getLocalBounds();
-
-        auto knobw = b.getHeight() / 2 - lbHt;
 
         // Knobs
         auto nKnobs = 4;
@@ -455,13 +460,13 @@ struct CurveLFOPane : juce::Component, HasEditor
         auto allKnobsWidth = b.getWidth() - allKnobsStartX;
         auto allKnobsHeight = b.getHeight()/2 - MG;
 
-        auto knobMg = 18;
+        auto knobMg = 15;
         auto knobWidth = (allKnobsWidth - knobMg * (nKnobs -1)) / nKnobs;
         auto knobHeight = allKnobsHeight;
 
         auto knobBounds = b.withWidth(knobWidth).withHeight(knobHeight).withX(allKnobsStartX).withY(allKnobsStartY);
         auto makeKnobBounds = [](auto &knob, auto &label, auto &knobBounds, int lbHt, int knobWidth, int knobHeight, int knobMg){
-            knob->setBounds(knobBounds.withTrimmedBottom(23)); // remove modulator_storage label
+            knob->setBounds(knobBounds.withTrimmedBottom(23 - MG)); // remove modulator_storage label
             label->setBounds(knobBounds.withTrimmedTop(knobHeight -lbHt));
             knobBounds = knobBounds.translated(knobWidth + knobMg, 0);
         };
@@ -495,14 +500,13 @@ struct CurveLFOPane : juce::Component, HasEditor
         auto curveBox = b.withY(bh/2).withWidth(3*getWidth()/5).withTrimmedBottom(bh/2);
         curveDraw->setBounds(curveBox);
 
-        auto buttonH = 18;
+        auto buttonH = BUTTON_H;
         unipolarB->setBounds(0, bh/2 - MG - buttonH, b.getWidth()/4, buttonH);
         useenvB->setBounds(0, bh/2, b.getWidth()/4, buttonH);
     }
 
     std::unique_ptr<LfoPane::attachment_t> rateA, deformA, phaseA, angleA;
     std::unique_ptr<jcmp::Knob> rateK, deformK, phaseK, angleK;
-    //std::unique_ptr<connectors::FakeModel> fakeModel;
     std::unique_ptr<jcmp::Label> rateL, deformL, phaseL, angleL;
 
     std::unique_ptr<LfoPane::boolAttachment_t> unipolarA, useenvA;
@@ -573,13 +577,13 @@ struct ENVLFOPane : juce::Component, HasEditor
         auto allKnobsWidth = b.getWidth() - allKnobsStartX;
         auto allKnobsHeight = b.getHeight()/2 - MG;
 
-        auto knobMg = 18;
+        auto knobMg = 15;
         auto knobWidth = (allKnobsWidth - knobMg * (nKnobs -1)) / nKnobs;
         auto knobHeight = allKnobsHeight;
 
         auto knobBounds = b.withWidth(knobWidth).withHeight(knobHeight).withX(allKnobsStartX).withY(allKnobsStartY);
         auto makeKnobBounds = [](auto &knob, auto &label, auto &knobBounds, int lbHt, int knobWidth, int knobHeight, int knobMg){
-            knob->setBounds(knobBounds.withTrimmedBottom(23)); // remove modulator_storage label
+            knob->setBounds(knobBounds.withTrimmedBottom(23 - MG)); // remove modulator_storage label
             label->setBounds(knobBounds.withTrimmedTop(knobHeight -lbHt));
             knobBounds = knobBounds.translated(knobWidth + knobMg, 0);
         };
@@ -755,14 +759,14 @@ void LfoPane::repositionContentAreaComponents()
     if (!modulatorShape) // these are all created at once so single check is fine
         return;
 
-    auto ht = 18;
-    auto triggerWidth = 66;
-    auto mg = 5;
+    auto ht = BUTTON_H;
+    auto triggerWidth = 72;
+    auto mg = MG;
 
     triggerMode->setBounds(getContentArea().getWidth() - (triggerWidth + mg), 0, triggerWidth, 5 * ht);
     triggerL->setBounds(getContentArea().getWidth() - (triggerWidth + mg), triggerMode->getHeight() + mg, triggerWidth, ht);
 
-    auto paneArea = getContentArea().withX(mg).withTrimmedRight(triggerWidth + mg*3).withY(0).withTrimmedBottom(mg);
+    auto paneArea = getContentArea().withX(mg).withTrimmedRight(triggerWidth + mg*4).withY(0).withTrimmedBottom(mg);
     stepLfoPane->setBounds(paneArea);
     envLfoPane->setBounds(paneArea);
     msegLfoPane->setBounds(paneArea);

--- a/src-ui/components/multi/LFOPane.cpp
+++ b/src-ui/components/multi/LFOPane.cpp
@@ -653,15 +653,6 @@ void LfoPane::rebuildPanelComponents()
     using tfac = connectors::SingleValueFactory<triggerAttachment_t,
                                                 cmsg::UpdateZoneOrGroupModStorageInt16TValue>;
 
-    sfac::attach(ms, ms.modulatorShape, this, modulatorShapeA, modulatorShape, forZone,
-                 selectedTab);
-    connectors::addGuiStep(*modulatorShapeA,
-                           [w = juce::Component::SafePointer(this)](const auto &x) {
-                               if (w)
-                                   w->setSubPaneVisibility();
-                           });
-
-    getContentAreaComponent()->addAndMakeVisible(*modulatorShape);
 
     tfac::attach(ms, ms.triggerMode, this, triggerModeA, triggerMode, forZone, selectedTab);
     getContentAreaComponent()->addAndMakeVisible(*triggerMode);
@@ -678,6 +669,16 @@ void LfoPane::rebuildPanelComponents()
     curveLfoPane = std::make_unique<CurveLFOPane>(this);
     getContentAreaComponent()->addChildComponent(*curveLfoPane);
 
+    sfac::attach(ms, ms.modulatorShape, this, modulatorShapeA, modulatorShape, forZone,
+                 selectedTab);
+    connectors::addGuiStep(*modulatorShapeA,
+                           [w = juce::Component::SafePointer(this)](const auto &x) {
+                               if (w)
+                                   w->setSubPaneVisibility();
+                           });
+
+    getContentAreaComponent()->addAndMakeVisible(*modulatorShape);
+    
     repositionContentAreaComponents();
     setSubPaneVisibility();
 

--- a/src-ui/components/multi/LFOPane.cpp
+++ b/src-ui/components/multi/LFOPane.cpp
@@ -447,9 +447,9 @@ struct CurveLFOPane : juce::Component, HasEditor
 
         auto b = getLocalBounds();
 
-        auto knobw = b.getHeight() / 2 - lbHt - mg;
+        auto knobw = b.getHeight() / 2 - lbHt;
 
-        auto bx = b.withWidth(knobw).withHeight(b.getHeight() / 2);
+        auto bx = b.withWidth(knobw).withHeight(b.getHeight() / 2).translated(b.getWidth()/2, 0);
         rateK->setBounds(bx.withHeight(knobw));
         rateL->setBounds(bx.withTrimmedTop(knobw));
         bx = bx.translated(knobw + mg, 0);
@@ -460,8 +460,7 @@ struct CurveLFOPane : juce::Component, HasEditor
         phaseL->setBounds(bx.withTrimmedTop(knobw));
         bx = bx.translated(knobw + mg, 0);
 
-        bx = b.withWidth(knobw).withHeight(b.getHeight() / 2).translated(0, b.getHeight() / 2);
-
+        bx = b.withWidth(knobw).withHeight(b.getHeight() / 2).translated(b.getWidth()/2, b.getHeight() / 2);
         for (int i = 0; i < envSlots; ++i)
         {
             envS[i]->setBounds(bx.withHeight(knobw));
@@ -469,11 +468,13 @@ struct CurveLFOPane : juce::Component, HasEditor
             bx = bx.translated(knobw + mg, 0);
         }
 
-        auto curveBox = b.withTrimmedLeft((knobw + mg) * 3).withTrimmedBottom(mg).reduced(mg, 0);
+        auto bh = b.getHeight();
+        auto curveBox = b.withY(bh/2).withTrimmedRight(getWidth()/2).withTrimmedBottom(bh/2);
         curveDraw->setBounds(curveBox);
 
-        unipolarB->setBounds(curveBox.getRight() - 32 - mg, 2, 32, 18);
-        useenvB->setBounds(curveBox.getRight() - 70 - mg, 2, 32, 18);
+        auto buttonH = 18;
+        unipolarB->setBounds(0, bh/2 - mg - buttonH, b.getWidth()/4, buttonH);
+        useenvB->setBounds(b.getWidth()/4, bh/2 - mg - buttonH, b.getWidth()/4, buttonH);
     }
 
     std::unique_ptr<LfoPane::attachment_t> rateA, deformA, phaseA;
@@ -485,7 +486,7 @@ struct CurveLFOPane : juce::Component, HasEditor
 
     static constexpr int envSlots{3}; // DAR
     std::array<std::unique_ptr<LfoPane::attachment_t>, envSlots> envA;
-    std::array<std::unique_ptr<jcmp::Knob>, envSlots> envS;
+    std::array<std::unique_ptr<jcmp::VSlider>, envSlots> envS;
     std::array<std::unique_ptr<jcmp::Label>, envSlots> envL;
 
     std::unique_ptr<CurveDraw> curveDraw;
@@ -508,18 +509,18 @@ struct ENVLFOPane : juce::Component, HasEditor
             addAndMakeVisible(*lb);
         };
 
-        auto makeO = [&, this](auto &mem, auto &A, auto &K, auto &L) {
-            fac::attachAndAdd(ms, mem, this, A, K, parent->forZone, parent->selectedTab);
+        auto makeO = [&, this](auto &mem, auto &A, auto &S, auto &L) {
+            fac::attachAndAdd(ms, mem, this, A, S, parent->forZone, parent->selectedTab);
 
             makeLabel(L, A->getLabel());
         };
 
-        makeO(ms.envLfoStorage.delay, delayA, delayK, delayL);
-        makeO(ms.envLfoStorage.attack, attackA, attackK, attackL);
-        makeO(ms.envLfoStorage.hold, holdA, holdK, holdL);
-        makeO(ms.envLfoStorage.decay, decayA, decayK, decayL);
-        makeO(ms.envLfoStorage.sustain, sustainA, sustainK, sustainL);
-        makeO(ms.envLfoStorage.release, releaseA, releaseK, releaseL);
+        makeO(ms.envLfoStorage.delay, delayA, delayS, delayL);
+        makeO(ms.envLfoStorage.attack, attackA, attackS, attackL);
+        makeO(ms.envLfoStorage.hold, holdA, holdS, holdL);
+        makeO(ms.envLfoStorage.decay, decayA, decayS, decayL);
+        makeO(ms.envLfoStorage.sustain, sustainA, sustainS, sustainL);
+        makeO(ms.envLfoStorage.release, releaseA, releaseS, releaseL);
     }
 
     void resized() override
@@ -532,36 +533,37 @@ struct ENVLFOPane : juce::Component, HasEditor
         auto knobw = b.getHeight() / 2 - lbHt - mg;
 
         auto bx = b.withWidth(knobw).withHeight(b.getHeight() / 2);
-        delayK->setBounds(bx.withHeight(knobw));
+        delayS->setBounds(bx.withHeight(knobw));
         delayL->setBounds(bx.withTrimmedTop(knobw));
         bx = bx.translated(knobw + mg, 0);
 
-        attackK->setBounds(bx.withHeight(knobw));
+        attackS->setBounds(bx.withHeight(knobw));
         attackL->setBounds(bx.withTrimmedTop(knobw));
         bx = bx.translated(knobw + mg, 0);
 
-        holdK->setBounds(bx.withHeight(knobw));
+        holdS->setBounds(bx.withHeight(knobw));
         holdL->setBounds(bx.withTrimmedTop(knobw));
         bx = bx.translated(knobw + mg, 0);
 
         bx = b.withWidth(knobw).withHeight(b.getHeight() / 2).translated(0, b.getHeight() / 2);
 
-        decayK->setBounds(bx.withHeight(knobw));
+        decayS->setBounds(bx.withHeight(knobw));
         decayL->setBounds(bx.withTrimmedTop(knobw));
         bx = bx.translated(knobw + mg, 0);
 
-        sustainK->setBounds(bx.withHeight(knobw));
+        sustainS->setBounds(bx.withHeight(knobw));
         sustainL->setBounds(bx.withTrimmedTop(knobw));
         bx = bx.translated(knobw + mg, 0);
 
-        releaseK->setBounds(bx.withHeight(knobw));
+        releaseS->setBounds(bx.withHeight(knobw));
         releaseL->setBounds(bx.withTrimmedTop(knobw));
         bx = bx.translated(knobw + mg, 0);
         bx = bx.translated(knobw + mg, 0);
     }
 
     std::unique_ptr<LfoPane::attachment_t> delayA, attackA, holdA, decayA, sustainA, releaseA;
-    std::unique_ptr<jcmp::Knob> delayK, attackK, holdK, decayK, sustainK, releaseK;
+    //std::unique_ptr<jcmp::Knob> delayK, attackK, holdK, decayK, sustainK, releaseK;
+    std::unique_ptr<jcmp::VSlider> delayS, attackS, holdS, decayS, sustainS, releaseS;
     std::unique_ptr<jcmp::Label> delayL, attackL, holdL, decayL, sustainL, releaseL;
 };
 
@@ -698,13 +700,13 @@ void LfoPane::repositionContentAreaComponents()
     auto wd = 66;
     auto mg = 5;
 
-    modulatorShape->setBounds(0, 0, wd, ht);
-    triggerMode->setBounds(0, ht + mg, wd, 5 * ht);
-    auto paneArea = getContentArea().withX(0).withTrimmedLeft(wd + mg).withY(0);
+    triggerMode->setBounds(getContentArea().getWidth() - (wd + mg), 0, wd, 5 * ht);
+    auto paneArea = getContentArea().withX(mg).withTrimmedRight(wd + mg*3).withY(0).withTrimmedBottom(mg); ; // Trim bottom as well? 
     stepLfoPane->setBounds(paneArea);
     envLfoPane->setBounds(paneArea);
     msegLfoPane->setBounds(paneArea);
     curveLfoPane->setBounds(paneArea);
+    modulatorShape->setBounds(mg, 0, wd, ht);
 }
 
 void LfoPane::setSubPaneVisibility()

--- a/src-ui/components/multi/LFOPane.cpp
+++ b/src-ui/components/multi/LFOPane.cpp
@@ -415,6 +415,10 @@ struct CurveLFOPane : juce::Component, HasEditor
                           parent->selectedTab);
         makeLabel(phaseL, "Phase");
 
+        fac::attachAndAdd(ms, ms.start_phase, this, angleA, angleK, parent->forZone,
+                          parent->selectedTab);
+        makeLabel(angleL, "Angle");
+
         fac::attachAndAdd(ms, ms.curveLfoStorage.delay, this, envA[0], envS[0], parent->forZone,
                           parent->selectedTab);
         makeLabel(envL[0], "Delay");
@@ -449,18 +453,29 @@ struct CurveLFOPane : juce::Component, HasEditor
 
         auto knobw = b.getHeight() / 2 - lbHt;
 
-        auto bx = b.withWidth(knobw).withHeight(b.getHeight() / 2).translated(b.getWidth()/2, 0);
-        rateK->setBounds(bx.withHeight(knobw));
-        rateL->setBounds(bx.withTrimmedTop(knobw));
-        bx = bx.translated(knobw + mg, 0);
-        deformK->setBounds(bx.withHeight(knobw));
-        deformL->setBounds(bx.withTrimmedTop(knobw));
-        bx = bx.translated(knobw + mg, 0);
-        phaseK->setBounds(bx.withHeight(knobw));
-        phaseL->setBounds(bx.withTrimmedTop(knobw));
-        bx = bx.translated(knobw + mg, 0);
+        auto nKnobs = 4;
+        auto allKnobsStartX = b.getWidth()/4 + mg*2;
+        auto allKnobsStartY = 0;
+        auto allKnobsWidth = 3*b.getWidth()/4 - mg*2;
+        auto allKnobsHeight = b.getHeight()/2 - mg;
 
-        bx = b.withWidth(knobw).withHeight(b.getHeight() / 2).translated(b.getWidth()/2, b.getHeight() / 2);
+        auto knobWidth = (allKnobsWidth - mg * (nKnobs -1)) / nKnobs;
+        auto knobHeight = allKnobsHeight;
+
+        auto knobBounds = b.withWidth(knobWidth).withHeight(knobHeight).withX(allKnobsStartX).withY(allKnobsStartY);
+        rateK->setBounds(knobBounds);
+        rateL->setBounds(knobBounds.withTrimmedTop(knobHeight -lbHt));
+        knobBounds = knobBounds.translated(knobWidth + mg, 0);
+        phaseK->setBounds(knobBounds);
+        phaseL->setBounds(knobBounds.withTrimmedTop(knobHeight -lbHt));
+        knobBounds = knobBounds.translated(knobWidth + mg, 0);
+        deformK->setBounds(knobBounds);
+        deformL->setBounds(knobBounds.withTrimmedTop(knobHeight -lbHt));
+        knobBounds = knobBounds.translated(knobWidth + mg, 0);
+        angleK->setBounds(knobBounds);
+        angleL->setBounds(knobBounds.withTrimmedTop(knobHeight -lbHt));
+
+        auto bx = b.withWidth(knobw).withHeight(b.getHeight() / 2).translated(b.getWidth()/2, b.getHeight() / 2);
         for (int i = 0; i < envSlots; ++i)
         {
             envS[i]->setBounds(bx.withHeight(knobw));
@@ -474,12 +489,12 @@ struct CurveLFOPane : juce::Component, HasEditor
 
         auto buttonH = 18;
         unipolarB->setBounds(0, bh/2 - mg - buttonH, b.getWidth()/4, buttonH);
-        useenvB->setBounds(b.getWidth()/4, bh/2 - mg - buttonH, b.getWidth()/4, buttonH);
+        useenvB->setBounds(0, bh/2, b.getWidth()/4, buttonH);
     }
 
-    std::unique_ptr<LfoPane::attachment_t> rateA, deformA, phaseA;
-    std::unique_ptr<jcmp::Knob> rateK, deformK, phaseK;
-    std::unique_ptr<jcmp::Label> rateL, deformL, phaseL;
+    std::unique_ptr<LfoPane::attachment_t> rateA, deformA, phaseA, angleA;
+    std::unique_ptr<jcmp::Knob> rateK, deformK, phaseK, angleK;
+    std::unique_ptr<jcmp::Label> rateL, deformL, phaseL, angleL;
 
     std::unique_ptr<LfoPane::boolAttachment_t> unipolarA, useenvA;
     std::unique_ptr<jcmp::ToggleButton> unipolarB, useenvB;
@@ -678,7 +693,7 @@ void LfoPane::rebuildPanelComponents()
                            });
 
     getContentAreaComponent()->addAndMakeVisible(*modulatorShape);
-    
+
     repositionContentAreaComponents();
     setSubPaneVisibility();
 
@@ -698,16 +713,16 @@ void LfoPane::repositionContentAreaComponents()
         return;
 
     auto ht = 18;
-    auto wd = 66;
+    auto triggerWidth = 66;
     auto mg = 5;
 
-    triggerMode->setBounds(getContentArea().getWidth() - (wd + mg), 0, wd, 5 * ht);
-    auto paneArea = getContentArea().withX(mg).withTrimmedRight(wd + mg*3).withY(0).withTrimmedBottom(mg); ; // Trim bottom as well? 
+    triggerMode->setBounds(getContentArea().getWidth() - (triggerWidth + mg), 0, triggerWidth, 5 * ht);
+    auto paneArea = getContentArea().withX(mg).withTrimmedRight(triggerWidth + mg*3).withY(0).withTrimmedBottom(mg);
     stepLfoPane->setBounds(paneArea);
     envLfoPane->setBounds(paneArea);
     msegLfoPane->setBounds(paneArea);
     curveLfoPane->setBounds(paneArea);
-    modulatorShape->setBounds(mg, 0, wd, ht);
+    modulatorShape->setBounds(mg, 0, paneArea.getWidth()/4, ht);
 }
 
 void LfoPane::setSubPaneVisibility()

--- a/src-ui/components/multi/LFOPane.cpp
+++ b/src-ui/components/multi/LFOPane.cpp
@@ -458,10 +458,11 @@ struct CurveLFOPane : juce::Component, HasEditor
 
         auto knobw = b.getHeight() / 2 - lbHt;
 
+        // Knobs
         auto nKnobs = 4;
         auto allKnobsStartX = b.getWidth()/4 + MG*2;
         auto allKnobsStartY = 0;
-        auto allKnobsWidth = 3*b.getWidth()/4 - MG*2;
+        auto allKnobsWidth = b.getWidth() - allKnobsStartX;
         auto allKnobsHeight = b.getHeight()/2 - MG;
 
         auto knobMg = 12;
@@ -478,17 +479,30 @@ struct CurveLFOPane : juce::Component, HasEditor
         makeKnobBounds(phaseK, phaseL, knobBounds, lbHt, knobWidth, knobHeight, knobMg);
         makeKnobBounds(deformK, deformL, knobBounds, lbHt, knobWidth, knobHeight, knobMg);
         makeKnobBounds(angleK, angleL, knobBounds, lbHt, knobWidth, knobHeight, knobMg);
+        // Knobs (END)
 
-        auto bx = b.withWidth(knobw).withHeight(b.getHeight() / 2).translated(b.getWidth()/2, b.getHeight() / 2);
+        // EnvSliders
+        auto nEnvSliders = 3;
+        auto allEnvSlidersStartX = 3*b.getWidth()/5 + MG*2;
+        auto allEnvSlidersStartY = b.getHeight()/2;
+        auto allEnvSlidersWidth = b.getWidth() - allEnvSlidersStartX;
+        auto allEnvSlidersHeight = b.getHeight()/2;
+
+        auto envSliderMg = 6;
+        auto envSliderWidth = (allEnvSlidersWidth - envSliderMg * (nEnvSliders -1)) / nEnvSliders;
+        auto envSliderHeight = allEnvSlidersHeight;
+
+        auto envSliderBounds = b.withWidth(envSliderWidth).withHeight(envSliderHeight).withX(allEnvSlidersStartX).withY(allEnvSlidersStartY);
         for (int i = 0; i < envSlots; ++i)
         {
-            envS[i]->setBounds(bx.withHeight(knobw));
-            envL[i]->setBounds(bx.withTrimmedTop(knobw));
-            bx = bx.translated(knobw + MG, 0);
+            envS[i]->setBounds(envSliderBounds.withTrimmedBottom(17));
+            envL[i]->setBounds(envSliderBounds.withTrimmedTop(envSliderHeight - lbHt));
+            envSliderBounds = envSliderBounds.translated(envSliderWidth + envSliderMg, 0);
         }
+        // EnvSliders (END)
 
         auto bh = b.getHeight();
-        auto curveBox = b.withY(bh/2).withTrimmedRight(getWidth()/2).withTrimmedBottom(bh/2);
+        auto curveBox = b.withY(bh/2).withWidth(3*getWidth()/5).withTrimmedBottom(bh/2);
         curveDraw->setBounds(curveBox);
 
         auto buttonH = 18;

--- a/src-ui/components/multi/LFOPane.h
+++ b/src-ui/components/multi/LFOPane.h
@@ -45,6 +45,8 @@
 namespace scxt::ui::multi
 {
 
+namespace jcmp = sst::jucegui::components;
+
 struct StepLFOPane;
 struct CurveLFOPane;
 struct ENVLFOPane;
@@ -94,6 +96,7 @@ struct LfoPane : sst::jucegui::components::NamedPanel, HasEditor
 
     std::unique_ptr<triggerAttachment_t> triggerModeA;
     std::unique_ptr<sst::jucegui::components::MultiSwitch> triggerMode;
+    std::unique_ptr<jcmp::Label> triggerL;
 
     std::array<modulation::ModulatorStorage, engine::lfosPerZone> modulatorStorageData;
 

--- a/src-ui/connectors/PayloadDataAttachment.h
+++ b/src-ui/connectors/PayloadDataAttachment.h
@@ -470,6 +470,30 @@ template <typename A, typename Msg, typename ABase = A> struct SingleValueFactor
     }
 };
 
+struct DummyContinuous : sst::jucegui::data::Continuous
+{
+    float f{0.5};
+    virtual float getValue() const override { return f; }
+    virtual void setValueFromGUI(const float &fv) override { f = fv; }
+    virtual void setValueFromModel(const float &fv) override { f = fv; };
+    virtual float getDefaultValue() const override { return 0.5f; };
+    virtual std::string getLabel() const override { return "Dummy"; };
+};
+template<typename T> std::unique_ptr<T> makeConnectedToDummy()
+{
+   auto res = std::make_unique<T>();
+   auto thisWillLeak = new DummyContinuous();
+   SCLOG("WARNING: Dummy Widget in ui. Memory leak until we attach");
+   //jassertfalse;
+   res->setSource(thisWillLeak);
+   return res;
+}
+
+struct FakeModel
+{
+   sst::jucegui::data::Continuous *getDummySourceFor(uint32_t id);
+};
+
 template <typename A, typename Msg>
 using BooleanSingleValueFactory =
     SingleValueFactory<A, Msg, DiscretePayloadDataAttachment<typename A::payload_t, bool>>;

--- a/src-ui/connectors/PayloadDataAttachment.h
+++ b/src-ui/connectors/PayloadDataAttachment.h
@@ -489,11 +489,6 @@ template<typename T> std::unique_ptr<T> makeConnectedToDummy()
    return res;
 }
 
-struct FakeModel
-{
-   sst::jucegui::data::Continuous *getDummySourceFor(uint32_t id);
-};
-
 template <typename A, typename Msg>
 using BooleanSingleValueFactory =
     SingleValueFactory<A, Msg, DiscretePayloadDataAttachment<typename A::payload_t, bool>>;


### PR DESCRIPTION
- Created a Dummy Connector;
- Moved and resized stuff in the LFO Pane to better match the Figma mockups;
- Added some knobs without the DSP (hence the Dummy Connectors).

Squash and rebase are probably better for this PR.

<img width="408" alt="image" src="https://github.com/surge-synthesizer/shortcircuit-xt/assets/100025288/7e31477d-1814-4b50-be86-87c18b6e6937">
<img width="408" alt="image" src="https://github.com/surge-synthesizer/shortcircuit-xt/assets/100025288/d5ff7be3-ffbb-4bed-9c44-3f1ee03d6be6">
<img width="408" alt="image" src="https://github.com/surge-synthesizer/shortcircuit-xt/assets/100025288/cfc6f1ef-9e9c-48df-ba2a-6a8388f39aac">
