### PR TITLE
Clamp float values on proc bool/int-restate change

### DIFF
--- a/src/engine/group_and_zone.h
+++ b/src/engine/group_and_zone.h
@@ -67,7 +67,8 @@ template <typename T> struct HasGroupZoneProcessors
     static constexpr int processorCount{scxt::processorsPerZoneAndGroup};
     void setProcessorType(int whichProcessor, dsp::processor::ProcessorType type);
     void setupProcessorControlDescriptions(int whichProcessor, dsp::processor::ProcessorType,
-                                           dsp::processor::Processor *tmpProcessor = nullptr);
+                                           dsp::processor::Processor *tmpProcessor = nullptr,
+                                           bool reClampFloatValues = false);
 
     dsp::processor::Processor *spawnTempProcessor(int whichProcessor,
                                                   dsp::processor::ProcessorType type, uint8_t *mem,

--- a/src/engine/group_and_zone_impl.h
+++ b/src/engine/group_and_zone_impl.h
@@ -71,7 +71,7 @@ void HasGroupZoneProcessors<T>::setProcessorType(int whichProcessor,
 template <typename T>
 void HasGroupZoneProcessors<T>::setupProcessorControlDescriptions(
     int whichProcessor, dsp::processor::ProcessorType type,
-    dsp::processor::Processor *tmpProcessorFromAfar)
+    dsp::processor::Processor *tmpProcessorFromAfar, bool reClampFloatValues)
 {
     if (type == dsp::processor::proct_none)
     {
@@ -105,6 +105,18 @@ void HasGroupZoneProcessors<T>::setupProcessorControlDescriptions(
     if (forGroup)
     {
         processorDescription[whichProcessor].supportsKeytrack = false;
+    }
+
+    if (reClampFloatValues)
+    {
+        // Clamp floats to min/max here. This matters when, say, you toggle
+        // keytrack and change ranges and so need to clamp inside the new range.
+        auto &pd = processorDescription[whichProcessor];
+        for (int i = 0; i < pd.numFloatParams; ++i)
+        {
+            ps.floatParams[i] = std::clamp(ps.floatParams[i], pd.floatControlDescriptions[i].minVal,
+                                           pd.floatControlDescriptions[i].maxVal);
+        }
     }
 
     if (!tmpProcessorFromAfar)
@@ -170,7 +182,7 @@ bool HasGroupZoneProcessors<T>::checkOrAdjustIntConsistency(int whichProcessor)
 
         auto restate = tmpProcessor->makeParametersConsistent();
 
-        setupProcessorControlDescriptions(whichProcessor, ps.type, tmpProcessor);
+        setupProcessorControlDescriptions(whichProcessor, ps.type, tmpProcessor, restate);
 
         if (restate)
         {
@@ -203,7 +215,7 @@ bool HasGroupZoneProcessors<T>::checkOrAdjustBoolConsistency(int whichProcessor)
         if (ps.previousIsKeytracked < 0 || ps.isKeytracked != ps.previousIsKeytracked)
         {
             ps.previousIsKeytracked = ps.isKeytracked ? 1 : 0;
-            asT()->setupProcessorControlDescriptions(whichProcessor, ps.type);
+            asT()->setupProcessorControlDescriptions(whichProcessor, ps.type, nullptr, true);
 
             messaging::audio::AudioToSerialization updateProc;
             updateProc.id = messaging::audio::a2s_processor_refresh;


### PR DESCRIPTION
Changing keytrack for instance wouldn't reset the float to be in range, so it would be out of range if max / keytrack.

Clamp optionally in these restate cases for int, and always for bool.

Closes #876