### PR TITLE
Proc ROuting Step 1; Also Clang-Format

### DIFF
--- a/src/dsp/processor/definition_helpers.h
+++ b/src/dsp/processor/definition_helpers.h
@@ -1,9 +1,32 @@
-//
-// Created by Paul Walker on 3/6/24.
-//
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
 
-#ifndef SHORTCIRCUITXT_DEFINITION_HELPERS_H
-#define SHORTCIRCUITXT_DEFINITION_HELPERS_H
+#ifndef SCXT_SRC_DSP_PROCESSOR_DEFINITION_HELPERS_H
+#define SCXT_SRC_DSP_PROCESSOR_DEFINITION_HELPERS_H
 
 // the varags at end are underlyer ctor args to the base type
 #define DEFINE_PROC(procClass, procImpl, osProcImpl, procID, procDisplayName, procDisplayGroup,    \

--- a/src/dsp/processor/routing.h
+++ b/src/dsp/processor/routing.h
@@ -1,0 +1,98 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_DSP_PROCESSOR_ROUTING_H
+#define SCXT_SRC_DSP_PROCESSOR_ROUTING_H
+
+#include "processor.h"
+
+namespace scxt::dsp::processor
+{
+template <bool OS, int N, typename Mix, typename Endpoints>
+void processSequential(float fpitch, Processor *processors[engine::processorCount],
+                       bool processorConsumesMono[engine::processorCount], Mix &mix,
+                       Endpoints *endpoints, bool &chainIsMono, float output[2][N])
+{
+    namespace mech = sst::basic_blocks::mechanics;
+
+    float tempbuf alignas(16)[2][BLOCK_SIZE << 1];
+
+    for (auto i = 0; i < engine::processorCount; ++i)
+    {
+        if (processors[i])
+        {
+            endpoints->processorTarget[i].snapValues();
+            // TODO: Snap int values here (and same in group)
+
+            mix[i].set_target(*endpoints->processorTarget[i].mixP);
+
+            if (chainIsMono && processorConsumesMono[i] &&
+                !processors[i]->monoInputCreatesStereoOutput())
+            {
+                // mono to mono
+                processors[i]->process_monoToMono(output[0], tempbuf[0], fpitch);
+                mix[i].fade_blocks(output[0], tempbuf[0], output[0]);
+            }
+            else if (chainIsMono && processorConsumesMono[i])
+            {
+                assert(processors[i]->monoInputCreatesStereoOutput());
+                // mono to stereo. process then toggle
+                processors[i]->process_monoToStereo(output[0], tempbuf[0], tempbuf[1], fpitch);
+
+                // this out[0] is NOT a typo. Input is mono
+                // And this order matters. Have to splat [1] first to keep [0] around
+                mix[i].fade_blocks(output[0], tempbuf[1], output[1]);
+                mix[i].fade_blocks(output[0], tempbuf[0], output[0]);
+
+                chainIsMono = false;
+            }
+            else if (chainIsMono)
+            {
+                assert(!processorConsumesMono[i]);
+                // stereo to stereo. copy L to R then process
+                mech::copy_from_to<blockSize << (OS ? 1 : 0)>(output[0], output[1]);
+                chainIsMono = false;
+                processors[i]->process_stereo(output[0], output[1], tempbuf[0], tempbuf[1], fpitch);
+                mix[i].fade_blocks(output[0], tempbuf[0], output[0]);
+                mix[i].fade_blocks(output[1], tempbuf[1], output[1]);
+            }
+            else
+            {
+                // stereo to stereo. process
+                processors[i]->process_stereo(output[0], output[1], tempbuf[0], tempbuf[1], fpitch);
+                mix[i].fade_blocks(output[0], tempbuf[0], output[0]);
+                mix[i].fade_blocks(output[1], tempbuf[1], output[1]);
+            }
+            // TODO: What was the filter_modout? Seems SC2 never finished it
+            /*
+            filter_modout[0] = voice_filter[0]->modulation_output;
+                                   */
+        }
+    }
+}
+} // namespace scxt::dsp::processor
+#endif // SHORTCIRCUITXT_ROUTING_H

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -203,21 +203,25 @@ void Engine::releaseVoice(int16_t channel, int16_t key, int32_t noteId, int32_t 
 #endif
 }
 
-void Engine::releaseAllVoices() {
-    for (auto &v : voices){
-        if (v && v->isVoiceAssigned) 
+void Engine::releaseAllVoices()
+{
+    for (auto &v : voices)
+    {
+        if (v && v->isVoiceAssigned)
             v->release();
     }
 }
 
-void Engine::stopAllSounds() {
+void Engine::stopAllSounds()
+{
     std::array<voice::Voice *, maxVoices> toCleanUp{};
     size_t cleanupIdx{0};
     for (auto &v : voices)
     {
         if (v && v->isVoiceAssigned)
         {
-            v->release(); // dont call cleanup here since it will break the weak pointers and the voices array
+            v->release(); // dont call cleanup here since it will break the weak pointers and the
+                          // voices array
             toCleanUp[cleanupIdx++] = v;
         }
     }

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -207,12 +207,8 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
         void setNoteExpression(voice::Voice *v, int32_t expression, double value) {}
         void setPolyphonicAftertouch(voice::Voice *v, int8_t pat) {}
         void setChannelPressure(voice::Voice *v, int8_t pres) {}
-        void allSoundsOff(){
-            engine.releaseAllVoices();
-        }
-        void allNotesOff(){
-            engine.stopAllSounds();
-        }
+        void allSoundsOff() { engine.releaseAllVoices(); }
+        void allNotesOff() { engine.stopAllSounds(); }
         void setMIDI1CC(voice::Voice *v, int8_t cc, int8_t val);
 
     } voiceManagerResponder{*this};

--- a/src/engine/group.cpp
+++ b/src/engine/group.cpp
@@ -40,6 +40,7 @@
 #include "patch.h"
 #include "engine.h"
 #include "group_and_zone_impl.h"
+#include "dsp/processor/routing.h"
 
 namespace scxt::engine
 {
@@ -163,6 +164,24 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
         }
     }
 
+    // Groups are always unpitched and stereo
+    auto fpitch = 0;
+    bool processorConsumesMono[4]{false, false, false, false};
+    bool chainIsMono{false};
+
+    if constexpr (OS)
+    {
+        scxt::dsp::processor::processSequential<true>(fpitch, processors.data(),
+                                                      processorConsumesMono, processorMixOS,
+                                                      &endpoints, chainIsMono, output);
+    }
+    else
+    {
+        scxt::dsp::processor::processSequential<false>(fpitch, processors.data(),
+                                                       processorConsumesMono, processorMix,
+                                                       &endpoints, chainIsMono, output);
+    }
+#if 0
     // for processor do the necessary
     for (int i = 0; i < engine::processorCount; ++i)
     {
@@ -189,6 +208,7 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
             }
         }
     }
+#endif
 
     // Pan
     auto pvo = std::clamp(*endpoints.outputTarget.panP, -1.f, 1.f);

--- a/src/messaging/client/enginestatus_messages.h
+++ b/src/messaging/client/enginestatus_messages.h
@@ -74,20 +74,17 @@ inline void onUnstream(const streamState_t &payload, engine::Engine &engine,
 CLIENT_TO_SERIAL(UnstreamIntoEngine, c2s_unstream_state, streamState_t,
                  onUnstream(payload, engine, cont));
 
-
-
-
 using stopSounds_t = bool;
-inline void stopSoundsMessage(const stopSounds_t &payload,
-                                messaging::MessageController &cont)
+inline void stopSoundsMessage(const stopSounds_t &payload, messaging::MessageController &cont)
 {
     cont.scheduleAudioThreadCallback([p = payload](scxt::engine::Engine &e) {
-        if (p) e.stopAllSounds();
-        else e.releaseAllVoices();
+        if (p)
+            e.stopAllSounds();
+        else
+            e.releaseAllVoices();
     });
 }
-CLIENT_TO_SERIAL(StopSounds, c2s_silence_engine, stopSounds_t,
-                 stopSoundsMessage(payload, cont));
+CLIENT_TO_SERIAL(StopSounds, c2s_silence_engine, stopSounds_t, stopSoundsMessage(payload, cont));
 } // namespace scxt::messaging::client
 
 #endif // SHORTCIRCUIT_ENGINESTATUS_MESSAGES_H

--- a/src/sample/loaders/load_mp3.cpp
+++ b/src/sample/loaders/load_mp3.cpp
@@ -1,6 +1,29 @@
-//
-// Created by Paul Walker on 5/29/24.
-//
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
 
 #include "sample/sample.h"
 

--- a/src/sample/multisample_support/multisample_import.cpp
+++ b/src/sample/multisample_support/multisample_import.cpp
@@ -1,6 +1,29 @@
-//
-// Created by Paul Walker on 3/25/24.
-//
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
 
 #include <map>
 

--- a/src/sample/multisample_support/multisample_import.h
+++ b/src/sample/multisample_support/multisample_import.h
@@ -1,9 +1,32 @@
-//
-// Created by Paul Walker on 3/25/24.
-//
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
 
-#ifndef SHORTCIRCUITXT_MULTISAMPLE_IMPORT_H
-#define SHORTCIRCUITXT_MULTISAMPLE_IMPORT_H
+#ifndef SCXT_SRC_SAMPLE_MULTISAMPLE_SUPPORT_MULTISAMPLE_IMPORT_H
+#define SCXT_SRC_SAMPLE_MULTISAMPLE_SUPPORT_MULTISAMPLE_IMPORT_H
 
 #include "filesystem/import.h"
 #include <engine/engine.h>

--- a/src/sample/sfz_support/sfz_import.h
+++ b/src/sample/sfz_support/sfz_import.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_SFZ_SUPPORT_SFZ_IMPORT_H
-#define SCXT_SRC_SFZ_SUPPORT_SFZ_IMPORT_H
+#ifndef SCXT_SRC_SAMPLE_SFZ_SUPPORT_SFZ_IMPORT_H
+#define SCXT_SRC_SAMPLE_SFZ_SUPPORT_SFZ_IMPORT_H
 
 #include "filesystem/import.h"
 #include <engine/engine.h>

--- a/src/sample/sfz_support/sfz_parse.h
+++ b/src/sample/sfz_support/sfz_parse.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_SFZ_SUPPORT_SFZ_PARSE_H
-#define SCXT_SRC_SFZ_SUPPORT_SFZ_PARSE_H
+#ifndef SCXT_SRC_SAMPLE_SFZ_SUPPORT_SFZ_PARSE_H
+#define SCXT_SRC_SAMPLE_SFZ_SUPPORT_SFZ_PARSE_H
 
 #include <string>
 #include <variant>


### PR DESCRIPTION
Proc Routing step 1: Move the routing to a shared function for linear and share it between group and voice.

Also I ran my clang formatter and it found lots of bad formatting and missing headers, so that's all swept in also. I wish it was separate but I can't unpick it now I did it. Sigh.