### PR TITLE
Add all ProcRouting types but dont impl and fix KT bug

### DIFF
--- a/src/engine/group.cpp
+++ b/src/engine/group.cpp
@@ -187,6 +187,11 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
         }
     }
     break;
+
+    case HasGroupZoneProcessors<Group>::procRoute_ser2:
+    case HasGroupZoneProcessors<Group>::procRoute_ser3:
+    case HasGroupZoneProcessors<Group>::procRoute_par1:
+    case HasGroupZoneProcessors<Group>::procRoute_par2:
     case HasGroupZoneProcessors<Group>::procRoute_bypass:
         break;
     }

--- a/src/engine/group_and_zone.h
+++ b/src/engine/group_and_zone.h
@@ -57,11 +57,16 @@ template <typename T> struct HasGroupZoneProcessors
      */
     enum ProcRoutingPath : int16_t
     {
-        procRoute_linear,
-        procRoute_bypass // leave this as last
+        procRoute_linear, // 1 -> 2 -> 3 -> 4
+        procRoute_ser2,   // -> { 1 | 2 } -> { 3 | 4 } ->
+        procRoute_ser3,   // -> 1 -> { 2 | 3 } -> 4 ->
+        procRoute_par1,   // -> { { 1->2 } | { 3 -> 4 } } ->
+        procRoute_par2,   // -> { 1 | 2 | 3 } -> 4
+        procRoute_bypass  // bypass all procs.
     };
     DECLARE_ENUM_STRING(ProcRoutingPath);
     static std::string getProcRoutingPathDisplayName(ProcRoutingPath p);
+    static std::string getProcRoutingPathShortName(ProcRoutingPath p);
 
     T *asT() { return static_cast<T *>(this); }
     static constexpr int processorCount{scxt::processorsPerZoneAndGroup};

--- a/src/engine/group_and_zone_impl.h
+++ b/src/engine/group_and_zone_impl.h
@@ -151,15 +151,14 @@ HasGroupZoneProcessors<T>::spawnTempProcessor(int whichProcessor,
                 ps.previousIsKeytracked = -1;
                 ps.isKeytracked = tmpProcessor->getDefaultKeytrack();
                 tmpProcessor->setKeytrack(ps.isKeytracked);
-
                 tmpProcessor->init_params(); // thos blows out with default}
 
                 if (tmpProcessor && tmpProcessor->supportsMakingParametersConsistent())
                 {
                     tmpProcessor->makeParametersConsistent();
-                    tmpProcessor->resetMetadata();
                 }
 
+                tmpProcessor->resetMetadata();
                 memcpy(&(ps.floatParams[0]), pfp, sizeof(ps.floatParams));
                 memcpy(&(ps.intParams[0]), ifp, sizeof(ps.intParams));
             }
@@ -242,6 +241,14 @@ std::string HasGroupZoneProcessors<T>::toStringProcRoutingPath(
     {
     case procRoute_linear:
         return "procRoute_linear";
+    case procRoute_ser2:
+        return "procRoute_ser2";
+    case procRoute_ser3:
+        return "procRoute_ser3";
+    case procRoute_par1:
+        return "procRoete_par1";
+    case procRoute_par2:
+        return "procRoete_par2";
     case procRoute_bypass:
         return "procRoute_bypass";
     }
@@ -269,8 +276,37 @@ std::string HasGroupZoneProcessors<T>::getProcRoutingPathDisplayName(
     {
     case procRoute_linear:
         return "Linear";
+    case procRoute_ser2:
+        return "> { 1 | 2 } > { 3 | 4 } >";
+    case procRoute_ser3:
+        return "> 1 > { 2 | 3 } > 4 >";
+    case procRoute_par1:
+        return "> { { 1>2 } | { 3 > 4 } } >";
+    case procRoute_par2:
+        return "> { 1 | 2 | 3 } > 4";
     case procRoute_bypass:
         return "Bypass";
+    }
+    return "ERROR";
+}
+
+template <typename T>
+std::string HasGroupZoneProcessors<T>::getProcRoutingPathShortName(ProcRoutingPath p)
+{
+    switch (p)
+    {
+    case procRoute_linear:
+        return "SER";
+    case procRoute_ser2:
+        return "SER2";
+    case procRoute_ser3:
+        return "SER3";
+    case procRoute_par1:
+        return "PAR1";
+    case procRoute_par2:
+        return "PAR2";
+    case procRoute_bypass:
+        return "BYP";
     }
     return "ERROR";
 }

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -329,6 +329,11 @@ template <bool OS> bool Voice::processWithOS()
         }
     }
     break;
+
+    case engine::HasGroupZoneProcessors<engine::Zone>::procRoute_ser2:
+    case engine::HasGroupZoneProcessors<engine::Zone>::procRoute_ser3:
+    case engine::HasGroupZoneProcessors<engine::Zone>::procRoute_par1:
+    case engine::HasGroupZoneProcessors<engine::Zone>::procRoute_par2:
     case engine::HasGroupZoneProcessors<engine::Zone>::procRoute_bypass:
         break;
     }


### PR DESCRIPTION
- Add all the routing types to the enum and the dropdown but everyone is bypass except linear still
- Fix a bug with keytrack and parak refresh on an absolutely clean state which ignored defaults