### PR TITLE
The None-As-Mute change

### DIFF
--- a/src-ui/components/multi/ProcessorPane.h
+++ b/src-ui/components/multi/ProcessorPane.h
@@ -84,6 +84,7 @@ struct ProcessorPane : sst::jucegui::components::NamedPanel, HasEditor, juce::Dr
     void attachRebuildToIntAttachment(int idx);
 
     void layoutControls();
+    void layoutControlsNone();
     void layoutControlsMicroGate();
     void layoutControlsSimpleDelay();
     void layoutControlsSurgeFilters();
@@ -193,7 +194,7 @@ struct ProcessorPane : sst::jucegui::components::NamedPanel, HasEditor, juce::Dr
     std::array<std::unique_ptr<int_attachment_t>, dsp::processor::maxProcessorFloatParams>
         intAttachments;
 
-    std::unique_ptr<bool_attachment_t> bypassAttachment, keytrackAttackment;
+    std::unique_ptr<bool_attachment_t> isActiveAttachment, keytrackAttackment;
 
     std::vector<std::unique_ptr<juce::Component>> otherEditors;
 

--- a/src/dsp/processor/processor.cpp
+++ b/src/dsp/processor/processor.cpp
@@ -74,7 +74,7 @@ template <size_t... Is> auto isProcessorImplemented(size_t ft, std::index_sequen
 template <size_t I> const char *implGetProcessorName()
 {
     if constexpr (I == ProcessorType::proct_none)
-        return "Off";
+        return scxt::dsp::processor::noneDisplayName;
 
     if constexpr (std::is_same<typename ProcessorImplementor<(ProcessorType)I>::T, unimpl_t>::value)
         return "error";
@@ -246,9 +246,9 @@ processorList_t getAllProcessorDescriptions()
         }
     }
     std::sort(res.begin(), res.end(), [](const auto &a, const auto &b) {
-        if (a.displayName == "Off")
+        if (a.displayName == scxt::dsp::processor::noneDisplayName)
             return true;
-        if (b.displayName == "Off")
+        if (b.displayName == scxt::dsp::processor::noneDisplayName)
             return false;
 
         if (a.displayGroup == b.displayGroup)
@@ -269,6 +269,17 @@ Processor *spawnProcessorInPlace(ProcessorType id, engine::MemoryPool *mp, uint8
                                  bool oversample, bool needsMetadata)
 {
     assert(memorySize >= processorMemoryBufferSize);
+    if (id == proct_none)
+    {
+        if (!ps.isActive)
+        {
+            if (oversample)
+                return new (memory) MuteSpecialProcessor<true>();
+            else
+                return new (memory) MuteSpecialProcessor<false>();
+        }
+        return nullptr;
+    }
     if (oversample)
     {
         return detail::spawnOntoOS(

--- a/src/dsp/processor/routing.h
+++ b/src/dsp/processor/routing.h
@@ -47,7 +47,10 @@ inline void runSingleProcessor(int i, float fpitch, Processor *processors[engine
 
     endpoints->processorTarget[i].snapValues();
 
-    mix[i].set_target(*endpoints->processorTarget[i].mixP);
+    auto mixl = *endpoints->processorTarget[i].mixP;
+    if (processors[i]->getType() == proct_none)
+        mixl = 1.0;
+    mix[i].set_target(mixl);
 
     if constexpr (forceStereo)
     {
@@ -120,10 +123,69 @@ inline void processSequential(float fpitch, Processor *processors[engine::proces
 }
 
 // -> { 1 | 2 } -> { 3 | 4 } ->
+
+// All in parallel
 template <bool OS, bool forceStereo, int N, typename Mix, typename Endpoints>
-void processSerial2Pattern(float fpitch, Processor *processors[engine::processorCount],
-                           bool processorConsumesMono[engine::processorCount], Mix &mix,
-                           Endpoints *endpoints, bool &chainIsMono, float output[2][N])
+void processPar1Pattern(float fpitch, Processor *processors[engine::processorCount],
+                        bool processorConsumesMono[engine::processorCount], Mix &mix,
+                        Endpoints *endpoints, bool &chainIsMono, float output[2][N])
+{
+    namespace mech = sst::basic_blocks::mechanics;
+
+    float tmpbuf alignas(16)[engine::processorCount][2][N];
+    bool isMute[engine::processorCount]{};
+
+    // The mono handling here is tricky so for now just force stereo. Fix this obvs
+    if (chainIsMono)
+    {
+        chainIsMono = false;
+        mech::copy_from_to<blockSize << OS>(output[0], output[1]);
+    }
+
+    int numUnMuted = 0;
+
+    for (int i = 0; i < engine::processorCount; ++i)
+    {
+        if (processors[i])
+        {
+            isMute[i] = processors[i]->isMuteProcessor();
+            runSingleProcessor<OS, true>(i, fpitch, processors, processorConsumesMono, mix,
+                                         endpoints, chainIsMono, output, tmpbuf[i]);
+        }
+        else
+        {
+            isMute[i] = false;
+            mech::copy_from_to<blockSize << OS>(output[0], tmpbuf[i][0]);
+            mech::copy_from_to<blockSize << OS>(output[1], tmpbuf[i][1]);
+        }
+        numUnMuted += (isMute[i] ? 0 : 1);
+    }
+
+    mech::clear_block<blockSize << OS>(output[0]);
+    mech::clear_block<blockSize << OS>(output[1]);
+    if (numUnMuted == 0)
+    {
+        // special case - we can't scale and don't have anything else to do
+    }
+    else
+    {
+        float scale = 1.f / numUnMuted;
+        for (int i = 0; i < engine::processorCount; ++i)
+        {
+            if (!isMute[i])
+            {
+                mech::scale_accumulate_from_to<blockSize << OS>(tmpbuf[i][0], scale, output[0]);
+                mech::scale_accumulate_from_to<blockSize << OS>(tmpbuf[i][1], scale, output[1]);
+            }
+        }
+    }
+}
+
+// -> { { 1->2} | { 3->4 } ->
+template <bool OS, bool forceStereo, int N, typename Mix, typename Endpoints>
+void processPar2Pattern(float fpitch, Processor *processors[engine::processorCount],
+                        bool processorConsumesMono[engine::processorCount], Mix &mix,
+                        Endpoints *endpoints, bool &chainIsMono, float output[2][N])
 {
     namespace mech = sst::basic_blocks::mechanics;
 
@@ -133,16 +195,21 @@ void processSerial2Pattern(float fpitch, Processor *processors[engine::processor
     bool mono12 = chainIsMono;
     bool mono34 = chainIsMono;
 
+    bool muteIn12 = false;
+    bool muteIn34 = false;
+
     mech::copy_from_to<scxt::blockSize << OS>(output[0], tempbuf12[0]);
     mech::copy_from_to<scxt::blockSize << OS>(output[1], tempbuf12[1]);
 
     if (processors[0])
     {
+        muteIn12 |= processors[0]->isMuteProcessor();
         runSingleProcessor<OS, forceStereo>(0, fpitch, processors, processorConsumesMono, mix,
                                             endpoints, mono12, tempbuf12, tempbuf12);
     }
     if (processors[1])
     {
+        muteIn12 |= processors[1]->isMuteProcessor();
         runSingleProcessor<OS, forceStereo>(1, fpitch, processors, processorConsumesMono, mix,
                                             endpoints, mono12, tempbuf12, tempbuf12);
     }
@@ -152,11 +219,13 @@ void processSerial2Pattern(float fpitch, Processor *processors[engine::processor
 
     if (processors[2])
     {
+        muteIn34 |= processors[2]->isMuteProcessor();
         runSingleProcessor<OS, forceStereo>(2, fpitch, processors, processorConsumesMono, mix,
                                             endpoints, mono34, tempbuf34, tempbuf34);
     }
     if (processors[3])
     {
+        muteIn34 |= processors[3]->isMuteProcessor();
         runSingleProcessor<OS, forceStereo>(3, fpitch, processors, processorConsumesMono, mix,
                                             endpoints, mono34, tempbuf34, tempbuf34);
     }
@@ -206,17 +275,20 @@ void processSerial2Pattern(float fpitch, Processor *processors[engine::processor
         mech::copy_from_to<scxt::blockSize << OS>(tempbuf34[1], output[1]);
     }
 
-    // since this sends the signal down both chains, half the
-    // amplitude.
-    // static constexpr float amp{0.707106781186548f};
-    static constexpr float amp{0.5f};
-    if (chainIsMono)
+    if (!muteIn12 && !muteIn34)
     {
-        mech::scale_by<scxt::blockSize << OS>(amp, output[0]);
-    }
-    else
-    {
-        mech::scale_by<scxt::blockSize << OS>(amp, output[0], output[1]);
+        // since this sends the signal down both chains, half the
+        // amplitude.
+        // static constexpr float amp{0.707106781186548f};
+        static constexpr float amp{0.5f};
+        if (chainIsMono)
+        {
+            mech::scale_by<scxt::blockSize << OS>(amp, output[0]);
+        }
+        else
+        {
+            mech::scale_by<scxt::blockSize << OS>(amp, output[0], output[1]);
+        }
     }
 }
 } // namespace scxt::dsp::processor

--- a/src/engine/group_and_zone.h
+++ b/src/engine/group_and_zone.h
@@ -60,8 +60,9 @@ template <typename T> struct HasGroupZoneProcessors
         procRoute_linear, // 1 -> 2 -> 3 -> 4
         procRoute_ser2,   // -> { 1 | 2 } -> { 3 | 4 } ->
         procRoute_ser3,   // -> 1 -> { 2 | 3 } -> 4 ->
-        procRoute_par1,   // -> { { 1->2 } | { 3 -> 4 } } ->
-        procRoute_par2,   // -> { 1 | 2 | 3 } -> 4
+        procRoute_par1,   // -> { 1|2|3|4 } ->
+        procRoute_par2,   // -> { { 1->2 } | { 3 -> 4 } } ->
+        procRoute_par3,   // -> { 1 | 2 | 3 } -> 4
         procRoute_bypass  // bypass all procs.
     };
     DECLARE_ENUM_STRING(ProcRoutingPath);

--- a/src/engine/group_and_zone_impl.h
+++ b/src/engine/group_and_zone_impl.h
@@ -76,7 +76,7 @@ void HasGroupZoneProcessors<T>::setupProcessorControlDescriptions(
     if (type == dsp::processor::proct_none)
     {
         processorDescription[whichProcessor] = {};
-        processorDescription[whichProcessor].typeDisplayName = "Off";
+        processorDescription[whichProcessor].typeDisplayName = dsp::processor::noneDisplayName;
         return;
     }
 
@@ -230,6 +230,13 @@ bool HasGroupZoneProcessors<T>::checkOrAdjustBoolConsistency(int whichProcessor)
         }
         // SCLOG("And check is required");
     }
+
+    if (pd.type == dsp::processor::proct_none && forGroup)
+    {
+        // This is a mute toggle
+        asT()->onProcessorTypeChanged(whichProcessor, dsp::processor::proct_none);
+    }
+
     return false;
 }
 
@@ -249,6 +256,8 @@ std::string HasGroupZoneProcessors<T>::toStringProcRoutingPath(
         return "procRoete_par1";
     case procRoute_par2:
         return "procRoete_par2";
+    case procRoute_par3:
+        return "procRoete_par3";
     case procRoute_bypass:
         return "procRoute_bypass";
     }
@@ -281,8 +290,10 @@ std::string HasGroupZoneProcessors<T>::getProcRoutingPathDisplayName(
     case procRoute_ser3:
         return "> 1 > { 2 | 3 } > 4 >";
     case procRoute_par1:
-        return "> { { 1>2 } | { 3 > 4 } } >";
+        return "> { 1 | 2 | 3 |4 } >";
     case procRoute_par2:
+        return "> { { 1>2 } | { 3 > 4 } } >";
+    case procRoute_par3:
         return "> { 1 | 2 | 3 } > 4";
     case procRoute_bypass:
         return "Bypass";
@@ -296,7 +307,7 @@ std::string HasGroupZoneProcessors<T>::getProcRoutingPathShortName(ProcRoutingPa
     switch (p)
     {
     case procRoute_linear:
-        return "SER";
+        return "SER1";
     case procRoute_ser2:
         return "SER2";
     case procRoute_ser3:
@@ -305,6 +316,8 @@ std::string HasGroupZoneProcessors<T>::getProcRoutingPathShortName(ProcRoutingPa
         return "PAR1";
     case procRoute_par2:
         return "PAR2";
+    case procRoute_par3:
+        return "PAR3";
     case procRoute_bypass:
         return "BYP";
     }

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -352,15 +352,19 @@ template <bool OS> bool Voice::processWithOS()
             CALL_ROUTE(processSequential);
         }
         break;
-
-        case engine::HasGroupZoneProcessors<engine::Zone>::procRoute_ser2:
+        case engine::HasGroupZoneProcessors<engine::Zone>::procRoute_par1:
         {
-            CALL_ROUTE(processSerial2Pattern);
+            CALL_ROUTE(processPar1Pattern);
         }
         break;
-        case engine::HasGroupZoneProcessors<engine::Zone>::procRoute_ser3:
-        case engine::HasGroupZoneProcessors<engine::Zone>::procRoute_par1:
         case engine::HasGroupZoneProcessors<engine::Zone>::procRoute_par2:
+        {
+            CALL_ROUTE(processPar2Pattern);
+        }
+        break;
+        case engine::HasGroupZoneProcessors<engine::Zone>::procRoute_ser2:
+        case engine::HasGroupZoneProcessors<engine::Zone>::procRoute_ser3:
+        case engine::HasGroupZoneProcessors<engine::Zone>::procRoute_par3:
         case engine::HasGroupZoneProcessors<engine::Zone>::procRoute_bypass:
             break;
         }
@@ -604,7 +608,8 @@ void Voice::initializeProcessors()
         memcpy(&processorIntParams[i][0], zone->processorStorage[i].intParams.data(),
                sizeof(processorIntParams[i]));
 
-        if (processorIsActive[i])
+        if ((processorIsActive[i] && processorType[i] != dsp::processor::proct_none) ||
+            (processorType[i] == dsp::processor::proct_none && !processorIsActive[i]))
         {
             processors[i] = dsp::processor::spawnProcessorInPlace(
                 processorType[i], zone->getEngine()->getMemoryPool().get(),


### PR DESCRIPTION
A processor with type None now

1. Is labeled None
2. Has a power button
3. If that power button is off the processor is a mute
4. If that power button is off the processor is and shows as mute

Additionally add Par1 shape but only in stereo

Some known bugs here. Namely

1. Par1 doesn't preserve mono
2. Toggling keytrack seems to reset the active state on the 'nones'

Figure out both of those but merge this so people can try it