### PR TITLE
Generator wasn't accounting for FIR padding

### DIFF
--- a/src-ui/components/multi/MappingPane.cpp
+++ b/src-ui/components/multi/MappingPane.cpp
@@ -429,8 +429,6 @@ struct MappingDisplay : juce::Component,
         iAdd(mappingView.rootKey, intAttachments.RootKey, textEds.RootKey);
         makeLabel(labels.RootKey, "Root Key");
 
-        SCLOG("Setup " << SCD(mappingView.keyboardRange.keyStart)
-                       << SCD(mappingView.keyboardRange.keyEnd));
         iAdd(mappingView.keyboardRange.keyStart, intAttachments.KeyStart, textEds.KeyStart);
         iAdd(mappingView.keyboardRange.keyEnd, intAttachments.KeyEnd, textEds.KeyEnd);
 

--- a/src/dsp/generator.cpp
+++ b/src/dsp/generator.cpp
@@ -510,6 +510,7 @@ void GeneratorSample(GeneratorState *__restrict GD, GeneratorIO *__restrict IO)
                     auto q = k + SamplePos;
                     if (q >= GD->loopUpperBound || q >= WaveSize)
                         q -= LoopOffset;
+
                     loopEndBufferL[k] = SampleDataL[q];
                     if (stereo)
                         loopEndBufferR[k] = SampleDataR[q];
@@ -585,7 +586,7 @@ void GeneratorSample(GeneratorState *__restrict GD, GeneratorIO *__restrict IO)
             }
             case InterpolationTypes::ZeroOrderHold:
             {
-                KPMono(InterpolationTypes::Sinc, type_from_cond, 1, readL, readFadeL);
+                KPMono(InterpolationTypes::ZeroOrderHold, type_from_cond, 1, readL, readFadeL);
                 break;
             }
             }
@@ -657,7 +658,9 @@ void GeneratorSample(GeneratorState *__restrict GD, GeneratorIO *__restrict IO)
             {
                 // Upper
                 if (offset > GD->loopUpperBound)
+                {
                     offset -= LoopOffset;
+                }
             }
             else
             {

--- a/src/modulation/group_matrix.h
+++ b/src/modulation/group_matrix.h
@@ -126,7 +126,7 @@ struct GroupMatrixEndpoints
         LFOTarget(engine::Engine *e, uint32_t p) : shared::LFOTargetEndpointData<TG, 'glfo'>(p)
         {
             if (e)
-                SCLOG_UNIMPL("Engine Attach LFO");
+                SCLOG_UNIMPL("Engine Attach Group LFO");
         }
         void bind(GroupMatrix &m, engine::Group &g);
     };

--- a/src/sample/loaders/load_mp3.cpp
+++ b/src/sample/loaders/load_mp3.cpp
@@ -54,18 +54,22 @@ bool Sample::parseMP3(const fs::path &p)
     if (channels == 1)
     {
         allocateI16(0, sample_length);
-        memcpy(sampleData[0], info.buffer, sample_length * sizeof(mp3d_sample_t));
+        auto *dat = GetSamplePtrI16(0);
+        memcpy(dat, info.buffer, sample_length * sizeof(mp3d_sample_t));
     }
     else
     {
         allocateI16(0, sample_length);
         allocateI16(1, sample_length);
 
+        auto *dat0 = GetSamplePtrI16(0);
+        auto *dat1 = GetSamplePtrI16(1);
+
         // de-interleave by hand I guess
         for (int i = 0; i < sample_length; ++i)
         {
-            ((int16_t *)sampleData[0])[i] = info.buffer[i * 2];
-            ((int16_t *)sampleData[1])[i] = info.buffer[i * 2 + 1];
+            dat0[i] = info.buffer[i * 2];
+            dat1[i] = info.buffer[i * 2 + 1];
         }
     }
 

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -505,8 +505,20 @@ void Voice::initializeGenerator()
 
     GDIO.outputL = output[0];
     GDIO.outputR = output[1];
-    GDIO.sampleDataL = s->sampleData[0];
-    GDIO.sampleDataR = s->sampleData[1];
+    if (s->bitDepth == sample::Sample::BD_I16)
+    {
+        GDIO.sampleDataL = s->GetSamplePtrI16(0);
+        GDIO.sampleDataR = s->GetSamplePtrI16(1);
+    }
+    else if (s->bitDepth == sample::Sample::BD_F32)
+    {
+        GDIO.sampleDataL = s->GetSamplePtrF32(0);
+        GDIO.sampleDataR = s->GetSamplePtrF32(1);
+    }
+    else
+    {
+        assert(false);
+    }
     GDIO.waveSize = s->sample_length;
 
     GD.samplePos = sampleData.startSample;


### PR DESCRIPTION
When samples load we load them with an 8-sample buffer on either side then use GetSamplePtrBlah to get the top of the actual sample buffer, so we can read "out of bounds" safely (namely sample[-1] is allocated memory set to zero and is not actually out of bounds).

But for that to work, you need to tell the generator to read samples from the top of the waveform not the zero point

This caused clicns and fades in perfect loop samples. Remediate.

Also clean up some distracting logs.

Closes #953