### PR TITLE
Zone Mapping to DB and show how Streaming Version works

### DIFF
--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -142,6 +142,9 @@ Engine::~Engine()
     }
 }
 
+thread_local bool Engine::isFullEngineUnstream{false};
+thread_local uint64_t Engine::fullEngineUnstreamStreamingVersion{0};
+
 voice::Voice *Engine::initiateVoice(const pathToZone_t &path)
 {
 #if DEBUG_VOICE_LIFECYCLE

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -324,6 +324,13 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
         } transportDisplay;
     } sharedUIMemoryState;
 
+    /* When we actually unstream an entire engine we want to know if we are doing
+     * that full unstream and what the version we are streaming from is. Lots of ways
+     * to do this, but the easiest is to have a thread local static set up in the unstream
+     */
+    static thread_local bool isFullEngineUnstream;
+    static thread_local uint64_t fullEngineUnstreamStreamingVersion;
+
     /**
      * The VoiceDisplayState structure is updated at some relatively low (like 30hz)
      * frequency by the engine for communication to a potential client if the message

--- a/src/engine/zone.h
+++ b/src/engine/zone.h
@@ -204,7 +204,7 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
         int16_t exclusiveGroup;
 
         float velocitySens{1.0};
-        float amplitude{1.0};   // linear
+        float amplitude{0.0};   // decibels
         float pan{0.0};         // -1..1
         float pitchOffset{0.0}; // semitones/keys
 
@@ -257,7 +257,7 @@ SC_DESCRIBE(
     SC_FIELD(velocityRange.fadeEnd, pmd().asMIDIPitch().withUnit("").withName("Velocity Fade End"));
     SC_FIELD(pbDown, pmd().asMIDIPitch().withUnit("").withDefault(2).withName("Pitch Bend Down"));
     SC_FIELD(pbUp, pmd().asMIDIPitch().withUnit("").withDefault(2).withName("Pitch Bend Up"));
-    SC_FIELD(amplitude, pmd().asPercent().withName("Amplitude").withDefault(1.0));
+    SC_FIELD(amplitude, pmd().asDecibelWithRange(-36, 36).withName("Amplitude").withDefault(0.f));
     SC_FIELD(pan, pmd().asPercentBipolar().withName("Pan").withDefault(0.0));
     SC_FIELD(pitchOffset, pmd().asSemitoneRange().withName("Pitch").withDefault(0.0)););
 

--- a/src/json/scxt_traits.h
+++ b/src/json/scxt_traits.h
@@ -35,6 +35,7 @@ namespace scxt::json
 template <typename T> struct scxt_traits : public tao::json::traits<T>
 {
 };
+
 using scxt_value = tao::json::basic_value<scxt_traits>;
 
 template <typename V, typename R> bool findIf(V &v, const std::string &key, R &r)
@@ -116,6 +117,9 @@ template <typename V, typename R> void findOrDefault(V &v, const std::string &ke
             toBlock                                                                                \
         }                                                                                          \
     };
+
+#define SC_UNSTREAMING_FROM_THIS_OR_OLDER(x)                                                       \
+    engine::Engine::isFullEngineUnstream &&engine::Engine::fullEngineUnstreamStreamingVersion <= x
 
 } // namespace scxt::json
 #endif // SHORTCIRCUIT_SCXT_TRAITS_H

--- a/src/json/stream.h
+++ b/src/json/stream.h
@@ -34,7 +34,7 @@
 namespace scxt::json
 {
 
-static constexpr uint64_t currentStreamingVersion{0x20230201};
+static constexpr uint64_t currentStreamingVersion{0x20240604};
 
 std::string streamPatch(const engine::Patch &p, bool pretty = false);
 std::string streamEngineState(const engine::Engine &e, bool pretty = false);

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -284,7 +284,7 @@ template <bool OS> bool Voice::processWithOS()
         mech::mul_block<blockSize << (OS ? 1 : 0)>(output[0], invsqrt2);
     }
 
-    auto pva = *endpoints->mappingTarget.ampP;
+    auto pva = dsp::dbTable.dbToLinear(*endpoints->mappingTarget.ampP);
 
     if constexpr (OS)
     {


### PR DESCRIPTION
1. Zome Mapping amplitude goes from 0->100% linear to instead +/- 36db boost. Adjust voice. Closes #972
2. Use this as an opportunity to develop and test the stream version mechanism. We won't do this regularly before our first solid beta but want to make sure we can, and we can. Closes #425