### PR TITLE
Document and Correct the FIR Positinoing in Generator

### DIFF
--- a/src/sample/loaders/load_riff_wave.cpp
+++ b/src/sample/loaders/load_riff_wave.cpp
@@ -175,6 +175,9 @@ bool Sample::parse_riff_wave(void *data, size_t filesize, bool skip_riffchunk)
     }
     int32_t WaveDataSamples = 8 * WaveDataSize / (wh.wBitsPerSample * wh.nChannels);
 
+    SCLOG("Loaded wav file " << SCD(wh.nChannels) << SCD(wh.nSamplesPerSec)
+                             << SCD(wh.wBitsPerSample) << SCD(WaveDataSamples));
+
     /* get pointer to the sampledata */
 
     unsigned char *loaddata = (unsigned char *)mf.ReadPtr(WaveDataSize);


### PR DESCRIPTION
The generator had, i think, never been quite correct with the FIR position of the samples. In 6e0df99 we fixed this sort of, in that we sent the right sample position to allow loops to not click, but by doing so invited a read beyond end of buffer. Whether to include the FIR offset or not in the read data was ambiguous and buggy.

So this commit aims to resolve that by

1. Clearly documenting the expectation
2. Adding the FIRoffsets in the appropriate places per the documentation
3. Testing, and hoping, but definitely improving

This addresses #982 quite nicely and I think just makes everything 'better' but requires some pretty careful testing