### PR TITLE
SFZ Cleanups continue

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -32,3 +32,5 @@ if (${SCXT_JUCE_CLASSIC_STYLE})
 else()
     add_subdirectory(clap-first)
 endif()
+
+add_subdirectory(sfz-token-dump)

--- a/clients/sfz-token-dump/CMakeLists.txt
+++ b/clients/sfz-token-dump/CMakeLists.txt
@@ -1,0 +1,11 @@
+
+project(scxt-sfz-token-dump)
+
+add_executable(${PROJECT_NAME} main.cpp)
+
+target_link_libraries(${PROJECT_NAME}
+        scxt-core
+        shortcircuit::catch2
+        )
+
+

--- a/clients/sfz-token-dump/main.cpp
+++ b/clients/sfz-token-dump/main.cpp
@@ -1,0 +1,32 @@
+#include <iostream>
+#include "sample/sfz_support/sfz_parse.h"
+
+int main(int argc, char **argv)
+{
+    if (argc != 2)
+    {
+        std::cout << "Usage: " << argv[0] << " (sfzfile)" << std::endl;
+        return 1;
+    }
+
+    auto f = fs::path{argv[1]};
+    scxt::sfz_support::SFZParser parser;
+    auto res = parser.parse(f);
+
+    std::cout << "<sfzdump file=\"" << f.u8string() << "\">" << std::endl;
+
+    for (const auto &[header, opcodes] : res)
+    {
+        std::cout << "  <header type=\"" << header.name << "\">" << std::endl;
+        for (const auto &[key, value] : opcodes)
+        {
+            std::cout << "    <opcode key=\"" << key << "\" value=\"" << value << "\"/>"
+                      << std::endl;
+        }
+        std::cout << "  </header>" << std::endl;
+    }
+
+    std::cout << "</sfzdump>" << std::endl;
+
+    return 0;
+}

--- a/src/sample/sfz_support/sfz_import.cpp
+++ b/src/sample/sfz_support/sfz_import.cpp
@@ -72,7 +72,6 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
     auto doc = parser.parse(f);
     auto rootDir = f.parent_path();
     auto sampleDir = rootDir;
-    SCLOG(SCD(rootDir.u8string()));
 
     auto pt = std::clamp(e.getSelectionManager()->selectedPart, 0, (int)numParts);
 
@@ -132,17 +131,9 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
                     sampleFileString = oc.value;
                 }
             }
-            // fs always works with / and on windows also works with back
+            // fs always works with / and on windows also works with back. Quotes are
+            // stripped by the parser now
             std::replace(sampleFileString.begin(), sampleFileString.end(), '\\', '/');
-            // Is it contained in quotes
-            if (sampleFileString.back() == '"')
-            {
-                sampleFileString = sampleFileString.substr(0, sampleFileString.size() - 1);
-            }
-            if (sampleFileString[0] == '"')
-            {
-                sampleFileString = sampleFileString.substr(1);
-            }
             auto sampleFile = fs::path{sampleFileString};
             auto samplePath = (sampleDir / sampleFile).lexically_normal();
 

--- a/src/sample/sfz_support/sfz_parse.cpp
+++ b/src/sample/sfz_support/sfz_parse.cpp
@@ -313,13 +313,21 @@ SFZParser::document_t SFZParser::parse(const std::string &s)
         return {oss.str(), from};
     };
 
-    auto stripTrailing = [](const auto &s) {
+    auto stripTrailingAndQuotes = [](const auto &s) {
         auto ep = s.size() - 1;
         while (ep >= 0 && (s[ep] == ' ' || s[ep] == '\n' || s[ep] == '\r'))
         {
             ep--;
         }
-        return s.substr(0, ep + 1);
+        auto res = s.substr(0, ep + 1);
+        if (!res.empty())
+        {
+            if (res.size() > 1 && res[0] == '"' && res.back() == '"')
+            {
+                res = res.substr(1, res.size() - 2);
+            }
+        }
+        return res;
     };
 
     auto e = s.size();
@@ -357,7 +365,7 @@ SFZParser::document_t SFZParser::parse(const std::string &s)
                 cp = pos - 1;
                 OpCode oc;
                 oc.name = opcode;
-                oc.value = stripTrailing(key);
+                oc.value = stripTrailingAndQuotes(key);
                 res.back().second.push_back(oc);
             }
             else


### PR DESCRIPTION
1. The parser strips leading/trailing quote pairs
2. Add a sfz-to-xml token dump using my parser as a standalone