### PR TITLE
SFZ ID issuance bug, clean log, support tune

### DIFF
--- a/src/sample/loaders/load_riff_wave.cpp
+++ b/src/sample/loaders/load_riff_wave.cpp
@@ -175,8 +175,8 @@ bool Sample::parse_riff_wave(void *data, size_t filesize, bool skip_riffchunk)
     }
     int32_t WaveDataSamples = 8 * WaveDataSize / (wh.wBitsPerSample * wh.nChannels);
 
-    SCLOG("Loaded wav file " << SCD(wh.nChannels) << SCD(wh.nSamplesPerSec)
-                             << SCD(wh.wBitsPerSample) << SCD(WaveDataSamples));
+    /*SCLOG("Loaded wav file " << SCD(wh.nChannels) << SCD(wh.nSamplesPerSec)
+                             << SCD(wh.wBitsPerSample) << SCD(WaveDataSamples)); */
 
     /* get pointer to the sampledata */
 

--- a/src/sample/sfz_support/sfz_import.cpp
+++ b/src/sample/sfz_support/sfz_import.cpp
@@ -288,6 +288,25 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
                         {
                             zn->mapping.amplitude = std::atof(oc.value.c_str()); // decibels
                         }
+                        else if (oc.name == "tune")
+                        {
+                            // Tune is supplied in cents. Our pitch offset is in semitones
+                            zn->mapping.pitchOffset = std::atof(oc.value.c_str()) * 0.01;
+                        }
+                        else if (oc.name == "loop_mode")
+                        {
+                            if (oc.value == "loop_continuous")
+                            {
+                                // FIXME: In round robin looping modes this is probably wrong
+                                zn->sampleData.samples[0].loopActive = true;
+                                zn->sampleData.samples[0].loopMode =
+                                    engine::Zone::LOOP_DURING_VOICE;
+                            }
+                            else
+                            {
+                                SCLOG("Unsupported loop_mode : " << oc.value);
+                            }
+                        }
 
 #define APPLYEG(v, d, t)                                                                           \
     else if (oc.name == v)                                                                         \
@@ -301,8 +320,9 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
                         APPLYEG("ampeg_release", 0, r)
                         else
                         {
-                            SCLOG("    Skipped " << n << "-originated OpCode for region: "
-                                                 << oc.name << " -> " << oc.value);
+                            if (n != "Group")
+                                SCLOG("    Skipped " << n << "-originated OpCode for region: "
+                                                     << oc.name << " -> " << oc.value);
                         }
                     }
                 }

--- a/src/sample/sfz_support/sfz_import.cpp
+++ b/src/sample/sfz_support/sfz_import.cpp
@@ -238,7 +238,7 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
             {
                 auto zn = std::make_unique<engine::Zone>(sid);
                 // SFZ defaults
-                zn->mapping.rootKey = 69;
+                zn->mapping.rootKey = 60;
                 zn->mapping.keyboardRange.keyStart = 0;
                 zn->mapping.keyboardRange.keyEnd = 127;
                 zn->mapping.velocityRange.velStart = 0;


### PR DESCRIPTION
A bug-like feature of the SFZ loader was if a sample was already loaded, it was re-used but we burned a sample id to discover that. change our logging and associated laoding path to check for already-loaded earlier.

Also support the tune opcode, clean up some logs elsewhere.