### PR TITLE
SF2 preset mapping to sample handled correclty

### DIFF
--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -637,7 +637,7 @@ void Engine::loadSf2MultiSampleIntoSelectedPart(const fs::path &p)
                     if (sfsamp == nullptr)
                         continue;
 
-                    auto sid = sampleManager->loadSampleFromSF2(p, sf.get(), i, j);
+                    auto sid = sampleManager->loadSampleFromSF2(p, sf.get(), pc, i, j);
                     if (!sid.has_value())
                         continue;
 

--- a/src/json/sample_traits.h
+++ b/src/json/sample_traits.h
@@ -100,6 +100,7 @@ template <> struct scxt_traits<sample::Sample::SampleFileAddress>
     {
         v = {{"type", f.type},
              {"path", f.path.u8string()},
+             {"preset", f.preset},
              {"instrument", f.instrument},
              {"region", f.region}};
     }
@@ -112,6 +113,7 @@ template <> struct scxt_traits<sample::Sample::SampleFileAddress>
         std::string p;
         findIf(v, "path", p);
         f.path = fs::path{p};
+        findOrSet(v, "preset", 0, f.preset); // 0 here since we forgot to stream for a bit
         findOrSet(v, "instrument", -1, f.instrument);
         findOrSet(v, "region", -1, f.region);
     }

--- a/src/sample/sample.cpp
+++ b/src/sample/sample.cpp
@@ -111,13 +111,30 @@ bool Sample::load(const fs::path &path)
     return false;
 }
 
-bool Sample::loadFromSF2(const fs::path &p, sf2::File *f, int inst, int reg)
+bool Sample::loadFromSF2(const fs::path &p, sf2::File *f, int presetNum, int inst, int reg)
 {
     mFileName = p;
+    preset = presetNum;
     instrument = inst;
     region = reg;
     type = SF2_FILE;
-    auto sfsample = f->GetInstrument(inst)->GetRegion(region)->GetSample();
+
+    auto *preset = f->GetPreset(presetNum);
+
+    auto *presetRegion = preset->GetRegion(inst);
+    sf2::Instrument *instr = presetRegion->pInstrument;
+
+    if (instr->pGlobalRegion)
+    {
+        // TODO: Global Region
+    }
+
+    auto sfsample = instr->GetRegion(region)->GetSample();
+    if (!sfsample)
+        return false;
+
+    SCLOG("Loading individual sf2 sample '" << sfsample->Name << "' " << SCD(presetNum)
+                                            << SCD(instrument) << SCD(region) << SCD(p.u8string()));
 
     auto frameSize = sfsample->GetFrameSize();
     channels = sfsample->GetChannelCount();

--- a/src/sample/sample.h
+++ b/src/sample/sample.h
@@ -55,11 +55,12 @@ struct alignas(16) Sample : MoveableOnly<Sample>
     std::string displayName{};
     std::string getDisplayName() const { return displayName; }
     bool load(const fs::path &path);
-    bool loadFromSF2(const fs::path &path, sf2::File *f, int inst, int region);
+    bool loadFromSF2(const fs::path &path, sf2::File *f, int preset, int inst, int region);
 
     const fs::path &getPath() const { return mFileName; }
 
-    int instrument{-1}, region{-1};
+    int preset{-1}, instrument{-1}, region{-1};
+    int getCompoundPreset() const { return preset; }
     int getCompoundInstrument() const { return instrument; }
     int getCompoundRegion() const { return region; }
 
@@ -67,13 +68,14 @@ struct alignas(16) Sample : MoveableOnly<Sample>
     {
         SourceType type{WAV_FILE};
         fs::path path{};
+        int preset{-1};
         int instrument{-1};
         int region{-1};
     };
 
     SampleFileAddress getSampleFileAddress() const
     {
-        return {type, getPath(), getCompoundInstrument(), getCompoundRegion()};
+        return {type, getPath(), getCompoundPreset(), getCompoundInstrument(), getCompoundRegion()};
     }
 
     size_t getDataSize() const { return sample_length * bitDepthByteSize(bitDepth) * channels; }

--- a/src/sample/sample_manager.cpp
+++ b/src/sample/sample_manager.cpp
@@ -53,7 +53,8 @@ void SampleManager::restoreFromSampleAddressesAndIDs(const sampleAddressesAndIds
             break;
             case Sample::SF2_FILE:
             {
-                loadSampleFromSF2ToID(addr.path, nullptr, addr.instrument, addr.region, id);
+                loadSampleFromSF2ToID(addr.path, nullptr, addr.preset, addr.instrument, addr.region,
+                                      id);
             }
             break;
             case Sample::MULTISAMPLE_FILE:
@@ -112,13 +113,13 @@ std::optional<SampleID> SampleManager::loadSampleByPathToID(const fs::path &p, c
 }
 
 std::optional<SampleID> SampleManager::loadSampleFromSF2(const fs::path &p, sf2::File *f,
-                                                         int instrument, int region)
+                                                         int preset, int instrument, int region)
 {
-    return loadSampleFromSF2ToID(p, f, instrument, region, SampleID::next());
+    return loadSampleFromSF2ToID(p, f, preset, instrument, region, SampleID::next());
 }
 
 std::optional<SampleID> SampleManager::loadSampleFromSF2ToID(const fs::path &p, sf2::File *f,
-                                                             int instrument, int region,
+                                                             int preset, int instrument, int region,
                                                              const SampleID &sid)
 {
     if (!f)
@@ -146,16 +147,15 @@ std::optional<SampleID> SampleManager::loadSampleFromSF2ToID(const fs::path &p, 
     {
         if (sm->type == Sample::SF2_FILE)
         {
-            const auto &[type, path, inst, reg] = sm->getSampleFileAddress();
-            if (path == p && instrument == inst && region == reg)
+            const auto &[type, path, pre, inst, reg] = sm->getSampleFileAddress();
+            if (path == p && pre == preset && instrument == inst && region == reg)
                 return id;
         }
     }
 
     auto sp = std::make_shared<Sample>(sid);
 
-    SCLOG("Loading individual sf2 sample " << SCD(instrument) << SCD(region) << SCD(p.u8string()));
-    if (!sp->loadFromSF2(p, f, instrument, region))
+    if (!sp->loadFromSF2(p, f, preset, instrument, region))
         return {};
 
     samples[sp->id] = sp;

--- a/src/sample/sample_manager.h
+++ b/src/sample/sample_manager.h
@@ -85,10 +85,11 @@ struct SampleManager : MoveableOnly<SampleManager>
 
     std::optional<SampleID> loadSampleFromSF2(const fs::path &,
                                               sf2::File *f, // if this is null I will re-open it
-                                              int instrument, int region);
+                                              int preset, int instrument, int region);
     std::optional<SampleID> loadSampleFromSF2ToID(const fs::path &,
                                                   sf2::File *f, // if this is null I will re-open it
-                                                  int instrument, int region, const SampleID &id);
+                                                  int preset, int instrument, int region,
+                                                  const SampleID &id);
 
     std::optional<SampleID> setupSampleFromMultifile(const fs::path &, int idx, void *data,
                                                      size_t dataSize);


### PR DESCRIPTION
The SF2 parser correctly handled the preset/instrument/region heirarchy but the SF2 sample loader did not. This means if a preset re-ordered samples the wrong sample would load in the wrong zone. Fix by threading the preset throughout