### PR TITLE
Add a block smoothing lipo for the processor output

### DIFF
--- a/src/engine/group.cpp
+++ b/src/engine/group.cpp
@@ -176,12 +176,14 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
     if constexpr (OS)                                                                              \
     {                                                                                              \
         scxt::dsp::processor::FNN<OS, true>(fpitch, processors.data(), processorConsumesMono,      \
-                                            processorMixOS, &endpoints, chainIsMono, output);      \
+                                            processorMixOS, processorLevelOS, &endpoints,          \
+                                            chainIsMono, output);                                  \
     }                                                                                              \
     else                                                                                           \
     {                                                                                              \
         scxt::dsp::processor::FNN<OS, true>(fpitch, processors.data(), processorConsumesMono,      \
-                                            processorMix, &endpoints, chainIsMono, output);        \
+                                            processorMix, processorLevel, &endpoints, chainIsMono, \
+                                            output);                                               \
     }
 
         switch (outputInfo.procRouting)
@@ -362,6 +364,11 @@ void Group::attack()
         const auto &ps = processorStorage[i];
         processorMix[i].set_target_instant(ps.mix);
         processorMixOS[i].set_target_instant(ps.mix);
+
+        auto ol = ps.outputCubAmp;
+        ol = ol * ol * ol * dsp::processor::ProcessorStorage::maxOutputAmp;
+        processorLevel[i].set_target_instant(ol);
+        processorLevelOS[i].set_target_instant(ol);
     }
 
     osDownFilter.reset();

--- a/src/engine/group.h
+++ b/src/engine/group.h
@@ -195,6 +195,8 @@ struct Group : MoveableOnly<Group>,
         16)[engine::processorCount][dsp::processor::maxProcessorIntParams];
     lipol processorMix[engine::processorCount];
     lipolOS processorMixOS[engine::processorCount];
+    lipol processorLevel[engine::processorCount];
+    lipolOS processorLevelOS[engine::processorCount];
 
     sst::basic_blocks::dsp::UIComponentLagHandler mUILag;
 

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -325,14 +325,14 @@ template <bool OS> bool Voice::processWithOS()
         if constexpr (OS)                                                                          \
         {                                                                                          \
             scxt::dsp::processor::FNN<OS, false>(fpitch, processors, processorConsumesMono,        \
-                                                 processorMixOS, endpoints.get(), chainIsMono,     \
-                                                 output);                                          \
+                                                 processorMixOS, processorLevelOS,                 \
+                                                 endpoints.get(), chainIsMono, output);            \
         }                                                                                          \
         else                                                                                       \
         {                                                                                          \
             scxt::dsp::processor::FNN<OS, false>(fpitch, processors, processorConsumesMono,        \
-                                                 processorMix, endpoints.get(), chainIsMono,       \
-                                                 output);                                          \
+                                                 processorMix, processorLevel, endpoints.get(),    \
+                                                 chainIsMono, output);                             \
         }                                                                                          \
     }                                                                                              \
     else                                                                                           \
@@ -340,14 +340,14 @@ template <bool OS> bool Voice::processWithOS()
         if constexpr (OS)                                                                          \
         {                                                                                          \
             scxt::dsp::processor::FNN<OS, true>(fpitch, processors, processorConsumesMono,         \
-                                                processorMixOS, endpoints.get(), chainIsMono,      \
-                                                output);                                           \
+                                                processorMixOS, processorLevelOS, endpoints.get(), \
+                                                chainIsMono, output);                              \
         }                                                                                          \
         else                                                                                       \
         {                                                                                          \
             scxt::dsp::processor::FNN<OS, true>(fpitch, processors, processorConsumesMono,         \
-                                                processorMix, endpoints.get(), chainIsMono,        \
-                                                output);                                           \
+                                                processorMix, processorLevel, endpoints.get(),     \
+                                                chainIsMono, output);                              \
         }                                                                                          \
     }
 
@@ -646,6 +646,12 @@ void Voice::initializeProcessors()
         processorIsActive[i] = zone->processorStorage[i].isActive;
         processorMix[i].set_target_instant(*endpoints->processorTarget[i].mixP);
         processorMixOS[i].set_target_instant(*endpoints->processorTarget[i].mixP);
+
+        auto ol = *endpoints->processorTarget[i].outputLevelDbP;
+        ol = ol * ol * ol * dsp::processor::ProcessorStorage::maxOutputAmp;
+
+        processorLevel[i].set_target_instant(ol);
+        processorLevelOS[i].set_target_instant(ol);
 
         processorType[i] = zone->processorStorage[i].type;
 

--- a/src/voice/voice.h
+++ b/src/voice/voice.h
@@ -149,9 +149,11 @@ struct alignas(16) Voice : MoveableOnly<Voice>,
 
     void panOutputsBy(bool inputIsMono, const lipol &pv);
 
-    // TODO - this should be more carefully structured for modulation onto the entire filter
     lipol processorMix[engine::processorCount];
     lipolOS processorMixOS[engine::processorCount];
+
+    lipol processorLevel[engine::processorCount];
+    lipolOS processorLevelOS[engine::processorCount];
 
     /*
      * Voice State on Creation


### PR DESCRIPTION
The processor output was snapped at block on so would have a sample length zipper ifmodulated. This fixes that by using the same lipol technique we use with mix.

Closes #979