### PR TITLE
JSON based Layouts and Deactavatable Proc Params

### DIFF
--- a/src-ui/CMakeLists.txt
+++ b/src-ui/CMakeLists.txt
@@ -33,12 +33,23 @@ add_library(${PROJECT_NAME} STATIC
         components/widgets/ShortCircuitMenuButton.cpp
 
         connectors/SCXTResources.cpp
+        connectors/JSONLayoutConsumer.cpp
 
         theme/ColorMap.cpp
         theme/ThemeApplier.cpp
 
         )
 
+message(STATUS "Globbing json-layout directory for cmrc")
+file(GLOB_RECURSE scxt_json_sources
+        LIST_DIRECTORIES false
+        RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+        json-layout/*.json
+)
+cmrc_add_resource_library(scxtui_json_layouts
+        NAMESPACE scxtui_json_layouts
+        ${scxt_json_sources}
+)
 
 target_link_libraries(${PROJECT_NAME} PUBLIC
         scxt-core
@@ -48,6 +59,8 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
 
         sst-plugininfra::strnatcmp
         melatonin_inspector
+
+        scxtui_json_layouts
         )
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE

--- a/src-ui/components/mixer/PartEffectsPane.h
+++ b/src-ui/components/mixer/PartEffectsPane.h
@@ -87,6 +87,7 @@ struct PartEffectsPane : public HasEditor, sst::jucegui::components::NamedPanel
     // move it.
     template <typename T> T *attachWidgetToFloat(int index);
     juce::Component *attachMenuButtonToInt(int index);
+    template <typename T> juce::Component *attachWidgetToInt(int index);
     juce::Component *attachToggleToDeactivated(int index);
     template <typename T> juce::Component *addTypedLabel(const std::string &txt);
     juce::Component *addLabel(const std::string &txt)
@@ -112,9 +113,10 @@ struct PartEffectsPane : public HasEditor, sst::jucegui::components::NamedPanel
         return r;
     }
 
-    // Generic
+    // Generic, no JSON
     void rebuildDefaultLayout();
-    void rebuildDelayLayout();
+    void rebuildFromJSONLibrary(const std::string &path);
+
     template <typename Att> void busEffectStorageChangedFromGUI(const Att &at, int idx);
 
     // Specific

--- a/src-ui/components/multi/ProcessorPane.h
+++ b/src-ui/components/multi/ProcessorPane.h
@@ -79,6 +79,7 @@ struct ProcessorPane : sst::jucegui::components::NamedPanel, HasEditor, juce::Dr
 
     void rebuildControlsFromDescription();
     void attachRebuildToIntAttachment(int idx);
+    void attachRebuildToDeactivateAttachment(int idx);
 
     void layoutControls();
     void layoutControlsMicroGate();
@@ -86,7 +87,6 @@ struct ProcessorPane : sst::jucegui::components::NamedPanel, HasEditor, juce::Dr
     void layoutControlsSurgeFilters();
     void layoutControlsFastSVF();
     void layoutControlsWaveshaper();
-    void layoutControlsBitcrusher();
     void layoutControlsEQNBandParm();
     void layoutControlsEQMorph();
     void layoutControlsEQGraphic();
@@ -100,6 +100,10 @@ struct ProcessorPane : sst::jucegui::components::NamedPanel, HasEditor, juce::Dr
     void layoutControlsFMFilter();
     void layoutControlsRingMod();
     void layoutControlsPhaseMod();
+
+    void layoutControlsFromJSON(const std::string &jsonpath);
+    void layoutControlsFromJSON(const std::string &jsonpath,
+                                sst::jucegui::layout::ExplicitLayout &elo);
 
     template <typename T = sst::jucegui::components::Knob>
     std::unique_ptr<
@@ -128,6 +132,19 @@ struct ProcessorPane : sst::jucegui::components::NamedPanel, HasEditor, juce::Dr
 
     template <typename T = sst::jucegui::components::Knob>
     std::unique_ptr<T> createWidgetAttachedTo(const std::unique_ptr<int_attachment_t> &at)
+    {
+        auto kn = std::make_unique<T>();
+        kn->setSource(at.get());
+        kn->setTitle(at->getLabel());
+        kn->setDescription(at->getLabel());
+
+        getContentAreaComponent()->addAndMakeVisible(*kn);
+
+        return std::move(kn);
+    }
+
+    template <typename T = sst::jucegui::components::ToggleButton>
+    std::unique_ptr<T> createWidgetAttachedTo(const std::unique_ptr<bool_attachment_t> &at)
     {
         auto kn = std::make_unique<T>();
         kn->setSource(at.get());
@@ -182,16 +199,21 @@ struct ProcessorPane : sst::jucegui::components::NamedPanel, HasEditor, juce::Dr
 
     using floatEditor_t =
         sst::jucegui::components::Labeled<sst::jucegui::components::ContinuousParamEditor>;
+    using intEditor_t =
+        sst::jucegui::components::Labeled<sst::jucegui::components::DiscreteParamEditor>;
+
     std::array<std::unique_ptr<floatEditor_t>, dsp::processor::maxProcessorFloatParams>
         floatEditors;
+    std::array<std::unique_ptr<intEditor_t>, dsp::processor::maxProcessorFloatParams>
+        floatDeactivateEditors;
     std::array<std::unique_ptr<attachment_t>, dsp::processor::maxProcessorFloatParams>
         floatAttachments;
 
-    using intEditor_t =
-        sst::jucegui::components::Labeled<sst::jucegui::components::DiscreteParamEditor>;
     std::array<std::unique_ptr<intEditor_t>, dsp::processor::maxProcessorIntParams> intEditors;
     std::array<std::unique_ptr<int_attachment_t>, dsp::processor::maxProcessorFloatParams>
         intAttachments;
+    std::array<std::unique_ptr<bool_attachment_t>, dsp::processor::maxProcessorFloatParams>
+        deactivateAttachments;
 
     std::unique_ptr<bool_attachment_t> bypassAttachment, keytrackAttackment, temposyncAttachment;
 

--- a/src-ui/connectors/JSONLayoutConsumer.cpp
+++ b/src-ui/connectors/JSONLayoutConsumer.cpp
@@ -1,0 +1,115 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include <fstream>
+
+#include <utils.h>
+
+#include <filesystem/import.h>
+#include "JSONLayoutConsumer.h"
+
+#include <cmrc/cmrc.hpp>
+
+CMRC_DECLARE(scxtui_json_layouts);
+
+namespace scxt::ui::connectors
+{
+std::string JSONLayoutLibrary::jsonForComponent(const std::string &nm)
+{
+    static bool checkedForLocal{false};
+    static bool isLocal{false};
+    static fs::path localPath{};
+
+    if (!checkedForLocal)
+    {
+        checkedForLocal = true;
+        auto se = getenv("SCXT_LAYOUT_SOURCE_DIR");
+        if (se)
+        {
+            auto sep = fs::path{se};
+            if (fs::exists(sep))
+            {
+                SCLOG("Setting JSON path from environment: " << sep.u8string());
+                isLocal = true;
+                localPath = sep;
+            }
+        }
+
+        if (!isLocal)
+        {
+            auto rp = fs::path{"src-ui"} / "json-layout";
+            if (fs::exists(rp))
+            {
+                SCLOG("Setting JSON path from working dir: " << rp.u8string());
+                isLocal = true;
+                localPath = rp;
+            }
+        }
+    }
+
+    if (isLocal)
+    {
+        auto rp = localPath / nm;
+        if (fs::exists(rp))
+        {
+            std::ifstream ifj(rp);
+            if (ifj.is_open())
+            {
+                std::stringstream buffer;
+                buffer << ifj.rdbuf();
+                ifj.close();
+                return buffer.str();
+            }
+            else
+            {
+                SCLOG("Unable to open json file: '" << rp.u8string() << "'");
+            }
+        }
+        else
+        {
+            SCLOG("isLocal is true and local json missing: '" << rp.u8string() << "'");
+        }
+    }
+
+    try
+    {
+        auto fs = cmrc::scxtui_json_layouts::get_filesystem();
+        auto fn = "json-layout/" + nm;
+        auto jsnf = fs.open(fn);
+        std::string json(jsnf.begin(), jsnf.end());
+
+        return json;
+    }
+    catch (std::exception &e)
+    {
+        SCLOG("Exception with cmrc : " << e.what())
+    }
+
+    SCLOG("Unable to resolve JSON from library: '" << nm);
+    return "{}";
+}
+} // namespace scxt::ui::connectors

--- a/src-ui/connectors/JSONLayoutConsumer.h
+++ b/src-ui/connectors/JSONLayoutConsumer.h
@@ -29,6 +29,7 @@
 #define SCXT_SRC_UI_CONNECTORS_JSONLAYOUTCONSUMER_H
 
 #include <string>
+#include <vector>
 
 #include "tao/json/binary_view.hpp"
 #include "tao/json/events/from_string.hpp"

--- a/src-ui/connectors/JSONLayoutConsumer.h
+++ b/src-ui/connectors/JSONLayoutConsumer.h
@@ -1,0 +1,305 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_UI_CONNECTORS_JSONLAYOUTCONSUMER_H
+#define SCXT_SRC_UI_CONNECTORS_JSONLAYOUTCONSUMER_H
+
+#include <string>
+
+#include "tao/json/binary_view.hpp"
+#include "tao/json/events/from_string.hpp"
+
+namespace scxt::ui::connectors
+{
+struct JSONLayoutLibrary
+{
+    static std::string jsonForComponent(const std::string &nm);
+};
+
+struct JSONLayoutConsumer
+{
+    static constexpr bool debugStateMachine{false};
+#define DLOG(x)                                                                                    \
+    if (debugStateMachine)                                                                         \
+        SCLOG(pfx << "[" << state << "] " << __func__ << x);
+#define DMARK() DLOG(" ")
+
+    enum State
+    {
+        NOTHING,
+        TOP_LEVEL,
+        IN_DEFAULTS,
+        COLLECT_DEFAULTS,
+        IN_COMPONENTS,
+        IN_COMPONENTS_ARRAY,
+        COLLECT_COMPONENT,
+        EXPECTING_INDEX,
+        COLLECT_COMPONENT_COORDS
+    } state{NOTHING};
+
+    std::string currKey{};
+    std::string currValString{};
+    int64_t currValInt{};
+    enum currValType
+    {
+        STRING,
+        I64
+    } currValType{STRING};
+
+    struct ComponentHelper
+    {
+        std::array<float, 4> coords{};
+        int index{-1};
+        std::unordered_map<std::string, std::string> map;
+        std::unordered_map<std::string, int64_t> intMap;
+    } currentComponent, defaultComponent;
+    int currentCoord{0};
+
+    std::vector<ComponentHelper> result;
+
+    std::string pfx{""};
+    void push() { pfx += "|--"; }
+    void pop() { pfx = pfx.substr(pfx.size() - 3); }
+
+    void null() {}
+    void boolean(const bool) {}
+    void number(const double n)
+    {
+        if (state == COLLECT_COMPONENT_COORDS)
+        {
+            assert(currentCoord < 4);
+            assert(currentCoord >= 0);
+            currentComponent.coords[currentCoord] = n;
+            currentCoord++;
+        }
+    }
+    void number(const std::int64_t n)
+    {
+        if (state == COLLECT_COMPONENT)
+        {
+            currValInt = n;
+            currValType = I64;
+        }
+    }
+    void number(const std::uint64_t n)
+    {
+        if (state == EXPECTING_INDEX)
+        {
+            currentComponent.index = n;
+        }
+        else if (state == COLLECT_COMPONENT_COORDS)
+        {
+            assert(currentCoord < 4);
+            assert(currentCoord >= 0);
+            currentComponent.coords[currentCoord] = n;
+            currentCoord++;
+        }
+        else if (state == COLLECT_COMPONENT)
+        {
+            currValInt = (int64_t)n;
+            currValType = I64;
+        }
+    }
+    void string(const std::string_view val)
+    {
+        currValString = "";
+        if (state == COLLECT_DEFAULTS || state == COLLECT_COMPONENT)
+        {
+            currValString = val;
+            currValType = STRING;
+        }
+    }
+    void binary(const tao::binary_view) {}
+    void begin_array(const std::size_t = 0)
+    {
+        switch (state)
+        {
+        case IN_COMPONENTS:
+            state = IN_COMPONENTS_ARRAY;
+            break;
+        case COLLECT_COMPONENT_COORDS:
+            break;
+        default:
+            DLOG("Warning: Array open unexpected");
+            break;
+        }
+
+        DMARK();
+        push();
+    }
+    void element() {}
+    void end_array(const std::size_t = 0)
+    {
+        switch (state)
+        {
+        case IN_COMPONENTS_ARRAY:
+            state = IN_COMPONENTS;
+            break;
+        case COLLECT_COMPONENT_COORDS:
+            break;
+        default:
+            DLOG("Warning: Unexpected end array");
+            break;
+        }
+        DMARK();
+        pop();
+    }
+    void begin_object(const std::size_t = 0)
+    {
+        switch (state)
+        {
+        case NOTHING:
+            state = TOP_LEVEL;
+            break;
+        case IN_DEFAULTS:
+            state = COLLECT_DEFAULTS;
+            break;
+        case IN_COMPONENTS_ARRAY:
+            state = COLLECT_COMPONENT;
+            currentComponent = defaultComponent;
+            break;
+        default:
+            DLOG("Warning: Unexpected begin object");
+            break;
+        }
+        DMARK();
+        push();
+    }
+    void key(const std::string_view s)
+    {
+        switch (state)
+        {
+        case TOP_LEVEL:
+            if (s == "defaults")
+            {
+                state = IN_DEFAULTS;
+            }
+            else if (s == "components")
+            {
+                state = IN_COMPONENTS;
+            }
+            else
+            {
+                throw std::runtime_error(std::string() + "Unexpected top level key " +
+                                         std::string(s));
+            }
+            break;
+        case COLLECT_DEFAULTS:
+            currKey = s;
+            break;
+        case COLLECT_COMPONENT:
+            currKey = s;
+            if (s == "coordinates")
+            {
+                state = COLLECT_COMPONENT_COORDS;
+                currentCoord = 0;
+            }
+            if (s == "index")
+            {
+                state = EXPECTING_INDEX;
+            }
+            break;
+        default:
+            DLOG("Warning: Unexpected key " << s);
+            break;
+        }
+        DMARK();
+    }
+    void member()
+    {
+        switch (state)
+        {
+        case COLLECT_DEFAULTS:
+        case COLLECT_COMPONENT:
+        {
+            auto tgt = &defaultComponent;
+            if (state == COLLECT_COMPONENT)
+                tgt = &currentComponent;
+            switch (currValType)
+            {
+            case STRING:
+                tgt->map[currKey] = currValString;
+                break;
+            case I64:
+                tgt->intMap[currKey] = currValInt;
+                break;
+            }
+        }
+        break;
+        case COLLECT_COMPONENT_COORDS:
+            state = COLLECT_COMPONENT;
+            break;
+        case EXPECTING_INDEX:
+            assert(currentComponent.index >= 0);
+            state = COLLECT_COMPONENT;
+            break;
+        case IN_DEFAULTS:
+        {
+            state = TOP_LEVEL;
+        }
+        break;
+        case IN_COMPONENTS:
+        {
+            state = TOP_LEVEL;
+        }
+        break;
+        default:
+            DLOG("Warning: Unexpected member call");
+            break;
+        }
+        DMARK();
+    }
+    void end_object(const std::size_t = 0)
+    {
+        switch (state)
+        {
+        case COLLECT_DEFAULTS:
+            state = IN_DEFAULTS;
+            break;
+        case COLLECT_COMPONENT:
+        {
+            state = IN_COMPONENTS_ARRAY;
+            result.push_back(currentComponent);
+        }
+        break;
+        case TOP_LEVEL:
+            state = NOTHING;
+            break;
+        default:
+            DLOG("Warning: Unexpected end of object");
+            break;
+        }
+        DMARK();
+        pop();
+    }
+
+#undef DLOG
+#undef DMARK
+};
+} // namespace scxt::ui::connectors
+
+#endif // SHORTCIRCUITXT_JSONLAYOUTCONSUMER_H

--- a/src-ui/connectors/PayloadDataAttachment.h
+++ b/src-ui/connectors/PayloadDataAttachment.h
@@ -276,11 +276,10 @@ struct DiscretePayloadDataAttachment : sst::jucegui::data::Discrete
     ValueType &value;
     ValueType prevValue;
     std::string label;
-    std::function<void(const DiscretePayloadDataAttachment &at)> onGuiValueChanged;
+    std::function<void(const onGui_t &at)> onGuiValueChanged;
 
     DiscretePayloadDataAttachment(const datamodel::pmd &cd,
-                                  std::function<void(const DiscretePayloadDataAttachment &at)> oGVC,
-                                  ValueType &v)
+                                  std::function<void(const onGui_t &at)> oGVC, ValueType &v)
         : description(cd), value(v), prevValue(v), label(cd.name),
           onGuiValueChanged(std::move(oGVC))
     {
@@ -356,6 +355,7 @@ struct BooleanPayloadDataAttachment : DiscretePayloadDataAttachment<Payload, boo
         : DiscretePayloadDataAttachment<Payload, bool>(p, v)
     {
     }
+
     int getMin() const override { return (int)0; }
     int getMax() const override { return (int)1; }
     int getValue() const override

--- a/src-ui/json-layout/README_JSON_LAYOUTS.md
+++ b/src-ui/json-layout/README_JSON_LAYOUTS.md
@@ -1,0 +1,60 @@
+# JSON Layouts
+
+Much of the SCXT ui is relatively fixed. Things like the
+mapping pane and bus layout and stuff. But a few components
+are typed and varied, currently the processors and bus
+effects (but in the future a per-sample pane may be
+the same, especiily if we add rendering algos).
+
+To make it so we don't have to write buckets of
+tedious C++ to lay these out, in July 24, Paul
+hacked together a quick JSON parse to read files
+per type and then lay out the widgets. At the
+same time he wronte the first version of this
+document, which is woefully incomplete as of
+the first commit.
+
+## Core Concepts - Mechanics
+
+- Each 'screen' has a json file which lives in `src-ui/json-layouts`
+- Those json files have a common high level model but based on the
+  type of thing they are mapping to, will have different features.
+  For instance, voice processors have float and int parameters
+  where as bus processors intermix them, so the specification
+  means subtly different things.
+- The JSON files are baked into the program using CMakeRC
+  so they are part of the resulting DLL
+- At development time, you can also load the files at each
+  rebuild, allowing dynamic editing of the file without restarting
+  the plugin
+    - Method 1: Run ShortCircuit with the working directory as the
+      root of the repo, and it will auto-detect the files
+    - Method 2: Set the environment variabe `SCXT_LAYOUT_SOURCE_DIR`
+      to the json-layout directory (so to `<scroot>/src-ui/json-layout`)
+    - With either of these methods in place, editing the source and
+      then rebuilding (so select a different zone and select back)
+      for procs or a different bus and back for FX) will reload
+      the JSON and re-layout
+
+## Core Concepts - Syntax
+
+THe JSON file is a top level object which contains two
+sub objects, `defaults` and `components`. `components` is an
+array of component specs and `defaults` provides the values
+which all component specs adopt.
+
+The `components` array lays out the on-screen components
+mapped to indices or constructed explicitly and positions
+them. The meanings of the innards of the compnents array
+are somewhat different for voice and bus effects but they
+share many features.
+
+## A Component - Bus Effect
+
+Document this after I do a few more and collect the result
+and scan for consistency
+
+## A Component - Voice Effect
+
+Document this after I do a few more and collect the result
+and scan for consistency

--- a/src-ui/json-layout/bus-effects/delay.json
+++ b/src-ui/json-layout/bus-effects/delay.json
@@ -1,0 +1,158 @@
+{
+    "defaults": {
+        "coordinate-system": "relative",
+        "component": "knob"
+    },
+    "components": [
+        {
+            "coordinates": [
+                0.05,
+                0.025,
+                0.35,
+                0.35
+            ],
+            "label": "Left",
+            "index": 0
+        },
+        {
+            "coordinates": [
+                0.6,
+                0.025,
+                0.35,
+                0.35
+            ],
+            "label": "Right",
+            "index": 1
+        },
+        {
+            "coordinates": [
+                0.425,
+                0.3,
+                0.15,
+                0.15
+            ],
+            "label": "Input",
+            "index": 8
+        },
+        {
+            "component": "subheader",
+            "coordinates": [
+                0.025,
+                0.58,
+                0.45,
+                0.06
+            ],
+            "label": "Feedback"
+        },
+        {
+            "coordinates": [
+                0.025,
+                0.65,
+                0.2,
+                0.2
+            ],
+            "label": "Feedback",
+            "index": 2
+        },
+        {
+            "coordinates": [
+                0.275,
+                0.65,
+                0.2,
+                0.2
+            ],
+            "label": "Cross",
+            "index": 3
+        },
+        {
+            "component": "subheader",
+            "coordinates": [
+                0.525,
+                0.58,
+                0.45,
+                0.06
+            ],
+            "label": "Filter"
+        },
+        {
+            "coordinates": [
+                0.525,
+                0.65,
+                0.2,
+                0.2
+            ],
+            "label": "Lo Cut",
+            "index": 4
+        },
+        {
+            "coordinates": [
+                0.775,
+                0.65,
+                0.2,
+                0.2
+            ],
+            "label": "Hi Cut",
+            "index": 5
+        },
+        {
+            "component": "subheader",
+            "coordinates": [
+                0.025,
+                0.98,
+                0.45,
+                0.06
+            ],
+            "label": "Modulation"
+        },
+        {
+            "coordinates": [
+                0.025,
+                1.05,
+                0.2,
+                0.2
+            ],
+            "label": "Rate",
+            "index": 7
+        },
+        {
+            "coordinates": [
+                0.275,
+                1.05,
+                0.2,
+                0.2
+            ],
+            "label": "Depth",
+            "index": 8
+        },
+        {
+            "component": "subheader",
+            "coordinates": [
+                0.525,
+                0.98,
+                0.45,
+                0.06
+            ],
+            "label": "Output"
+        },
+        {
+            "coordinates": [
+                0.525,
+                1.05,
+                0.2,
+                0.2
+            ],
+            "label": "Width",
+            "index": 11
+        },
+        {
+            "coordinates": [
+                0.775,
+                1.05,
+                0.2,
+                0.2
+            ],
+            "label": "Mix",
+            "index": 10
+        }
+    ]
+}

--- a/src-ui/json-layout/bus-effects/phaser.json
+++ b/src-ui/json-layout/bus-effects/phaser.json
@@ -1,0 +1,181 @@
+{
+    "defaults": {
+        "coordinate-system": "relative",
+        "component": "knob"
+    },
+    "components": [
+        {
+            "name": "rate",
+            "coordinates": [
+                0.04,
+                0.025,
+                0.25,
+                0.25
+            ],
+            "label": "Rate",
+            "index": 3
+        },
+        {
+            "name": "depth",
+            "coordinates": [
+                0.37,
+                0.025,
+                0.25,
+                0.25
+            ],
+            "label": "Depth",
+            "index": 4
+        },
+        {
+            "name": "stereo",
+            "coordinates": [
+                0.71,
+                0.025,
+                0.25,
+                0.25
+            ],
+            "label": "Stereo",
+            "index": 5
+        },
+        {
+            "component": "subheader",
+            "label": "Stages",
+            "coordinates": [
+                0.03,
+                0.36,
+                0.45,
+                0.08
+            ]
+        },
+        {
+            "index": 8,
+            "component": "menubutton",
+            "coordinates": [
+                0.03,
+                0.44,
+                0.44,
+                0.1
+            ]
+        },
+        {
+            "component": "subheader",
+            "label": "Waveform",
+            "coordinates": [
+                0.53,
+                0.36,
+                0.44,
+                0.08
+            ]
+        },
+        {
+            "index": 10,
+            "component": "menubutton",
+            "coordinates": [
+                0.53,
+                0.44,
+                0.44,
+                0.1
+            ]
+        },
+        {
+            "component": "subheader",
+            "coordinates": [
+                0.025,
+                0.58,
+                0.95,
+                0.06
+            ],
+            "label": "Stages"
+        },
+        {
+            "coordinates": [
+                0.025,
+                0.66,
+                0.2,
+                0.2
+            ],
+            "label": "Spread",
+            "index": 9
+        },
+        {
+            "coordinates": [
+                0.275,
+                0.66,
+                0.2,
+                0.2
+            ],
+            "label": "Center",
+            "index": 0
+        },
+        {
+            "coordinates": [
+                0.525,
+                0.66,
+                0.2,
+                0.2
+            ],
+            "label": "Sharpness",
+            "index": 2
+        },
+        {
+            "coordinates": [
+                0.775,
+                0.66,
+                0.2,
+                0.2
+            ],
+            "label": "Feedback",
+            "index": 1
+        },
+        {
+            "component": "subheader",
+            "coordinates": [
+                0.025,
+                0.98,
+                0.2,
+                0.06
+            ],
+            "label": "Filter"
+        },
+        {
+            "component": "subheader",
+            "coordinates": [
+                0.525,
+                0.99,
+                0.45,
+                0.06
+            ],
+            "label": "Output"
+        },
+        {
+            "coordinates": [
+                0.025,
+                1.05,
+                0.2,
+                0.2
+            ],
+            "label": "Tone",
+            "index": 11
+        },
+        {
+            "coordinates": [
+                0.525,
+                1.05,
+                0.2,
+                0.2
+            ],
+            "label": "Width",
+            "index": 7
+        },
+        {
+            "coordinates": [
+                0.775,
+                1.05,
+                0.2,
+                0.2
+            ],
+            "label": "Mix",
+            "index": 6
+        }
+    ]
+}

--- a/src-ui/json-layout/processors/bitcrusher.json
+++ b/src-ui/json-layout/processors/bitcrusher.json
@@ -1,0 +1,68 @@
+{
+    "defaults": {
+        "coordinate-system": "absolute",
+        "component": "knob",
+        "label-mode": "auto",
+        "type": "float"
+    },
+    "components": [
+        {
+            "index": 0,
+            "coordinates": [
+                10,
+                5,
+                50,
+                50
+            ]
+        },
+        {
+            "index": 1,
+            "coordinates": [
+                70,
+                5,
+                50,
+                50
+            ]
+        },
+        {
+            "index": 2,
+            "coordinates": [
+                130,
+                5,
+                50,
+                50
+            ]
+        },
+        {
+            "index": 3,
+            "coordinates": [
+                40,
+                80,
+                50,
+                50
+            ],
+            "enable-if": 0
+        },
+        {
+            "index": 4,
+            "coordinates": [
+                100,
+                80,
+                50,
+                50
+            ],
+            "enable-if": 0
+        },
+        {
+            "type": "int",
+            "component": "power",
+            "index": 0,
+            "coordinates": [
+                100,
+                80,
+                50,
+                50
+            ]
+        }
+    ]
+}

--- a/src-ui/json-layout/processors/waveshaper.json
+++ b/src-ui/json-layout/processors/waveshaper.json
@@ -1,0 +1,65 @@
+{
+    "defaults": {
+        "coordinate-system": "absolute",
+        "component": "knob",
+        "label-mode": "auto",
+        "type": "float"
+    },
+    "components": [
+        {
+            "index": 0,
+            "coordinates": [
+                5,
+                15,
+                80,
+                80
+            ]
+        },
+        {
+            "index": 1,
+            "coordinates": [
+                87,
+                5,
+                40,
+                40
+            ]
+        },
+        {
+            "index": 2,
+            "coordinates": [
+                87,
+                65,
+                40,
+                40
+            ]
+        },
+        {
+            "index": 3,
+            "coordinates": [
+                140,
+                5,
+                40,
+                40
+            ]
+        },
+        {
+            "index": 4,
+            "coordinates": [
+                140,
+                65,
+                40,
+                40
+            ]
+        },
+        {
+            "name": "wstype",
+            "component": "custom",
+            "coordinates": [
+                10,
+                128,
+                180,
+                22
+            ]
+        }
+    ]
+}

--- a/src/dsp/processor/processor.h
+++ b/src/dsp/processor/processor.h
@@ -191,6 +191,7 @@ struct ProcessorStorage
     float mix{0}, outputCubAmp{zeroDbAmp}; // thats 1.0 / cubrt(maxOutputAmp)
     std::array<float, maxProcessorFloatParams> floatParams;
     std::array<int32_t, maxProcessorIntParams> intParams;
+    std::array<bool, maxProcessorIntParams> deactivated{};
     bool isActive{true};
     bool isKeytracked{false};
     int previousIsKeytracked{-1}; // make this an int and -1 means don't know previous
@@ -308,6 +309,7 @@ struct Processor : MoveableOnly<Processor>, SampleRateSupport
     engine::MemoryPool *memoryPool{nullptr};
     float *param{nullptr};
     int *iparam{nullptr};
+    const bool *deactivated{nullptr};
     const bool *temposync{nullptr};
     int floatParameterCount{0};
     std::array<sst::basic_blocks::params::ParamMetaData, maxProcessorFloatParams>

--- a/src/dsp/processor/processor_impl.h
+++ b/src/dsp/processor/processor_impl.h
@@ -87,6 +87,14 @@ template <int OSFactor> struct SCXTVFXConfig
         return false;
     }
 
+    static bool isDeactivated(const BaseClass *c, int index)
+    {
+        auto ts = c->deactivated;
+        if (ts)
+            return ts[index];
+        return false;
+    }
+
     static double *getTempoPointer(const BaseClass *c)
     {
         assert(c->getTempoPointer());
@@ -324,6 +332,7 @@ void Processor::setupProcessor(T *that, ProcessorType t, engine::MemoryPool *mp,
     param = fp;
     iparam = ip;
     temposync = &p.isTemposynced;
+    deactivated = p.deactivated.data();
 
     setKeytrack(p.isKeytracked);
 

--- a/src/json/dsp_traits.h
+++ b/src/json/dsp_traits.h
@@ -54,6 +54,7 @@ SC_STREAMDEF(scxt::dsp::processor::ProcessorStorage, SC_FROM({
                           {"isTemposynced", t.isTemposynced},
                           {"floatParams", t.floatParams},
                           {"intParams", t.intParams},
+                          {"deactivated", t.deactivated},
                           {"isActive", t.isActive}};
                  }
              }),
@@ -80,6 +81,7 @@ SC_STREAMDEF(scxt::dsp::processor::ProcessorStorage, SC_FROM({
                      findIf(v, "out", result.outputCubAmp);
                      fromArrayWithSizeDifference(v.at("floatParams"), result.floatParams);
                      fromArrayWithSizeDifference(v.at("intParams"), result.intParams);
+                     findIf(v, "deactivated", result.deactivated);
                      findOrSet(v, "isActive", false, result.isActive);
                      findOrSet(v, "isKeytracked", false, result.isKeytracked);
                      findOrSet(v, "isTemposynced", false, result.isTemposynced);


### PR DESCRIPTION
1. Introdfuce JSON based layouts, experimental and under development still, and use them for bus/delay bus/phaser voice/bitcruserh and voice/waveshaper screens.
2. Mechanics and documentation for above feature, Partial runtime interpreter support
3. Simultaenously, make per-float-param deactivation part of the fundamental voice effect model, like it is for bus effects, and deal with streaming, ui, etc.... Use this to change the waveshaper LP/HP activation model.