### PR TITLE
Initial multi-part support

### DIFF
--- a/src-ui/components/HasEditor.h
+++ b/src-ui/components/HasEditor.h
@@ -28,7 +28,9 @@
 #ifndef SCXT_SRC_UI_COMPONENTS_HASEDITOR_H
 #define SCXT_SRC_UI_COMPONENTS_HASEDITOR_H
 
-#include "sst/jucegui/style/StyleAndSettingsConsumer.h"
+#include <cstdint>
+#include <cassert>
+#include <type_traits>
 
 namespace scxt::ui
 {

--- a/src-ui/components/SCXTEditor.cpp
+++ b/src-ui/components/SCXTEditor.cpp
@@ -374,4 +374,6 @@ void SCXTEditor::configureHasDiscreteMenuBuilder(
     };
 }
 
+int16_t SCXTEditor::getSelectedPart() const { return selectedPart; }
+
 } // namespace scxt::ui

--- a/src-ui/components/SCXTEditor.h
+++ b/src-ui/components/SCXTEditor.h
@@ -193,6 +193,8 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::DragAndDropCont
 
     void onGroupZoneMappingSummary(const scxt::engine::Part::zoneMappingSummary_t &);
     void onSelectionState(const scxt::messaging::client::selectedStateMessage_t &);
+    void onSelectedPart(const int16_t);
+    int16_t getSelectedPart() const;
 
     void onMixerBusEffectFullData(const scxt::messaging::client::busEffectFullData_t &);
     void onMixerBusSendData(const scxt::messaging::client::busSendData_t &);
@@ -216,6 +218,7 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::DragAndDropCont
     std::optional<selection::SelectionManager::ZoneAddress> currentLeadZoneSelection;
     selection::SelectionManager::selectedZones_t allZoneSelections;
     selection::SelectionManager::selectedZones_t allGroupSelections;
+    int16_t selectedPart{0};
 
     // TODO: Do we allow part multi-select? I think we don't
     std::set<int> groupsWithSelectedZones;

--- a/src-ui/components/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/components/SCXTEditorResponseHandlers.cpp
@@ -217,6 +217,15 @@ void SCXTEditor::onGroupOutputInfoUpdated(const scxt::messaging::client::groupOu
 void SCXTEditor::onGroupZoneMappingSummary(const scxt::engine::Part::zoneMappingSummary_t &d)
 {
     multiScreen->sample->setGroupZoneMappingSummary(d);
+
+    if constexpr (scxt::log::uiStructure)
+    {
+        SCLOG("Updated zone mapping summary");
+        for (const auto &[addr, item] : d)
+        {
+            SCLOG("  " << addr << " " << std::get<2>(item));
+        }
+    }
 }
 
 void SCXTEditor::onErrorFromEngine(const scxt::messaging::client::s2cError_t &e)
@@ -229,6 +238,7 @@ void SCXTEditor::onSelectionState(const scxt::messaging::client::selectedStateMe
 {
     allZoneSelections = std::get<1>(a);
     allGroupSelections = std::get<2>(a);
+
     auto optLead = std::get<0>(a);
     if (optLead.has_value())
     {
@@ -249,6 +259,32 @@ void SCXTEditor::onSelectionState(const scxt::messaging::client::selectedStateMe
 
     multiScreen->parts->editorSelectionChanged();
     multiScreen->sample->editorSelectionChanged();
+
+    repaint();
+
+    if constexpr (scxt::log::selection)
+    {
+        SCLOG("Selection State Update");
+        for (const auto &z : allZoneSelections)
+        {
+            SCLOG("   z : " << z);
+        }
+        for (const auto &z : allGroupSelections)
+        {
+            SCLOG("   g : " << z);
+        }
+    }
+}
+
+void SCXTEditor::onSelectedPart(const int16_t p)
+{
+    if constexpr (scxt::log::uiStructure)
+    {
+        SCLOG("Selected Part: " << p);
+    }
+    selectedPart = p; // I presume I will shortly get structure messages so don't do anything else
+    if (multiScreen && multiScreen->parts)
+        multiScreen->parts->selectedPartChanged();
 
     repaint();
 }

--- a/src-ui/components/multi/MappingPane.cpp
+++ b/src-ui/components/multi/MappingPane.cpp
@@ -908,9 +908,13 @@ void MappingZones::mouseDown(const juce::MouseEvent &e)
     {
         auto r = rectangleForZone(z.second);
         if (r.contains(e.position) && display->editor->isAnyZoneFromGroupSelected(z.first.group))
+        {
             potentialZones.push_back(z.first);
+            SCLOG("Adding potential zone " << z.first);
+        }
     }
     selection::SelectionManager::ZoneAddress nextZone;
+
     if (!potentialZones.empty())
     {
         if (potentialZones.size() == 1)

--- a/src-ui/components/multi/PartGroupSidebar.h
+++ b/src-ui/components/multi/PartGroupSidebar.h
@@ -47,6 +47,7 @@ struct PartGroupSidebar : sst::jucegui::components::NamedPanel, HasEditor
     engine::Engine::pgzStructure_t pgzStructure;
     void setPartGroupZoneStructure(const engine::Engine::pgzStructure_t &p);
     void editorSelectionChanged();
+    void selectedPartChanged();
 
     void selectParts() {}
     void selectGroups() {}

--- a/src-ui/components/multi/detail/GroupZoneTreeControl.h
+++ b/src-ui/components/multi/detail/GroupZoneTreeControl.h
@@ -48,13 +48,11 @@ template <typename SidebarParent> struct GroupZoneListBoxModel : juce::ListBoxMo
     void rebuild()
     {
         auto &sbo = sidebar->editor->currentLeadZoneSelection;
-        sidebar->part = 0;
-        if (sbo.has_value() && sbo->part >= 0)
-            sidebar->part = sbo->part;
+
         auto &pgz = sidebar->partGroupSidebar->pgzStructure;
         thisGroup.clear();
         for (const auto &el : pgz)
-            if (el.first.part == sidebar->part && el.first.group >= 0)
+            if (el.first.part == sidebar->editor->selectedPart && el.first.group >= 0)
                 thisGroup.push_back(el);
     }
     int getNumRows() override { return thisGroup.size() + 1; /* for the plus */ }

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -67,8 +67,17 @@ static constexpr uint16_t maxSamplesPerZone{16};
 
 static constexpr uint16_t lfosPerGroup{4};
 static constexpr uint16_t egPerGroup{2};
-
 static constexpr uint16_t processorsPerZoneAndGroup{4};
+
+/*
+ * This namespace guards some very useful debugging guards and logs in the code.
+ */
+namespace log
+{
+static constexpr bool selection{false};
+static constexpr bool uiStructure{false};
+static constexpr bool groupZoneMutation{false};
+} // namespace log
 
 } // namespace scxt
 #endif // __SCXT__CONFIGURATION_H

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -393,15 +393,12 @@ Engine::getProcessorStorage(const processorAddress_t &addr) const
     return {};
 }
 
-Engine::pgzStructure_t Engine::getPartGroupZoneStructure(int partFilter) const
+Engine::pgzStructure_t Engine::getPartGroupZoneStructure() const
 {
     Engine::pgzStructure_t res;
     int32_t partidx{0};
     for (const auto &part : *patch)
     {
-        if (partFilter >= 0 && partFilter != partidx)
-            continue;
-
         res.push_back({{partidx, -1, -1}, part->getName()});
 
         int32_t groupidx{0};
@@ -420,11 +417,14 @@ Engine::pgzStructure_t Engine::getPartGroupZoneStructure(int partFilter) const
 
         partidx++;
     }
-    /*
-    SCLOG( "Returning partgroup structure size " << res.size() );;
-    for (const auto &pg : res)
-        SCLOG( "   " << pg.first );;
-        */
+    if constexpr (scxt::log::uiStructure)
+    {
+        SCLOG("Returning partgroup structure size " << res.size());
+
+        for (const auto &pg : res)
+            SCLOG("   " << pg.first << " @ " << pg.second);
+    }
+
     return res;
 }
 
@@ -499,7 +499,7 @@ void Engine::loadSampleIntoSelectedPartAndGroup(const fs::path &p, int16_t rootK
             loadSf2MultiSampleIntoSelectedPart(p);
             messageController->restartAudioThreadFromSerial();
             serializationSendToClient(messaging::client::s2c_send_pgz_structure,
-                                      getPartGroupZoneStructure(-1), *messageController);
+                                      getPartGroupZoneStructure(), *messageController);
         });
         return;
     }
@@ -512,7 +512,7 @@ void Engine::loadSampleIntoSelectedPartAndGroup(const fs::path &p, int16_t rootK
                 messageController->reportErrorToClient("SFZ Import Failed", "Dunno why");
             messageController->restartAudioThreadFromSerial();
             serializationSendToClient(messaging::client::s2c_send_pgz_structure,
-                                      getPartGroupZoneStructure(-1), *messageController);
+                                      getPartGroupZoneStructure(), *messageController);
         });
         return;
     }
@@ -524,7 +524,7 @@ void Engine::loadSampleIntoSelectedPartAndGroup(const fs::path &p, int16_t rootK
                 messageController->reportErrorToClient("SFZ Import Failed", "Dunno why");
             messageController->restartAudioThreadFromSerial();
             serializationSendToClient(messaging::client::s2c_send_pgz_structure,
-                                      getPartGroupZoneStructure(-1), *messageController);
+                                      getPartGroupZoneStructure(), *messageController);
         });
         return;
     }

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -395,11 +395,10 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
      * Get the Part/Group/Zone structure as a set o fzone addreses. A part with
      * no groups will be (p,-1,-1); a group with no zones will be (p,g,-1).
      *
-     * @param partFilter -1 for all parts; 0-16 for a specific part
-     * @return The vector of zones matching the filter in the running engine
+     * @return The vector of zones in the running engine
      * independent of selection.
      */
-    pgzStructure_t getPartGroupZoneStructure(int partFilter) const;
+    pgzStructure_t getPartGroupZoneStructure() const;
 
     const std::unique_ptr<MemoryPool> &getMemoryPool()
     {

--- a/src/engine/part.cpp
+++ b/src/engine/part.cpp
@@ -69,7 +69,7 @@ Part::zoneMappingSummary_t Part::getZoneMappingSummary()
 {
     zoneMappingSummary_t res;
 
-    int pidx{0}; // FIXME this is obviously wrong
+    int pidx{partNumber};
     int gidx{0};
     for (const auto &g : groups)
     {

--- a/src/engine/patch.h
+++ b/src/engine/patch.h
@@ -166,7 +166,7 @@ struct Patch : MoveableOnly<Patch>, SampleRateSupport
         // If it is the year 2112 and you just had a regtest fail because
         // this is earlier than the streaming version you just changed, then
         // this software lived too long
-        streamingVersion = 0x21120101;
+        streamingVersion = 0x2112'01'01;
         for (int i = 0; i < numParts; ++i)
         {
             parts[i] = std::make_unique<Part>(i);

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -253,7 +253,7 @@ template <> struct scxt_traits<scxt::engine::Zone::ZoneMappingData>
         findIf(v, "pbUp", zmd.pbUp);
 
         findIf(v, "amplitude", zmd.amplitude);
-        if (SC_UNSTREAMING_FROM_THIS_OR_OLDER(0x20240603))
+        if (SC_UNSTREAMING_FROM_THIS_OR_OLDER(0x2024'06'03))
         {
             // amplitude used to be in percent 0...1 and now
             // is in decibels -36 to 36.

--- a/src/json/scxt_traits.h
+++ b/src/json/scxt_traits.h
@@ -121,5 +121,8 @@ template <typename V, typename R> void findOrDefault(V &v, const std::string &ke
 #define SC_UNSTREAMING_FROM_THIS_OR_OLDER(x)                                                       \
     engine::Engine::isFullEngineUnstream &&engine::Engine::fullEngineUnstreamStreamingVersion <= x
 
+#define SC_UNSTREAMING_FROM_PRIOR_TO(x)                                                            \
+    engine::Engine::isFullEngineUnstream &&engine::Engine::fullEngineUnstreamStreamingVersion < x
+
 } // namespace scxt::json
 #endif // SHORTCIRCUIT_SCXT_TRAITS_H

--- a/src/json/selection_traits.h
+++ b/src/json/selection_traits.h
@@ -101,19 +101,33 @@ template <> struct scxt_traits<selection::SelectionManager>
         v = {{"zones", e.allSelectedZones},
              {"leadZone", e.leadZone},
              {"groups", e.allSelectedGroups},
-             {"tabs", e.otherTabSelection}};
+             {"tabs", e.otherTabSelection},
+             {"selectedPart", e.selectedPart}};
     }
 
     template <template <typename...> class Traits>
     static void to(const tao::json::basic_value<Traits> &v, sm_t &z)
     {
-        selection::SelectionManager::ZoneAddress za;
-        findIf(v, "tabs", z.otherTabSelection);
-        findIf(v, "zones", z.allSelectedZones);
-        findIf(v, "groups", z.allSelectedGroups);
-        findIf(v, "leadZone", z.leadZone);
+        if (SC_UNSTREAMING_FROM_PRIOR_TO(0x2024'07'24))
+        {
+            z.selectedPart = 0;
+            findIf(v, "tabs", z.otherTabSelection);
+            findIf(v, "zones", z.allSelectedZones[0]);
+            findIf(v, "groups", z.allSelectedGroups[0]);
+            findIf(v, "leadZone", z.leadZone[0]);
+        }
+        else
+        {
+            findIf(v, "tabs", z.otherTabSelection);
+            findIf(v, "zones", z.allSelectedZones);
+            findIf(v, "groups", z.allSelectedGroups);
+            findIf(v, "leadZone", z.leadZone);
+            findIf(v, "selectedPart", z.selectedPart);
+        }
 
-        selection::SelectionManager::SelectActionContents sac{z.leadZone};
+        selection::SelectionManager::ZoneAddress za;
+
+        selection::SelectionManager::SelectActionContents sac{z.leadZone[z.selectedPart]};
         sac.distinct = false;
         z.selectAction(sac);
     }

--- a/src/json/stream.h
+++ b/src/json/stream.h
@@ -34,7 +34,7 @@
 namespace scxt::json
 {
 
-static constexpr uint64_t currentStreamingVersion{0x20240604};
+static constexpr uint64_t currentStreamingVersion{0x2024'07'24};
 
 std::string streamPatch(const engine::Patch &p, bool pretty = false);
 std::string streamEngineState(const engine::Engine &e, bool pretty = false);

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -46,6 +46,7 @@ enum ClientToSerializationMessagesIds
     c2s_single_select_address,
     c2s_do_select_action,
     c2s_do_multi_select_action,
+    c2s_select_part,
 
     c2s_begin_edit, // not implemented yet
     c2s_end_edit,   // implemented as a hammer
@@ -135,6 +136,7 @@ enum SerializationToClientMessageIds
     s2c_respond_single_processor_metadata_and_data,
     s2c_notify_mismatched_processors_for_zone,
 
+    s2c_send_selected_part,
     s2c_send_selected_group_zone_mapping_summary,
     s2c_send_selection_state,
 

--- a/src/messaging/client/group_messages.h
+++ b/src/messaging/client/group_messages.h
@@ -61,7 +61,7 @@ inline void renameGroup(const renameGroup_t &payload, const engine::Engine &engi
 {
     const auto &[p, g, z] = std::get<0>(payload);
     engine.getPatch()->getPart(p)->getGroup(g)->name = std::get<1>(payload);
-    serializationSendToClient(s2c_send_pgz_structure, engine.getPartGroupZoneStructure(p), cont);
+    serializationSendToClient(s2c_send_pgz_structure, engine.getPartGroupZoneStructure(), cont);
 }
 CLIENT_TO_SERIAL(RenameGroup, c2s_rename_group, renameGroup_t, renameGroup(payload, engine, cont));
 

--- a/src/messaging/client/part_messages.h
+++ b/src/messaging/client/part_messages.h
@@ -34,6 +34,7 @@
 
 namespace scxt::messaging::client
 {
+SERIAL_TO_CLIENT(SelectedPart, s2c_send_selected_part, int16_t, onSelectedPart);
 SERIAL_TO_CLIENT(SelectedGroupZoneMappingSummary, s2c_send_selected_group_zone_mapping_summary,
                  engine::Part::zoneMappingSummary_t, onGroupZoneMappingSummary);
 } // namespace scxt::messaging::client

--- a/src/messaging/client/selection_messages.h
+++ b/src/messaging/client/selection_messages.h
@@ -54,6 +54,9 @@ CLIENT_TO_SERIAL(DoMultiSelectAction, c2s_do_multi_select_action,
                  std::vector<selection::SelectionManager::SelectActionContents>,
                  doMultiSelectAction(payload, engine));
 
+CLIENT_TO_SERIAL(DoSelectPart, c2s_select_part, int16_t,
+                 engine.getSelectionManager()->selectPart(payload));
+
 // Lead Zone, Zone Selection, Gropu Selection
 typedef std::tuple<std::optional<selection::SelectionManager::ZoneAddress>,
                    selection::SelectionManager::selectedZones_t,

--- a/src/messaging/messaging.cpp
+++ b/src/messaging/messaging.cpp
@@ -51,7 +51,7 @@ void MessageController::parseAudioMessageOnSerializationThread(
     case audio::a2s_structure_refresh:
         // TODO: Factor this a bit better
         serializationSendToClient(client::s2c_send_pgz_structure,
-                                  engine.getPartGroupZoneStructure(-1), *this);
+                                  engine.getPartGroupZoneStructure(), *this);
         break;
     case audio::a2s_processor_refresh:
         SCLOG("Processor Refresh Requestioned. TODO: Minimize this message "

--- a/src/sample/multisample_support/multisample_import.cpp
+++ b/src/sample/multisample_support/multisample_import.cpp
@@ -82,7 +82,7 @@ bool importMultisample(const fs::path &p, engine::Engine &engine)
         return false;
     }
 
-    auto pt = std::clamp(engine.getSelectionManager()->selectedPart, 0, (int)numParts);
+    auto pt = std::clamp(engine.getSelectionManager()->selectedPart, (int16_t)0, (int16_t)numParts);
     auto &part = engine.getPatch()->getPart(pt);
 
     std::vector<int> addedGroupIndices;

--- a/src/sample/sample_manager.h
+++ b/src/sample/sample_manager.h
@@ -122,13 +122,13 @@ struct SampleManager : MoveableOnly<SampleManager>
     {
         samples.clear();
         sf2FilesByPath.clear();
-        streamingVersion = 0x21120101;
+        streamingVersion = 0x2112'01'01;
     }
 
     std::vector<fs::path> missingList;
     void resetMissingList() { missingList.clear(); }
 
-    uint64_t streamingVersion{0x21120101}; // see comment in patch.h
+    uint64_t streamingVersion{0x2112'01'01}; // see comment in patch.h
     std::unordered_map<SampleID, std::shared_ptr<Sample>> samples;
 
   private:

--- a/src/sample/sfz_support/sfz_import.cpp
+++ b/src/sample/sfz_support/sfz_import.cpp
@@ -73,7 +73,7 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
     auto rootDir = f.parent_path();
     auto sampleDir = rootDir;
 
-    auto pt = std::clamp(e.getSelectionManager()->selectedPart, 0, (int)numParts);
+    auto pt = std::clamp(e.getSelectionManager()->selectedPart, (int16_t)0, (int16_t)numParts);
 
     auto &part = e.getPatch()->getPart(pt);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -283,6 +283,14 @@ std::string logTimestamp();
         x842132 = true;                                                                            \
     }
 
+#define SCLOG_IF(x, ...)                                                                           \
+    {                                                                                              \
+        if constexpr (scxt::log::x)                                                                \
+        {                                                                                          \
+            SCLOG(__VA_ARGS__);                                                                    \
+        }                                                                                          \
+    }
+
 #define SCLOG_WFUNC(...) SCLOG(__func__ << " " << __VA_ARGS__)
 #define SCLOG_UNIMPL(...) SCLOG("\033[1;33mUnimpl [" << __func__ << "]\033[0m " << __VA_ARGS__);
 #define SCD(x) #x << "=" << (x) << " "


### PR DESCRIPTION
Very initial multi-part support in the front end

1. The parts pane lets you pickparts
2. Selection is moved to per-part not just per-instrument
3. On change, select, etc... the front end messages to back end correctly

Basically the 'part-as-group' feature seems to work here.

Next up some of the actual part features like midi routing and so on get checked.