### PR TITLE
Save Multi, Improve User Paths, and More

### DIFF
--- a/src-ui/components/HeaderRegion.h
+++ b/src-ui/components/HeaderRegion.h
@@ -47,7 +47,7 @@ namespace scxt::ui
 {
 struct SCXTEditor;
 
-struct HeaderRegion : juce::Component, HasEditor
+struct HeaderRegion : juce::Component, HasEditor, juce::FileDragAndDropTarget
 {
     std::unique_ptr<sst::jucegui::components::ToggleButtonRadioGroup> selectedPage;
     std::unique_ptr<sst::jucegui::data::Discrete> selectedPageData;
@@ -75,6 +75,9 @@ struct HeaderRegion : juce::Component, HasEditor
         }
     }
 
+    bool isInterestedInFileDrag(const juce::StringArray &files) override;
+    void filesDropped(const juce::StringArray &files, int x, int y) override;
+
     float memUsageInMegabytes{0.f};
     void setMemUsage(float m)
     {
@@ -90,6 +93,12 @@ struct HeaderRegion : juce::Component, HasEditor
 
     float cpuLevValue{-100};
     void setCPULevel(float);
+
+    void showSaveMenu();
+    void doSaveMulti();
+    void doLoadMulti();
+
+    std::unique_ptr<juce::FileChooser> fileChooser;
 };
 } // namespace scxt::ui
 

--- a/src-ui/components/SCXTEditor.cpp
+++ b/src-ui/components/SCXTEditor.cpp
@@ -302,22 +302,6 @@ void SCXTEditor::doMultiSelectionAction(
     repaint();
 }
 
-bool SCXTEditor::isInterestedInFileDrag(const juce::StringArray &files)
-{
-    // TODO be more parsimonious
-    return std::all_of(files.begin(), files.end(), [this](const auto &f) {
-        try
-        {
-            auto pt = fs::path{(const char *)(f.toUTF8())};
-            return browser.isLoadableFile(pt);
-        }
-        catch (fs::filesystem_error &e)
-        {
-        }
-        return false;
-    });
-}
-
 void SCXTEditor::showTooltip(const juce::Component &relativeTo)
 {
     auto fb = getLocalArea(&relativeTo, relativeTo.getLocalBounds());

--- a/src-ui/components/SCXTEditor.h
+++ b/src-ui/components/SCXTEditor.h
@@ -152,9 +152,6 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::DragAndDropCont
     void resized() override;
     void parentHierarchyChanged() override;
 
-    // no more used as FileDragAndDropTarget but still used by children
-    bool isInterestedInFileDrag(const juce::StringArray &files);
-
     // Deal with message queues.
     void idle();
     void drainCallbackQueue();
@@ -162,9 +159,11 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::DragAndDropCont
     uint64_t inboundMessageBytes{0};
 
     // Popup Menu Options
-    juce::PopupMenu::Options defaultPopupMenuOptions()
+    juce::PopupMenu::Options defaultPopupMenuOptions(juce::Component *on = nullptr)
     {
         auto r = juce::PopupMenu::Options().withParentComponent(this);
+        if (on)
+            r = r.withTargetComponent(on);
         return r;
     }
     void configureHasDiscreteMenuBuilder(sst::jucegui::components::HasDiscreteParamMenuBuilder *);

--- a/src-ui/components/SCXTEditorMenus.cpp
+++ b/src-ui/components/SCXTEditorMenus.cpp
@@ -51,6 +51,7 @@ void SCXTEditor::showMainMenu()
 
     m.addSectionHeader("ShortCircuit XT");
 #if BUILD_IS_DEBUG
+    m.addSeparator();
     m.addSectionHeader("(Debug Build)");
 #endif
 
@@ -138,7 +139,14 @@ void SCXTEditor::showMainMenu()
 
     m.addSubMenu("Developer", dp);
 
-    m.showMenuAsync(defaultPopupMenuOptions());
+    if (headerRegion && headerRegion->scMenu)
+    {
+        m.showMenuAsync(defaultPopupMenuOptions(headerRegion->scMenu.get()));
+    }
+    else
+    {
+        m.showMenuAsync(defaultPopupMenuOptions());
+    }
 }
 
 void SCXTEditor::addTuningMenu(juce::PopupMenu &p, bool addTitle)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,6 +48,8 @@ add_library(${PROJECT_NAME} STATIC
 
         voice/voice.cpp
 
+        patch_io/patch_io.cpp
+
         utils.cpp
         )
 

--- a/src/browser/browser.cpp
+++ b/src/browser/browser.cpp
@@ -31,9 +31,25 @@
 
 namespace scxt::browser
 {
-Browser::Browser(BrowserDB &db, const infrastructure::DefaultsProvider &dp)
-    : browserDb(db), defaultsProvider(dp)
+Browser::Browser(BrowserDB &db, const infrastructure::DefaultsProvider &dp, const fs::path &ud,
+                 errorReporter_t er)
+    : browserDb(db), defaultsProvider(dp), userDirectory(ud), errorReporter(er)
 {
+    auto create = [&](const auto &l) -> fs::path {
+        try
+        {
+            auto p = userDirectory / l;
+            if (!fs::is_directory(p))
+                fs::create_directories(p);
+            return p;
+        }
+        catch (const fs::filesystem_error &e)
+        {
+            errorReporter(std::string("Unable to create ") + l + " directory", e.what());
+        }
+        return {};
+    };
+    patchIODirectory = create("Patches");
 }
 
 std::vector<std::pair<fs::path, std::string>> Browser::getRootPathsForDeviceView() const
@@ -51,12 +67,31 @@ const std::vector<std::string> Browser::LoadableFile::singleSample{".wav", ".fla
                                                                    ".aiff"};
 
 const std::vector<std::string> Browser::LoadableFile::multiSample{".sf2", ".sfz", ".multisample"};
+const std::vector<std::string> Browser::LoadableFile::shortcircuitFormats{".scm", ".scp"};
 
 bool Browser::isLoadableFile(const fs::path &p)
 {
+    return isLoadableSample(p) || isShortCircuitFormatFile(p);
+}
+bool Browser::isLoadableSample(const fs::path &p)
+{
+    return isLoadableSingleSample(p) || isLoadableMultiSample(p);
+}
+bool Browser::isLoadableSingleSample(const fs::path &p)
+{
     return std::any_of(LoadableFile::singleSample.begin(), LoadableFile::singleSample.end(),
-                       [p](auto e) { return extensionMatches(p, e); }) ||
-           std::any_of(LoadableFile::multiSample.begin(), LoadableFile::multiSample.end(),
+                       [p](auto e) { return extensionMatches(p, e); });
+}
+bool Browser::isLoadableMultiSample(const fs::path &p)
+{
+    return std::any_of(LoadableFile::multiSample.begin(), LoadableFile::multiSample.end(),
+                       [p](auto e) { return extensionMatches(p, e); });
+}
+
+bool Browser::isShortCircuitFormatFile(const fs::path &p)
+{
+    return std::any_of(LoadableFile::shortcircuitFormats.begin(),
+                       LoadableFile::shortcircuitFormats.end(),
                        [p](auto e) { return extensionMatches(p, e); });
 }
 

--- a/src/browser/browser.h
+++ b/src/browser/browser.h
@@ -55,7 +55,16 @@ struct BrowserDB;
  */
 struct Browser
 {
-    Browser(BrowserDB &, const infrastructure::DefaultsProvider &);
+    using errorReporter_t = std::function<void(const std::string &, const std::string &)>;
+
+    Browser(BrowserDB &, const infrastructure::DefaultsProvider &, const fs::path &userDirectory,
+            errorReporter_t reportError);
+
+    /*
+     * Paths for user content
+     */
+    fs::path userDirectory;    // like "Documents"/Shortcircuit XT
+    fs::path patchIODirectory; // user/Patches
 
     /*
      * Filesystem Views: Very simple. The Browser gives you a set of
@@ -68,17 +77,23 @@ struct Browser
     void addRootPathForDeviceView(const fs::path &);
 
     static bool isLoadableFile(const fs::path &);
+    static bool isLoadableSample(const fs::path &);
+    static bool isLoadableSingleSample(const fs::path &);
+    static bool isLoadableMultiSample(const fs::path &);
+    static bool isShortCircuitFormatFile(const fs::path &);
 
     struct LoadableFile
     {
         static const std::vector<std::string> singleSample;
         static const std::vector<std::string> multiSample;
+        static const std::vector<std::string> shortcircuitFormats;
     };
 
     std::vector<std::pair<fs::path, std::string>> getOSDefaultRootPathsForDeviceView() const;
 
     const infrastructure::DefaultsProvider &defaultsProvider;
     BrowserDB &browserDb;
+    errorReporter_t errorReporter;
 };
 } // namespace scxt::browser
 #endif // SHORTCIRCUITXT_BROWSER_H

--- a/src/browser/browser.h
+++ b/src/browser/browser.h
@@ -31,6 +31,7 @@
 #include <vector>
 #include <string>
 #include <utility>
+#include <functional>
 #include "filesystem/import.h"
 
 namespace scxt::infrastructure

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -374,9 +374,16 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     void sendMetadataToClient() const;
 
     /*
+     * Send everything we need upon a reset or register
+     */
+    void sendFullRefreshToClient() const;
+
+    /*
      * Update the audio playing state
      */
     void sendEngineStatusToClient() const;
+
+    void clearAll();
 
     struct EngineStatusMessage
     {
@@ -453,6 +460,8 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
      */
     void terminateVoicesForZone(Zone &z);
     void terminateVoicesForGroup(Group &g);
+
+    std::optional<fs::path> setupUserStorageDirectory();
 
   private:
     std::unique_ptr<Patch> patch;

--- a/src/engine/group.h
+++ b/src/engine/group.h
@@ -139,7 +139,7 @@ struct Group : MoveableOnly<Group>,
         return zones[idx];
     }
 
-    std::unique_ptr<Zone> removeZone(ZoneID &zid)
+    std::unique_ptr<Zone> removeZone(const ZoneID &zid)
     {
         auto idx = getZoneIndex(zid);
         if (idx < 0 || idx >= (int)zones.size())

--- a/src/engine/part.h
+++ b/src/engine/part.h
@@ -163,7 +163,7 @@ struct Part : MoveableOnly<Part>, SampleRateSupport
                 return idx;
         return -1;
     }
-    std::unique_ptr<Group> removeGroup(GroupID &zid)
+    std::unique_ptr<Group> removeGroup(const GroupID &zid)
     {
         auto idx = getGroupIndex(zid);
         if (idx < 0 || idx >= (int)groups.size())

--- a/src/json/scxt_traits.h
+++ b/src/json/scxt_traits.h
@@ -87,13 +87,20 @@ template <typename V, typename R> void findOrDefault(V &v, const std::string &ke
         template <template <typename...> class Traits>                                             \
         static void assign(tao::json::basic_value<Traits> &v, const E &s)                          \
         {                                                                                          \
-            v = {{#E, toS(s)}};                                                                    \
+            v = {{"e", toS(s)}};                                                                   \
         }                                                                                          \
         template <template <typename...> class Traits>                                             \
         static void to(const tao::json::basic_value<Traits> &v, E &r)                              \
         {                                                                                          \
             std::string s;                                                                         \
-            findIf(v, #E, s);                                                                      \
+            if (SC_UNSTREAMING_FROM_PRIOR_TO(0x2024'08'04))                                        \
+            {                                                                                      \
+                findIf(v, #E, s);                                                                  \
+            }                                                                                      \
+            else                                                                                   \
+            {                                                                                      \
+                findIf(v, "e", s);                                                                 \
+            }                                                                                      \
             r = fromS(s);                                                                          \
         }                                                                                          \
     };

--- a/src/messaging/client/client_messages.h
+++ b/src/messaging/client/client_messages.h
@@ -41,5 +41,6 @@
 #include "mixer_messages.h"
 #include "browser_messages.h"
 #include "debug_messages.h"
+#include "patch_io_messages.h"
 
 #endif // SHORTCIRCUIT_CLIENT_MESSAGE_IMPLS_H

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -111,6 +111,12 @@ enum ClientToSerializationMessagesIds
 
     c2s_silence_engine,
 
+    c2s_save_multi,
+    c2s_save_part,
+
+    c2s_load_multi,
+    c2s_load_part,
+
     num_clientToSerializationMessages
 };
 

--- a/src/messaging/client/patch_io_messages.h
+++ b/src/messaging/client/patch_io_messages.h
@@ -25,20 +25,23 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_JSON_STREAM_H
-#define SCXT_SRC_JSON_STREAM_H
+#ifndef SCXT_SRC_MESSAGING_CLIENT_PATCH_IO_MESSAGES_H
+#define SCXT_SRC_MESSAGING_CLIENT_PATCH_IO_MESSAGES_H
 
-#include "engine/patch.h"
-#include "engine/engine.h"
+#include "patch_io/patch_io.h"
 
-namespace scxt::json
+namespace scxt::messaging::client
 {
+inline void doSaveMulti(const std::string &s, engine::Engine &engine, MessageController &cont)
+{
+    patch_io::saveMulti(fs::path{s}, engine);
 
-static constexpr uint64_t currentStreamingVersion{0x2024'08'04};
+    SCLOG("Remember to update the browser also");
+    // engine.getBrowser()->doSomething;
+}
+CLIENT_TO_SERIAL(SaveMulti, c2s_save_multi, std::string, doSaveMulti(payload, engine, cont));
 
-std::string streamPatch(const engine::Patch &p, bool pretty = false);
-std::string streamEngineState(const engine::Engine &e, bool pretty = false);
-void unstreamEngineState(engine::Engine &e, const std::string &jsonData, bool msgPack = false);
-} // namespace scxt::json
-
-#endif // SHORTCIRCUIT_STREAM_H
+CLIENT_TO_SERIAL(LoadMulti, c2s_load_multi, std::string,
+                 patch_io::loadMulti(fs::path{payload}, engine));
+} // namespace scxt::messaging::client
+#endif // SHORTCIRCUITXT_PATCH_IO_MESSAGES_H

--- a/src/patch_io/patch_io.cpp
+++ b/src/patch_io/patch_io.cpp
@@ -1,0 +1,158 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include <fstream>
+
+#include "tao/json/msgpack/consume_string.hpp"
+#include "tao/json/msgpack/from_binary.hpp"
+#include "tao/json/msgpack/from_input.hpp"
+#include "tao/json/msgpack/from_string.hpp"
+#include "tao/json/msgpack/parts_parser.hpp"
+#include "tao/json/msgpack/to_stream.hpp"
+#include "tao/json/msgpack/to_string.hpp"
+
+#include "RIFF.h" // from libgig
+
+#include "utils.h"
+#include "patch_io.h"
+#include "engine/engine.h"
+#include "messaging/messaging.h"
+
+#include "json/engine_traits.h"
+
+namespace scxt::patch_io
+{
+void addSCManifest(const std::unique_ptr<RIFF::File> &f, const std::string &type)
+{
+    std::map<std::string, std::string> manifest;
+    manifest["version"] = "1";
+    manifest["type"] = type;
+    auto mmsg = tao::json::to_string(json::scxt_value(manifest));
+    auto c = f->AddSubChunk('scmf', mmsg.size());
+    auto d = (uint8_t *)c->LoadChunkData();
+    memcpy(d, mmsg.data(), mmsg.size());
+}
+
+std::unordered_map<std::string, std::string> readSCManifest(const std::unique_ptr<RIFF::File> &f)
+{
+    auto c1 = f->GetSubChunk('scmf');
+    std::string s((char *)c1->LoadChunkData());
+
+    tao::json::events::transformer<tao::json::events::to_basic_value<json::scxt_traits>> consumer;
+    tao::json::events::from_string(consumer, s);
+    auto jv = std::move(consumer.value);
+    std::unordered_map<std::string, std::string> manifest;
+    jv.to(manifest);
+
+    return manifest;
+}
+
+void addSCDataChunk(const std::unique_ptr<RIFF::File> &f, const std::string &msg)
+{
+    auto c = f->AddSubChunk('scdt', msg.size());
+    auto d = (uint8_t *)c->LoadChunkData();
+    memcpy(d, msg.data(), msg.size());
+}
+
+std::string readSCDataChunk(const std::unique_ptr<RIFF::File> &f)
+{
+    auto cp = f->GetSubChunk('scdt');
+    return std::string((char *)cp->LoadChunkData(), cp->GetSize());
+}
+
+bool saveMulti(const fs::path &p, const scxt::engine::Engine &e)
+{
+    SCLOG("Made it to the patch code " << p.u8string());
+
+    try
+    {
+        auto msg = tao::json::msgpack::to_string(json::scxt_value(e));
+
+        auto f = std::make_unique<RIFF::File>('SCXT');
+        f->SetByteOrder(RIFF::endian_little);
+        addSCManifest(f, "multi");
+        addSCDataChunk(f, msg);
+
+        // TODO: If embeeding samples, add a list here with them
+        f->Save(p.u8string());
+    }
+    catch (const RIFF::Exception &e)
+    {
+        SCLOG(e.Message);
+    }
+    return true;
+}
+
+bool loadMulti(const fs::path &p, scxt::engine::Engine &engine)
+{
+    SCLOG("loadMulti " << p.u8string());
+
+    std::string payload;
+    try
+    {
+        auto f = std::make_unique<RIFF::File>(p.u8string());
+        auto manifest = readSCManifest(f);
+        payload = readSCDataChunk(f);
+    }
+    catch (const RIFF::Exception &e)
+    {
+        SCLOG("RIFF::Exception " << e.Message);
+        return false;
+    }
+
+    auto &cont = engine.getMessageController();
+    if (cont->isAudioRunning)
+    {
+        cont->stopAudioThreadThenRunOnSerial([payload, &nonconste = engine](auto &e) {
+            try
+            {
+                nonconste.stopAllSounds();
+                scxt::json::unstreamEngineState(nonconste, payload, true);
+                auto &cont = *e.getMessageController();
+                cont.restartAudioThreadFromSerial();
+            }
+            catch (std::exception &err)
+            {
+                SCLOG("Unable to load [" << err.what() << "]");
+            }
+        });
+    }
+    else
+    {
+        try
+        {
+            engine.stopAllSounds();
+            scxt::json::unstreamEngineState(engine, payload, true);
+        }
+        catch (std::exception &err)
+        {
+            SCLOG("Unable to load [" << err.what() << "]");
+        }
+    }
+    return true;
+}
+} // namespace scxt::patch_io

--- a/src/patch_io/patch_io.h
+++ b/src/patch_io/patch_io.h
@@ -25,20 +25,18 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_JSON_STREAM_H
-#define SCXT_SRC_JSON_STREAM_H
+#ifndef SCXT_SRC_PATCH_IO_PATCH_IO_H
+#define SCXT_SRC_PATCH_IO_PATCH_IO_H
 
 #include "engine/patch.h"
-#include "engine/engine.h"
+#include "engine/part.h"
 
-namespace scxt::json
+namespace scxt::patch_io
 {
+bool saveMulti(const fs::path &toFile, const scxt::engine::Engine &);
+bool loadMulti(const fs::path &fromFile, scxt::engine::Engine &);
+bool streamPart(const fs::path &toFile, const scxt::engine::Part &);
+bool unstreamPart(const fs::path &fromFile, scxt::engine::Part &);
+} // namespace scxt::patch_io
 
-static constexpr uint64_t currentStreamingVersion{0x2024'08'04};
-
-std::string streamPatch(const engine::Patch &p, bool pretty = false);
-std::string streamEngineState(const engine::Engine &e, bool pretty = false);
-void unstreamEngineState(engine::Engine &e, const std::string &jsonData, bool msgPack = false);
-} // namespace scxt::json
-
-#endif // SHORTCIRCUIT_STREAM_H
+#endif // SHORTCIRCUITXT_PATCH_IO_H


### PR DESCRIPTION
This commit is the first commit which allows you to save a multi (without embedded samples at this time) to a file and then load it later cleanly in a running session. It contains a wide set of changes.

The basic design though is to save a RIFF file with state and associated data. This is all an internal format in patch_io writing RIFF with the libgig RIFF tools.

As well as those changes, to get it working at the same time I made the following:

- User data paths are now on the browser
- Browser can determine loadable single vs multi vs sc files
- Update streaming version and fix enum streaming
- Change the drag and drop logic
- Add multiple isLoadable methods to the browser
- Add drop on header of shortcircuit file to load
- Tuning and Zoom Menu in place
- All other buttons pop 'coming soon'
- Clear engine function implemented