### PR TITLE
A few small performance tweaks

### DIFF
--- a/src/engine/bus.cpp
+++ b/src/engine/bus.cpp
@@ -289,7 +289,15 @@ void Bus::process()
     for (int c = 0; c < 2; ++c)
     {
         vuLevel[c] = std::min(2.f, a * vuLevel[c]);
-        vuLevel[c] = std::max((float)vuLevel[c], mech::blockAbsMax<BLOCK_SIZE>(output[c]));
+        /* we use this as a proxy for a silent block without having to scan the entire
+         * block. If the block isn't silent, we will get the next vlock if we just get
+         * unlucky with sample 0 except in a super pathological case of an exactly
+         * 16 sample sin wave or something.
+         */
+        if (std::fabs(output[c][0]) > 1e-15)
+        {
+            vuLevel[c] = std::max((float)vuLevel[c], mech::blockAbsMax<BLOCK_SIZE>(output[c]));
+        }
     }
 }
 

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -229,7 +229,8 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     void stopAllSounds();
 
     // TODO: All this gets ripped out when voice management is fixed
-    uint32_t activeVoiceCount();
+    void assertActiveVoiceCount();
+    std::atomic<uint32_t> activeVoices{0};
 
     const std::unique_ptr<messaging::MessageController> &getMessageController() const
     {

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -68,6 +68,7 @@ void Voice::cleanupVoice()
     zone = nullptr;
     isVoiceAssigned = false;
     engine->voiceManagerResponder.doVoiceEndCallback(this);
+    engine->activeVoices--;
 
     // We cleanup processors here since they may have, say,
     // memory pool resources checked out that others could

--- a/src/voice/voice.h
+++ b/src/voice/voice.h
@@ -178,6 +178,7 @@ struct alignas(16) Voice : MoveableOnly<Voice>,
 
         isVoicePlaying = true;
         isVoiceAssigned = true;
+
         voiceStarted();
     }
     void release() { isGated = false; }


### PR DESCRIPTION
Turns out the active voice calculation was kidna expensive as were VUs on busses we weren't using, so do a couple of little optimizations for each of those.

The bug ones (don't evaluate busses with no activity at all) still isn't done.

Addresses #1068