### PR TITLE
Clap First Migration

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -32,20 +32,20 @@ jobs:
             target: scxt_plugin_Standalone
             runTests: true
 
-          - name: "windows clap first"
+          - name: "windows juce style"
             os: windows-latest
             target: shortcircuit-installer
-            cmakeConfig: -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DSCXT_JUCE_CLASSIC_STYLE=FALSE
+            cmakeConfig: -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DSCXT_JUCE_CLASSIC_STYLE=TRUE
             runTests: false
-          - name: "mac clap first"
+          - name: "mac juce style"
             os: macos-latest
             target: shortcircuit-installer
-            cmakeConfig: -DSCXT_JUCE_CLASSIC_STYLE=FALSE
+            cmakeConfig: -DSCXT_JUCE_CLASSIC_STYLE=TRUE
             runTests: false
-          - name: "ubuntu clap first"
+          - name: "ubuntu juce style"
             os: ubuntu-latest
             target: shortcircuit-installer
-            cmakeConfig: -DSCXT_JUCE_CLASSIC_STYLE=FALSE
+            cmakeConfig: -DSCXT_JUCE_CLASSIC_STYLE=TRUE
             runTests: false
 
 

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -15,36 +15,36 @@ jobs:
         include:
           - name: "windows msvc"
             os: windows-latest
-            target: scxt_plugin_Standalone
+            target: scxt_clapfirst_Standalone
             cmakeConfig: -A x64
             runTests: false
           - name: "windows clang"
             os: windows-latest
-            target: scxt_plugin_Standalone
+            target: scxt_clapfirst_Standalone
             cmakeConfig: -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
             runTests: false
           - name: "mac standalone"
             os: macos-latest
-            target: scxt_plugin_Standalone
+            target: scxt_clapfirst_Standalone
             runTests: true
           - name: "ubuntu standalone"
             os: ubuntu-latest
-            target: scxt_plugin_Standalone
+            target: shortcircuit-installer
             runTests: true
 
           - name: "windows juce style"
             os: windows-latest
-            target: shortcircuit-installer
+            target: scxt_plugin_Standalone
             cmakeConfig: -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DSCXT_JUCE_CLASSIC_STYLE=TRUE
             runTests: false
           - name: "mac juce style"
             os: macos-latest
-            target: shortcircuit-installer
+            target: scxt_plugin_Standalone
             cmakeConfig: -DSCXT_JUCE_CLASSIC_STYLE=TRUE
             runTests: false
           - name: "ubuntu juce style"
             os: ubuntu-latest
-            target: shortcircuit-installer
+            target: scxt_plugin_Standalone
             cmakeConfig: -DSCXT_JUCE_CLASSIC_STYLE=TRUE
             runTests: false
 
@@ -87,5 +87,5 @@ jobs:
           username: ${{ github.actor }}
           token: ${{ secrets.GITHUB_TOKEN }}
           cmakeArgs: -DCMAKE_BUILD_TYPE=Debug -GNinja
-          target: scxt_plugin_Standalone
+          target: shortcircuit-products
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ math(EXPR PART1 "${DAY_OF_YEAR} + 1")
 project(ShortcircuitXT VERSION 0.${PART0}.${PART1}.0 LANGUAGES C CXX ASM)
 set(ShortcircuitXT_VERSION ${PROJECT_VERSION})
 
-option(SCXT_JUCE_CLASSIC_STYLE "Use juse classic vs clap-first style" ON)
+option(SCXT_JUCE_CLASSIC_STYLE "Use juse classic vs clap-first style" OFF)
 
 if (APPLE)
     enable_language(OBJC)

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -2,6 +2,7 @@ project(scxt-clients LANGUAGES CXX)
 
 
 if (${SCXT_JUCE_CLASSIC_STYLE})
+    message(STATUS "Building JUCE_CLASSIC style plugins")
     add_subdirectory(juce-plugin)
 
     if(DEFINED ENV{ASIOSDK_DIR} OR BUILD_USING_MY_ASIO_LICENSE)
@@ -30,6 +31,7 @@ if (${SCXT_JUCE_CLASSIC_STYLE})
         set(JUCE_ASIO_SUPPORT TRUE)
     endif()
 else()
+    message(STATUS "Building clap-first / wrapper plugins")
     add_subdirectory(clap-first)
 endif()
 

--- a/clients/clap-first/CMakeLists.txt
+++ b/clients/clap-first/CMakeLists.txt
@@ -23,8 +23,8 @@ add_library(${CLAP_TARGET} MODULE scxt-clap-entry.cpp)
 target_link_libraries(${CLAP_TARGET} PUBLIC ${IMPL_TARGET})
 target_library_make_clap(TARGET ${CLAP_TARGET}
         CLAP_NAME ${name}
-        CLAP_MACOS_BUNDLE_IDENTIFIER "org.surge-synth-team.scxt.clap_first.clap"
-        CLAP_MACOS_BUNDLE_VERSION "0.0.1"
+        CLAP_MACOS_BUNDLE_IDENTIFIER "org.surge-synth-team.shortcircuit-xt.clap"
+        CLAP_MACOS_BUNDLE_VERSION "${ShortcircuitXT_VERSION}"
         COPY_AFTER_BUILD ${SCXT_COPY_PLUGIN_AFTER_BUILD}
         )
 
@@ -36,7 +36,11 @@ target_add_vst3_wrapper(TARGET ${VST3_TARGET}
         OUTPUT_NAME ${name}
         SUPPORTS_ALL_NOTE_EXPRESSIONS TRUE
         WINDOWS_FOLDER_VST3 TRUE
-        )
+        # Re-use the JUCE tuid
+        SINGLE_PLUGIN_TUID ABCDEF019182FAEB566D624153635854
+        BUNDLE_IDENTIFIER "org.surge-synth-team.shortcircuit-xt.vst3"
+        BUNDLE_VERSION "${ShortcircuitXT_VERSION}"
+)
 if (${SCXT_COPY_PLUGIN_AFTER_BUILD})
     target_vst3_copy_after_build(TARGET ${VST3_TARGET})
 endif()
@@ -49,10 +53,17 @@ if (APPLE)
     target_add_auv2_wrapper(
             TARGET ${AUV2_TARGET}
             OUTPUT_NAME ${name}
-            BUNDLE_IDENTIFIER "org.surge-synth-team.scxt.clap_first.auv2"
-            BUNDLE_VERSION 0.0.1
 
             CLAP_TARGET_FOR_CONFIG ${CLAP_TARGET}
+
+            MANUFACTURER_NAME "Surge Synth Team"
+            MANUFACTURER_CODE VmbA
+            SUBTYPE_CODE ScXT
+
+            DICTIONARY_STREAM_FORMAT "JUCE"
+
+            BUNDLE_IDENTIFIER "org.surge-synth-team.shortcircuit-xt.component"
+            BUNDLE_VERSION "${ShortcircuitXT_VERSION}"
     )
     if (${SCXT_COPY_PLUGIN_AFTER_BUILD})
         target_auv2_copy_after_build(TARGET ${AUV2_TARGET})

--- a/clients/clap-first/scxt-clap-entry.cpp
+++ b/clients/clap-first/scxt-clap-entry.cpp
@@ -85,7 +85,7 @@ static bool clap_get_auv2_info(const clap_plugin_factory_as_auv2 *factory, uint3
 
     if (strcmp(plugin_id, scxt::clap_first::scxt_plugin::getDescription()->id) == 0)
     {
-        strncpy(info->au_subt, "scCF", 5);
+        strncpy(info->au_subt, "ScXT", 5);
         return true;
     }
 

--- a/clients/clap-first/scxt-plugin/scxt-plugin.cpp
+++ b/clients/clap-first/scxt-plugin/scxt-plugin.cpp
@@ -38,8 +38,8 @@ const clap_plugin_descriptor *getDescription()
     static const char *features[] = {CLAP_PLUGIN_FEATURE_INSTRUMENT, CLAP_PLUGIN_FEATURE_SAMPLER,
                                      CLAP_PLUGIN_FEATURE_SYNTHESIZER, nullptr};
     static clap_plugin_descriptor desc = {CLAP_VERSION,
-                                          "org.surge-synth-team.scxt.clap-first.scxt-plugin",
-                                          "Shortcircuit XT (Clap First Version)",
+                                          "org.surge-synth-team.shortcircuit-xt",
+                                          "Shortcircuit XT",
                                           "Surge Synth Team",
                                           "https://surge-synth-team.org",
                                           "",
@@ -93,7 +93,7 @@ bool SCXTPlugin::stateSave(const clap_ostream *ostream) noexcept
         auto xml = scxt::json::streamEngineState(*engine);
 
         auto c = xml.c_str();
-        auto s = xml.length(); // write the null terminator
+        auto s = xml.length() + 1; // write the null terminator
         while (s > 0)
         {
             auto r = ostream->write(ostream, c, s);


### PR DESCRIPTION
Turn on the clap-first / clap-wrapper plugin format and standalone by default. Set up the various ids and names so this should (gulp) be a seamless transition for all users.