### PR TITLE
RAM display more useful. Start of macro frame-out

### DIFF
--- a/src-ui/components/HeaderRegion.h
+++ b/src-ui/components/HeaderRegion.h
@@ -42,6 +42,7 @@
 #include "sst/jucegui/components/ToggleButtonRadioGroup.h"
 #include "sst/jucegui/data/Discrete.h"
 #include "HasEditor.h"
+#include "utils.h"
 
 namespace scxt::ui
 {
@@ -78,13 +79,25 @@ struct HeaderRegion : juce::Component, HasEditor, juce::FileDragAndDropTarget
     bool isInterestedInFileDrag(const juce::StringArray &files) override;
     void filesDropped(const juce::StringArray &files, int x, int y) override;
 
-    float memUsageInMegabytes{0.f};
+    float memUsageInBytes{-1.f};
     void setMemUsage(float m)
     {
-        if (m != memUsageInMegabytes)
+        if (m != memUsageInBytes)
         {
-            memUsageInMegabytes = m;
-            ramLevel->setText(fmt::format("{:.0f} MB", m));
+            memUsageInBytes = m;
+            auto mb = memUsageInBytes / 1024.f / 1024.f;
+            if (mb < 10)
+            {
+                ramLevel->setText(fmt::format("{:.2f} MB", mb));
+            }
+            else if (mb < 100)
+            {
+                ramLevel->setText(fmt::format("{:.1f} MB", mb));
+            }
+            else
+            {
+                ramLevel->setText(fmt::format("{:.0f} MB", mb));
+            }
         }
     }
 

--- a/src-ui/components/SCXTEditor.cpp
+++ b/src-ui/components/SCXTEditor.cpp
@@ -256,7 +256,7 @@ void SCXTEditor::idle()
         mixerScreen->setVULevelForBusses(sharedUiMemoryState.busVULevels);
     }
 
-    headerRegion->setMemUsage((float)std::round(sampleManager.sampleMemoryInBytes / 1024 / 1024));
+    headerRegion->setMemUsage(sampleManager.sampleMemoryInBytes);
 
     if (checkWelcomeCountdown == 0)
     {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(${PROJECT_NAME} STATIC
         engine/patch.cpp
         engine/memory_pool.cpp
         engine/bus.cpp
+        engine/macros.cpp
 
         json/stream.cpp
 

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -44,6 +44,8 @@ static constexpr uint16_t mainOutput{0};
 static constexpr uint16_t firstPartOutput{1};
 static constexpr uint16_t firstAuxOutput{firstPartOutput + numParts};
 
+static constexpr size_t macrosPerPart{16};
+
 static constexpr uint16_t numNonMainPluginOutputs{20};
 static constexpr uint16_t numPluginOutputs{numNonMainPluginOutputs + 1};
 

--- a/src/engine/macros.cpp
+++ b/src/engine/macros.cpp
@@ -1,0 +1,33 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "macros.h"
+
+namespace scxt::engine
+{
+sst::basic_blocks::params::ParamMetaData Macro::getMetadata() const { return {}; }
+} // namespace scxt::engine

--- a/src/engine/macros.h
+++ b/src/engine/macros.h
@@ -1,0 +1,47 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_ENGINE_MACROS_H
+#define SCXT_SRC_ENGINE_MACROS_H
+
+#include "sst/basic-blocks/params/ParamMetadata.h"
+
+namespace scxt::engine
+{
+struct Macro
+{
+    float normalizedValue{0.f}; // always 0...1
+    float modulationValue{0.f}; // Calcluated from normalized value
+
+    bool isBipolar{false};
+
+    void setNormalizedValue(float f);
+
+    sst::basic_blocks::params::ParamMetaData getMetadata() const;
+};
+} // namespace scxt::engine
+#endif // SHORTCIRCUITXT_MACROS_H

--- a/src/engine/part.h
+++ b/src/engine/part.h
@@ -38,6 +38,7 @@
 #include "dsp/smoothers.h"
 
 #include "bus.h"
+#include "macros.h"
 
 namespace scxt::engine
 {
@@ -150,6 +151,8 @@ struct Part : MoveableOnly<Part>, SampleRateSupport
         for (auto &g : groups)
             g->setSampleRate(samplerate);
     }
+
+    std::array<Macro, macrosPerPart> macros;
 
     // TODO: A group by ID which throws an SCXTError
     typedef std::vector<std::unique_ptr<Group>> groupContainer_t;

--- a/src/sample/sample_manager.cpp
+++ b/src/sample/sample_manager.cpp
@@ -162,7 +162,6 @@ std::optional<SampleID> SampleManager::loadSampleFromSF2ToID(const fs::path &p, 
         return {};
 
     sp->md5Sum = std::get<2>(sf2FilesByPath[p.u8string()]);
-    SCLOG("Sapmle MD5 Sum is " << sp->md5Sum);
 
     samples[sp->id] = sp;
     updateSampleMemory();


### PR DESCRIPTION
The RAM display was not updated on startup and had the wrong precision. Closes #1086

While there, start some super rudimentary plumbing for macros but I'm going to take a break and wanted to push the above fix so sweep those new and basically unused files here.