### PR TITLE
Macros as Plugin Edge Parameters working

### DIFF
--- a/clients/clap-first/scxt-juce-standalone/scxt-juce-standalone.cpp
+++ b/clients/clap-first/scxt-juce-standalone/scxt-juce-standalone.cpp
@@ -63,6 +63,7 @@ struct SCXTApplicationWindow : juce::DocumentWindow, juce::Button::Listener
           optionsButton("Options")
     {
         engine = std::make_unique<scxt::engine::Engine>();
+        engine->runningEnvironment = "Temporary SCXT Standalone";
 
         editor = std::make_unique<scxt::ui::SCXTEditor>(
             *(engine->getMessageController()), *(engine->defaults), *(engine->getSampleManager()),

--- a/src-ui/components/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/components/SCXTEditorResponseHandlers.cpp
@@ -340,8 +340,10 @@ void SCXTEditor::onMacroFullState(const scxt::messaging::client::macroFullState_
     multiScreen->sample->macroDataChanged(part, index);
 }
 
-void SCXTEditor::onMacroValue(const scxt::messaging::client::macroValue_t &)
+void SCXTEditor::onMacroValue(const scxt::messaging::client::macroValue_t &s)
 {
-    SCLOG_WFUNC("Implement");
+    const auto &[part, index, value] = s;
+    macroCache[part][index].value = value;
+    multiScreen->sample->repaint();
 }
 } // namespace scxt::ui

--- a/src-ui/components/multi/ModPane.cpp
+++ b/src-ui/components/multi/ModPane.cpp
@@ -252,14 +252,11 @@ template <typename GZTrait> struct ModRow : juce::Component, HasEditor
         curve->setLabel("-");
 
         auto makeSourceName = [](auto &si, auto &sn) {
-            // This is the second location where we are assuming default macro name
-            // as mentioned in part.h
             auto nm = sn.second;
 
             if (si.gid == 'zmac' || si.gid == 'gmac')
             {
-                auto defname = "Macro " + std::to_string(si.index + 1);
-                if (nm != defname)
+                if (nm != scxt::engine::Macro::defaultNameFor(si.index))
                 {
                     nm = "M" + std::to_string(si.index + 1) + ": " + nm;
                 }
@@ -456,12 +453,9 @@ template <typename GZTrait> struct ModRow : juce::Component, HasEditor
             auto nm = sn.second;
             if (si.gid == 'gmac' || si.gid == 'zmac')
             {
-                // This is where we are assuming default macro name
-                // from part.h
-                auto defName = "Macro " + std::to_string(si.index + 1);
-                if (nm != defName)
+                if (nm != scxt::engine::Macro::defaultNameFor(si.index))
                 {
-                    nm = defName + " (" + nm + ")";
+                    nm = scxt::engine::Macro::defaultNameFor(si.index) + " (" + nm + ")";
                 }
             }
             sub.addItem(nm, true, selected, mkCallback(si));

--- a/src-ui/components/multi/SingleMacroEditor.cpp
+++ b/src-ui/components/multi/SingleMacroEditor.cpp
@@ -126,14 +126,27 @@ SingleMacroEditor::SingleMacroEditor(SCXTEditor *e, int p, int i)
         w->editor->showTooltip(*(w->knob));
         w->editor->setTooltipContents(w->valueAttachment->getLabel(),
                                       w->valueAttachment->getValueAsString());
+        w->sendToSerialization(messaging::client::MacroBeginEndEdit({true, w->part, w->index}));
     };
     knob->onEndEdit = [w = juce::Component::SafePointer(this)]() {
         if (!w)
             return;
         w->editor->hideTooltip();
+        w->sendToSerialization(messaging::client::MacroBeginEndEdit({false, w->part, w->index}));
     };
-    knob->onIdleHover = knob->onBeginEdit;
-    knob->onIdleHoverEnd = knob->onEndEdit;
+
+    knob->onIdleHover = [w = juce::Component::SafePointer(this)]() {
+        if (!w)
+            return;
+        w->editor->showTooltip(*(w->knob));
+        w->editor->setTooltipContents(w->valueAttachment->getLabel(),
+                                      w->valueAttachment->getValueAsString());
+    };
+    knob->onIdleHoverEnd = [w = juce::Component::SafePointer(this)]() {
+        if (!w)
+            return;
+        w->editor->hideTooltip();
+    };
 
     valueAttachment = std::make_unique<MacroValueAttachment>(editor, part, index);
     knob->setSource(valueAttachment.get());
@@ -150,6 +163,7 @@ SingleMacroEditor::~SingleMacroEditor() {}
 void SingleMacroEditor::changePart(int p)
 {
     valueAttachment->part = p;
+    part = p;
     repaint();
 }
 

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -462,6 +462,8 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     void terminateVoicesForZone(Zone &z);
     void terminateVoicesForGroup(Group &g);
 
+    void setMacro01ValueFromPlugin(int part, int index, float value01);
+
     std::optional<fs::path> setupUserStorageDirectory();
 
   private:

--- a/src/engine/macros.h
+++ b/src/engine/macros.h
@@ -32,8 +32,10 @@
 #include <cstdint>
 #include <cstddef>
 #include <algorithm>
+#include <fmt/core.h>
 
 #include "sst/basic-blocks/params/ParamMetadata.h"
+#include "configuration.h"
 
 namespace scxt::engine
 {
@@ -53,17 +55,83 @@ struct Macro
         setValueConstrained(value);
     }
     void setValueConstrained(float f) { value = std::clamp(f, isBipolar ? -1.f : 0.f, 1.f); }
-    void setFrom01(float f)
+    void setValue01(float f)
     {
         assert(f >= 0.f && f <= 1.f);
         if (isBipolar)
         {
-            value = f * 2 - 1.0;
+            setValueConstrained(f * 2 - 1.0);
         }
         else
         {
-            value = f;
+            setValueConstrained(f);
         }
+    }
+    float getValue01() const
+    {
+        float res = value;
+        if (isBipolar)
+        {
+            res = (res + 1) * 0.5;
+        }
+        return std::clamp(res, 0.f, 1.f);
+    }
+
+    float valueFromString(const std::string &s) const
+    {
+        auto sv = std::atof(s.c_str());
+        return std::clamp((float)sv, isBipolar ? -1.f : 0.f, 1.f);
+    }
+
+    float value01FromString(const std::string &s) const
+    {
+        auto v = valueFromString(s);
+        if (isBipolar)
+            v = (v + 1) * 0.5;
+        return v;
+    }
+
+    std::string value01ToString(float dv) const
+    {
+        auto fv = dv;
+        if (isBipolar)
+            fv = fv * 2 - 1;
+        return fmt::format("{:.4f}", fv);
+    }
+
+    static std::string defaultNameFor(int index) { return "Macro " + std::to_string(index + 1); }
+    std::string pluginParameterNameFor(int part, int index) const
+    {
+        auto dn = defaultNameFor(index);
+        if (name == dn)
+        {
+            return std::string("P" + std::to_string(part + 1) + " " + name);
+        }
+        else
+        {
+            return std::string("P" + std::to_string(part + 1) + " M" + std::to_string(index + 1) +
+                               " - " + name);
+        }
+    }
+
+    /*
+     * Clap ID to Macro ID handling. This lives here so the engine can generate the
+     * associated clap id and so on outside the wrapper
+     */
+    static constexpr uint32_t firstMacroParam{0x30000};
+    static constexpr uint32_t macroParamPartStride{0x100};
+    static_assert(scxt::macrosPerPart < macroParamPartStride,
+                  "If you hit this you need to figure out what to do with those higher macros");
+    static bool isMacroID(uint32_t id)
+    {
+        return id >= firstMacroParam &&
+               id < firstMacroParam + macroParamPartStride * (scxt::numParts + 1);
+    }
+    static int macroIDToPart(uint32_t id) { return (id - firstMacroParam) / macroParamPartStride; }
+    static int macroIDToIndex(uint32_t id) { return (id - firstMacroParam) % macroParamPartStride; }
+    static uint32_t partIndexToMacroID(uint32_t part, uint32_t index)
+    {
+        return firstMacroParam + part * macroParamPartStride + index;
     }
 };
 } // namespace scxt::engine

--- a/src/engine/part.h
+++ b/src/engine/part.h
@@ -50,13 +50,10 @@ struct Part : MoveableOnly<Part>, SampleRateSupport
     Part(int16_t c) : id(PartID::next()), partNumber(c), channel(c)
     {
         pitchBendSmoother.setTarget(0);
-        int idx{1};
+        int idx{0};
         for (auto &m : macros)
         {
-            // If you change this format you also need to change
-            // the two comparisons with default in src-ui/.../ModPane.cpp
-            // at the comments "assuming default macro name"
-            m.name = "Macro " + std::to_string(idx);
+            m.name = Macro::defaultNameFor(idx);
             idx++;
         }
     }

--- a/src/messaging/audio/audio_serial.h
+++ b/src/messaging/audio/audio_serial.h
@@ -52,6 +52,7 @@ enum AudioToSerializationMessageId
     a2s_note_off,
     a2s_structure_refresh,
     a2s_processor_refresh,
+    a2s_macro_updated,
 };
 
 /**
@@ -94,7 +95,11 @@ enum SerializationToAudioMessageId
 {
     s2a_none,
     s2a_dispatch_to_pointer,
-    s2a_dispatch_to_pointer_under_structurelock
+    s2a_dispatch_to_pointer_under_structurelock,
+
+    s2a_param_beginendedit,
+    s2a_param_set_value,
+    s2a_param_refresh
 };
 
 /**
@@ -106,6 +111,11 @@ struct SerializationToAudio
 
     // std::variant does not allow an array type and
     // i kinda want this fixed size anyway
+    struct FourUintsFourFloats
+    {
+        uint32_t u[4];
+        float f[4];
+    };
     union Payload
     {
         int32_t i[8];
@@ -113,6 +123,7 @@ struct SerializationToAudio
         float f[8];
         char c[32];
         void *p;
+        FourUintsFourFloats mix;
     } payload{};
 
     enum PayloadType : uint8_t
@@ -122,7 +133,8 @@ struct SerializationToAudio
         UINT,
         FLOAT,
         CHAR,
-        VOID_STAR
+        VOID_STAR,
+        FOUR_FOUR_MIX
     } payloadType{INT};
 };
 

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -120,6 +120,9 @@ enum ClientToSerializationMessagesIds
     c2s_set_macro_full_state,
     c2s_set_macro_value,
 
+    c2s_request_host_callback,
+    c2s_macro_begin_end_edit,
+
     num_clientToSerializationMessages
 };
 

--- a/src/messaging/client/interaction_messages.h
+++ b/src/messaging/client/interaction_messages.h
@@ -72,5 +72,16 @@ inline void processMidiFromGUI(const noteOnOff_t &g, const engine::Engine &engin
     }
 }
 CLIENT_TO_SERIAL(NoteFromGUI, c2s_noteonoff, noteOnOff_t, processMidiFromGUI(payload, engine, cont))
+
+inline void doHostCallback(uint64_t pl, MessageController &cont)
+{
+    if (cont.requestHostCallback)
+    {
+        cont.requestHostCallback(pl);
+    }
+}
+CLIENT_TO_SERIAL(RequestHostCallback, c2s_request_host_callback, uint64_t,
+                 doHostCallback(payload, cont));
+
 } // namespace scxt::messaging::client
 #endif // SHORTCIRCUIT_INTERACTION_MESSAGES_H

--- a/src/messaging/messaging.cpp
+++ b/src/messaging/messaging.cpp
@@ -53,6 +53,17 @@ void MessageController::parseAudioMessageOnSerializationThread(
         serializationSendToClient(client::s2c_send_pgz_structure,
                                   engine.getPartGroupZoneStructure(), *this);
         break;
+    case audio::a2s_macro_updated:
+    {
+        int16_t pt = as.payload.i[0];
+        int16_t idx = as.payload.i[1];
+
+        serializationSendToClient(client::s2c_update_macro_value,
+                                  messaging::client::macroValue_t{
+                                      pt, idx, engine.getPatch()->getPart(pt)->macros[idx].value},
+                                  *this);
+    }
+    break;
     case audio::a2s_processor_refresh:
         SCLOG("Processor Refresh Requestioned. TODO: Minimize this message "
               << (as.payload.i[0] ? "Zone" : "Group") << " slot " << as.payload.i[1]);


### PR DESCRIPTION
- Macros appear as CLAP/VST3/AU parameters
- Lots had to happen to make this work including parameter id math, messages across the queues, implementing the params in clap, and other bits and bobs involving the wrapper. So this is a big diff.
- Biggest differences include engine output audio event queue optionally and robust clap params.
- Some bugs known still include 
  - engine -> ui doesn't throttle at all on automation. OK? 
  - vst3 and auv2 rename doesn't reset param name. CLAP does.