### PR TITLE
Tiny cleanups

### DIFF
--- a/clients/clap-first/scxt-plugin/scxt-plugin.cpp
+++ b/clients/clap-first/scxt-plugin/scxt-plugin.cpp
@@ -552,7 +552,6 @@ void SCXTPlugin::onMainThread() noexcept
     {
         if (_host.canUseParams())
         {
-            SCLOG("Rescanning params");
             _host.paramsRescan(CLAP_PARAM_RESCAN_INFO | CLAP_PARAM_RESCAN_VALUES |
                                CLAP_PARAM_RESCAN_TEXT);
         }

--- a/src-ui/theme/ThemeApplier.cpp
+++ b/src-ui/theme/ThemeApplier.cpp
@@ -209,6 +209,7 @@ void ThemeApplier::applyZoneMultiScreenTheme(juce::Component *toThis)
 void ThemeApplier::applyGroupMultiScreenModulationTheme(juce::Component *toThis)
 {
     jstl::CustomTypeMap map;
+    map.addCustomClass<jcmp::NamedPanel>(detail::multi::group::ModulationNamedPanel);
     map.addCustomClass<jcmp::MultiSwitch>(detail::multi::group::ModulationMultiSwitch);
     map.addCustomClass<jcmp::NamedPanel>(detail::multi::group::NamedPanel);
     map.addCustomClass<jcmp::VSlider>(detail::multi::group::ModulationVSlider);
@@ -484,6 +485,9 @@ void applyColors(const sheet_t::ptr_t &base, const ColorMap &cols)
     base->setColour(ModulationKnob, jcmp::Knob::Styles::value, cols.get(ColorMap::accent_2a));
     base->setColour(ModulationKnob, jcmp::Knob::Styles::value_hover,
                     cols.get(ColorMap::accent_2a).brighter(0.1));
+
+    base->setColour(ModulationNamedPanel, jcmp::NamedPanel::Styles::selectedtab,
+                    cols.get(ColorMap::accent_2a));
 }
 } // namespace group
 } // namespace multi

--- a/src/messaging/client/macro_messages.h
+++ b/src/messaging/client/macro_messages.h
@@ -46,7 +46,6 @@ inline void updateMacroFullState(const macroFullState_t &t, const engine::Engine
                                  MessageController &cont)
 {
     const auto &[p, i, m] = t;
-    SCLOG("ToDo: Rebuild mod matrix when this is called");
     cont.scheduleAudioThreadCallback(
         [part = p, index = i, macro = m](auto &e) {
             // Set everything except the value


### PR DESCRIPTION
- Remove a client log on rescan
- Remove a specious macro rename matrix log message
- Make the group macros tabs accent_2 not 1