### PR TITLE
Throttle engine -> serial -> ui macro update messages

### DIFF
--- a/src-ui/components/SCXTEditor.cpp
+++ b/src-ui/components/SCXTEditor.cpp
@@ -298,7 +298,7 @@ void SCXTEditor::drainCallbackQueue()
 #if BUILD_IS_DEBUG
             inboundMessageCount++;
             inboundMessageBytes += queueMsg.size();
-            if (inboundMessageCount % 100 == 0)
+            if (inboundMessageCount % 500 == 0)
             {
                 SCLOG("Serial -> Client Message Count: "
                       << inboundMessageCount << " size: " << inboundMessageBytes

--- a/src-ui/theme/ThemeApplier.cpp
+++ b/src-ui/theme/ThemeApplier.cpp
@@ -301,7 +301,7 @@ void applyColors(const sheet_t::ptr_t &base, const ColorMap &cols)
     base->setColour(PushButton::styleClass, PushButton::fill_pressed,
                     cols.getHover(ColorMap::bg_1));
 
-    base->setColour(ValueBearing::styleClass, ValueBearing::value, cols.get(ColorMap::accent_1a));
+    base->setColour(ValueBearing::styleClass, ValueBearing::value, cols.get(ColorMap::accent_1b));
     base->setColour(ValueBearing::styleClass, ValueBearing::value_hover,
                     cols.getHover(ColorMap::accent_1a));
     base->setColour(ValueBearing::styleClass, ValueBearing::valuelabel,


### PR DESCRIPTION
bitwig can set a macro every 64 samples.
A ui can show a knob at around 120hz
so we should compress those messages, which we do here in the serializatoin thread.

Closes #1115