### PR TITLE
A concerted short war on annoyances

### DIFF
--- a/src-ui/components/HeaderRegion.cpp
+++ b/src-ui/components/HeaderRegion.cpp
@@ -153,7 +153,10 @@ HeaderRegion::HeaderRegion(SCXTEditor *e) : HasEditor(e)
 
     multiMenuButton = std::make_unique<jcmp::MenuButton>();
     multiMenuButton->setLabel("This is my Super Awesome Multi");
-    multiMenuButton->setOnCallback(comingSoon);
+    multiMenuButton->setOnCallback([w = juce::Component::SafePointer(this)]() {
+        if (w)
+            w->showMultiSelectionMenu();
+    });
     addAndMakeVisible(*multiMenuButton);
 
     cpuLabel = std::make_unique<jcmp::Label>();
@@ -310,6 +313,27 @@ void HeaderRegion::showSaveMenu()
         if (w)
             w->doLoadMulti();
     });
+    p.addSeparator();
+    p.addItem("Reset Engine To Blank", [w = juce::Component::SafePointer(this)]() {
+        if (w)
+        {
+            w->sendToSerialization(cmsg::ResetEngine(true));
+        }
+    });
     p.showMenuAsync(editor->defaultPopupMenuOptions(saveAsButton.get()));
+}
+
+void HeaderRegion::showMultiSelectionMenu()
+{
+    auto p = juce::PopupMenu();
+    p.addSectionHeader("Multis - Coming Soon");
+    p.addSeparator();
+    p.addItem("Reset Engine To Blank", [w = juce::Component::SafePointer(this)]() {
+        if (w)
+        {
+            w->sendToSerialization(cmsg::ResetEngine(true));
+        }
+    });
+    p.showMenuAsync(editor->defaultPopupMenuOptions(multiMenuButton.get()));
 }
 } // namespace scxt::ui

--- a/src-ui/components/HeaderRegion.h
+++ b/src-ui/components/HeaderRegion.h
@@ -111,6 +111,8 @@ struct HeaderRegion : juce::Component, HasEditor, juce::FileDragAndDropTarget
     void doSaveMulti();
     void doLoadMulti();
 
+    void showMultiSelectionMenu();
+
     std::unique_ptr<juce::FileChooser> fileChooser;
 };
 } // namespace scxt::ui

--- a/src-ui/components/multi/MappingPane.cpp
+++ b/src-ui/components/multi/MappingPane.cpp
@@ -1077,7 +1077,7 @@ void MappingZones::mouseDoubleClick(const juce::MouseEvent &e)
         if (ks.contains(e.position))
         {
             // CHECK SPACE HERE
-            display->parentPane->selectTab(1);
+            display->parentPane->selectTab(2);
             return;
         }
     }
@@ -1346,7 +1346,6 @@ void MappingZones::mouseUp(const juce::MouseEvent &e)
     if (mouseState == CREATE_EMPTY_ZONE)
     {
         auto r = juce::Rectangle<float>(firstMousePos, e.position);
-        SCLOG("Creating empty zone " << r.toString());
 
         auto lb = getLocalBounds().toFloat();
         auto displayRegion = lb.withTrimmedBottom(Keyboard::keyboardHeight);
@@ -2866,7 +2865,7 @@ void SampleWaveform::mouseMove(const juce::MouseEvent &e)
 
 void SampleWaveform::mouseDoubleClick(const juce::MouseEvent &e)
 {
-    display->parentPane->selectTab(0);
+    display->parentPane->selectTab(1);
 }
 
 void SampleWaveform::paint(juce::Graphics &g)
@@ -3014,7 +3013,8 @@ MappingPane::MappingPane(SCXTEditor *e) : sst::jucegui::components::NamedPanel("
 {
     hasHamburger = true;
     isTabbed = true;
-    tabNames = {"MAPPING", "SAMPLE", "MACROS"};
+    tabNames = {"MACROS", "MAPPING", "SAMPLE"};
+    selectTab(1);
 
     mappingDisplay = std::make_unique<MappingDisplay>(this);
     addAndMakeVisible(*mappingDisplay);
@@ -3030,9 +3030,9 @@ MappingPane::MappingPane(SCXTEditor *e) : sst::jucegui::components::NamedPanel("
     onTabSelected = [wt = juce::Component::SafePointer(this)](int i) {
         if (wt)
         {
-            wt->mappingDisplay->setVisible(i == 0);
-            wt->sampleDisplay->setVisible(i == 1);
-            wt->macroDisplay->setVisible(i == 2);
+            wt->sampleDisplay->setVisible(i == 2);
+            wt->mappingDisplay->setVisible(i == 1);
+            wt->macroDisplay->setVisible(i == 0);
         }
     };
 }
@@ -3061,9 +3061,10 @@ void MappingPane::setSampleData(const engine::Zone::AssociatedSampleSet &m)
 void MappingPane::setActive(bool b)
 {
     mappingDisplay->setActive(b);
-    mappingDisplay->setVisible(selectedTab == 0);
+    mappingDisplay->setVisible(selectedTab == 1);
     sampleDisplay->setActive(b);
-    sampleDisplay->setVisible(selectedTab == 1);
+    sampleDisplay->setVisible(selectedTab == 2);
+    macroDisplay->setVisible(selectedTab == 0);
 }
 
 void MappingPane::setGroupZoneMappingSummary(const engine::Part::zoneMappingSummary_t &d)

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -666,12 +666,7 @@ void Engine::loadSf2MultiSampleIntoSelectedPart(const fs::path &p)
         auto sf = std::make_unique<sf2::File>(riff.get());
         auto md5 = infrastructure::createMD5SumFromFile(p);
 
-        auto sz = getSelectionManager()->currentLeadZone(*this);
-        auto pt = 0;
-        if (sz.has_value())
-            pt = sz->part;
-        if (pt < 0 || pt >= numParts)
-            pt = 0;
+        auto pt = getSelectionManager()->selectedPart;
 
         auto &part = getPatch()->getPart(pt);
         int firstGroup = -1;
@@ -980,6 +975,9 @@ void Engine::sendFullRefreshToClient() const
                 *(getMessageController()));
         }
     }
+    getSelectionManager()->sendClientDataForLeadSelectionState();
+    getSelectionManager()->sendSelectedZonesToClient();
+    getSelectionManager()->sendSelectedPartMacrosToClient();
 }
 
 void Engine::clearAll()
@@ -1025,4 +1023,5 @@ void Engine::setMacro01ValueFromPlugin(int part, int index, float value01)
     a2s.payload.i[1] = index;
     getMessageController()->sendAudioToSerialization(a2s);
 }
+
 } // namespace scxt::engine

--- a/src/json/selection_traits.h
+++ b/src/json/selection_traits.h
@@ -127,9 +127,12 @@ template <> struct scxt_traits<selection::SelectionManager>
 
         selection::SelectionManager::ZoneAddress za;
 
-        selection::SelectionManager::SelectActionContents sac{z.leadZone[z.selectedPart]};
-        sac.distinct = false;
-        z.selectAction(sac);
+        if (!z.allSelectedZones[z.selectedPart].empty())
+        {
+            selection::SelectionManager::SelectActionContents sac{z.leadZone[z.selectedPart]};
+            sac.distinct = false;
+            z.selectAction(sac);
+        }
     }
 };
 } // namespace scxt::json

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -40,6 +40,7 @@ namespace scxt::messaging::client
 enum ClientToSerializationMessagesIds
 {
     c2s_on_register,
+    c2s_reset_engine,
 
     c2s_unstream_state,
 

--- a/src/messaging/client/interaction_messages.h
+++ b/src/messaging/client/interaction_messages.h
@@ -83,5 +83,19 @@ inline void doHostCallback(uint64_t pl, MessageController &cont)
 CLIENT_TO_SERIAL(RequestHostCallback, c2s_request_host_callback, uint64_t,
                  doHostCallback(payload, cont));
 
+inline void doResetEngine(bool pl, const engine::Engine &e, MessageController &cont)
+{
+    cont.scheduleAudioThreadCallback(
+        [](auto &engine) {
+            engine.stopAllSounds();
+            engine.getPatch()->resetToBlankPatch();
+        },
+        [](auto &engine) {
+            engine.getSelectionManager()->clearAllSelections();
+            engine.sendFullRefreshToClient();
+        });
+}
+CLIENT_TO_SERIAL(ResetEngine, c2s_reset_engine, bool, doResetEngine(payload, engine, cont));
+
 } // namespace scxt::messaging::client
 #endif // SHORTCIRCUIT_INTERACTION_MESSAGES_H

--- a/src/messaging/client/zone_messages.h
+++ b/src/messaging/client/zone_messages.h
@@ -138,8 +138,6 @@ inline void addBlankZone(const addBlankZonePayload_t &payload, engine::Engine &e
                          MessageController &cont)
 {
     auto [part, group, ks, ke, vs, ve] = payload;
-    SCLOG("Adding to part/group " << part << " " << group);
-    SCLOG("Would add zone at " << ks << " " << ke << " " << vs << " " << ve);
     engine.createEmptyZone({ks, ke}, {vs, ve});
 }
 

--- a/src/selection/selection_manager.cpp
+++ b/src/selection/selection_manager.cpp
@@ -747,4 +747,17 @@ void SelectionManager::sendSelectedPartMacrosToClient()
                                   cms::macroFullState_t{selectedPart, i, part->macros[i]},
                                   *(engine.getMessageController()));
 }
+
+void SelectionManager::clearAllSelections()
+{
+    for (auto &s : allSelectedZones)
+        s.clear();
+    for (auto &s : allSelectedGroups)
+        s.clear();
+    for (auto &z : leadZone)
+        z = {};
+    for (auto &g : leadGroup)
+        g = {};
+    selectedPart = 0;
+}
 } // namespace scxt::selection

--- a/src/selection/selection_manager.h
+++ b/src/selection/selection_manager.h
@@ -152,6 +152,7 @@ struct SelectionManager
     void multiSelectAction(const std::vector<SelectActionContents> &v);
     void guaranteeConsistencyAfterDeletes(const engine::Engine &);
     void selectPart(int16_t part);
+    void clearAllSelections();
 
   protected:
     void adjustInternalStateForAction(const SelectActionContents &);
@@ -198,9 +199,6 @@ struct SelectionManager
     std::unordered_map<std::string, std::string> otherTabSelection;
     std::array<selectedZones_t, scxt::numParts> allSelectedZones, allSelectedGroups;
     std::array<ZoneAddress, scxt::numParts> leadZone, leadGroup;
-
-  protected:
-    std::map<size_t, std::set<size_t>> selectedGroupByPart;
 };
 } // namespace scxt::selection
 


### PR DESCRIPTION
- You can reset the engine both in the save and in the multi-load menu. (Need to move that menu but had to hang it somewhere). Closes #156
- With no selected zones, dont try and set a lead zone on unstream which caused a (harmless) error when loading empty patches. Closes #1096
- SF2 into selected part actually uses selected part. Closes #1063
- Rework macro/mapping/sample tabs to match wireframe
- 24 and 32 bit flacs load (only tested 24 though). Closes #406