### PR TITLE
Streaming Upgrades, and mark as Alpha

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -124,8 +124,8 @@ jobs:
         with:
           webhook: ${{ secrets.DISCORD_SHORTCIRCUIT_WEBHOOK }}
           tag: Nightly
-          title: "A New ShortCircuit Nightly is Available"
-          subtitle: "Still pre-alpha! Use care!"
+          title: "A New Shortcircuit XT Nightly is Available"
+          subtitle: "Shortcircuit XT is alpha software. Please use care."
 
 
   publish-scxt-release:

--- a/clients/clap-first/scxt-juce-standalone/scxt-juce-standalone.cpp
+++ b/clients/clap-first/scxt-juce-standalone/scxt-juce-standalone.cpp
@@ -117,6 +117,7 @@ struct SCXTApplicationWindow : juce::DocumentWindow, juce::Button::Listener
         engine->getSampleManager()->purgeUnreferencedSamples();
         try
         {
+            auto sg = scxt::engine::Engine::StreamGuard(scxt::engine::Engine::FOR_DAW);
             auto engineXml = scxt::json::streamEngineState(*engine);
             SCLOG("Streaming State Information: " << engineXml.size() << " bytes");
             properties->setValue("engineState", juce::String(engineXml));

--- a/clients/clap-first/scxt-plugin/scxt-plugin.cpp
+++ b/clients/clap-first/scxt-plugin/scxt-plugin.cpp
@@ -111,6 +111,7 @@ bool SCXTPlugin::stateSave(const clap_ostream *ostream) noexcept
     engine->getSampleManager()->purgeUnreferencedSamples();
     try
     {
+        auto sg = scxt::engine::Engine::StreamGuard(engine::Engine::FOR_DAW);
         auto xml = scxt::json::streamEngineState(*engine);
 
         auto c = xml.c_str();

--- a/clients/juce-plugin/SCXTProcessor.cpp
+++ b/clients/juce-plugin/SCXTProcessor.cpp
@@ -318,6 +318,7 @@ void SCXTProcessor::getStateInformation(juce::MemoryBlock &destData)
     engine->getSampleManager()->purgeUnreferencedSamples();
     try
     {
+        auto sg = scxt::engine::Engine::StreamGuard(scxt::engine::Engine::FOR_DAW);
         auto xml = scxt::json::streamEngineState(*engine);
         SCLOG("Streaming State Information: " << xml.size() << " bytes");
         destData.replaceAll(xml.c_str(), xml.size() + 1);

--- a/resources/NightlyBlurb.md
+++ b/resources/NightlyBlurb.md
@@ -1,4 +1,4 @@
-ShortCircuit XT is a sample-initiated instrument being actively developed by the Surge Synth Team. The build below is our latest pre-alpha github version, but it is very incomplete.
+ShortCircuit XT is a sample-initiated instrument being actively developed by the Surge Synth Team. The build below is our latest alpha github version, but it is very incomplete.
 
 The instrument has many features incomplete, still has unresolved crashing bugs, and may have DSP errors which cause unbounded sound. Still, it is becoming more stable and usable and we do have testers and developers running it.
 
@@ -6,6 +6,7 @@ If you use ShortCircuit a few things of note:
 
 - You may want to use a limiter on the SC bus, in case there is a DSP error, and definitely do not use in-ear headphones
 - Most of the discussion about what works and doesn't happens on our discord. Please join!
-- [This figma document](https://www.figma.com/proto/LWyY0E29tISj1djAp40EDL/ED-SST-Wireframes?node-id=3228-2774&starting-point-node-id=3228%3A2774) serves as a design guide for where we are going
+- [This figma document](https://www.figma.com/proto/LWyY0E29tISj1djAp40EDL/ED-SST-Wireframes?node-id=3228-2774&starting-point-node-id=3228%3A2774)
+  serves as a design guide for where we are going
 - The more the merrier! If you are a dev jump in.
 

--- a/src-ui/components/SCXTEditorMenus.cpp
+++ b/src-ui/components/SCXTEditorMenus.cpp
@@ -95,7 +95,17 @@ void SCXTEditor::showMainMenu()
     auto dp = juce::PopupMenu();
     dp.addSectionHeader("Developer");
     dp.addSeparator();
-    dp.addItem("Pretty JSON", [w = juce::Component::SafePointer(this)]() {
+    dp.addItem("Pretty JSON (DAW)", [w = juce::Component::SafePointer(this)]() {
+        if (!w)
+            return;
+        w->sendToSerialization(cmsg::RequestDebugAction{cmsg::DebugActions::pretty_json_daw});
+    });
+    dp.addItem("Pretty JSON (MULTI)", [w = juce::Component::SafePointer(this)]() {
+        if (!w)
+            return;
+        w->sendToSerialization(cmsg::RequestDebugAction{cmsg::DebugActions::pretty_json_multi});
+    });
+    dp.addItem("Pretty JSON (PROCESS)", [w = juce::Component::SafePointer(this)]() {
         if (!w)
             return;
         w->sendToSerialization(cmsg::RequestDebugAction{cmsg::DebugActions::pretty_json});

--- a/src-ui/components/WelcomeScreen.cpp
+++ b/src-ui/components/WelcomeScreen.cpp
@@ -38,7 +38,7 @@ namespace scxt::ui
 WelcomeScreen::WelcomeScreen(SCXTEditor *e) : HasEditor(e)
 {
     setAccessible(true);
-    setTitle("Welcome to ShortCircuit XT Pre-Alpha. Please use care. Press escape to use sampler.");
+    setTitle("Welcome to ShortCircuit XT Alpha. Please use care. Press escape to use sampler.");
     setWantsKeyboardFocus(true);
 }
 void WelcomeScreen::visibilityChanged()
@@ -64,14 +64,15 @@ void WelcomeScreen::okGotItDontShowAgain()
 }
 
 auto txt =
-    "Shortcircuit XT is in a pre-alpha release. This version has incomplete and "
-    "missing features, may have crashing bugs, may generate improper sounds, and is not streaming "
-    "stable (so saved sessions may not work in the future).\n"
+    "Shortcircuit XT is in a alpha release. This version has incomplete and "
+    "missing features, may have crashing bugs, and may generate improper sounds\n"
     "\n"
     "We welcome testers in this pre-alpha period but recommend a few precautions:\n\n"
     "- Consider using limiter and don't use in-ear headphones when experimenting.\n"
-    "- The platform is not streaming stable; if you make music you like, bounce stems.\n"
     "- There is no missing sample resolution; don't move underlying files.\n"
+    "- We beleive we have both the streaming and Plugin ID/Params stable as of mid Aug 24\n"
+    "   but we could be wrong. If you make music you love, please do bounce stems so you can\n"
+    "   recreate it.\n"
 
     "\n"
     "We love early testers, documenters, and designers on all our projects. The best way to "
@@ -89,7 +90,7 @@ void WelcomeScreen::paint(juce::Graphics &g)
 
     g.fillAll(editor->themeColor(theme::ColorMap::bg_1).withAlpha(0.6f));
 
-    auto bd = r.reduced(140, 130);
+    auto bd = r.reduced(140, 120);
 
     g.setColour(editor->themeColor(theme::ColorMap::bg_1));
     g.fillRect(bd);
@@ -99,8 +100,7 @@ void WelcomeScreen::paint(juce::Graphics &g)
     g.setColour(editor->themeColor(theme::ColorMap::generic_content_highest));
     g.drawText("Welcome to ShortcircuitXT", bd.reduced(10), juce::Justification::centredTop);
     g.setColour(editor->themeColor(theme::ColorMap::warning_1a));
-    g.drawText("Pre-Alpha Release", bd.reduced(10).translated(0, 50),
-               juce::Justification::centredTop);
+    g.drawText("Alpha Release", bd.reduced(10).translated(0, 50), juce::Justification::centredTop);
 
     g.setFont(editor->themeApplier.interLightFor(22));
     g.setColour(editor->themeColor(theme::ColorMap::generic_content_high));

--- a/src-ui/components/WelcomeScreen.h
+++ b/src-ui/components/WelcomeScreen.h
@@ -40,7 +40,7 @@ struct WelcomeScreen : juce::Component, HasEditor
      * If you update this version the user will see the welcome screen
      * on their next startup even if they dismissed a prior version
      */
-    static constexpr int welcomeVersion{1};
+    static constexpr int welcomeVersion{2};
     WelcomeScreen(SCXTEditor *e);
 
     void visibilityChanged() override;

--- a/src-ui/components/mixer/ChannelStrip.h
+++ b/src-ui/components/mixer/ChannelStrip.h
@@ -98,6 +98,11 @@ struct ChannelStrip : public HasEditor, sst::jucegui::components::NamedPanel
     void onDataChanged()
     {
         labelPluginOutput();
+        for (int i = 0; i < numAux; ++i)
+        {
+            if (auxPrePost[i])
+                resetAuxRoutingGlyph(i);
+        }
         repaint();
     }
 

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -33,6 +33,8 @@
 
 namespace scxt
 {
+static constexpr uint64_t currentStreamingVersion{0x2024'08'16};
+
 static constexpr uint16_t blockSize{16};
 static constexpr uint16_t blockSizeQuad{16 >> 2};
 static constexpr double blockSizeInv{1.0 / blockSize};

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -148,6 +148,7 @@ Engine::~Engine()
 }
 
 thread_local bool Engine::isFullEngineUnstream{false};
+thread_local Engine::StreamReason Engine::streamReason{StreamReason::IN_PROCESS};
 thread_local uint64_t Engine::fullEngineUnstreamStreamingVersion{0};
 
 voice::Voice *Engine::initiateVoice(const pathToZone_t &path)

--- a/src/engine/patch.h
+++ b/src/engine/patch.h
@@ -163,10 +163,6 @@ struct Patch : MoveableOnly<Patch>, SampleRateSupport
 
     void resetToBlankPatch()
     {
-        // If it is the year 2112 and you just had a regtest fail because
-        // this is earlier than the streaming version you just changed, then
-        // this software lived too long
-        streamingVersion = 0x2112'01'01;
         for (int i = 0; i < numParts; ++i)
         {
             parts[i] = std::make_unique<Part>(i);
@@ -178,7 +174,6 @@ struct Patch : MoveableOnly<Patch>, SampleRateSupport
     bool usesOutputBus(int bus) { return busses.usesOutput[bus]; }
     void setupBussesOnUnstream(Engine &e);
     PatchID id;
-    uint64_t streamingVersion{0}; // we use hex dates for these
 
     Engine *parentEngine{nullptr};
 

--- a/src/engine/zone.h
+++ b/src/engine/zone.h
@@ -202,7 +202,7 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
 
         int16_t pbDown{2}, pbUp{2};
 
-        int16_t exclusiveGroup;
+        int16_t exclusiveGroup{0};
 
         float velocitySens{1.0};
         float amplitude{0.0};   // decibels

--- a/src/json/datamodel_traits.h
+++ b/src/json/datamodel_traits.h
@@ -40,59 +40,60 @@ namespace scxt::json
 {
 
 SC_STREAMDEF(datamodel::pmd, SC_FROM({
+                 assert(SC_STREAMING_FOR_IN_PROCESS);
                  std::vector<std::pair<int, std::string>> dvStream;
                  for (const auto &[k, mv] : t.discreteValues)
                      dvStream.emplace_back(k, mv);
 
-                 v = {{"type", (int)t.type},
-                      {"name", t.name},
-                      {"minVal", t.minVal},
-                      {"maxVal", t.maxVal},
-                      {"defaultVal", t.defaultVal},
-                      {"canTemposync", t.canTemposync},
-                      {"canExtend", t.canExtend},
-                      {"canDeactivate", t.canDeactivate},
-                      {"canAbsolute", t.canAbsolute},
-                      {"temposyncMultiplier", t.temposyncMultiplier},
-                      {"supportsStringConversion", t.supportsStringConversion},
-                      {"displayScale", (int)t.displayScale},
+                 v = {{"t", (int)t.type},
+                      {"n", t.name},
+                      {"mn", t.minVal},
+                      {"mx", t.maxVal},
+                      {"df", t.defaultVal},
+                      {"ts", t.canTemposync},
+                      {"ex", t.canExtend},
+                      {"de", t.canDeactivate},
+                      {"ab", t.canAbsolute},
+                      {"tsm", t.temposyncMultiplier},
+                      {"ssc", t.supportsStringConversion},
+                      {"dsc", (int)t.displayScale},
                       {"unit", t.unit},
-                      {"customMinDisplay", t.customMinDisplay},
-                      {"customMaxDisplay", t.customMaxDisplay},
-                      {"discreteValues", dvStream},
-                      {"decimalPlaces", t.decimalPlaces},
-                      {"quantization", (int)t.quantization},
-                      {"quantizationParam", t.quantizationParam},
+                      {"qt", (int)t.quantization},
+                      {"qtp", t.quantizationParam},
+                      {"cmid", t.customMinDisplay},
+                      {"cmxd", t.customMaxDisplay},
+                      {"discv", dvStream},
+                      {"dep", t.decimalPlaces},
                       {"svA", t.svA},
                       {"svB", t.svB},
                       {"svC", t.svC},
                       {"svD", t.svD}};
              }),
              SC_TO({
-                 findEnumIf(v, "type", to.type);
-                 findIf(v, "name", to.name);
-                 findIf(v, "minVal", to.minVal);
-                 findIf(v, "maxVal", to.maxVal);
-                 findIf(v, "defaultVal", to.defaultVal);
-                 findIf(v, "canTemposync", to.canTemposync);
-                 findIf(v, "canDeactivate", to.canDeactivate);
-                 findIf(v, "canExtend", to.canExtend);
-                 findIf(v, "canAbsolute", to.canAbsolute);
-                 findIf(v, "temposyncMultiplier", to.temposyncMultiplier);
-                 findIf(v, "supportsStringConversion", to.supportsStringConversion);
-                 findEnumIf(v, "displayScale", to.displayScale);
-                 findEnumIf(v, "quantization", to.quantization);
-                 findIf(v, "quantizationParam", to.quantizationParam);
+                 findEnumIf(v, "t", to.type);
+                 findIf(v, "n", to.name);
+                 findIf(v, "mn", to.minVal);
+                 findIf(v, "mx", to.maxVal);
+                 findIf(v, "df", to.defaultVal);
+                 findIf(v, "ts", to.canTemposync);
+                 findIf(v, "de", to.canDeactivate);
+                 findIf(v, "ex", to.canExtend);
+                 findIf(v, "ab", to.canAbsolute);
+                 findIf(v, "tsm", to.temposyncMultiplier);
+                 findIf(v, "ssc", to.supportsStringConversion);
+                 findEnumIf(v, "dsc", to.displayScale);
+                 findEnumIf(v, "qt", to.quantization);
+                 findIf(v, "qtp", to.quantizationParam);
                  findIf(v, "unit", to.unit);
-                 findIf(v, "customMinDisplay", to.customMinDisplay);
-                 findIf(v, "customMaxDisplay", to.customMaxDisplay);
+                 findIf(v, "cmid", to.customMinDisplay);
+                 findIf(v, "cmxd", to.customMaxDisplay);
 
                  std::vector<std::pair<int, std::string>> dvStream;
-                 findIf(v, "discreteValues", dvStream);
+                 findIf(v, "discv", dvStream);
                  for (const auto &[k, mv] : dvStream)
                      to.discreteValues[k] = mv;
 
-                 findIf(v, "decimalPlaces", to.decimalPlaces);
+                 findIf(v, "dep", to.decimalPlaces);
                  findIf(v, "svA", to.svA);
                  findIf(v, "svB", to.svB);
                  findIf(v, "svC", to.svC);

--- a/src/json/dsp_traits.h
+++ b/src/json/dsp_traits.h
@@ -43,7 +43,7 @@ SC_STREAMDEF(scxt::dsp::processor::ProcessorStorage, SC_FROM({
                  auto &t = from;
                  if (t.type == dsp::processor::proct_none)
                  {
-                     v = {{"type", scxt::dsp::processor::getProcessorStreamingName(t.type)}};
+                     v = tao::json::empty_object;
                  }
                  else
                  {
@@ -62,8 +62,13 @@ SC_STREAMDEF(scxt::dsp::processor::ProcessorStorage, SC_FROM({
                  auto &result = to;
                  const auto &object = v.get_object();
 
-                 auto optType = scxt::dsp::processor::fromProcessorStreamingName(
-                     v.at("type").template as<std::string>());
+                 std::string type;
+                 findOrSet(
+                     v, {"t", "type"},
+                     scxt::dsp::processor::getProcessorStreamingName(dsp::processor::proct_none),
+                     type);
+
+                 auto optType = scxt::dsp::processor::fromProcessorStreamingName(type);
 
                  if (optType.has_value())
                      result.type = *optType;

--- a/src/json/modulation_traits.h
+++ b/src/json/modulation_traits.h
@@ -55,50 +55,67 @@ SC_STREAMDEF(scxt::modulation::modulators::StepLFOStorage, SC_FROM({
              }))
 
 SC_STREAMDEF(scxt::modulation::modulators::CurveLFOStorage, SC_FROM({
-                 v = {{"deform", t.deform},   {"delay", t.delay},       {"attack", t.attack},
-                      {"release", t.release}, {"unipolar", t.unipolar}, {"useenv", t.useenv}};
+                 v = tao::json::empty_object;
+                 addUnlessDefault<val_t>(v, "attack", 0.f, from.attack);
+                 addUnlessDefault<val_t>(v, "deform", 0.f, from.deform);
+                 addUnlessDefault<val_t>(v, "delay", 0.f, from.delay);
+                 addUnlessDefault<val_t>(v, "release", 0.f, from.release);
+                 addUnlessDefault<val_t>(v, "unipolar", false, from.unipolar);
+                 addUnlessDefault<val_t>(v, "useenv", false, from.useenv);
              }),
              SC_TO({
                  const auto &object = v.get_object();
-                 findIf(v, "deform", result.deform);
-                 findIf(v, "delay", result.delay);
-                 findIf(v, "attack", result.attack);
-                 findIf(v, "release", result.release);
-                 findIf(v, "unipolar", result.unipolar);
-                 findIf(v, "useenv", result.useenv);
+                 findOrSet(v, "deform", 0.f, result.deform);
+                 findOrSet(v, "delay", 0.f, result.delay);
+                 findOrSet(v, "attack", 0.f, result.attack);
+                 findOrSet(v, "release", 0.f, result.release);
+                 findOrSet(v, "unipolar", false, result.unipolar);
+                 findOrSet(v, "useenv", false, result.useenv);
              }))
 
 SC_STREAMDEF(scxt::modulation::modulators::EnvLFOStorage, SC_FROM({
-                 v = {{"deform", t.deform},  {"delay", t.delay}, {"attack", t.attack},
-                      {"hold", t.hold},      {"decay", t.decay}, {"sustain", t.sustain},
-                      {"release", t.release}};
+                 v = tao::json::empty_object;
+                 addUnlessDefault<val_t>(v, "attack", 0.f, from.attack);
+                 addUnlessDefault<val_t>(v, "decay", 0.f, from.decay);
+                 addUnlessDefault<val_t>(v, "deform", 0.f, from.deform);
+                 addUnlessDefault<val_t>(v, "delay", 0.f, from.delay);
+                 addUnlessDefault<val_t>(v, "hold", 0.f, from.hold);
+                 addUnlessDefault<val_t>(v, "release", 0.f, from.release);
+                 addUnlessDefault<val_t>(v, "sustain", 1.f, from.sustain);
              }),
              SC_TO({
                  const auto &object = v.get_object();
-                 findIf(v, "deform", result.deform);
-                 findIf(v, "delay", result.delay);
-                 findIf(v, "attack", result.attack);
-                 findIf(v, "hold", result.hold);
-                 findIf(v, "decay", result.decay);
-                 findIf(v, "sustain", result.sustain);
-                 findIf(v, "release", result.release);
+                 findOrSet(v, "deform", 0.f, result.deform);
+                 findOrSet(v, "delay", 0.f, result.delay);
+                 findOrSet(v, "attack", 0.f, result.attack);
+                 findOrSet(v, "hold", 0.f, result.hold);
+                 findOrSet(v, "decay", 0.f, result.decay);
+                 findOrSet(v, "sustain", 1.f, result.sustain);
+                 findOrSet(v, "release", 0.f, result.release);
              }))
 
 SC_STREAMDEF(modulation::modulators::AdsrStorage, SC_FROM({
-                 v = {{"a", t.a},           {"h", t.h},           {"d", t.d},
-                      {"s", t.s},           {"r", t.r},           {"isDigital", t.isDigital},
-                      {"aShape", t.aShape}, {"dShape", t.dShape}, {"rShape", t.rShape}};
+                 v = tao::json::empty_object;
+                 addUnlessDefault<val_t>(v, "a", 0.f, from.a);
+                 addUnlessDefault<val_t>(v, "d", 0.f, from.d);
+                 addUnlessDefault<val_t>(v, "h", 0.f, from.h);
+                 addUnlessDefault<val_t>(v, "s", 1.f, from.s);
+                 addUnlessDefault<val_t>(v, "r", 0.5f, from.r);
+                 addUnlessDefault<val_t>(v, "aShape", 0.f, from.aShape);
+                 addUnlessDefault<val_t>(v, "dShape", 0.f, from.dShape);
+                 addUnlessDefault<val_t>(v, "rShape", 0.f, from.rShape);
+                 addUnlessDefault<val_t>(v, "isDigital", true, from.isDigital);
              }),
              SC_TO({
-                 findIf(v, "a", result.a);
-                 findIf(v, "h", result.h);
-                 findIf(v, "d", result.d);
-                 findIf(v, "s", result.s);
-                 findIf(v, "r", result.r);
-                 findIf(v, "isDigital", result.isDigital);
-                 findIf(v, "aShape", result.aShape);
-                 findIf(v, "dShape", result.dShape);
-                 findIf(v, "rShape", result.rShape);
+                 findOrSet(v, "a", 0.f, result.a);
+                 findOrSet(v, "h", 0.f, result.h);
+                 findOrSet(v, "d", 0.f, result.d);
+                 findOrSet(v, "s", 1.f, result.s);
+                 findOrSet(v, "r", 0.5f, result.r);
+                 findOrSet(v, "isDigital", true, result.isDigital);
+                 findOrSet(v, "aShape", 0.f, result.aShape);
+                 findOrSet(v, "dShape", 0.f, result.dShape);
+                 findOrSet(v, "rShape", 0.f, result.rShape);
              }))
 
 STREAM_ENUM(modulation::ModulatorStorage::ModulatorShape,
@@ -166,15 +183,20 @@ SC_STREAMDEF(scxt::modulation::shared::RoutingExtraPayload, SC_FROM({
 // Its a mild bummer we have to dup this for group and zone but they differ by trait so have
 // distinct types Ahh well. Fixable with an annoying refactor but leave it for now
 SC_STREAMDEF(scxt::voice::modulation::Matrix::RoutingTable::Routing, SC_FROM({
-                 v = {{"active", t.active},
-                      {"source", t.source},
-                      {"sourceVia", t.sourceVia},
-                      {"target", t.target},
-                      {"curve", t.curve},
-                      {"depth", t.depth},
-                      {"extraPayload", t.extraPayload}};
+                 if (t.hasDefaultValues())
+                 {
+                     v = tao::json::empty_object;
+                 }
+                 else
+                 {
+                     v = {{"active", t.active}, {"source", t.source}, {"sourceVia", t.sourceVia},
+                          {"target", t.target}, {"curve", t.curve},   {"depth", t.depth}};
+                     if (SC_STREAMING_FOR_IN_PROCESS)
+                         addToObject<val_t>(v, "extraPayload", t.extraPayload);
+                 }
              }),
              SC_TO({
+                 result = rt_t();
                  findIf(v, "active", result.active);
                  findIf(v, "source", result.source);
                  findIf(v, "sourceVia", result.sourceVia);
@@ -198,15 +220,20 @@ SC_STREAMDEF(scxt::voice::modulation::Matrix::RoutingTable, SC_FROM({
              }));
 
 SC_STREAMDEF(scxt::modulation::GroupMatrix::RoutingTable::Routing, SC_FROM({
-                 v = {{"active", t.active},
-                      {"source", t.source},
-                      {"sourceVia", t.sourceVia},
-                      {"target", t.target},
-                      {"curve", t.curve},
-                      {"depth", t.depth},
-                      {"extraPayload", t.extraPayload}};
+                 if (t.hasDefaultValues())
+                 {
+                     v = tao::json::empty_object;
+                 }
+                 else
+                 {
+                     v = {{"active", t.active}, {"source", t.source}, {"sourceVia", t.sourceVia},
+                          {"target", t.target}, {"curve", t.curve},   {"depth", t.depth}};
+                     if (SC_STREAMING_FOR_IN_PROCESS)
+                         addToObject<val_t>(v, "extraPayload", t.extraPayload);
+                 }
              }),
              SC_TO({
+                 result = rt_t();
                  findIf(v, "active", result.active);
                  findIf(v, "source", result.source);
                  findIf(v, "sourceVia", result.sourceVia);

--- a/src/json/stream.h
+++ b/src/json/stream.h
@@ -30,12 +30,10 @@
 
 #include "engine/patch.h"
 #include "engine/engine.h"
+#include "configuration.h"
 
 namespace scxt::json
 {
-
-static constexpr uint64_t currentStreamingVersion{0x2024'08'06};
-
 std::string streamPatch(const engine::Patch &p, bool pretty = false);
 std::string streamEngineState(const engine::Engine &e, bool pretty = false);
 void unstreamEngineState(engine::Engine &e, const std::string &jsonData, bool msgPack = false);

--- a/src/json/utils_traits.h
+++ b/src/json/utils_traits.h
@@ -37,6 +37,9 @@
 
 namespace scxt::json
 {
+/*
+ * Leave this one un-convererd to SC_STREAMDEF because of the double template
+ */
 template <int idType> struct scxt_traits<ID<idType>>
 {
     template <template <typename...> class Traits>

--- a/src/messaging/client/debug_messages.h
+++ b/src/messaging/client/debug_messages.h
@@ -48,6 +48,8 @@ SERIAL_TO_CLIENT(DebugInfoGenerated, s2c_send_debug_info, debugResponse_t, onDeb
 struct DebugActions
 {
     static constexpr const char *pretty_json{"pretty_json"};
+    static constexpr const char *pretty_json_daw{"pretty_json_daw"};
+    static constexpr const char *pretty_json_multi{"pretty_json_multi"};
     static constexpr const char *pretty_json_part{"pretty_json_part"};
 };
 
@@ -62,10 +64,24 @@ inline void dbto_pretty_stream(std::ostream &os, const tao::json::basic_value<Tr
 inline void doDebugAction(const std::string &payload, const engine::Engine &engine,
                           MessageController &cont)
 {
-    if (payload == DebugActions::pretty_json)
+    if (payload == DebugActions::pretty_json || payload == DebugActions::pretty_json_daw ||
+        payload == DebugActions::pretty_json_multi)
     {
+        auto sr = scxt::engine::Engine::StreamReason::IN_PROCESS;
+        if (payload == DebugActions::pretty_json_multi)
+        {
+            sr = engine::Engine::FOR_MULTI;
+        }
+        if (payload == DebugActions::pretty_json_daw)
+        {
+            sr = engine::Engine::FOR_DAW;
+        }
+        auto g = scxt::engine::Engine::StreamGuard(sr);
         auto res = scxt::json::streamEngineState(engine, true);
         SCLOG(res);
+
+        auto nopres = scxt::json::streamEngineState(engine, false);
+        SCLOG("Non-pretty engine state size " << nopres.size());
     }
     else if (payload == DebugActions::pretty_json_part)
     {

--- a/src/patch_io/patch_io.cpp
+++ b/src/patch_io/patch_io.cpp
@@ -90,6 +90,7 @@ bool saveMulti(const fs::path &p, const scxt::engine::Engine &e)
 
     try
     {
+        auto sg = scxt::engine::Engine::StreamGuard(engine::Engine::FOR_MULTI);
         auto msg = tao::json::msgpack::to_string(json::scxt_value(e));
 
         auto f = std::make_unique<RIFF::File>('SCXT');

--- a/src/utils.h
+++ b/src/utils.h
@@ -327,6 +327,11 @@ inline bool extensionMatches(const fs::path &p, const std::string &s)
     };
     return std::equal(pes.begin(), pes.end(), s.begin(), cic);
 }
+
+inline std::string humanReadableVersion(uint64_t v)
+{
+    return fmt::format("{:04x}-{:02x}-{:02x}", (v >> 16) & 0xFFFF, (v >> 8) & 0xFF, v & 0xFF);
+}
 } // namespace scxt
 
 // Make the ID hashable so we can use it as a map key


### PR DESCRIPTION
This commit is a large commit which provides us the tooling so we can more efficiently make and modify streams for appropriate situation, and does a bunch of work to optimize our stream. (A mid sized patch shrunk by half with these changed).

It's a large change which closes #1069 and should allow us to be streaming stable from hereon out. At least that's the plan!

- Make -1/-1/-1 Zone Address stream as {}
- Processor Storage none is streamed as {} now
- Zone::AssociatedSampleData inactive -> {}
- Move current streaming version to configuration.,h
- Remove the extra streaming version variable on patch
- Have a human readable streaming version fn and include it in engine json and log messages
- Add capability to support streaming an enum with default, but be careful
- Use that on bus aux
- Fix a channel strip display bug that it didn't show the routing on refresh properly
- Use default routing row to shrink stream size / parse time
- Add a "StreamReason" like "Unstream" data which lets you know if you are streaming for process, daw or multi
- Don't send route extraPalyload for daw or multi
- Move the streamguards into engine next to the thread local states
- Add template functions to add and addUnlessDefault for an object
- Bus mute solo pan and level default stream
- Stream sample udpate and up streaming version for big streamathon
- Move to SC_STREAMDEF everywhere (except ID for reasons)
- Compact a whole bunch of keys and do some optionals
- Some more key compaction
- Finally, Pre-Alpha to Alpha

Closes #1069