### PR TITLE
Tab State in Selection manager

### DIFF
--- a/src-ui/components/HeaderRegion.cpp
+++ b/src-ui/components/HeaderRegion.cpp
@@ -336,4 +336,5 @@ void HeaderRegion::showMultiSelectionMenu()
     });
     p.showMenuAsync(editor->defaultPopupMenuOptions(multiMenuButton.get()));
 }
+
 } // namespace scxt::ui

--- a/src-ui/components/MixerScreen.cpp
+++ b/src-ui/components/MixerScreen.cpp
@@ -114,6 +114,7 @@ void MixerScreen::selectBus(int index)
         b->setSelected(false);
     }
     busPane->channelStrips[index]->selected = true;
+    editor->setTabSelection("mixer_screen", std::to_string(index));
     repaint();
 }
 
@@ -194,6 +195,19 @@ void MixerScreen::setVULevelForBusses(
     for (const auto &[i, cs] : sst::cpputils::enumerate(busPane->channelStrips))
     {
         cs->setVULevel(x[i][0], x[i][1]);
+    }
+}
+
+void MixerScreen::onOtherTabSelection()
+{
+    auto bs = editor->queryTabSelection("mixer_screen");
+    if (!bs.empty())
+    {
+        auto v = std::atoi(bs.c_str());
+        if (v >= 0 && v < busPane->channelStrips.size())
+        {
+            selectBus(v);
+        }
     }
 }
 

--- a/src-ui/components/MixerScreen.h
+++ b/src-ui/components/MixerScreen.h
@@ -87,6 +87,8 @@ struct MixerScreen : juce::Component, HasEditor
 
     void setVULevelForBusses(
         const std::array<std::array<std::atomic<float>, 2>, engine::Patch::Busses::busCount> &x);
+
+    void onOtherTabSelection();
 };
 } // namespace scxt::ui
 #endif // SHORTCIRCUIT_SENDFXSCREEN_H

--- a/src-ui/components/MultiScreen.cpp
+++ b/src-ui/components/MultiScreen.cpp
@@ -236,6 +236,44 @@ void MultiScreen::ZoneOrGroupElements<ZGTrait>::layoutInto(const juce::Rectangle
     lfo->setBounds(envRect.withWidth(ew * 2).translated(ew * 2, 0));
 }
 
+void MultiScreen::onOtherTabSelection()
+{
+    auto pgz = editor->queryTabSelection(tabKey("multi.pgz"));
+    if (pgz.empty())
+    {
+    }
+    if (pgz == "part")
+        parts->setSelectedTab(0);
+    else if (pgz == "group")
+        parts->setSelectedTab(1);
+    else if (pgz == "zone")
+        parts->setSelectedTab(2);
+    else
+        SCLOG("Unknown multi.pgz key " << pgz);
+
+    auto gts = editor->queryTabSelection(tabKey("multi.group.lfo"));
+    if (!gts.empty())
+    {
+        auto gt = std::atoi(gts.c_str());
+        if (gt >= 0 && gt < lfosPerGroup)
+            groupElements->lfo->selectTab(gt);
+    }
+    auto zts = editor->queryTabSelection(tabKey("multi.zone.lfo"));
+    if (!zts.empty())
+    {
+        auto zt = std::atoi(zts.c_str());
+        if (zt >= 0 && zt < lfosPerZone)
+            zoneElements->lfo->selectTab(zt);
+    }
+    auto mts = editor->queryTabSelection(tabKey("multi.mapping"));
+    if (!mts.empty())
+    {
+        auto mt = std::atoi(mts.c_str());
+        if (mt >= 0 && mt < 3)
+            sample->setSelectedTab(mt);
+    }
+}
+
 template struct MultiScreen::ZoneOrGroupElements<typename MultiScreen::ZoneTraits>;
 template struct MultiScreen::ZoneOrGroupElements<typename MultiScreen::GroupTraits>;
 } // namespace scxt::ui

--- a/src-ui/components/MultiScreen.h
+++ b/src-ui/components/MultiScreen.h
@@ -131,6 +131,11 @@ struct MultiScreen : juce::Component, HasEditor
     } selectionMode{SelectionMode::NONE};
     void setSelectionMode(SelectionMode m);
 
+    void onOtherTabSelection();
+    // This allows us, in the future, to make this return s + selected part to have
+    // part differentiated selection
+    std::string tabKey(const std::string &s) { return s; }
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MultiScreen);
 };
 } // namespace scxt::ui

--- a/src-ui/components/SCXTEditor.cpp
+++ b/src-ui/components/SCXTEditor.cpp
@@ -129,12 +129,14 @@ void SCXTEditor::setActiveScreen(ActiveScreen s)
     activeScreen = s;
     aboutScreen->setVisible(false);
     logScreen->setVisible(false);
+    std::string val{};
     switch (s)
     {
     case MULTI:
         multiScreen->setVisible(true);
         mixerScreen->setVisible(false);
         playScreen->setVisible(false);
+        val = "multi";
         resized();
         break;
 
@@ -142,6 +144,7 @@ void SCXTEditor::setActiveScreen(ActiveScreen s)
         multiScreen->setVisible(false);
         mixerScreen->setVisible(true);
         playScreen->setVisible(false);
+        val = "mixer";
         resized();
         break;
 
@@ -149,9 +152,12 @@ void SCXTEditor::setActiveScreen(ActiveScreen s)
         multiScreen->setVisible(false);
         mixerScreen->setVisible(false);
         playScreen->setVisible(true);
+        val = "play";
         resized();
         break;
     }
+
+    setTabSelection("main_screen", val);
     repaint();
 }
 
@@ -415,4 +421,16 @@ void SCXTEditor::resetColorsFromUserPreferences()
     themeApplier.recolorStylesheetWith(std::move(cm), style());
 }
 
+std::string SCXTEditor::queryTabSelection(const std::string &k)
+{
+    auto p = otherTabSelection.find(k);
+    if (p != otherTabSelection.end())
+        return p->second;
+    return {};
+}
+
+void SCXTEditor::setTabSelection(const std::string &k, const std::string &t)
+{
+    sendToSerialization(messaging::client::UpdateOtherTabSelection({k, t}));
+}
 } // namespace scxt::ui

--- a/src-ui/components/SCXTEditor.h
+++ b/src-ui/components/SCXTEditor.h
@@ -201,6 +201,11 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::DragAndDropCont
     void onSelectedPart(const int16_t);
     int16_t getSelectedPart() const;
 
+    selection::SelectionManager::otherTabSelection_t otherTabSelection;
+    void onOtherTabSelection(const scxt::selection::SelectionManager::otherTabSelection_t &p);
+    std::string queryTabSelection(const std::string &k);
+    void setTabSelection(const std::string &k, const std::string &t);
+
     void onMixerBusEffectFullData(const scxt::messaging::client::busEffectFullData_t &);
     void onMixerBusSendData(const scxt::messaging::client::busSendData_t &);
 

--- a/src-ui/components/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/components/SCXTEditorResponseHandlers.cpp
@@ -288,6 +288,8 @@ void SCXTEditor::onSelectedPart(const int16_t p)
         multiScreen->parts->selectedPartChanged();
     if (multiScreen && multiScreen->sample)
         multiScreen->sample->selectedPartChanged();
+    if (multiScreen)
+        multiScreen->onOtherTabSelection();
 
     repaint();
 }
@@ -349,5 +351,42 @@ void SCXTEditor::onMacroValue(const scxt::messaging::client::macroValue_t &s)
     macroCache[part][index].value = value;
     multiScreen->sample->repaint();
     playScreen->repaint();
+}
+
+void SCXTEditor::onOtherTabSelection(
+    const scxt::selection::SelectionManager::otherTabSelection_t &p)
+{
+    otherTabSelection = p;
+
+    auto mainScreen = queryTabSelection("main_screen");
+    if (mainScreen.empty())
+    {
+    }
+    else if (mainScreen == "mixer")
+    {
+        setActiveScreen(MIXER);
+    }
+    else if (mainScreen == "multi")
+    {
+        setActiveScreen(MULTI);
+    }
+    else if (mainScreen == "play")
+    {
+        setActiveScreen(PLAY);
+    }
+    else
+    {
+        SCLOG("Unknown main screen " << mainScreen);
+    }
+
+    if (mixerScreen)
+    {
+        mixerScreen->onOtherTabSelection();
+    }
+
+    if (multiScreen)
+    {
+        multiScreen->onOtherTabSelection();
+    }
 }
 } // namespace scxt::ui

--- a/src-ui/components/multi/LFOPane.cpp
+++ b/src-ui/components/multi/LFOPane.cpp
@@ -40,6 +40,7 @@
 
 // Included so we can have UI-thread exceution for curve rendering
 #include "modulation/modulators/steplfo.h"
+#include "components/MultiScreen.h"
 
 namespace scxt::ui::multi
 {
@@ -712,6 +713,8 @@ void LfoPane::tabChanged(int i)
 {
     getContentAreaComponent()->removeAllChildren();
     rebuildPanelComponents();
+    auto kn = std::string("multi") + (forZone ? ".zone.lfo" : ".group.lfo");
+    editor->setTabSelection(editor->multiScreen->tabKey(kn), std::to_string(i));
 }
 
 void LfoPane::setActive(int i, bool b)

--- a/src-ui/components/multi/MappingPane.cpp
+++ b/src-ui/components/multi/MappingPane.cpp
@@ -27,6 +27,7 @@
 
 #include "MappingPane.h"
 #include "components/SCXTEditor.h"
+#include "components/MultiScreen.h"
 #include "components/multi/SingleMacroEditor.h"
 #include "datamodel/metadata.h"
 #include "selection/selection_manager.h"
@@ -2414,7 +2415,7 @@ struct SampleDisplay : juce::Component, HasEditor
             for (const auto &entry : fs::directory_iterator(parent_path))
             {
                 if (entry.is_regular_file() &&
-                    browser::Browser::isLoadableSingleSample(entry.path()))
+                    scxt::browser::Browser::isLoadableSingleSample(entry.path()))
                 {
                     v.push_back(entry.path().u8string());
                 }
@@ -2455,7 +2456,7 @@ struct SampleDisplay : juce::Component, HasEditor
     void showFileBrowser()
     {
         std::string filePattern;
-        for (auto s : browser::Browser::LoadableFile::singleSample)
+        for (auto s : scxt::browser::Browser::LoadableFile::singleSample)
         {
             filePattern += "*" + s + ",";
         }
@@ -3030,14 +3031,25 @@ MappingPane::MappingPane(SCXTEditor *e) : sst::jucegui::components::NamedPanel("
     onTabSelected = [wt = juce::Component::SafePointer(this)](int i) {
         if (wt)
         {
-            wt->sampleDisplay->setVisible(i == 2);
-            wt->mappingDisplay->setVisible(i == 1);
-            wt->macroDisplay->setVisible(i == 0);
+            wt->setSelectedTab(i);
         }
     };
 }
 
 MappingPane::~MappingPane() {}
+
+void MappingPane::setSelectedTab(int i)
+{
+    if (i < 0 || i > 2)
+        return;
+    selectedTab = i;
+    sampleDisplay->setVisible(i == 2);
+    mappingDisplay->setVisible(i == 1);
+    macroDisplay->setVisible(i == 0);
+
+    repaint();
+    editor->setTabSelection(editor->multiScreen->tabKey("multi.mapping"), std::to_string(i));
+}
 
 void MappingPane::resized()
 {

--- a/src-ui/components/multi/MappingPane.h
+++ b/src-ui/components/multi/MappingPane.h
@@ -55,6 +55,7 @@ struct MappingPane : sst::jucegui::components::NamedPanel, HasEditor
     void macroDataChanged(int part, int index);
     void editorSelectionChanged();
     void setActive(bool b);
+    void setSelectedTab(int i);
 
     std::unique_ptr<MappingDisplay> mappingDisplay;
     std::unique_ptr<SampleDisplay> sampleDisplay;

--- a/src-ui/components/multi/PartGroupSidebar.cpp
+++ b/src-ui/components/multi/PartGroupSidebar.cpp
@@ -364,18 +364,7 @@ PartGroupSidebar::PartGroupSidebar(SCXTEditor *e)
         if (!w->partSidebar || !w->groupSidebar || !w->zoneSidebar)
             return;
 
-        bool p = (t == 0), g = (t == 1), z = (t == 2);
-        w->partSidebar->setVisible(p);
-        w->groupSidebar->setVisible(g);
-        w->zoneSidebar->setVisible(z);
-
-        w->editor->multiScreen->setSelectionMode(g ? MultiScreen::SelectionMode::GROUP
-                                                   : MultiScreen::SelectionMode::ZONE);
-
-        if (g)
-            w->editor->themeApplier.applyGroupMultiScreenTheme(w);
-        else
-            w->editor->themeApplier.applyZoneMultiScreenTheme(w);
+        w->setSelectedTab(t);
     };
     resetTabState();
 
@@ -453,6 +442,27 @@ void PartGroupSidebar::editorSelectionChanged()
     {
         zoneSidebar->updateSelection();
     }
+    repaint();
+}
+
+void PartGroupSidebar::setSelectedTab(int t)
+{
+    selectedTab = t;
+    bool p = (t == 0), g = (t == 1), z = (t == 2);
+    partSidebar->setVisible(p);
+    groupSidebar->setVisible(g);
+    zoneSidebar->setVisible(z);
+
+    editor->multiScreen->setSelectionMode(g ? MultiScreen::SelectionMode::GROUP
+                                            : MultiScreen::SelectionMode::ZONE);
+
+    if (g)
+        editor->themeApplier.applyGroupMultiScreenTheme(this);
+    else
+        editor->themeApplier.applyZoneMultiScreenTheme(this);
+
+    editor->setTabSelection(editor->multiScreen->tabKey("multi.pgz"),
+                            (t == 0 ? "part" : (t == 1 ? "group" : "zone")));
     repaint();
 }
 } // namespace scxt::ui::multi

--- a/src-ui/components/multi/PartGroupSidebar.h
+++ b/src-ui/components/multi/PartGroupSidebar.h
@@ -52,6 +52,8 @@ struct PartGroupSidebar : sst::jucegui::components::NamedPanel, HasEditor
     void selectParts() {}
     void selectGroups() {}
 
+    void setSelectedTab(int t); // part / group / zone
+
     std::unique_ptr<ZoneSidebar> zoneSidebar;
     std::unique_ptr<GroupSidebar> groupSidebar;
     std::unique_ptr<PartSidebar> partSidebar;

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -979,6 +979,7 @@ void Engine::sendFullRefreshToClient() const
     getSelectionManager()->sendClientDataForLeadSelectionState();
     getSelectionManager()->sendSelectedZonesToClient();
     getSelectionManager()->sendSelectedPartMacrosToClient();
+    getSelectionManager()->sendOtherTabsSelectionToClient();
 }
 
 void Engine::clearAll()

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -124,6 +124,8 @@ enum ClientToSerializationMessagesIds
     c2s_request_host_callback,
     c2s_macro_begin_end_edit,
 
+    c2s_set_othertab_selection,
+
     num_clientToSerializationMessages
 };
 
@@ -152,6 +154,7 @@ enum SerializationToClientMessageIds
     s2c_send_selected_part,
     s2c_send_selected_group_zone_mapping_summary,
     s2c_send_selection_state,
+    s2c_send_othertab_selection,
 
     s2c_bus_effect_full_data,
     s2c_bus_send_data,

--- a/src/messaging/client/selection_messages.h
+++ b/src/messaging/client/selection_messages.h
@@ -65,6 +65,17 @@ typedef std::tuple<std::optional<selection::SelectionManager::ZoneAddress>,
 SERIAL_TO_CLIENT(SetSelectionState, s2c_send_selection_state, selectedStateMessage_t,
                  onSelectionState);
 
+SERIAL_TO_CLIENT(SetOtherTabSelection, s2c_send_othertab_selection,
+                 scxt::selection::SelectionManager::otherTabSelection_t, onOtherTabSelection);
+
+using updateOther_t = std::pair<std::string, std::string>;
+inline void doUpdateOtherTabSelection(const updateOther_t &pl, const engine::Engine &engine)
+{
+    engine.getSelectionManager()->otherTabSelection[pl.first] = pl.second;
+}
+CLIENT_TO_SERIAL(UpdateOtherTabSelection, c2s_set_othertab_selection, updateOther_t,
+                 doUpdateOtherTabSelection(payload, engine));
+
 // Begin and End Edit messages. These are a mess. See #775
 using editGestureFor_t = bool;
 inline void doBeginEndEdit(bool isBegin, const editGestureFor_t &payload,

--- a/src/selection/selection_manager.cpp
+++ b/src/selection/selection_manager.cpp
@@ -748,6 +748,12 @@ void SelectionManager::sendSelectedPartMacrosToClient()
                                   *(engine.getMessageController()));
 }
 
+void SelectionManager::sendOtherTabsSelectionToClient()
+{
+    serializationSendToClient(cms::s2c_send_othertab_selection, otherTabSelection,
+                              *(engine.getMessageController()));
+}
+
 void SelectionManager::clearAllSelections()
 {
     for (auto &s : allSelectedZones)

--- a/src/selection/selection_manager.h
+++ b/src/selection/selection_manager.h
@@ -188,6 +188,7 @@ struct SelectionManager
     void sendDisplayDataForSingleGroup(int part, int group);
     void sendDisplayDataForNoGroupSelected();
     void sendSelectedPartMacrosToClient();
+    void sendOtherTabsSelectionToClient();
     void configureAndSendZoneModMatrixMetadata(int p, int g, int z);
 
     // To ponder. Does this belong on this object or the engine?
@@ -196,7 +197,8 @@ struct SelectionManager
     std::set<dsp::processor::ProcessorType> processorTypesForSelectedZones(int pidx);
 
   public:
-    std::unordered_map<std::string, std::string> otherTabSelection;
+    using otherTabSelection_t = std::unordered_map<std::string, std::string>;
+    otherTabSelection_t otherTabSelection;
     std::array<selectedZones_t, scxt::numParts> allSelectedZones, allSelectedGroups;
     std::array<ZoneAddress, scxt::numParts> leadZone, leadGroup;
 };


### PR DESCRIPTION
The tab states (play/mix/multi, but also internally like selected LFO, selected bus) are saved in the selection manager and we have a way to do this for future tabbed things also which is modertaly non-tedious

Also go to non-specular knobs

CLoses #1112