### PR TITLE
Mod Matrix follows Processor Drag Re-Order

### DIFF
--- a/src-ui/components/MultiScreen.cpp
+++ b/src-ui/components/MultiScreen.cpp
@@ -180,7 +180,8 @@ MultiScreen::ZoneOrGroupElements<ZGTrait>::ZoneOrGroupElements(MultiScreen *pare
     }
     else
     {
-        lfo->tabNames = {"GLFO 1", "GLFO 2", "GLFO 3"};
+        lfo->tabNames = {"GLFO 1", "GLFO 2", "GLFO 3", "GLFO 4"};
+        assert(lfo->tabNames.size() == scxt::lfosPerGroup);
         lfo->resetTabState();
         eg[0]->setName("GRP EG1");
         eg[1]->setName("GRP EG2");

--- a/src-ui/components/SCXTEditor.cpp
+++ b/src-ui/components/SCXTEditor.cpp
@@ -431,6 +431,7 @@ std::string SCXTEditor::queryTabSelection(const std::string &k)
 
 void SCXTEditor::setTabSelection(const std::string &k, const std::string &t)
 {
+    otherTabSelection[k] = t;
     sendToSerialization(messaging::client::UpdateOtherTabSelection({k, t}));
 }
 } // namespace scxt::ui

--- a/src/engine/group_and_zone.h
+++ b/src/engine/group_and_zone.h
@@ -83,6 +83,7 @@ template <typename T> struct HasGroupZoneProcessors
     // Returns true if I changed anything
     bool checkOrAdjustIntConsistency(int whichProcessor);
     bool checkOrAdjustBoolConsistency(int whichProcessor);
+    void updateRoutingTableAfterProcessorSwap(size_t f, size_t t);
 
     std::array<dsp::processor::ProcessorStorage, processorCount> processorStorage;
     std::array<dsp::processor::ProcessorControlDescription, processorCount> processorDescription;

--- a/src/engine/group_and_zone_impl.h
+++ b/src/engine/group_and_zone_impl.h
@@ -321,4 +321,19 @@ std::string HasGroupZoneProcessors<T>::getProcRoutingPathShortName(ProcRoutingPa
     }
     return "ERROR";
 }
+
+template <typename T>
+void HasGroupZoneProcessors<T>::updateRoutingTableAfterProcessorSwap(size_t f, size_t t)
+{
+    for (auto &r : asT()->routingTable.routes)
+    {
+        if (r.active && r.target.has_value())
+        {
+            if (r.target->isProcessorTarget(f))
+                r.target->setProcessorTargetTo(t);
+            else if (r.target->isProcessorTarget(t))
+                r.target->setProcessorTargetTo(f);
+        }
+    }
+}
 } // namespace scxt::engine

--- a/src/engine/zone.h
+++ b/src/engine/zone.h
@@ -225,6 +225,7 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
     void removeVoice(voice::Voice *);
 
     voice::modulation::Matrix::RoutingTable routingTable;
+
     std::array<modulation::ModulatorStorage, lfosPerZone> modulatorStorage;
 
     // 0 is the AEG, 1 is EG2

--- a/src/messaging/client/processor_messages.h
+++ b/src/messaging/client/processor_messages.h
@@ -204,6 +204,8 @@ inline void swapZoneProcessors(const processorPair_t &whichToType, const engine:
                     z->processorStorage[f] = ts;
                     z->processorStorage[t] = fs;
 
+                    z->updateRoutingTableAfterProcessorSwap(f, t);
+
                     z->checkOrAdjustBoolConsistency(f);
                     z->checkOrAdjustIntConsistency(f);
                     z->checkOrAdjustBoolConsistency(t);
@@ -246,6 +248,8 @@ inline void swapGroupProcessors(const processorPair_t &whichToType, const engine
 
                     g->processorStorage[f] = ts;
                     g->processorStorage[t] = fs;
+
+                    g->updateRoutingTableAfterProcessorSwap(f, t);
 
                     g->checkOrAdjustBoolConsistency(f);
                     g->checkOrAdjustIntConsistency(f);

--- a/src/modulation/matrix_shared.h
+++ b/src/modulation/matrix_shared.h
@@ -57,6 +57,17 @@ struct TargetIdentifier
     {
         return gid == other.gid && tid == other.tid && index == other.index;
     }
+
+    bool isProcessorTarget(size_t procNum) const
+    {
+        return (gid == 'proc' || gid == 'gprc') && index == procNum;
+    }
+
+    void setProcessorTargetTo(size_t t)
+    {
+        assert(gid == 'proc' || gid == 'gprc');
+        index = t;
+    }
 };
 
 struct RoutingExtraPayload


### PR DESCRIPTION
1. Mod Matrix follows processor swap repointing targets appropriately. Closes #734
2. Fix a small problem with cache-not-updated on sticky tabs which could in some cases force you to group or zone from zone or group on actions.
3. We have 4 LFOs in group - show them all.