### PR TITLE
More sensitve and 1 note drop. Move themse to sctheme extension

### DIFF
--- a/src-ui/components/SCXTEditorMenus.cpp
+++ b/src-ui/components/SCXTEditorMenus.cpp
@@ -255,7 +255,7 @@ void SCXTEditor::addUIThemesMenu(juce::PopupMenu &p, bool addTitle)
         if (!w)
             return;
         w->fileChooser = std::make_unique<juce::FileChooser>(
-            "Save Theme", juce::File(w->browser.themeDirectory.u8string()), "*.json");
+            "Save Theme", juce::File(w->browser.themeDirectory.u8string()), "*.sctheme");
         w->fileChooser->launchAsync(juce::FileBrowserComponent::canSelectFiles |
                                         juce::FileBrowserComponent::saveMode |
                                         juce::FileBrowserComponent::warnAboutOverwriting,
@@ -274,7 +274,7 @@ void SCXTEditor::addUIThemesMenu(juce::PopupMenu &p, bool addTitle)
         if (!w)
             return;
         w->fileChooser = std::make_unique<juce::FileChooser>(
-            "Load Theme", juce::File(w->browser.themeDirectory.u8string()), "*.json");
+            "Load Theme", juce::File(w->browser.themeDirectory.u8string()), "*.sctheme");
         w->fileChooser->launchAsync(
             juce::FileBrowserComponent::canSelectFiles | juce::FileBrowserComponent::openMode,
             [w](const juce::FileChooser &c) {

--- a/src-ui/components/multi/MappingPane.cpp
+++ b/src-ui/components/multi/MappingPane.cpp
@@ -1760,7 +1760,7 @@ std::array<int16_t, 3> MappingZones::rootAndRangeForPosition(const juce::Point<i
                               (float)Keyboard::firstMidiNote, (float)Keyboard::lastMidiNote);
 
     auto fromTop = std::clamp(p.getY(), 0, getHeight()) * 1.f / getHeight();
-    auto span = (1.0f - fromTop) * 80 + 1;
+    auto span = (1.0f - sqrt(fromTop)) * 80;
     auto low = std::clamp(rootKey - span, 0.f, 127.f);
     auto high = std::clamp(rootKey + span, 0.f, 127.f);
     return {(int16_t)rootKey, (int16_t)low, (int16_t)high};


### PR DESCRIPTION
- The drop a file gesture now is more sensitive allowing finer control over small width regions but also allowing a 1-wide drop. Closes #1131
- .sctheme is the expension for colormaps