### PR TITLE
Reset also resets busses

### DIFF
--- a/src/engine/bus.h
+++ b/src/engine/bus.h
@@ -134,6 +134,16 @@ struct Bus : MoveableOnly<Bus>, SampleRateSupport
         assert(address != DEFAULT_BUS && address != ERROR_BUS);
     }
 
+    void resetBus()
+    {
+        busSendStorage = BusSendStorage();
+        for (int i = 0; i < maxEffectsPerBus; ++i)
+        {
+            busEffectStorage[i] = BusEffectStorage();
+            busEffects[i].reset();
+        }
+    }
+
     float output alignas(16)[2][blockSize];
     float outputOS alignas(16)[2][blockSize << 1];
     bool hasOSSignal{false}, previousHadOSSignal{false};

--- a/src/engine/patch.h
+++ b/src/engine/patch.h
@@ -43,13 +43,16 @@ struct Patch : MoveableOnly<Patch>, SampleRateSupport
     // TODO - does this really belong in the patch? I think it probably does
     struct Busses
     {
-        Busses() : mainBus(MAIN_0)
+        Busses() : mainBus(MAIN_0) { initialize(); }
+        void initialize()
         {
             std::fill(partToVSTRouting.begin(), partToVSTRouting.end(), 0);
             std::fill(auxToVSTRouting.begin(), auxToVSTRouting.end(), 0);
             int adr = PART_0;
+            mainBus.resetBus();
             for (auto &p : partBusses)
             {
+                p.resetBus();
                 p.address = (BusAddress)adr;
                 p.busSendStorage.supportsSends = true;
                 adr++;
@@ -57,6 +60,7 @@ struct Patch : MoveableOnly<Patch>, SampleRateSupport
             adr = AUX_0;
             for (auto &p : auxBusses)
             {
+                p.resetBus();
                 p.address = (BusAddress)adr;
                 adr++;
             }
@@ -168,6 +172,7 @@ struct Patch : MoveableOnly<Patch>, SampleRateSupport
             parts[i] = std::make_unique<Part>(i);
             parts[i]->parentPatch = this;
         }
+        busses.initialize();
         setSampleRate(1);
     }
 

--- a/src/patch_io/patch_io.cpp
+++ b/src/patch_io/patch_io.cpp
@@ -60,7 +60,7 @@ void addSCManifest(const std::unique_ptr<RIFF::File> &f, const std::string &type
 std::unordered_map<std::string, std::string> readSCManifest(const std::unique_ptr<RIFF::File> &f)
 {
     auto c1 = f->GetSubChunk('scmf');
-    std::string s((char *)c1->LoadChunkData());
+    std::string s((char *)c1->LoadChunkData(), c1->GetSize());
 
     tao::json::events::transformer<tao::json::events::to_basic_value<json::scxt_traits>> consumer;
     tao::json::events::from_string(consumer, s);


### PR DESCRIPTION
Reset reset the parts but not the mixer. Fix that. Closes #1124 Also fix a multi load problem which ASAN caught reading beyond a chunk in a string construction.