### PR TITLE
Mapping/Sample zoom - part one

### DIFF
--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -606,8 +606,6 @@ void Engine::loadSampleIntoSelectedPartAndGroup(const fs::path &p, int16_t rootK
 
 void Engine::createEmptyZone(scxt::engine::KeyboardRange krange, scxt::engine::VelocityRange vrange)
 {
-    SCLOG("Engine Create Empty Zone");
-
     assert(messageController->threadingChecker.isSerialThread());
 
     // 2. Create a zone object on this thread but don't add it


### PR DESCRIPTION
This makes the mapping/sample zoom continuous and also supports mac tracpad gesture and also uses shift for the less frequent vertical zoom.

Still does not address the sizing and bound issues reported in #1018 and #1140