### PR TITLE
Selection on Deleteion. Tab memory.

### DIFF
--- a/src-ui/app/edit-screen/EditScreen.cpp
+++ b/src-ui/app/edit-screen/EditScreen.cpp
@@ -267,6 +267,21 @@ void EditScreen::onOtherTabSelection()
         if (zt >= 0 && zt < lfosPerZone)
             zoneElements->lfo->selectTab(zt);
     }
+
+    gts = editor->queryTabSelection(tabKey("multi.group.output"));
+    if (!gts.empty())
+    {
+        auto gt = std::atoi(gts.c_str());
+        if (gt >= 0 && gt < lfosPerGroup)
+            groupElements->outPane->selectTab(gt);
+    }
+    zts = editor->queryTabSelection(tabKey("multi.zone.output"));
+    if (!zts.empty())
+    {
+        auto zt = std::atoi(zts.c_str());
+        if (zt >= 0 && zt < lfosPerZone)
+            zoneElements->outPane->selectTab(zt);
+    }
     auto mts = editor->queryTabSelection(tabKey("multi.mapping"));
     if (!mts.empty())
     {

--- a/src-ui/app/edit-screen/components/OutputPane.cpp
+++ b/src-ui/app/edit-screen/components/OutputPane.cpp
@@ -36,6 +36,7 @@
 #include "connectors/PayloadDataAttachment.h"
 #include "datamodel/metadata.h"
 #include "theme/Layout.h"
+#include "app/edit-screen/EditScreen.h"
 
 namespace scxt::ui::app::edit_screen
 {

--- a/src-ui/app/edit-screen/components/OutputPane.cpp
+++ b/src-ui/app/edit-screen/components/OutputPane.cpp
@@ -297,21 +297,28 @@ OutputPane<OTTraits>::OutputPane(SCXTEditor *e) : jcmp::NamedPanel(""), HasEdito
     onTabSelected = [wt = juce::Component::SafePointer(this)](int i) {
         if (!wt)
             return;
-        if ((OTTraits::forZone && i == 1) || (!OTTraits::forZone && i == 0))
-        {
-            wt->output->setVisible(wt->active);
-            wt->proc->setVisible(false);
-        }
-        else
-        {
-            wt->output->setVisible(false);
-            wt->proc->setVisible(wt->active);
-        }
+        wt->setSelectedTab(i);
     };
     onTabSelected(selectedTab);
 }
 
 template <typename OTTraits> OutputPane<OTTraits>::~OutputPane() {}
+
+template <typename OTTraits> void OutputPane<OTTraits>::setSelectedTab(int i)
+{
+    if ((OTTraits::forZone && i == 1) || (!OTTraits::forZone && i == 0))
+    {
+        output->setVisible(active);
+        proc->setVisible(false);
+    }
+    else
+    {
+        output->setVisible(false);
+        proc->setVisible(active);
+    }
+    auto kn = std::string("multi") + (OTTraits::forZone ? ".zone.output" : ".group.output");
+    editor->setTabSelection(editor->editScreen->tabKey(kn), std::to_string(i));
+}
 
 template <typename OTTraits> void OutputPane<OTTraits>::resized()
 {

--- a/src-ui/app/edit-screen/components/OutputPane.h
+++ b/src-ui/app/edit-screen/components/OutputPane.h
@@ -87,6 +87,8 @@ template <typename OTTraits> struct OutputPane : sst::jucegui::components::Named
     void updateFromProcessorPanes();
     std::array<juce::Component::SafePointer<ProcessorPane>, scxt::processorsPerZoneAndGroup>
         procWeakRefs;
+
+    void setSelectedTab(int i);
 };
 } // namespace scxt::ui::app::edit_screen
 #endif // SHORTCIRCUIT_MAPPINGPANE_H

--- a/src/messaging/client/structure_messages.h
+++ b/src/messaging/client/structure_messages.h
@@ -164,7 +164,7 @@ inline void removeZone(const selection::SelectionManager::ZoneAddress &a, engine
         },
         [t = a](auto &engine) {
             engine.getSampleManager()->purgeUnreferencedSamples();
-            engine.getSelectionManager()->guaranteeConsistencyAfterDeletes(engine);
+            engine.getSelectionManager()->guaranteeConsistencyAfterDeletes(engine, true, t);
             serializationSendToClient(s2c_send_pgz_structure, engine.getPartGroupZoneStructure(),
                                       *(engine.getMessageController()));
             serializationSendToClient(s2c_send_selected_group_zone_mapping_summary,
@@ -202,7 +202,8 @@ inline void removeSelectedZones(const bool &, engine::Engine &engine, MessageCon
         },
         [t = part](auto &engine) {
             engine.getSampleManager()->purgeUnreferencedSamples();
-            engine.getSelectionManager()->guaranteeConsistencyAfterDeletes(engine);
+            engine.getSelectionManager()->guaranteeConsistencyAfterDeletes(engine, true,
+                                                                           {t, -1, -1});
 
             serializationSendToClient(s2c_send_pgz_structure, engine.getPartGroupZoneStructure(),
                                       *(engine.getMessageController()));
@@ -237,7 +238,7 @@ inline void removeGroup(const selection::SelectionManager::ZoneAddress &a, engin
         },
         [t = a](auto &engine) {
             engine.getSampleManager()->purgeUnreferencedSamples();
-            engine.getSelectionManager()->guaranteeConsistencyAfterDeletes(engine);
+            engine.getSelectionManager()->guaranteeConsistencyAfterDeletes(engine, false, t);
 
             serializationSendToClient(s2c_send_pgz_structure, engine.getPartGroupZoneStructure(),
                                       *(engine.getMessageController()));
@@ -264,7 +265,8 @@ inline void clearPart(const int p, engine::Engine &engine, MessageController &co
         },
         [pt = p](auto &engine) {
             engine.getSampleManager()->purgeUnreferencedSamples();
-            engine.getSelectionManager()->guaranteeConsistencyAfterDeletes(engine);
+            engine.getSelectionManager()->guaranteeConsistencyAfterDeletes(engine, false,
+                                                                           {pt, -1, -1});
 
             serializationSendToClient(s2c_send_pgz_structure, engine.getPartGroupZoneStructure(),
                                       *(engine.getMessageController()));

--- a/src/selection/selection_manager.h
+++ b/src/selection/selection_manager.h
@@ -150,13 +150,15 @@ struct SelectionManager
 
     void selectAction(const SelectActionContents &z);
     void multiSelectAction(const std::vector<SelectActionContents> &v);
-    void guaranteeConsistencyAfterDeletes(const engine::Engine &);
+    void guaranteeConsistencyAfterDeletes(const engine::Engine &, bool zoneDeleted,
+                                          const ZoneAddress &addressDeleted);
     void selectPart(int16_t part);
     void clearAllSelections();
 
   protected:
     void adjustInternalStateForAction(const SelectActionContents &);
     void guaranteeSelectedLead();
+    void guaranteeSelectedLeadSomewhereIn(int part, int group, int zone);
     void debugDumpSelectionState();
 
   public:


### PR DESCRIPTION
- Deleting the selected zone reliabl finds at least something else to be the selected zone. Closes #1151
- OutputInfo stored in otherTab persistence structure. Closes #1163