### PR TITLE
Add client notification messages

### DIFF
--- a/src-ui/app/SCXTEditor.h
+++ b/src-ui/app/SCXTEditor.h
@@ -236,6 +236,8 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::DragAndDropCont
         allProcessors = v;
     }
 
+    void onActivityNotification(const scxt::messaging::client::activityNotificationPayload_t &);
+
     std::array<std::array<scxt::engine::Macro, scxt::macrosPerPart>, scxt::numParts> macroCache;
     void onMacroFullState(const scxt::messaging::client::macroFullState_t &);
     void onMacroValue(const scxt::messaging::client::macroValue_t &);

--- a/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -402,4 +402,12 @@ void SCXTEditor::onPartConfiguration(
     if (editScreen && editScreen->partSidebar)
         editScreen->partSidebar->partConfigurationChanged(pt);
 }
+
+void SCXTEditor::onActivityNotification(
+    const scxt::messaging::client::activityNotificationPayload_t &payload)
+{
+    auto [idx, msg] = payload;
+    // SCLOG((idx == 1 ? "Open" : (idx == 0 ? "Close" : "Update")) << " [" << msg << "]");
+    SCLOG_ONCE("Update activity messages currently ignored");
+}
 } // namespace scxt::ui::app

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -661,6 +661,9 @@ void Engine::loadSf2MultiSampleIntoSelectedPart(const fs::path &p)
 {
     assert(messageController->threadingChecker.isSerialThread());
 
+    auto cng = messaging::MessageController::ClientActivityNotificationGuard(
+        "Loading SF2", *(getMessageController()));
+
     try
     {
         auto riff = std::make_unique<RIFF::File>(p.u8string());
@@ -697,6 +700,8 @@ void Engine::loadSf2MultiSampleIntoSelectedPart(const fs::path &p)
                     if (sfsamp == nullptr)
                         continue;
 
+                    messageController->updateClientActivityNotification("Loading sample " +
+                                                                        std::to_string(j));
                     auto sid = sampleManager->loadSampleFromSF2(p, sf.get(), pc, i, j);
                     if (!sid.has_value())
                         continue;

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -47,8 +47,8 @@ namespace scxt::messaging::client
  *   s2c_send_selection_state
  * - Name the object a camelcase version of the enum without s2c,
  *   so for instance SendSelectionState
- * - Make the SCXT Editor callback names onObjectName
- * - name the payloads as objectNamePayload_t so sendSelectionStatePayload_t
+ * - Make the SCXT Editor callback names onSelectionState
+ * - name the payloads as objectNamePayload_t so selectionStatePayload_t
  *   if the payload type is a custom type.
  *
  * C2S:
@@ -158,6 +158,8 @@ enum SerializationToClientMessageIds
     s2c_report_error,
     s2c_send_initial_metadata,
     s2c_send_debug_info,
+    s2c_send_activity_notification,
+
     s2c_engine_status,
     s2c_update_group_or_zone_adsr_view,
     s2c_respond_zone_mapping,

--- a/src/messaging/client/enginestatus_messages.h
+++ b/src/messaging/client/enginestatus_messages.h
@@ -89,6 +89,11 @@ inline void stopSoundsMessage(const stopSounds_t &payload, messaging::MessageCon
     });
 }
 CLIENT_TO_SERIAL(StopSounds, c2s_silence_engine, stopSounds_t, stopSoundsMessage(payload, cont));
+
+// First in here is: -1, show if open, 0, close, 1, show and open
+using activityNotificationPayload_t = std::pair<int, std::string>;
+SERIAL_TO_CLIENT(SendActivityNotification, s2c_send_activity_notification,
+                 activityNotificationPayload_t, onActivityNotification);
 } // namespace scxt::messaging::client
 
 #endif // SHORTCIRCUIT_ENGINESTATUS_MESSAGES_H

--- a/src/messaging/messaging.cpp
+++ b/src/messaging/messaging.cpp
@@ -370,4 +370,23 @@ void MessageController::serializationThreadPostAudioQueueDrain()
         macroSetValueCompressorUsed = false;
     }
 }
+
+void MessageController::updateClientActivityNotification(const std::string &msg, int idx)
+{
+    serializationSendToClient(client::s2c_send_activity_notification,
+                              client::activityNotificationPayload_t{idx, msg},
+                              *(engine.getMessageController()));
+}
+
+MessageController::ClientActivityNotificationGuard::ClientActivityNotificationGuard(
+    const std::string &ms, MessageController &m)
+    : man(m)
+{
+    man.updateClientActivityNotification(ms, 1);
+}
+
+MessageController::ClientActivityNotificationGuard::~ClientActivityNotificationGuard()
+{
+    man.updateClientActivityNotification("", 0);
+}
 } // namespace scxt::messaging

--- a/src/messaging/messaging.h
+++ b/src/messaging/messaging.h
@@ -344,6 +344,17 @@ struct MessageController : MoveableOnly<MessageController>
         streamNotificationConditionVariable.notify_all();
     }
 
+    /*
+     * Helping the client know things like a waiting message and so on
+     */
+    void updateClientActivityNotification(const std::string &msg, int idx = -1);
+    struct ClientActivityNotificationGuard
+    {
+        MessageController &man;
+        ClientActivityNotificationGuard(const std::string &ms, MessageController &m);
+        ~ClientActivityNotificationGuard();
+    };
+
   private:
     uint64_t inboundClientMessageCount{0};
     void runSerialization();

--- a/src/selection/selection_manager.cpp
+++ b/src/selection/selection_manager.cpp
@@ -127,7 +127,6 @@ void SelectionManager::selectAction(
         auto zt = z.contiguousFrom;
         if (zt < zf)
         {
-            SCLOG("Swapping ZF and ZT");
             std::swap(zf, zt);
         }
         if (zf.part != zt.part)
@@ -809,4 +808,5 @@ void SelectionManager::clearAllSelections()
         g = {};
     selectedPart = 0;
 }
+
 } // namespace scxt::selection


### PR DESCRIPTION
Per #1159 we now at least have a serialization thread message which the engine can send to the UI with an open/close/update type semantic. We send the messages from SF2 load but we don't do anything with them other than a SCLOG_ONCE for now. Just some progress to get in the codebase before I close my laptop.