### PR TITLE
Code Cleanup: Run fixcode after big UI restructure

### DIFF
--- a/src-ui/app/HasEditor.h
+++ b/src-ui/app/HasEditor.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_HASEDITOR_H
-#define SCXT_SRC_UI_COMPONENTS_HASEDITOR_H
+#ifndef SCXT_SRC_UI_APP_HASEDITOR_H
+#define SCXT_SRC_UI_APP_HASEDITOR_H
 
 #include <cstdint>
 #include <cassert>

--- a/src-ui/app/SCXTEditor.h
+++ b/src-ui/app/SCXTEditor.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_SCXTEDITOR_H
-#define SCXT_SRC_UI_COMPONENTS_SCXTEDITOR_H
+#ifndef SCXT_SRC_UI_APP_SCXTEDITOR_H
+#define SCXT_SRC_UI_APP_SCXTEDITOR_H
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <memory>

--- a/src-ui/app/browser-ui/BrowserPane.h
+++ b/src-ui/app/browser-ui/BrowserPane.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_BROWSER_BROWSERPANE_H
-#define SCXT_SRC_UI_COMPONENTS_BROWSER_BROWSERPANE_H
+#ifndef SCXT_SRC_UI_APP_BROWSER_UI_BROWSERPANE_H
+#define SCXT_SRC_UI_APP_BROWSER_UI_BROWSERPANE_H
 
 #include <vector>
 #include "filesystem/import.h"

--- a/src-ui/app/edit-screen/EditScreen.h
+++ b/src-ui/app/edit-screen/EditScreen.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_MULTISCREEN_H
-#define SCXT_SRC_UI_COMPONENTS_MULTISCREEN_H
+#ifndef SCXT_SRC_UI_APP_EDIT_SCREEN_EDITSCREEN_H
+#define SCXT_SRC_UI_APP_EDIT_SCREEN_EDITSCREEN_H
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <memory>

--- a/src-ui/app/edit-screen/components/AdsrPane.h
+++ b/src-ui/app/edit-screen/components/AdsrPane.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_MULTI_ADSRPANE_H
-#define SCXT_SRC_UI_COMPONENTS_MULTI_ADSRPANE_H
+#ifndef SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_ADSRPANE_H
+#define SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_ADSRPANE_H
 
 #include <unordered_map>
 #include <juce_gui_basics/juce_gui_basics.h>

--- a/src-ui/app/edit-screen/components/GroupZoneTreeControl.h
+++ b/src-ui/app/edit-screen/components/GroupZoneTreeControl.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_MULTI_DETAIL_GROUPZONETREECONTROL_H
-#define SCXT_SRC_UI_COMPONENTS_MULTI_DETAIL_GROUPZONETREECONTROL_H
+#ifndef SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_GROUPZONETREECONTROL_H
+#define SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_GROUPZONETREECONTROL_H
 
 #include <juce_graphics/juce_graphics.h>
 #include <juce_core/juce_core.h>

--- a/src-ui/app/edit-screen/components/LFOPane.h
+++ b/src-ui/app/edit-screen/components/LFOPane.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_MULTI_LFOPANE_H
-#define SCXT_SRC_UI_COMPONENTS_MULTI_LFOPANE_H
+#ifndef SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_LFOPANE_H
+#define SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_LFOPANE_H
 
 #include "sst/jucegui/components/GlyphButton.h"
 #include "sst/jucegui/components/NamedPanel.h"

--- a/src-ui/app/edit-screen/components/MappingPane.h
+++ b/src-ui/app/edit-screen/components/MappingPane.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_MULTI_MAPPINGPANE_H
-#define SCXT_SRC_UI_COMPONENTS_MULTI_MAPPINGPANE_H
+#ifndef SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_MAPPINGPANE_H
+#define SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_MAPPINGPANE_H
 
 #include "sst/jucegui/components/NamedPanel.h"
 #include "app/HasEditor.h"

--- a/src-ui/app/edit-screen/components/ModPane.h
+++ b/src-ui/app/edit-screen/components/ModPane.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_MULTI_MODPANE_H
-#define SCXT_SRC_UI_COMPONENTS_MULTI_MODPANE_H
+#ifndef SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_MODPANE_H
+#define SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_MODPANE_H
 
 #include "sst/jucegui/components/NamedPanel.h"
 #include "app/HasEditor.h"

--- a/src-ui/app/edit-screen/components/OutputPane.h
+++ b/src-ui/app/edit-screen/components/OutputPane.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_MULTI_OUTPUTPANE_H
-#define SCXT_SRC_UI_COMPONENTS_MULTI_OUTPUTPANE_H
+#ifndef SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_OUTPUTPANE_H
+#define SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_OUTPUTPANE_H
 
 #include "sst/jucegui/components/NamedPanel.h"
 #include "app/HasEditor.h"

--- a/src-ui/app/edit-screen/components/PartGroupSidebar.h
+++ b/src-ui/app/edit-screen/components/PartGroupSidebar.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_MULTI_PARTGROUPSIDEBAR_H
-#define SCXT_SRC_UI_COMPONENTS_MULTI_PARTGROUPSIDEBAR_H
+#ifndef SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_PARTGROUPSIDEBAR_H
+#define SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_PARTGROUPSIDEBAR_H
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include "sst/jucegui/components/NamedPanel.h"

--- a/src-ui/app/edit-screen/components/ProcessorPane.h
+++ b/src-ui/app/edit-screen/components/ProcessorPane.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_MULTI_PROCESSORPANE_H
-#define SCXT_SRC_UI_COMPONENTS_MULTI_PROCESSORPANE_H
+#ifndef SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_PROCESSORPANE_H
+#define SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_PROCESSORPANE_H
 
 #include <unordered_map>
 #include <juce_gui_basics/juce_gui_basics.h>

--- a/src-ui/app/editor-impl/SCXTJuceLookAndFeel.h
+++ b/src-ui/app/editor-impl/SCXTJuceLookAndFeel.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_SCXTJUCELOOKANDFEEL_H
-#define SCXT_SRC_UI_COMPONENTS_SCXTJUCELOOKANDFEEL_H
+#ifndef SCXT_SRC_UI_APP_EDITOR_IMPL_SCXTJUCELOOKANDFEEL_H
+#define SCXT_SRC_UI_APP_EDITOR_IMPL_SCXTJUCELOOKANDFEEL_H
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include "connectors/SCXTResources.h"

--- a/src-ui/app/mixer-screen/MixerScreen.h
+++ b/src-ui/app/mixer-screen/MixerScreen.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_MIXERSCREEN_H
-#define SCXT_SRC_UI_COMPONENTS_MIXERSCREEN_H
+#ifndef SCXT_SRC_UI_APP_MIXER_SCREEN_MIXERSCREEN_H
+#define SCXT_SRC_UI_APP_MIXER_SCREEN_MIXERSCREEN_H
 
 #include "configuration.h"
 #include "app/HasEditor.h"

--- a/src-ui/app/mixer-screen/components/BusPane.h
+++ b/src-ui/app/mixer-screen/components/BusPane.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_MIXER_BUSPANE_H
-#define SCXT_SRC_UI_COMPONENTS_MIXER_BUSPANE_H
+#ifndef SCXT_SRC_UI_APP_MIXER_SCREEN_COMPONENTS_BUSPANE_H
+#define SCXT_SRC_UI_APP_MIXER_SCREEN_COMPONENTS_BUSPANE_H
 
 #include <juce_gui_basics/juce_gui_basics.h>
 

--- a/src-ui/app/mixer-screen/components/ChannelStrip.h
+++ b/src-ui/app/mixer-screen/components/ChannelStrip.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_MIXER_CHANNELSTRIP_H
-#define SCXT_SRC_UI_COMPONENTS_MIXER_CHANNELSTRIP_H
+#ifndef SCXT_SRC_UI_APP_MIXER_SCREEN_COMPONENTS_CHANNELSTRIP_H
+#define SCXT_SRC_UI_APP_MIXER_SCREEN_COMPONENTS_CHANNELSTRIP_H
 
 #include "engine/bus.h"
 #include "app/HasEditor.h"

--- a/src-ui/app/mixer-screen/components/PartEffectsPane.h
+++ b/src-ui/app/mixer-screen/components/PartEffectsPane.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_MIXER_PARTEFFECTSPANE_H
-#define SCXT_SRC_UI_COMPONENTS_MIXER_PARTEFFECTSPANE_H
+#ifndef SCXT_SRC_UI_APP_MIXER_SCREEN_COMPONENTS_PARTEFFECTSPANE_H
+#define SCXT_SRC_UI_APP_MIXER_SCREEN_COMPONENTS_PARTEFFECTSPANE_H
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <sst/jucegui/components/NamedPanel.h>

--- a/src-ui/app/other-screens/AboutScreen.h
+++ b/src-ui/app/other-screens/AboutScreen.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_ABOUTSCREEN_H
-#define SCXT_SRC_UI_COMPONENTS_ABOUTSCREEN_H
+#ifndef SCXT_SRC_UI_APP_OTHER_SCREENS_ABOUTSCREEN_H
+#define SCXT_SRC_UI_APP_OTHER_SCREENS_ABOUTSCREEN_H
 
 #include "app/HasEditor.h"
 #include <juce_gui_basics/juce_gui_basics.h>

--- a/src-ui/app/other-screens/LogScreen.h
+++ b/src-ui/app/other-screens/LogScreen.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_LOGSCREEN_H
-#define SCXT_SRC_UI_COMPONENTS_LOGSCREEN_H
+#ifndef SCXT_SRC_UI_APP_OTHER_SCREENS_LOGSCREEN_H
+#define SCXT_SRC_UI_APP_OTHER_SCREENS_LOGSCREEN_H
 
 #include "app/HasEditor.h"
 #include <juce_gui_basics/juce_gui_basics.h>

--- a/src-ui/app/other-screens/WelcomeScreen.h
+++ b/src-ui/app/other-screens/WelcomeScreen.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_WELCOMESCREEN_H
-#define SCXT_SRC_UI_COMPONENTS_WELCOMESCREEN_H
+#ifndef SCXT_SRC_UI_APP_OTHER_SCREENS_WELCOMESCREEN_H
+#define SCXT_SRC_UI_APP_OTHER_SCREENS_WELCOMESCREEN_H
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include "sst/jucegui/components/TextPushButton.h"

--- a/src-ui/app/play-screen/PlayScreen.h
+++ b/src-ui/app/play-screen/PlayScreen.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_PLAYSCREEN_H
-#define SCXT_SRC_UI_COMPONENTS_PLAYSCREEN_H
+#ifndef SCXT_SRC_UI_APP_PLAY_SCREEN_PLAYSCREEN_H
+#define SCXT_SRC_UI_APP_PLAY_SCREEN_PLAYSCREEN_H
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <array>

--- a/src-ui/app/shared/HeaderRegion.h
+++ b/src-ui/app/shared/HeaderRegion.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_HEADERREGION_H
-#define SCXT_SRC_UI_COMPONENTS_HEADERREGION_H
+#ifndef SCXT_SRC_UI_APP_SHARED_HEADERREGION_H
+#define SCXT_SRC_UI_APP_SHARED_HEADERREGION_H
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <sst/jucegui/components/ToggleButton.h>

--- a/src-ui/app/shared/PartSidebarCard.h
+++ b/src-ui/app/shared/PartSidebarCard.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_MULTI_PARTSIDEBARCARD_H
-#define SCXT_SRC_UI_COMPONENTS_MULTI_PARTSIDEBARCARD_H
+#ifndef SCXT_SRC_UI_APP_SHARED_PARTSIDEBARCARD_H
+#define SCXT_SRC_UI_APP_SHARED_PARTSIDEBARCARD_H
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include "sst/jucegui/components/MenuButton.h"

--- a/src-ui/app/shared/SingleMacroEditor.h
+++ b/src-ui/app/shared/SingleMacroEditor.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_COMPONENTS_MULTI_SINGLEMACROEDITOR_H
-#define SCXT_SRC_UI_COMPONENTS_MULTI_SINGLEMACROEDITOR_H
+#ifndef SCXT_SRC_UI_APP_SHARED_SINGLEMACROEDITOR_H
+#define SCXT_SRC_UI_APP_SHARED_SINGLEMACROEDITOR_H
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include "sst/jucegui/components/Knob.h"

--- a/src-ui/connectors/JSONAssetSupport.h
+++ b/src-ui/connectors/JSONAssetSupport.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_CONNECTORS_JSONLAYOUTCONSUMER_H
-#define SCXT_SRC_UI_CONNECTORS_JSONLAYOUTCONSUMER_H
+#ifndef SCXT_SRC_UI_CONNECTORS_JSONASSETSUPPORT_H
+#define SCXT_SRC_UI_CONNECTORS_JSONASSETSUPPORT_H
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
I forgot to run fix-code when i did the ui restructure so the header include names hadn't been rebuilt. No biggie but it means runnign fix code again gave loads of diffs, so package those up into a single pr and get on with life