### PR TITLE
Group Processor Ringout support

### DIFF
--- a/src/dsp/processor/processor.h
+++ b/src/dsp/processor/processor.h
@@ -294,9 +294,11 @@ struct Processor : MoveableOnly<Processor>, SampleRateSupport
         assert(false);
     }
 
-    // processors are required to be able to process stereo blocks if stereo is true in the
-    // constructor
     virtual void suspend() {}
+
+    /*
+     * Tail length in samples
+     */
     virtual int tail_length() { return 0; }
 
     float modulation_output; // processors can use this to output modulation data to the matrix

--- a/src/engine/group.cpp
+++ b/src/engine/group.cpp
@@ -279,6 +279,8 @@ void Group::addActiveZone()
         parentPart->addActiveGroup();
         attack();
     }
+    // Important we do this *after* the attack since it allows
+    // isActive to be accurate with processor ringout
     activeZones++;
     ringoutTime = 0;
 }
@@ -412,6 +414,13 @@ void Group::onProcessorTypeChanged(int w, dsp::processor::ProcessorType t)
 
 void Group::attack()
 {
+    if (isActive())
+    {
+        // I *thin* we need to do this
+        rePrepareAndBindGroupMatrix();
+        return;
+    }
+
     for (int i = 0; i < processorsPerZoneAndGroup; ++i)
     {
         const auto &ps = processorStorage[i];

--- a/src/engine/group.h
+++ b/src/engine/group.h
@@ -152,7 +152,7 @@ struct Group : MoveableOnly<Group>,
         return res;
     }
 
-    bool isActive() { return activeZones != 0; }
+    bool isActive() const;
     void addActiveZone();
     void removeActiveZone();
 
@@ -204,6 +204,10 @@ struct Group : MoveableOnly<Group>,
     void onProcessorTypeChanged(int w, dsp::processor::ProcessorType t);
 
     uint32_t activeZones{0};
+    int32_t ringoutTime{0};
+    int32_t ringoutMax{0};
+
+    bool updateRingout();
 
     typedef std::vector<std::unique_ptr<Zone>> zoneContainer_t;
 


### PR DESCRIPTION
This adds support for a processor to implement tailLength and then keep a group alie through its tail. it also adds a reasonable tailLength implementation to ShortDelay (but no other processor).

Addresses #852. Once we do the same with EG12 release that issue will be mostly wrapped, but we do need to visit all the procs for a tail.