### PR TITLE
More work on message name coherence

### DIFF
--- a/src-ui/app/edit-screen/components/AdsrPane.cpp
+++ b/src-ui/app/edit-screen/components/AdsrPane.cpp
@@ -40,7 +40,7 @@ AdsrPane::AdsrPane(SCXTEditor *e, int idx, bool fz)
 {
     hasHamburger = true;
 
-    using fac = connectors::SingleValueFactory<attachment_t, cmsg::UpdateZoneGroupEGFloatValue>;
+    using fac = connectors::SingleValueFactory<attachment_t, cmsg::UpdateZoneOrGroupEGFloatValue>;
 
     // c++ partial application is a bummer
     auto attc = [&](auto &t, auto &a, auto &w) {

--- a/src-ui/app/edit-screen/components/MappingPane.cpp
+++ b/src-ui/app/edit-screen/components/MappingPane.cpp
@@ -646,10 +646,7 @@ struct MappingDisplay : juce::Component,
         textEds.Pitch->setBounds(cQ(3));
     }
 
-    void mappingChangedFromGUI()
-    {
-        sendToSerialization(cmsg::MappingSelectedZoneUpdateRequest(mappingView));
-    }
+    void mappingChangedFromGUI() { sendToSerialization(cmsg::UpdateLeadZoneMapping(mappingView)); }
 
     void setActive(bool b) { setVisible(b); }
 
@@ -2288,7 +2285,7 @@ struct SampleDisplay : juce::Component, HasEditor
 
     void onSamplePointChangedFromGUI()
     {
-        sendToSerialization(cmsg::SamplesSelectedZoneUpdateRequest{
+        sendToSerialization(cmsg::UpdateLeadZoneAssociatedSample{
             {selectedVariation, sampleView.samples[selectedVariation]}});
         waveforms[selectedVariation].waveform->rebuildHotZones();
         waveforms[selectedVariation].waveform->repaint();

--- a/src-ui/app/edit-screen/components/ModPane.cpp
+++ b/src-ui/app/edit-screen/components/ModPane.cpp
@@ -375,12 +375,12 @@ template <typename GZTrait> struct ModRow : juce::Component, HasEditor
     {
         if constexpr (GZTrait::forZone)
         {
-            sendToSerialization(cmsg::IndexedZoneRoutingRowUpdated(
+            sendToSerialization(cmsg::UpdateZoneRoutingRow(
                 {index, parent->routingTable.routes[index], forceUpdate}));
         }
         else
         {
-            sendToSerialization(cmsg::IndexedGroupRoutingRowUpdated(
+            sendToSerialization(cmsg::UpdateGroupRoutingRow(
                 {index, parent->routingTable.routes[index], forceUpdate}));
         }
     }

--- a/src-ui/app/edit-screen/components/PartGroupSidebar.cpp
+++ b/src-ui/app/edit-screen/components/PartGroupSidebar.cpp
@@ -122,7 +122,7 @@ struct GroupZoneSidebarBase : juce::Component, HasEditor, juce::DragAndDropConta
         {
             p.addItem("Part " + std::to_string(i + 1), true, i == editor->selectedPart,
                       [w = juce::Component::SafePointer(this), index = i]() {
-                          w->sendToSerialization(cmsg::DoSelectPart(index));
+                          w->sendToSerialization(cmsg::SelectPart(index));
                       });
         }
         p.showMenuAsync(editor->defaultPopupMenuOptions());

--- a/src-ui/app/editor-impl/SCXTEditor.cpp
+++ b/src-ui/app/editor-impl/SCXTEditor.cpp
@@ -316,7 +316,7 @@ void SCXTEditor::doSelectionAction(const selection::SelectionManager::ZoneAddres
 {
     namespace cmsg = scxt::messaging::client;
     currentLeadZoneSelection = a;
-    sendToSerialization(cmsg::DoSelectAction(selection::SelectionManager::SelectActionContents{
+    sendToSerialization(cmsg::ApplySelectAction(selection::SelectionManager::SelectActionContents{
         a.part, a.group, a.zone, selecting, distinct, asLead}));
     repaint();
 }
@@ -324,14 +324,14 @@ void SCXTEditor::doSelectionAction(const selection::SelectionManager::ZoneAddres
 void SCXTEditor::doSelectionAction(const selection::SelectionManager::SelectActionContents &p)
 {
     namespace cmsg = scxt::messaging::client;
-    sendToSerialization(cmsg::DoSelectAction(p));
+    sendToSerialization(cmsg::ApplySelectAction(p));
     repaint();
 }
 void SCXTEditor::doMultiSelectionAction(
     const std::vector<selection::SelectionManager::SelectActionContents> &p)
 {
     namespace cmsg = scxt::messaging::client;
-    sendToSerialization(cmsg::DoMultiSelectAction(p));
+    sendToSerialization(cmsg::ApplyMultiSelectAction(p));
     repaint();
 }
 

--- a/src-ui/app/shared/PartSidebarCard.cpp
+++ b/src-ui/app/shared/PartSidebarCard.cpp
@@ -110,7 +110,7 @@ PartSidebarCard::PartSidebarCard(int p, SCXTEditor *e) : part(p), HasEditor(e)
 
 void PartSidebarCard::mouseDown(const juce::MouseEvent &event)
 {
-    sendToSerialization(cmsg::DoSelectPart(part));
+    sendToSerialization(cmsg::SelectPart(part));
 }
 
 void PartSidebarCard::paint(juce::Graphics &g)

--- a/src/messaging/client/browser_messages.h
+++ b/src/messaging/client/browser_messages.h
@@ -39,14 +39,14 @@
 namespace scxt::messaging::client
 {
 
-inline void addDeviceLocation(const fs::path &p, const engine::Engine &engine,
-                              MessageController &cont)
+inline void doAddBrowserDeviceLocation(const fs::path &p, const engine::Engine &engine,
+                                       MessageController &cont)
 {
     engine.getBrowser()->addRootPathForDeviceView(p);
     serializationSendToClient(s2c_refresh_browser, true, cont);
 }
-CLIENT_TO_SERIAL(AddBrowserDeviceLocation, c2s_browser_add_device_location, std::string,
-                 addDeviceLocation(fs::path{payload}, engine, cont));
+CLIENT_TO_SERIAL(AddBrowserDeviceLocation, c2s_add_browser_device_location, std::string,
+                 doAddBrowserDeviceLocation(fs::path{payload}, engine, cont));
 
 SERIAL_TO_CLIENT(RefreshBrowser, s2c_refresh_browser, bool, onBrowserRefresh)
 

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -72,38 +72,36 @@ enum ClientToSerializationMessagesIds
     c2s_load_multi,
     c2s_load_part_into,
 
-    // Messages we haven't dealt with yet
-    c2s_do_select_action,
-    c2s_do_multi_select_action,
+    c2s_apply_select_action,
+    c2s_apply_multi_select_action,
     c2s_select_part,
 
     c2s_begin_edit, // not implemented yet
     c2s_end_edit,   // implemented as a hammer
 
-    c2s_update_zone_or_group_adsr_value,
-
+    c2s_update_zone_or_group_eg_float_value,
     c2s_update_zone_or_group_modstorage_float_value,
     c2s_update_zone_or_group_modstorage_bool_value,
     c2s_update_zone_or_group_modstorage_int16_t_value,
 
-    c2s_update_zone_mapping,
+    c2s_update_lead_zone_mapping,
     c2s_update_zone_mapping_float,
     c2s_update_zone_mapping_int16_t,
-    c2s_update_zone_samples,
-    c2s_update_zone_sampleset_int16_t,
-    c2s_update_zone_routing_row,
+    c2s_update_lead_zone_associated_sample,
+    c2s_update_zone_associated_sample_set_int16_t,
 
     c2s_update_zone_output_float_value,
     c2s_update_zone_output_int16_t_value,
+
+    c2s_update_zone_routing_row,
 
     c2s_update_group_routing_row,
     c2s_update_group_output_float_value,
     c2s_update_group_output_int16_t_value,
     c2s_update_group_output_bool_value,
 
-    c2s_update_group_or_zone_individual_modulator_storage,
-
-    c2s_request_pgz_structure,
+    // #1141 done up until here. Below this point the name rubric above isn't confirmed in place
+    c2s_request_pgz_structure, // ?
 
     c2s_update_single_processor_float_value,
     c2s_update_single_processor_bool_value,
@@ -134,7 +132,7 @@ enum ClientToSerializationMessagesIds
     c2s_set_mixer_effect_storage,
     c2s_set_mixer_send_storage,
 
-    c2s_browser_add_device_location,
+    c2s_add_browser_device_location,
 
     c2s_request_debug_action,
 

--- a/src/messaging/client/group_or_zone_messages.h
+++ b/src/messaging/client/group_or_zone_messages.h
@@ -35,7 +35,7 @@ typedef std::tuple<bool, int, bool, modulation::modulators::AdsrStorage> adsrVie
 SERIAL_TO_CLIENT(AdsrGroupOrZoneUpdate, s2c_update_group_or_zone_adsr_view,
                  adsrViewResponsePayload_t, onGroupOrZoneEnvelopeUpdated);
 
-CLIENT_TO_SERIAL_CONSTRAINED(UpdateZoneGroupEGFloatValue, c2s_update_zone_or_group_adsr_value,
+CLIENT_TO_SERIAL_CONSTRAINED(UpdateZoneOrGroupEGFloatValue, c2s_update_zone_or_group_eg_float_value,
                              detail::indexedZoneOrGroupDiffMsg_t<float>,
                              modulation::modulators::AdsrStorage,
                              detail::updateZoneOrGroupIndexedMemberValue(&engine::Zone::egStorage,

--- a/src/messaging/client/modulation_messages.h
+++ b/src/messaging/client/modulation_messages.h
@@ -50,9 +50,9 @@ SERIAL_TO_CLIENT(UpdateGroupMatrix, s2c_update_group_matrix, modulation::GroupMa
 
 // which row, what data, and force a full update
 typedef std::tuple<int, voice::modulation::Matrix::RoutingTable::Routing, bool>
-    indexedZoneRowUpdate_t;
-inline void indexedZoneRoutingRowUpdated(const indexedZoneRowUpdate_t &payload,
-                                         const engine::Engine &engine, MessageController &cont)
+    zoneRoutingRowPayload_t;
+inline void doUpdateZoneRoutingRow(const zoneRoutingRowPayload_t &payload,
+                                   const engine::Engine &engine, MessageController &cont)
 {
     // TODO Selected Zone State
     const auto &[i, r, b] = payload;
@@ -87,14 +87,14 @@ inline void indexedZoneRoutingRowUpdated(const indexedZoneRowUpdate_t &payload,
             });
     }
 }
-CLIENT_TO_SERIAL(IndexedZoneRoutingRowUpdated, c2s_update_zone_routing_row, indexedZoneRowUpdate_t,
-                 indexedZoneRoutingRowUpdated(payload, engine, cont));
+CLIENT_TO_SERIAL(UpdateZoneRoutingRow, c2s_update_zone_routing_row, zoneRoutingRowPayload_t,
+                 doUpdateZoneRoutingRow(payload, engine, cont));
 
 // which row, what data, and force a full update
 typedef std::tuple<int, modulation::GroupMatrix::RoutingTable::Routing, bool>
-    indexedGroupRowUpdate_t;
-inline void indexedGroupRoutingRowUpdated(const indexedGroupRowUpdate_t &payload,
-                                          const engine::Engine &engine, MessageController &cont)
+    updateGroupRoutingRowPayload_t;
+inline void doUpdateGroupRoutingRow(const updateGroupRoutingRowPayload_t &payload,
+                                    const engine::Engine &engine, MessageController &cont)
 {
     // TODO Selected Zone State
     const auto &[i, r, b] = payload;
@@ -127,8 +127,8 @@ inline void indexedGroupRoutingRowUpdated(const indexedGroupRowUpdate_t &payload
             });
     }
 }
-CLIENT_TO_SERIAL(IndexedGroupRoutingRowUpdated, c2s_update_group_routing_row,
-                 indexedGroupRowUpdate_t, indexedGroupRoutingRowUpdated(payload, engine, cont));
+CLIENT_TO_SERIAL(UpdateGroupRoutingRow, c2s_update_group_routing_row,
+                 updateGroupRoutingRowPayload_t, doUpdateGroupRoutingRow(payload, engine, cont));
 
 // forzone, active, which, data
 typedef std::tuple<bool, bool, int, modulation::ModulatorStorage> indexedModulatorStorageUpdate_t;

--- a/src/messaging/client/selection_messages.h
+++ b/src/messaging/client/selection_messages.h
@@ -35,26 +35,26 @@
 namespace scxt::messaging::client
 {
 
-inline void doSelectAction(const selection::SelectionManager::SelectActionContents &za,
-                           const engine::Engine &engine)
+inline void doApplySelectAction(const selection::SelectionManager::SelectActionContents &za,
+                                const engine::Engine &engine)
 {
     engine.getSelectionManager()->selectAction(za);
 }
-CLIENT_TO_SERIAL(DoSelectAction, c2s_do_select_action,
+CLIENT_TO_SERIAL(ApplySelectAction, c2s_apply_select_action,
                  selection::SelectionManager::SelectActionContents,
-                 doSelectAction(payload, engine));
+                 doApplySelectAction(payload, engine));
 
 inline void
-doMultiSelectAction(const std::vector<selection::SelectionManager::SelectActionContents> &za,
-                    const engine::Engine &engine)
+doApplyMultiSelectAction(const std::vector<selection::SelectionManager::SelectActionContents> &za,
+                         const engine::Engine &engine)
 {
     engine.getSelectionManager()->multiSelectAction(za);
 }
-CLIENT_TO_SERIAL(DoMultiSelectAction, c2s_do_multi_select_action,
+CLIENT_TO_SERIAL(ApplyMultiSelectAction, c2s_apply_multi_select_action,
                  std::vector<selection::SelectionManager::SelectActionContents>,
-                 doMultiSelectAction(payload, engine));
+                 doApplyMultiSelectAction(payload, engine));
 
-CLIENT_TO_SERIAL(DoSelectPart, c2s_select_part, int16_t,
+CLIENT_TO_SERIAL(SelectPart, c2s_select_part, int16_t,
                  engine.getSelectionManager()->selectPart(payload));
 
 // Lead Zone, Zone Selection, Gropu Selection

--- a/src/messaging/client/zone_messages.h
+++ b/src/messaging/client/zone_messages.h
@@ -47,8 +47,8 @@ SERIAL_TO_CLIENT(MappingSelectedZoneView, s2c_respond_zone_mapping,
  * also have per-field updates for the UI elements below and associated
  * bound metadata
  */
-inline void mappingSelectedZoneUpdate(const engine::Zone::ZoneMappingData &payload,
-                                      const engine::Engine &engine, MessageController &cont)
+inline void doUpdateLeadZoneMapping(const engine::Zone::ZoneMappingData &payload,
+                                    const engine::Engine &engine, MessageController &cont)
 {
     // TODO Selected Zone State
     const auto &mapping = payload;
@@ -68,8 +68,8 @@ inline void mappingSelectedZoneUpdate(const engine::Zone::ZoneMappingData &paylo
             });
     }
 }
-CLIENT_TO_SERIAL(MappingSelectedZoneUpdateRequest, c2s_update_zone_mapping,
-                 engine::Zone::ZoneMappingData, mappingSelectedZoneUpdate(payload, engine, cont));
+CLIENT_TO_SERIAL(UpdateLeadZoneMapping, c2s_update_lead_zone_mapping, engine::Zone::ZoneMappingData,
+                 doUpdateLeadZoneMapping(payload, engine, cont));
 
 // Updating mapping rather than try and calculate the image client side just
 // resend the resulting mapped zones with selection state back to the UI
@@ -93,9 +93,9 @@ typedef std::tuple<bool, engine::Zone::AssociatedSampleSet> sampleSelectedZoneVi
 SERIAL_TO_CLIENT(SampleSelectedZoneView, s2c_respond_zone_samples, sampleSelectedZoneViewResposne_t,
                  onSamplesUpdated);
 
-using associatedSampleVariationPayload_t = std::tuple<size_t, engine::Zone::AssociatedSample>;
-inline void samplesSelectedZoneUpdate(const associatedSampleVariationPayload_t &payload,
-                                      const engine::Engine &engine, MessageController &cont)
+using updateLeadZoneAssociatedSample_t = std::tuple<size_t, engine::Zone::AssociatedSample>;
+inline void doUpdateLeadZoneAssociatedSample(const updateLeadZoneAssociatedSample_t &payload,
+                                             const engine::Engine &engine, MessageController &cont)
 {
     // TODO Selected Zone State
     const auto &samples = payload;
@@ -109,13 +109,13 @@ inline void samplesSelectedZoneUpdate(const associatedSampleVariationPayload_t &
         });
     }
 }
-CLIENT_TO_SERIAL(SamplesSelectedZoneUpdateRequest, c2s_update_zone_samples,
-                 associatedSampleVariationPayload_t,
-                 samplesSelectedZoneUpdate(payload, engine, cont));
+CLIENT_TO_SERIAL(UpdateLeadZoneAssociatedSample, c2s_update_lead_zone_associated_sample,
+                 updateLeadZoneAssociatedSample_t,
+                 doUpdateLeadZoneAssociatedSample(payload, engine, cont));
 
 CLIENT_TO_SERIAL_CONSTRAINED(UpdateZoneAssociatedSampleSetInt16TValue,
-                             c2s_update_zone_sampleset_int16_t, detail::diffMsg_t<int16_t>,
-                             engine::Zone::AssociatedSampleSet,
+                             c2s_update_zone_associated_sample_set_int16_t,
+                             detail::diffMsg_t<int16_t>, engine::Zone::AssociatedSampleSet,
                              detail::updateZoneMemberValue(&engine::Zone::sampleData, payload,
                                                            engine, cont));
 
@@ -134,15 +134,15 @@ CLIENT_TO_SERIAL_CONSTRAINED(UpdateZoneOutputInt16TValue, c2s_update_zone_output
                                                            engine, cont));
 
 using addBlankZonePayload_t = std::array<int, 6>;
-inline void addBlankZone(const addBlankZonePayload_t &payload, engine::Engine &engine,
-                         MessageController &cont)
+inline void doAddBlankZone(const addBlankZonePayload_t &payload, engine::Engine &engine,
+                           MessageController &cont)
 {
     auto [part, group, ks, ke, vs, ve] = payload;
     engine.createEmptyZone({ks, ke}, {vs, ve});
 }
 
 CLIENT_TO_SERIAL(AddBlankZone, c2s_add_blank_zone, addBlankZonePayload_t,
-                 addBlankZone(payload, engine, cont));
+                 doAddBlankZone(payload, engine, cont));
 
 } // namespace scxt::messaging::client
 


### PR DESCRIPTION
This continues the march to clean up 18 months of message names with no rubric rhyme or reason. but its tedious work so stalled out a bit furhter down. Addresses #1141