### PR TITLE
Mapping Constraints and Self Mod Sort

### DIFF
--- a/src/modulation/voice_matrix.cpp
+++ b/src/modulation/voice_matrix.cpp
@@ -191,7 +191,7 @@ voiceMatrixMetadata_t getVoiceMatrixMetadata(const engine::Zone &z)
         const auto &srcb = b.first;
         const auto &ida = a.second;
         const auto &idb = b.second;
-        if (srca.gid == 'zmac' && srcb.gid == 'zmac')
+        if (srca.gid == srcb.gid && (srca.gid == 'zmac' || srca.gid == 'self'))
         {
             return srca.index < srcb.index;
         }


### PR DESCRIPTION
Mapping constraints (1) are hard on drag and (2) reject inversions in the typeins, Closes #761

The self-modulation list in the mod pane is now sorted by index. Closes #1185