### PR TITLE
Rename zones and start on reorder zones

### DIFF
--- a/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -106,7 +106,12 @@ void SCXTEditor::onSamplesUpdated(
 void SCXTEditor::onStructureUpdated(const engine::Engine::pgzStructure_t &s)
 {
     if (editScreen && editScreen->partSidebar)
+    {
         editScreen->partSidebar->setPartGroupZoneStructure(s);
+    }
+    if (editScreen && editScreen->mappingPane)
+    {
+    }
 }
 
 void SCXTEditor::onGroupOrZoneProcessorDataAndMetadata(

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -624,10 +624,12 @@ void Engine::createEmptyZone(scxt::engine::KeyboardRange krange, scxt::engine::V
 
     // 2. Create a zone object on this thread but don't add it
     auto zptr = std::make_unique<Zone>();
-    // TODO fixme
     zptr->mapping.keyboardRange = krange;
     zptr->mapping.velocityRange = vrange;
     zptr->mapping.rootKey = (krange.keyStart + krange.keyEnd) / 2;
+    zptr->givenName = "Empty Zone (" + std::to_string(zptr->id.id) + ")";
+
+    // give it a name
 
     // Drop into selected group logic goes here
     auto [sp, sg] = selectionManager->bestPartGroupForNewSample(*this);

--- a/src/engine/group.h
+++ b/src/engine/group.h
@@ -152,6 +152,11 @@ struct Group : MoveableOnly<Group>,
         return res;
     }
 
+    void swapZonesByIndex(size_t zoneIndex0, size_t zoneIndex1)
+    {
+        std::swap(zones[zoneIndex0], zones[zoneIndex1]);
+    }
+
     bool isActive() const;
     void addActiveZone();
     void removeActiveZone();

--- a/src/engine/zone.h
+++ b/src/engine/zone.h
@@ -162,9 +162,11 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
     void process(Engine &onto);
     template <bool OS> void processWithOS(Engine &onto);
 
-    // TODO: editable name
+    std::string givenName{};
     std::string getName() const
     {
+        if (!givenName.empty())
+            return givenName;
         if (samplePointers[0])
             return samplePointers[0]->getDisplayName();
         return id.to_string();

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -360,10 +360,22 @@ SC_STREAMDEF(scxt::engine::Zone::AssociatedSampleSet, SC_FROM({
              }));
 
 SC_STREAMDEF(scxt::engine::Zone, SC_FROM({
+                 // special case. before given name for empty samples we used id.
+                 // crystalize this name for old patches. You can probably remove this
+                 // code in october 2024.
+                 auto useGivenName = t.givenName;
+                 if (useGivenName.empty() && !t.sampleData.samples[0].active)
+                 {
+                     SCLOG("Crystalizing given name on stream");
+                     useGivenName = t.getName();
+                 }
+                 // but just that bit
+
                  v = {{"sampleData", t.sampleData},     {"mappingData", t.mapping},
                       {"outputInfo", t.outputInfo},     {"processorStorage", t.processorStorage},
                       {"routingTable", t.routingTable}, {"modulatorStorage", t.modulatorStorage},
-                      {"aegStorage", t.egStorage[0]},   {"eg2Storage", t.egStorage[1]}};
+                      {"aegStorage", t.egStorage[0]},   {"eg2Storage", t.egStorage[1]},
+                      {"givenName", useGivenName}};
              }),
              SC_TO({
                  auto &zone = to;
@@ -377,6 +389,7 @@ SC_STREAMDEF(scxt::engine::Zone, SC_FROM({
                  findIfArray(v, "modulatorStorage", zone.modulatorStorage);
                  findOrDefault(v, "aegStorage", zone.egStorage[0]);
                  findOrDefault(v, "eg2Storage", zone.egStorage[1]);
+                 findOrSet(v, "givenName", "", zone.givenName);
                  zone.onRoutingChanged();
              }));
 

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -121,6 +121,7 @@ enum ClientToSerializationMessagesIds
     c2s_delete_selected_zones,
     c2s_delete_group,
     c2s_clear_part,
+    c2s_rename_zone,
     c2s_rename_group,
 
     c2s_set_tuning_mode,

--- a/src/messaging/client/group_messages.h
+++ b/src/messaging/client/group_messages.h
@@ -55,15 +55,5 @@ CLIENT_TO_SERIAL_CONSTRAINED(UpdateGroupOutputBoolValue, c2s_update_group_output
                              detail::updateGroupMemberValue(&engine::Group::outputInfo, payload,
                                                             engine, cont));
 
-using renameGroup_t = std::tuple<selection::SelectionManager::ZoneAddress, std::string>;
-inline void renameGroup(const renameGroup_t &payload, const engine::Engine &engine,
-                        MessageController &cont)
-{
-    const auto &[p, g, z] = std::get<0>(payload);
-    engine.getPatch()->getPart(p)->getGroup(g)->name = std::get<1>(payload);
-    serializationSendToClient(s2c_send_pgz_structure, engine.getPartGroupZoneStructure(), cont);
-}
-CLIENT_TO_SERIAL(RenameGroup, c2s_rename_group, renameGroup_t, renameGroup(payload, engine, cont));
-
 } // namespace scxt::messaging::client
 #endif // SHORTCIRCUIT_GROUP_MESSAGES_H

--- a/src/messaging/client/group_or_zone_messages.h
+++ b/src/messaging/client/group_or_zone_messages.h
@@ -95,5 +95,29 @@ CLIENT_TO_SERIAL_CONSTRAINED(
             }
         }))
 
+using renameGroupZonePayload_t = std::tuple<selection::SelectionManager::ZoneAddress, std::string>;
+inline void doRenameGroup(const renameGroupZonePayload_t &payload, const engine::Engine &engine,
+                          MessageController &cont)
+{
+    const auto &[p, g, z] = std::get<0>(payload);
+    engine.getPatch()->getPart(p)->getGroup(g)->name = std::get<1>(payload);
+    serializationSendToClient(s2c_send_pgz_structure, engine.getPartGroupZoneStructure(), cont);
+}
+CLIENT_TO_SERIAL(RenameGroup, c2s_rename_group, renameGroupZonePayload_t,
+                 doRenameGroup(payload, engine, cont));
+
+inline void doRenameZone(const renameGroupZonePayload_t &payload, const engine::Engine &engine,
+                         MessageController &cont)
+{
+    const auto &[p, g, z] = std::get<0>(payload);
+    engine.getPatch()->getPart(p)->getGroup(g)->getZone(z)->givenName = std::get<1>(payload);
+    serializationSendToClient(s2c_send_pgz_structure, engine.getPartGroupZoneStructure(), cont);
+    serializationSendToClient(s2c_send_selected_group_zone_mapping_summary,
+                              engine.getPatch()->getPart(p)->getZoneMappingSummary(),
+                              *(engine.getMessageController()));
+}
+CLIENT_TO_SERIAL(RenameZone, c2s_rename_zone, renameGroupZonePayload_t,
+                 doRenameZone(payload, engine, cont));
+
 } // namespace scxt::messaging::client
 #endif // SHORTCIRCUITXT_GROUP_OR_ZONE_MESSAGES_H


### PR DESCRIPTION
Implement a givenName for zone; set it on empty zone. Make it so the UI gesture renames it. Allow a drag to reorder of zones which is starting to work ok but has some selection bugs.

Addresses #1198