### PR TITLE
Rename AssociatedSampleEtc to VariantEtc in Zone

### DIFF
--- a/src-ui/app/edit-screen/components/MappingPane.h
+++ b/src-ui/app/edit-screen/components/MappingPane.h
@@ -49,7 +49,7 @@ struct MappingPane : sst::jucegui::components::NamedPanel, HasEditor
     void resized() override;
 
     void setMappingData(const engine::Zone::ZoneMappingData &);
-    void setSampleData(const engine::Zone::AssociatedSampleSet &);
+    void setSampleData(const engine::Zone::Variants &);
     void setGroupZoneMappingSummary(const engine::Part::zoneMappingSummary_t &);
     void selectedPartChanged();
     void macroDataChanged(int part, int index);
@@ -62,7 +62,7 @@ struct MappingPane : sst::jucegui::components::NamedPanel, HasEditor
     std::unique_ptr<MacroDisplay> macroDisplay;
 
     engine::Zone::ZoneMappingData mappingView;
-    engine::Zone::AssociatedSampleSet sampleView;
+    engine::Zone::Variants sampleView;
 
     void updateSamplePlaybackPosition(size_t sampleIndex, int64_t samplePos);
 

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -68,7 +68,7 @@ static constexpr size_t maxProcessorIntParams{5};
 
 static constexpr uint16_t lfosPerZone{4};
 static constexpr uint16_t egsPerZone{2};
-static constexpr uint16_t maxSamplesPerZone{16};
+static constexpr uint16_t maxVariantsPerZone{16};
 
 static constexpr uint16_t lfosPerGroup{4};
 static constexpr uint16_t egsPerGroup{2};

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -466,7 +466,7 @@ void Engine::loadSampleIntoZone(const fs::path &p, int16_t partID, int16_t group
                                 VelocityRange vrange)
 {
     assert(messageController->threadingChecker.isSerialThread());
-    assert(sampleID < maxSamplesPerZone);
+    assert(sampleID < maxVariantsPerZone);
 
     // TODO: Deal with compound types more comprehensively
     // If you add a type here add it to Browser::isLoadableFile also
@@ -508,8 +508,8 @@ void Engine::loadSampleIntoZone(const fs::path &p, int16_t partID, int16_t group
         [p = partID, g = groupID, z = zoneID, sID = sampleID, sample = *sid](auto &e) {
             auto &zone = e.getPatch()->getPart(p)->getGroup(g)->getZone(z);
             zone->terminateAllVoices();
-            zone->sampleData.samples[sID].sampleID = sample;
-            zone->sampleData.samples[sID].active = true;
+            zone->variantData.variants[sID].sampleID = sample;
+            zone->variantData.variants[sID].active = true;
             zone->attachToSample(*e.getSampleManager(), sID,
                                  (Zone::SampleInformationRead)(Zone::LOOP | Zone::ENDPOINTS));
         },
@@ -755,7 +755,7 @@ void Engine::loadSf2MultiSampleIntoSelectedPart(const fs::path &p)
                         SCLOG("ERROR: Can't attach to sample");
                         return;
                     }
-                    auto &znSD = zn->sampleData.samples[0];
+                    auto &znSD = zn->variantData.variants[0];
 
                     auto p = region->GetPan(presetRegion);
                     // pan in SF2 is -64 to 63 so hackety hack a bit

--- a/src/engine/engine_voice_responder.cpp
+++ b/src/engine/engine_voice_responder.cpp
@@ -67,7 +67,7 @@ int32_t Engine::VoiceManagerResponder::initializeMultipleVoices(
             }
             voiceInitWorkingBuffer[idx] = v;
         }
-        else if (z->sampleData.variantPlaybackMode == Zone::UNISON)
+        else if (z->variantData.variantPlaybackMode == Zone::UNISON)
         {
             for (int uv = 0; uv < nbSampleLoadedInZone; ++uv)
             {
@@ -95,15 +95,15 @@ int32_t Engine::VoiceManagerResponder::initializeMultipleVoices(
             }
             else
             {
-                if (z->sampleData.variantPlaybackMode == Zone::FORWARD_RR)
+                if (z->variantData.variantPlaybackMode == Zone::FORWARD_RR)
                 {
                     z->sampleIndex = (z->sampleIndex + 1) % nbSampleLoadedInZone;
                 }
-                else if (z->sampleData.variantPlaybackMode == Zone::TRUE_RANDOM)
+                else if (z->variantData.variantPlaybackMode == Zone::TRUE_RANDOM)
                 {
                     z->sampleIndex = engine.rng.unifInt(0, nbSampleLoadedInZone);
                 }
-                else if (z->sampleData.variantPlaybackMode == Zone::RANDOM_CYCLE)
+                else if (z->variantData.variantPlaybackMode == Zone::RANDOM_CYCLE)
                 {
                     if (z->numAvail == 0 || z->setupFor != nbSampleLoadedInZone)
                     {

--- a/src/engine/zone.cpp
+++ b/src/engine/zone.cpp
@@ -195,7 +195,7 @@ void Zone::setupOnUnstream(const engine::Engine &e)
 bool Zone::attachToSample(const sample::SampleManager &manager, int index,
                           SampleInformationRead sir)
 {
-    auto &s = sampleData.samples[index];
+    auto &s = variantData.variants[index];
     if (s.sampleID.isValid())
     {
         samplePointers[index] = manager.getSample(s.sampleID);

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -301,7 +301,7 @@ STREAM_ENUM(engine::Group::ProcRoutingPath, engine::Group::toStringProcRoutingPa
 STREAM_ENUM(engine::Zone::VariantPlaybackMode, engine::Zone::toStringVariantPlaybackMode,
             engine::Zone::fromStringVariantPlaybackMode);
 
-SC_STREAMDEF(scxt::engine::Zone::AssociatedSample, SC_FROM({
+SC_STREAMDEF(scxt::engine::Zone::SingleVariant, SC_FROM({
                  auto &s = from;
                  if (s.active)
                  {
@@ -346,16 +346,16 @@ SC_STREAMDEF(scxt::engine::Zone::AssociatedSample, SC_FROM({
                  }
                  else
                  {
-                     s = scxt::engine::Zone::AssociatedSample();
+                     s = scxt::engine::Zone::SingleVariant();
                      assert(!s.active);
                  }
              }));
 
-SC_STREAMDEF(scxt::engine::Zone::AssociatedSampleSet, SC_FROM({
-                 v = {{"samples", t.samples}, {"variantPlaybackMode", t.variantPlaybackMode}};
+SC_STREAMDEF(scxt::engine::Zone::Variants, SC_FROM({
+                 v = {{"variants", t.variants}, {"variantPlaybackMode", t.variantPlaybackMode}};
              }),
              SC_TO({
-                 findIf(v, "samples", result.samples);
+                 findIf(v, {"variants", "samples"}, result.variants);
                  findIf(v, "variantPlaybackMode", result.variantPlaybackMode);
              }));
 
@@ -364,14 +364,14 @@ SC_STREAMDEF(scxt::engine::Zone, SC_FROM({
                  // crystalize this name for old patches. You can probably remove this
                  // code in october 2024.
                  auto useGivenName = t.givenName;
-                 if (useGivenName.empty() && !t.sampleData.samples[0].active)
+                 if (useGivenName.empty() && !t.variantData.variants[0].active)
                  {
                      SCLOG("Crystalizing given name on stream");
                      useGivenName = t.getName();
                  }
                  // but just that bit
 
-                 v = {{"sampleData", t.sampleData},     {"mappingData", t.mapping},
+                 v = {{"variantData", t.variantData},   {"mappingData", t.mapping},
                       {"outputInfo", t.outputInfo},     {"processorStorage", t.processorStorage},
                       {"routingTable", t.routingTable}, {"modulatorStorage", t.modulatorStorage},
                       {"aegStorage", t.egStorage[0]},   {"eg2Storage", t.egStorage[1]},
@@ -379,7 +379,7 @@ SC_STREAMDEF(scxt::engine::Zone, SC_FROM({
              }),
              SC_TO({
                  auto &zone = to;
-                 findIf(v, "sampleData", zone.sampleData);
+                 findIf(v, {"variantData", "sampleData"}, zone.variantData);
                  findIf(v, "mappingData", zone.mapping);
                  findIf(v, "outputInfo", zone.outputInfo);
                  fromArrayWithSizeDifference<Traits>(v.at("processorStorage"),

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -87,8 +87,8 @@ enum ClientToSerializationMessagesIds
     c2s_update_lead_zone_mapping,
     c2s_update_zone_mapping_float,
     c2s_update_zone_mapping_int16_t,
-    c2s_update_lead_zone_associated_sample,
-    c2s_update_zone_associated_sample_set_int16_t,
+    c2s_update_lead_zone_single_variant,
+    c2s_update_zone_variants_int16_t,
 
     c2s_update_zone_output_float_value,
     c2s_update_zone_output_int16_t_value,

--- a/src/messaging/client/zone_messages.h
+++ b/src/messaging/client/zone_messages.h
@@ -89,13 +89,13 @@ CLIENT_TO_SERIAL_CONSTRAINED(
                 *(eng.getMessageController()));
         }));
 
-typedef std::tuple<bool, engine::Zone::AssociatedSampleSet> sampleSelectedZoneViewResposne_t;
+typedef std::tuple<bool, engine::Zone::Variants> sampleSelectedZoneViewResposne_t;
 SERIAL_TO_CLIENT(SampleSelectedZoneView, s2c_respond_zone_samples, sampleSelectedZoneViewResposne_t,
                  onSamplesUpdated);
 
-using updateLeadZoneAssociatedSample_t = std::tuple<size_t, engine::Zone::AssociatedSample>;
-inline void doUpdateLeadZoneAssociatedSample(const updateLeadZoneAssociatedSample_t &payload,
-                                             const engine::Engine &engine, MessageController &cont)
+using updateLeadZoneSingleVariantPayload_t = std::tuple<size_t, engine::Zone::SingleVariant>;
+inline void doUpdateLeadZoneSingleVariant(const updateLeadZoneSingleVariantPayload_t &payload,
+                                          const engine::Engine &engine, MessageController &cont)
 {
     // TODO Selected Zone State
     const auto &samples = payload;
@@ -105,18 +105,17 @@ inline void doUpdateLeadZoneAssociatedSample(const updateLeadZoneAssociatedSampl
         auto [ps, gs, zs] = *sz;
         cont.scheduleAudioThreadCallback([p = ps, g = gs, z = zs, sampv = samples](auto &eng) {
             auto &[idx, smp] = sampv;
-            eng.getPatch()->getPart(p)->getGroup(g)->getZone(z)->sampleData.samples[idx] = smp;
+            eng.getPatch()->getPart(p)->getGroup(g)->getZone(z)->variantData.variants[idx] = smp;
         });
     }
 }
-CLIENT_TO_SERIAL(UpdateLeadZoneAssociatedSample, c2s_update_lead_zone_associated_sample,
-                 updateLeadZoneAssociatedSample_t,
-                 doUpdateLeadZoneAssociatedSample(payload, engine, cont));
+CLIENT_TO_SERIAL(UpdateLeadZoneSingleVariant, c2s_update_lead_zone_single_variant,
+                 updateLeadZoneSingleVariantPayload_t,
+                 doUpdateLeadZoneSingleVariant(payload, engine, cont));
 
-CLIENT_TO_SERIAL_CONSTRAINED(UpdateZoneAssociatedSampleSetInt16TValue,
-                             c2s_update_zone_associated_sample_set_int16_t,
-                             detail::diffMsg_t<int16_t>, engine::Zone::AssociatedSampleSet,
-                             detail::updateZoneMemberValue(&engine::Zone::sampleData, payload,
+CLIENT_TO_SERIAL_CONSTRAINED(UpdateZoneVariantsInt16TValue, c2s_update_zone_variants_int16_t,
+                             detail::diffMsg_t<int16_t>, engine::Zone::Variants,
+                             detail::updateZoneMemberValue(&engine::Zone::variantData, payload,
                                                            engine, cont));
 
 using zoneOutputInfoUpdate_t = std::pair<bool, engine::Zone::ZoneOutputInfo>;

--- a/src/sample/sfz_support/sfz_import.cpp
+++ b/src/sample/sfz_support/sfz_import.cpp
@@ -298,8 +298,8 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
                             if (oc.value == "loop_continuous")
                             {
                                 // FIXME: In round robin looping modes this is probably wrong
-                                zn->sampleData.samples[0].loopActive = true;
-                                zn->sampleData.samples[0].loopMode =
+                                zn->variantData.variants[0].loopActive = true;
+                                zn->variantData.variants[0].loopMode =
                                     engine::Zone::LOOP_DURING_VOICE;
                             }
                             else

--- a/src/selection/selection_manager.cpp
+++ b/src/selection/selection_manager.cpp
@@ -490,7 +490,7 @@ void SelectionManager::sendDisplayDataForZonesBasedOnLead(int p, int g, int z)
                               cms::MappingSelectedZoneView::s2c_payload_t{true, zp->mapping},
                               *(engine.getMessageController()));
     serializationSendToClient(cms::s2c_respond_zone_samples,
-                              cms::SampleSelectedZoneView::s2c_payload_t{true, zp->sampleData},
+                              cms::SampleSelectedZoneView::s2c_payload_t{true, zp->variantData},
                               *(engine.getMessageController()));
     serializationSendToClient(
         cms::s2c_update_group_or_zone_adsr_view,

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -207,11 +207,11 @@ template <bool OS> bool Voice::processWithOS()
     bool envGate{isGated};
     if (sampleIndex >= 0)
     {
-        auto &sdata = zone->sampleData.samples[sampleIndex];
+        auto &vdata = zone->variantData.variants[sampleIndex];
 
-        envGate = (sdata.playMode == engine::Zone::NORMAL && isGated) ||
-                  (sdata.playMode == engine::Zone::ONE_SHOT && isGeneratorRunning) ||
-                  (sdata.playMode == engine::Zone::ON_RELEASE && isGeneratorRunning);
+        envGate = (vdata.playMode == engine::Zone::NORMAL && isGated) ||
+                  (vdata.playMode == engine::Zone::ONE_SHOT && isGeneratorRunning) ||
+                  (vdata.playMode == engine::Zone::ON_RELEASE && isGeneratorRunning);
     }
 
     /*
@@ -541,7 +541,7 @@ void Voice::initializeGenerator()
 
     // but the default of course is to use the sapmle index
     auto &s = zone->samplePointers[sampleIndex];
-    auto &sampleData = zone->sampleData.samples[sampleIndex];
+    auto &variantData = zone->variantData.variants[sampleIndex];
     assert(s);
 
     GDIO.outputL = output[0];
@@ -562,23 +562,23 @@ void Voice::initializeGenerator()
     }
     GDIO.waveSize = s->sample_length;
 
-    GD.samplePos = sampleData.startSample;
+    GD.samplePos = variantData.startSample;
     GD.sampleSubPos = 0;
-    GD.loopLowerBound = sampleData.startSample;
-    GD.loopUpperBound = sampleData.endSample;
-    GD.loopFade = sampleData.loopFade;
-    GD.playbackLowerBound = sampleData.startSample;
-    GD.playbackUpperBound = sampleData.endSample;
+    GD.loopLowerBound = variantData.startSample;
+    GD.loopUpperBound = variantData.endSample;
+    GD.loopFade = variantData.loopFade;
+    GD.playbackLowerBound = variantData.startSample;
+    GD.playbackUpperBound = variantData.endSample;
     GD.direction = 1;
     GD.isFinished = false;
 
-    if (sampleData.loopActive)
+    if (variantData.loopActive)
     {
-        GD.loopLowerBound = sampleData.startLoop;
-        GD.loopUpperBound = sampleData.endLoop;
+        GD.loopLowerBound = variantData.startLoop;
+        GD.loopUpperBound = variantData.endLoop;
     }
 
-    if (sampleData.playReverse)
+    if (variantData.playReverse)
     {
         GD.samplePos = GD.playbackUpperBound;
         GD.direction = -1;
@@ -598,9 +598,9 @@ void Voice::initializeGenerator()
 
     monoGenerator = s->channels == 1;
     Generator = dsp::GetFPtrGeneratorSample(!monoGenerator, s->bitDepth == sample::Sample::BD_F32,
-                                            sampleData.loopActive,
-                                            sampleData.loopDirection == engine::Zone::FORWARD_ONLY,
-                                            sampleData.loopMode == engine::Zone::LOOP_WHILE_GATED);
+                                            variantData.loopActive,
+                                            variantData.loopDirection == engine::Zone::FORWARD_ONLY,
+                                            variantData.loopMode == engine::Zone::LOOP_WHILE_GATED);
 }
 
 float Voice::calculateVoicePitch()


### PR DESCRIPTION
Zone.h now has two classes Variants and SingleVariant, which used to be called AssociatedSampleSet and AssociatedSample

Variants now has a member .variants rather than .samples

It streams as "variants" rather than "samples" (but unstreams as either for backwards compat)

maxSamplePerZone is now maxVariantsPerZone

Addresses #1141