### PR TITLE
Temporary workaround for accidental move on select

### DIFF
--- a/src-ui/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
+++ b/src-ui/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
@@ -280,6 +280,10 @@ void ZoneLayoutDisplay::mouseDrag(const juce::MouseEvent &e)
 {
     if (mouseState == DRAG_SELECTED_ZONE)
     {
+        if (e.getDistanceFromDragStart() < 3)
+        {
+            return;
+        }
         auto lb = getLocalBounds().toFloat();
         auto displayRegion = lb;
 


### PR DESCRIPTION
In  bd2b2e4 we made select start a drag event but this meant tiny mosue movements when selecting would send a drag event simultaneously with the select event on the wrong zone, making zones overlap.

The correct fix for this is to wait for the new selected zone or update the view internally when selecting, so this is not a good solution long term, buit this fixes the bug in the interim.

Addresses #1270