### PR TITLE
Lift bus effects to voice

### DIFF
--- a/src-ui/app/edit-screen/components/MacroMappingVariantPane.h
+++ b/src-ui/app/edit-screen/components/MacroMappingVariantPane.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_MAPPINGPANE_H
-#define SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_MAPPINGPANE_H
+#ifndef SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_MACROMAPPINGVARIANTPANE_H
+#define SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_MACROMAPPINGVARIANTPANE_H
 
 #include "sst/jucegui/components/NamedPanel.h"
 #include "app/HasEditor.h"

--- a/src-ui/app/edit-screen/components/ProcessorPane.cpp
+++ b/src-ui/app/edit-screen/components/ProcessorPane.cpp
@@ -83,6 +83,9 @@ void ProcessorPane::showHamburgerMenu()
     std::string priorGroup = "none";
     for (const auto &pd : editor->allProcessors)
     {
+        if (pd.groupOnly && forZone)
+            continue;
+
         if (pd.displayGroup != priorGroup && priorGroup != "none")
         {
             p.addSubMenu(priorGroup, subMenu);

--- a/src-ui/app/edit-screen/components/mapping-pane/VariantDisplay.h
+++ b/src-ui/app/edit-screen/components/mapping-pane/VariantDisplay.h
@@ -25,8 +25,8 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_MAPPING_PANE_SAMPLEDISPLAY_H
-#define SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_MAPPING_PANE_SAMPLEDISPLAY_H
+#ifndef SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_MAPPING_PANE_VARIANTDISPLAY_H
+#define SCXT_SRC_UI_APP_EDIT_SCREEN_COMPONENTS_MAPPING_PANE_VARIANTDISPLAY_H
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include "sst/jucegui/components/ZoomContainer.h"

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -82,6 +82,7 @@ namespace log
 static constexpr bool selection{false};
 static constexpr bool uiStructure{false};
 static constexpr bool groupZoneMutation{false};
+static constexpr bool memoryPool{false};
 } // namespace log
 
 } // namespace scxt

--- a/src/dsp/processor/definition_helpers.h
+++ b/src/dsp/processor/definition_helpers.h
@@ -76,4 +76,10 @@
         static constexpr float defaultMix{mix};                                                    \
     };
 
+#define PROC_FOR_GROUP_ONLY(proct)                                                                 \
+    template <> struct ProcessorForGroupOnly<proct>                                                \
+    {                                                                                              \
+        static constexpr bool isGroupOnly{true};                                                   \
+    };
+
 #endif // SHORTCIRCUITXT_DEFINITION_HELPERS_H

--- a/src/dsp/processor/processor.cpp
+++ b/src/dsp/processor/processor.cpp
@@ -121,6 +121,11 @@ template <size_t I> float implGetProcessorDefaultMix()
     return ProcessorDefaultMix<(ProcessorType)I>::defaultMix;
 }
 
+template <size_t I> bool implGetForGroupOnly()
+{
+    return ProcessorForGroupOnly<(ProcessorType)I>::isGroupOnly;
+}
+
 template <size_t... Is> auto getProcessorDisplayGroup(size_t ft, std::index_sequence<Is...>)
 {
     constexpr constCharOp_t fnc[] = {detail::implGetProcessorDisplayGroup<Is>...};
@@ -132,6 +137,13 @@ template <size_t... Is> auto getProcessorDefaultMix(size_t ft, std::index_sequen
     constexpr floatOp_t fnc[] = {detail::implGetProcessorDefaultMix<Is>...};
     return fnc[ft]();
 }
+
+template <size_t... Is> auto getForGroupOnly(size_t ft, std::index_sequence<Is...>)
+{
+    constexpr boolOp_t fnc[] = {detail::implGetForGroupOnly<Is>...};
+    return fnc[ft]();
+}
+
 template <size_t I>
 Processor *returnSpawnOnto(uint8_t *m, engine::MemoryPool *mp, const ProcessorStorage &ps, float *f,
                            int *i, bool needsMetadata)
@@ -222,6 +234,12 @@ float getProcessorDefaultMix(ProcessorType id)
         id, std::make_index_sequence<(size_t)ProcessorType::proct_num_types>());
 }
 
+bool getProcessorGroupOnly(ProcessorType id)
+{
+    return detail::getForGroupOnly(
+        id, std::make_index_sequence<(size_t)ProcessorType::proct_num_types>());
+}
+
 std::optional<ProcessorType> fromProcessorStreamingName(const std::string &s)
 {
     // A bit gross but hey
@@ -242,7 +260,7 @@ processorList_t getAllProcessorDescriptions()
         if (isProcessorImplemented(pt))
         {
             res.push_back({pt, getProcessorStreamingName(pt), getProcessorName(pt),
-                           getProcessorDisplayGroup(pt)});
+                           getProcessorDisplayGroup(pt), getProcessorGroupOnly(pt)});
         }
     }
     std::sort(res.begin(), res.end(), [](const auto &a, const auto &b) {

--- a/src/dsp/processor/processor.h
+++ b/src/dsp/processor/processor.h
@@ -147,6 +147,11 @@ enum ProcessorType
     proct_noise_am,
     proct_osc_phasemod, // last part/fx
 
+    proct_lifted_reverb1,
+    proct_lifted_reverb2,
+    proct_lifted_delay,
+    proct_lifted_flanger,
+
     proct_fx_treemonster,
     proct_osc_VA,
     proct_osc_tiltnoise,
@@ -161,12 +166,14 @@ const char *getProcessorName(ProcessorType id);
 const char *getProcessorStreamingName(ProcessorType id);
 const char *getProcessorDisplayGroup(ProcessorType id);
 float getProcessorDefaultMix(ProcessorType id);
+bool getProcessorGroupOnly(ProcessorType id);
 std::optional<ProcessorType> fromProcessorStreamingName(const std::string &s);
 
 struct ProcessorDescription
 {
     ProcessorType id;
     std::string streamingName{"ERROR"}, displayName{"ERROR"}, displayGroup{"ERROR"};
+    bool groupOnly{false};
 };
 
 typedef std::vector<ProcessorDescription> processorList_t;
@@ -243,6 +250,7 @@ struct Processor : MoveableOnly<Processor>, SampleRateSupport
 
   public:
     size_t preReserveSize[16]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    size_t preReserveSingleInstanceSize[16]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
     ProcessorType getType() const { return myType; }
     std::string getName() const { return getProcessorName(getType()); }
@@ -348,6 +356,11 @@ template <ProcessorType ft> struct ProcessorImplementor
 template <ProcessorType ft> struct ProcessorDefaultMix
 {
     static constexpr float defaultMix{1.0};
+};
+
+template <ProcessorType ft> struct ProcessorForGroupOnly
+{
+    static constexpr bool isGroupOnly{false};
 };
 
 } // namespace scxt::dsp::processor

--- a/src/dsp/processor/processor_defs.h
+++ b/src/dsp/processor/processor_defs.h
@@ -97,6 +97,11 @@
 #include "sst/voice-effects/dynamics/Compressor.h"
 #include "sst/voice-effects/dynamics/AutoWah.h"
 
+#include "sst/voice-effects/lifted_bus_effects/LiftedReverb1.h"
+#include "sst/voice-effects/lifted_bus_effects/LiftedReverb2.h"
+#include "sst/voice-effects/lifted_bus_effects/LiftedDelay.h"
+#include "sst/voice-effects/lifted_bus_effects/LiftedFlanger.h"
+
 namespace scxt::dsp::processor
 {
 // Just don't change the id or streaming name, basically
@@ -214,6 +219,29 @@ DEFINE_PROC(ShepardPhaser, sst::voice_effects::modulation::ShepardPhaser<SCXTVFX
 DEFINE_PROC(Chorus, sst::voice_effects::delay::Chorus<SCXTVFXConfig<1>>,
             sst::voice_effects::delay::Chorus<SCXTVFXConfig<2>>, proct_Chorus, "Chorus",
             "Modulation", "voice-chorus", dsp::surgeSincTable);
+
+DEFINE_PROC(LiftedReverb1, sst::voice_effects::liftbus::LiftedReverb1<SCXTVFXConfig<1>>,
+            sst::voice_effects::liftbus::LiftedReverb1<SCXTVFXConfig<2>>, proct_lifted_reverb1,
+            "Reverb1", "Reverb", "lifted-reverb1");
+PROC_FOR_GROUP_ONLY(proct_lifted_reverb1);
+PROC_DEFAULT_MIX(proct_lifted_reverb1, 0.333);
+
+DEFINE_PROC(LiftedReverb2, sst::voice_effects::liftbus::LiftedReverb2<SCXTVFXConfig<1>>,
+            sst::voice_effects::liftbus::LiftedReverb2<SCXTVFXConfig<2>>, proct_lifted_reverb2,
+            "Reverb2", "Reverb", "lifted-reverb2");
+PROC_FOR_GROUP_ONLY(proct_lifted_reverb2);
+PROC_DEFAULT_MIX(proct_lifted_reverb2, 0.333);
+
+DEFINE_PROC(LiftedDelay, sst::voice_effects::liftbus::LiftedDelay<SCXTVFXConfig<1>>,
+            sst::voice_effects::liftbus::LiftedDelay<SCXTVFXConfig<2>>, proct_lifted_delay,
+            "Dual Delay", "Delay", "lifted-delay");
+PROC_FOR_GROUP_ONLY(proct_lifted_delay);
+PROC_DEFAULT_MIX(proct_lifted_delay, 0.333);
+
+DEFINE_PROC(LiftedFlanger, sst::voice_effects::liftbus::LiftedFlanger<SCXTVFXConfig<1>>,
+            sst::voice_effects::liftbus::LiftedFlanger<SCXTVFXConfig<2>>, proct_lifted_flanger,
+            "Flanger", "Modulation", "lifted-flanger");
+PROC_FOR_GROUP_ONLY(proct_lifted_flanger);
 
 } // namespace scxt::dsp::processor
 

--- a/src/dsp/processor/processor_impl.h
+++ b/src/dsp/processor/processor_impl.h
@@ -61,6 +61,25 @@ template <int OSFactor> struct SCXTVFXConfig
         }
     }
 
+    static void preReserveSingleInstancePool(BaseClass *b, size_t s)
+    {
+        if (b->memoryPool)
+        {
+            b->memoryPool->preReserveSingleInstancePool(s);
+        }
+        else
+        {
+            for (int i = 0; i < 16; ++i)
+            {
+                if (b->preReserveSingleInstanceSize[i] == 0)
+                {
+                    b->preReserveSingleInstanceSize[i] = s;
+                    break;
+                }
+            }
+        }
+    }
+
     static uint8_t *checkoutBlock(BaseClass *b, size_t s)
     {
         assert(b->memoryPool);
@@ -350,6 +369,11 @@ void Processor::setupProcessor(T *that, ProcessorType t, engine::MemoryPool *mp,
         {
             assert(memoryPool);
             memoryPool->preReservePool(preReserveSize[i]);
+        }
+        if (preReserveSingleInstanceSize[i] > 0)
+        {
+            assert(memoryPool);
+            memoryPool->preReserveSingleInstancePool(preReserveSingleInstanceSize[i]);
         }
     }
 }

--- a/src/engine/group.h
+++ b/src/engine/group.h
@@ -67,7 +67,6 @@ struct Group : MoveableOnly<Group>,
         {
             if (p)
             {
-                SCLOG("Group Destructor: Unspawning Processors");
                 dsp::processor::unspawnProcessor(p);
             }
         }

--- a/src/engine/group_and_zone_impl.h
+++ b/src/engine/group_and_zone_impl.h
@@ -132,15 +132,17 @@ HasGroupZoneProcessors<T>::spawnTempProcessor(int whichProcessor,
                                               dsp::processor::ProcessorType type, uint8_t *mem,
                                               float *pfp, int *ifp, bool initFromDefaults)
 {
-    dsp::processor::Processor *tmpProcessor{nullptr};
+    auto &tc = asT()->getEngine()->getMessageController()->threadingChecker;
 
-    auto &ps = processorStorage[whichProcessor];
-    tmpProcessor = dsp::processor::spawnProcessorInPlace(
-        type, asT()->getEngine()->getMemoryPool().get(), mem,
-        dsp::processor::processorMemoryBufferSize, ps, pfp, ifp, false, true);
+    dsp::processor::Processor *tmpProcessor{nullptr};
 
     if (type != dsp::processor::proct_none)
     {
+        auto &ps = processorStorage[whichProcessor];
+        tmpProcessor = dsp::processor::spawnProcessorInPlace(
+            type, asT()->getEngine()->getMemoryPool().get(), mem,
+            dsp::processor::processorMemoryBufferSize, ps, pfp, ifp, false, true);
+
         assert(tmpProcessor);
         assert(asT()->getEngine());
         if (asT()->getEngine()->isSampleRateSet())

--- a/src/engine/memory_pool.cpp
+++ b/src/engine/memory_pool.cpp
@@ -27,6 +27,7 @@
 
 #include "memory_pool.h"
 #include <cassert>
+#include "configuration.h"
 
 namespace scxt::engine
 {
@@ -38,34 +39,19 @@ namespace scxt::engine
 
 MemoryPool::~MemoryPool()
 {
+    SCLOG_IF(memoryPool, "Destroying memory pool " << SCD(debugCheckouts) << SCD(debugReturns));
     assert(debugCheckouts == debugReturns);
 
     for (auto &[sz, s] : cache)
     {
-        while (!s.empty())
+        SCLOG_IF(memoryPool, "Cleaning up pool of size " << sz);
+        while (!s.data.empty())
         {
-            delete[] s.front();
-            s.pop();
+            delete[] s.data.front();
+            s.data.pop();
         }
     }
 }
-
-#define ALLOCATE_IMPLEMENTATION 0
-#if ALLOCATE_IMPLEMENTATION
-void MemoryPool::preReservePool(size_t blockSize) {}
-MemoryPool::data_t *MemoryPool::checkoutBlock(size_t blockSize)
-{
-    // Technically don't need this in the naive impl but lets avoid some bugs
-    debugCheckouts++;
-    auto ubs = nearestBlock(blockSize);
-    return new data_t[ubs];
-}
-void MemoryPool::returnBlock(data_t *block, size_t blockSize)
-{
-    debugReturns++;
-    delete[] block;
-}
-#else
 
 static constexpr size_t initialPoolSize{16};
 MemoryPool::data_t *MemoryPool::checkoutBlock(size_t requestBlockSize)
@@ -73,20 +59,23 @@ MemoryPool::data_t *MemoryPool::checkoutBlock(size_t requestBlockSize)
     // Technically don't need this in the naive impl but lets avoid some bugs
     auto blockSize = nearestBlock(requestBlockSize);
     auto cacheP = cache.find(blockSize);
+    SCLOG_IF(memoryPool,
+             "Checkout Block " << blockSize << " from pool of size " << cacheP->second.data.size());
     assert(cacheP != cache.end()); // If you hit this you didn't pre-reserve
     if (cacheP == cache.end())
     {
         return nullptr;
     }
-    if (cacheP->second.empty())
+    assert(cacheP->second.associatedSize == blockSize);
+    if (cacheP->second.data.empty())
     {
-        growBlock(requestBlockSize, initialPoolSize);
+        growBlock(requestBlockSize, false);
         return checkoutBlock(requestBlockSize);
     }
 
     debugCheckouts++;
-    auto res = cacheP->second.front();
-    cacheP->second.pop();
+    auto res = cacheP->second.data.front();
+    cacheP->second.data.pop();
 
     // Please leave these in. Handy to debug
     // SCLOG(blockSize << " : Post checkout size is " << cacheP->second.size());
@@ -99,38 +88,73 @@ void MemoryPool::returnBlock(data_t *block, size_t requestBlockSize)
     auto cacheP = cache.find(blockSize);
     assert(cacheP != cache.end()); // If you hit this you didn't pre-reserve
 
-    cacheP->second.push(block);
-
-    // SCLOG(blockSize << ": Post return size is " << cacheP->second.size());
+    cacheP->second.data.push(block);
+    SCLOG_IF(memoryPool, "Return Block " << blockSize << " now have " << cacheP->second.data.size()
+                                         << " entries");
 }
 
-void MemoryPool::growBlock(size_t requestBlockSize, size_t byEntries)
+void MemoryPool::growBlock(size_t requestBlockSize, bool initialize)
 {
     auto blockSize = nearestBlock(requestBlockSize);
+    SCLOG_IF(memoryPool, "Growing block size " << blockSize << " init=" << initialize);
     // SCLOG(blockSize << ": Growing pool " << blockSize);
     auto cacheP = cache.find(blockSize);
     assert(cacheP != cache.end()); // If you hit this you didn't pre-reserve
 
-    for (auto i = 0U; i < initialPoolSize; ++i)
+    auto gb = initialize ? cacheP->second.initialPoolSize : cacheP->second.growSize;
+
+    SCLOG_IF(memoryPool, "Adding entries from " << cacheP->second.data.size() << " to " << gb);
+
+    for (auto i = cacheP->second.data.size(); i < gb; ++i)
     {
-        cacheP->second.push(new data_t[blockSize]);
+        cacheP->second.data.push(new data_t[blockSize]);
     }
-    // SCLOG(blockSize << ": Post grow size is " << cacheP->second.size());
 }
 
 void MemoryPool::preReservePool(size_t requestBlockSize)
 {
     auto blockSize = nearestBlock(requestBlockSize);
+    SCLOG_IF(memoryPool, "preReserve Pool " << blockSize);
+    auto cacheP = cache.find(blockSize);
+    if (cacheP == cache.end())
+    {
+        auto cacheSet = pool_t();
+        cacheSet.associatedSize = blockSize;
+        cacheSet.initialPoolSize = initialPoolSize;
+        cacheSet.growSize = initialPoolSize >> 1;
+
+        cache.insert({blockSize, std::move(cacheSet)});
+        growBlock(requestBlockSize, true);
+    }
+    SCLOG_IF(memoryPool,
+             "preReserve complete " << blockSize << " " << cache[blockSize].data.size());
+}
+
+void MemoryPool::preReserveSingleInstancePool(size_t requestBlockSize)
+{
+    auto blockSize = nearestBlock(requestBlockSize);
+    SCLOG_IF(memoryPool, "preReserve Single Instance Pool " << blockSize);
+
     auto cacheP = cache.find(blockSize);
     if (cacheP == cache.end())
     {
         auto cacheSet = pool_t();
 
-        cache.insert({blockSize, cacheSet});
-        growBlock(requestBlockSize, initialPoolSize);
+        cacheSet.associatedSize = blockSize;
+        cacheSet.initialPoolSize = 1;
+        cacheSet.growSize = 1;
+
+        cache.insert({blockSize, std::move(cacheSet)});
+        growBlock(requestBlockSize, true);
     }
-    // SCLOG(blockSize << ": Pre-Reserve cache found " << cache.at(blockSize).size() << " entries")
+    // For single pool make sure its there if i pre-reserve it.
+    const auto &pool = cache[blockSize];
+    if (pool.data.size() < pool.initialPoolSize)
+    {
+        growBlock(requestBlockSize, true);
+    }
+    SCLOG_IF(memoryPool,
+             "preReserve Single complete " << blockSize << " " << cache[blockSize].data.size());
 }
-#endif
 
 } // namespace scxt::engine

--- a/src/engine/memory_pool.h
+++ b/src/engine/memory_pool.h
@@ -45,6 +45,7 @@ struct MemoryPool : MoveableOnly<MemoryPool>
     ~MemoryPool();
 
     void preReservePool(size_t blockSize);
+    void preReserveSingleInstancePool(size_t blockSize);
 
     data_t *checkoutBlock(size_t blockSize);
     void returnBlock(data_t *block, size_t blockSize);
@@ -54,8 +55,14 @@ struct MemoryPool : MoveableOnly<MemoryPool>
     {
         return ((x >> N) + 1) * (1 << N);
     }
-    void growBlock(size_t blockSize, size_t byEntries);
-    using pool_t = std::queue<data_t *>;
+    void growBlock(size_t blockSize, bool initialize);
+    struct SinglePool : MoveableOnly<SinglePool>
+    {
+        size_t associatedSize;
+        size_t initialPoolSize, growSize;
+        std::queue<data_t *> data;
+    };
+    using pool_t = SinglePool;
     using cache_t = std::unordered_map<size_t, pool_t>;
     cache_t cache;
 

--- a/src/json/dsp_traits.h
+++ b/src/json/dsp_traits.h
@@ -97,10 +97,9 @@ SC_STREAMDEF(scxt::dsp::processor::ProcessorDescription,
              SC_FROM({ // Streaming this type as an int is fine since the processor storage
                  // stringifies definitively. This is just for in-session communication
                  v = {
-                     {"id", (int32_t)t.id},
-                     {"streamingName", t.streamingName},
-                     {"displayName", t.displayName},
-                     {"displayGroup", t.displayGroup},
+                     {"id", (int32_t)t.id},          {"streamingName", t.streamingName},
+                     {"displayName", t.displayName}, {"displayGroup", t.displayGroup},
+                     {"groupOnly", t.groupOnly},
                  };
              }),
              SC_TO({
@@ -110,6 +109,7 @@ SC_STREAMDEF(scxt::dsp::processor::ProcessorDescription,
                  findIf(v, "streamingName", result.streamingName);
                  findIf(v, "displayName", result.displayName);
                  findIf(v, "displayGroup", result.displayGroup);
+                 findIf(v, "groupOnly", result.groupOnly);
              }))
 
 SC_STREAMDEF(

--- a/src/utils.h
+++ b/src/utils.h
@@ -239,7 +239,7 @@ std::string logTimestamp();
     {                                                                                              \
         if constexpr (scxt::log::x)                                                                \
         {                                                                                          \
-            SCLOG(__VA_ARGS__);                                                                    \
+            SCLOG("[" << #x << "] " << __VA_ARGS__);                                               \
         }                                                                                          \
     }
 


### PR DESCRIPTION
this commit allows bus-to-voice effects to be used on group processors. It also introduces an api for group-only processors. It brings in R1, R2, Delay and Flanger. It updates the memory pool API

It does not support temposync, and it usese the
underlying tail apis, which for delay at least is
incorrect. I'll open a new issue for those. But this can close a couple of others

Closes #1280
Closes #1281