### PR TITLE
Fix UTF encoding issues for wav sample and MSVC build

### DIFF
--- a/cmake/compiler-and-git.cmake
+++ b/cmake/compiler-and-git.cmake
@@ -67,6 +67,7 @@ else ()
                 /wd4018   # signed unsigned compare
                 /wd4996   # don't warn on stricmp vs _stricmp and other posix names
                 /wd4267   # converting size_t <-> int
+                /utf-8
                 )
     endif ()
 

--- a/src-ui/app/browser-ui/BrowserPane.cpp
+++ b/src-ui/app/browser-ui/BrowserPane.cpp
@@ -314,8 +314,9 @@ struct DriveFSListBoxRow : public juce::Component
             if (auto *container = juce::DragAndDropContainer::findParentDragContainerFor(this))
             {
                 const auto &data = browserPane->devicesPane->driveFSArea->contents;
-                getProperties().set("DragAndDropSample",
-                                    juce::String::fromUTF8(data[rowNumber].path().u8string().c_str()));
+                getProperties().set(
+                    "DragAndDropSample",
+                    juce::String::fromUTF8(data[rowNumber].path().u8string().c_str()));
                 container->startDragging("FileSystem Row", this);
                 isDragging = true;
             }

--- a/src-ui/app/browser-ui/BrowserPane.cpp
+++ b/src-ui/app/browser-ui/BrowserPane.cpp
@@ -314,9 +314,8 @@ struct DriveFSListBoxRow : public juce::Component
             if (auto *container = juce::DragAndDropContainer::findParentDragContainerFor(this))
             {
                 const auto &data = browserPane->devicesPane->driveFSArea->contents;
-
                 getProperties().set("DragAndDropSample",
-                                    juce::String(data[rowNumber].path().u8string()));
+                                    juce::String::fromUTF8(data[rowNumber].path().u8string().c_str()));
                 container->startDragging("FileSystem Row", this);
                 isDragging = true;
             }

--- a/src-ui/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
+++ b/src-ui/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
@@ -695,12 +695,13 @@ void VariantDisplay::showLoopModeMenu()
     p.addSeparator();
 
     auto add = [&p, this](auto e, bool alt, auto n) {
+        auto that = this;
         p.addItem(n, true,
                   variantView.variants[selectedVariation].loopMode == e &&
                       variantView.variants[selectedVariation].loopDirection ==
                           (alt ? engine::Zone::LoopDirection::ALTERNATE_DIRECTIONS
                                : engine::Zone::LoopDirection::FORWARD_ONLY),
-                  [w = juce::Component::SafePointer(this), e, alt]() {
+                  [w = juce::Component::SafePointer(that), e, alt]() {
                       if (!w)
                           return;
                       w->variantView.variants[w->selectedVariation].loopMode = e;

--- a/src/json/sample_traits.h
+++ b/src/json/sample_traits.h
@@ -124,7 +124,7 @@ SC_STREAMDEF(sample::Sample::SampleFileAddress, SC_FROM({
                  findOrSet(v, "type", sample::Sample::WAV_FILE, to.type);
                  std::string p;
                  findIf(v, "path", p);
-                 to.path = fs::path{p};
+                 to.path = fs::path(fs::u8path(p));
                  findIf(v, "md5sum", to.md5sum);
                  findOrSet(v, "preset", 0, to.preset); // 0 here since we forgot to stream for a bit
                  findOrSet(v, "instrument", -1, to.instrument);

--- a/src/messaging/client/structure_messages.h
+++ b/src/messaging/client/structure_messages.h
@@ -91,7 +91,7 @@ inline void addSampleWithRange(const addSampleWithRange_t &payload, engine::Engi
                                MessageController &cont)
 {
     assert(cont.threadingChecker.isSerialThread());
-    auto p = fs::path{std::get<0>(payload)};
+    auto p = fs::path(fs::u8path(std::get<0>(payload)));
     auto rk = std::get<1>(payload);
     auto kr = engine::KeyboardRange(std::get<2>(payload), std::get<3>(payload));
     auto vr = engine::VelocityRange(std::get<4>(payload), std::get<5>(payload));


### PR DESCRIPTION
Reliably maintain unicode encoding on all strings for dragging a wav file from the browser into the engine and storing it in a multi. This fixes that simple case but we need a top to bottom review of all the other stream-a-path gestures in the codebase (although I think this is the majority of them)

Also MSVC has a bug with double-this-binding in lambdas which this commit fixes