### PR TITLE
Portable simple mode and defense against no user dir

### DIFF
--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -55,7 +55,7 @@
 #include <mutex>
 #include "messaging/client/client_serial.h"
 
-namespace scxt::engine
+namespace scxt::enginer
 {
 
 Engine::Engine()
@@ -990,7 +990,6 @@ std::optional<fs::path> Engine::setupUserStorageDirectory()
     try
     {
         auto res = sst::plugininfra::paths::bestDocumentsFolderPathFor(productName);
-        res = fs::path("/usr/share/notw");
         if (!fs::is_directory(res))
             fs::create_directories(res);
         if (fs::is_directory(res))


### PR DESCRIPTION
1. Add a simple portable mode for documents looking for ShortcircuitXTUserData
2. If its not there and you can't use system documents, make the portable directory and warn
3. If that fails at least use a temp directory so you stand a chance of not crashing