### PR TITLE
More parsominous with clobbering wav metadata in sfz load

### DIFF
--- a/src/engine/zone.h
+++ b/src/engine/zone.h
@@ -195,12 +195,12 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
     bool attachToSample(const sample::SampleManager &manager, int index = 0,
                         SampleInformationRead sir = ALL);
     bool attachToSampleAtVariation(const sample::SampleManager &manager, const SampleID &sid,
-                                   int16_t variation)
+                                   int16_t variation, SampleInformationRead sir = ALL)
     {
         variantData.variants[variation].sampleID = sid;
         variantData.variants[variation].active = true;
 
-        return attachToSample(manager, variation);
+        return attachToSample(manager, variation, sir);
     }
 
     void setNormalizedSampleLevel(bool usePeak = false, int associatedSampleID = -1);

--- a/src/sample/sfz_support/sfz_import.cpp
+++ b/src/sample/sfz_support/sfz_import.cpp
@@ -222,7 +222,8 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
                         z->mapping.velocityRange.velEnd == ve)
                     {
                         int idx = roundRobinPosition - 1;
-                        z->attachToSampleAtVariation(*e.getSampleManager(), sid, idx);
+                        z->attachToSampleAtVariation(*e.getSampleManager(), sid, idx,
+                                                     engine::Zone::ENDPOINTS);
                         attached = true;
                         break;
                     }
@@ -304,7 +305,7 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
                             }
                             else
                             {
-                                SCLOG("Unsupported loop_mode : " << oc.value);
+                                SCLOG("SFZ Unsupported loop_mode : " << oc.value);
                             }
                         }
 
@@ -326,7 +327,8 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
                         }
                     }
                 }
-                zn->attachToSample(*e.getSampleManager());
+                zn->attachToSample(*e.getSampleManager(), 0,
+                                   engine::Zone::SampleInformationRead::ENDPOINTS);
                 group->addZone(zn);
             }
             if (firstGroupWithZonesAdded == -1)


### PR DESCRIPTION
Basically don't clobber. Just the endpoints. Still not correct. Will open an issue on correct behavior when merging htis.

But this closes #1308