### PR TITLE
Fix a couple of zone reorder bugs

### DIFF
--- a/src-ui/app/edit-screen/components/GroupZoneTreeControl.h
+++ b/src-ui/app/edit-screen/components/GroupZoneTreeControl.h
@@ -177,8 +177,18 @@ template <typename SidebarParent, bool fz> struct GroupZoneListBoxModel : juce::
 
                 if (dragOverState == DRAG_OVER)
                 {
-                    g.setColour(editor->themeColor(theme::ColorMap::accent_1b));
-                    g.drawHorizontalLine(1, 0, getWidth());
+                    if (isZone())
+                    {
+                        g.setColour(editor->themeColor(theme::ColorMap::accent_1b));
+                        g.drawHorizontalLine(1, 0, getWidth());
+                    }
+                    else
+                    {
+                        g.setColour(editor->themeColor(theme::ColorMap::accent_1b).withAlpha(0.1f));
+                        g.fillRect(getLocalBounds());
+                        g.setColour(editor->themeColor(theme::ColorMap::accent_1b));
+                        g.drawRect(getLocalBounds(), 1);
+                    }
                 }
             }
             else
@@ -318,7 +328,6 @@ template <typename SidebarParent, bool fz> struct GroupZoneListBoxModel : juce::
 
         void itemDragEnter(const SourceDetails &dragSourceDetails) override
         {
-            SCLOG("Item Drag Enter");
             dragOverState = DRAG_OVER;
             repaint();
         }

--- a/src/messaging/client/structure_messages.h
+++ b/src/messaging/client/structure_messages.h
@@ -293,13 +293,20 @@ inline void moveZoneFromTo(const zoneAddressFromTo_t &payload, engine::Engine &e
         [s = src, t = tgt](auto &e) {
             if (s.group == t.group)
             {
-                // Its a zone swap
-                auto &group = e.getPatch()->getPart(s.part)->getGroup(s.group);
-                auto &zoneS = group->getZone(s.zone);
-                auto &zoneT = group->getZone(t.zone);
-                e.terminateVoicesForZone(*zoneS);
-                e.terminateVoicesForZone(*zoneT);
-                group->swapZonesByIndex(s.zone, t.zone);
+                if (t.zone == -1)
+                {
+                    // You've moved an item onto its own goroup. So that's a noop
+                }
+                else
+                {
+                    // Its a zone swap
+                    auto &group = e.getPatch()->getPart(s.part)->getGroup(s.group);
+                    auto &zoneS = group->getZone(s.zone);
+                    auto &zoneT = group->getZone(t.zone);
+                    e.terminateVoicesForZone(*zoneS);
+                    e.terminateVoicesForZone(*zoneT);
+                    group->swapZonesByIndex(s.zone, t.zone);
+                }
             }
             else
             {


### PR DESCRIPTION
If you moved a zone ontos its own group, bad things would happen which looked like 'crash with running voice' but crash with running voice in other cases was just fine.

Make the UI a little clearer also so this is a bit less error prone

Closes #1305