### PR TITLE
Tiny optimization

### DIFF
--- a/src/engine/group.h
+++ b/src/engine/group.h
@@ -103,6 +103,7 @@ struct Group : MoveableOnly<Group>,
     size_t addZone(std::unique_ptr<Zone> &z)
     {
         z->parentGroup = this;
+        z->engine = getEngine();
         zones.push_back(std::move(z));
         return zones.size();
     }
@@ -110,6 +111,7 @@ struct Group : MoveableOnly<Group>,
     size_t addZone(std::unique_ptr<Zone> &&z)
     {
         z->parentGroup = this;
+        z->engine = getEngine();
         zones.push_back(std::move(z));
         return zones.size();
     }

--- a/src/engine/zone.cpp
+++ b/src/engine/zone.cpp
@@ -188,20 +188,6 @@ void Zone::clearNormalizedSampleLevel(const int associatedSampleID)
     }
 }
 
-engine::Engine *Zone::getEngine()
-{
-    if (parentGroup && parentGroup->parentPart && parentGroup->parentPart->parentPatch)
-        return parentGroup->parentPart->parentPatch->parentEngine;
-    return nullptr;
-}
-
-const engine::Engine *Zone::getEngine() const
-{
-    if (parentGroup && parentGroup->parentPart && parentGroup->parentPart->parentPatch)
-        return parentGroup->parentPart->parentPatch->parentEngine;
-    return nullptr;
-}
-
 void Zone::initialize()
 {
     for (auto &v : voiceWeakPointers)

--- a/src/engine/zone.h
+++ b/src/engine/zone.h
@@ -250,8 +250,17 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
     void onProcessorTypeChanged(int, dsp::processor::ProcessorType) {}
 
     void setupOnUnstream(const engine::Engine &e);
-    engine::Engine *getEngine();
-    const engine::Engine *getEngine() const;
+    engine::Engine *engine{nullptr};
+    engine::Engine *getEngine()
+    {
+        assert(engine);
+        return engine;
+    }
+    const engine::Engine *getEngine() const
+    {
+        assert(engine);
+        return engine;
+    }
 
     sst::basic_blocks::dsp::UIComponentLagHandler mUILag;
     void onSampleRateChanged() override;


### PR DESCRIPTION
So I've started running it in the profiler and the obvious stuff like running-unused-lfos and summing-unused-busses is dominant but funnily the if in getEngine showed up as a 3% usage when playing basic samples, so knock that out.