### PR TITLE
A continuous control RMB

### DIFF
--- a/src-ui/app/HasEditor.h
+++ b/src-ui/app/HasEditor.h
@@ -55,7 +55,7 @@ struct HasEditor
 
     template <typename T> void updateValueTooltip(const T &attachment);
     template <typename W, typename A>
-    void setupWidgetForValueTooltip(const W &widget, const A &attachment);
+    void setupWidgetForValueTooltip(W *widget, const A &attachment);
 };
 } // namespace scxt::ui::app
 #endif // SHORTCIRCUIT_HASEDITOR_H

--- a/src-ui/app/SCXTEditor.h
+++ b/src-ui/app/SCXTEditor.h
@@ -186,6 +186,7 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::DragAndDropCont
         return r;
     }
     void configureHasDiscreteMenuBuilder(sst::jucegui::components::HasDiscreteParamMenuBuilder *);
+    void popupMenuForContinuous(sst::jucegui::components::ContinuousParamEditor *e);
 
     // Serialization to Client Messages
     void onErrorFromEngine(const scxt::messaging::client::s2cError_t &);
@@ -328,7 +329,7 @@ template <typename T> inline void HasEditor::updateValueTooltip(const T &at)
 }
 
 template <typename W, typename A>
-inline void HasEditor::setupWidgetForValueTooltip(const W &w, const A &a)
+inline void HasEditor::setupWidgetForValueTooltip(W *w, const A &a)
 {
     w->onBeginEdit = [this, &slRef = *w, &atRef = *a]() {
         editor->showTooltip(slRef);
@@ -344,6 +345,14 @@ inline void HasEditor::setupWidgetForValueTooltip(const W &w, const A &a)
         updateValueTooltip(atRef);
     };
     w->onIdleHoverEnd = [this]() { editor->hideTooltip(); };
+    if constexpr (std::is_base_of_v<sst::jucegui::components::ContinuousParamEditor,
+                                    std::remove_pointer_t<W>>)
+    {
+        w->onPopupMenu = [this, q = juce::Component::SafePointer(w)](auto &mods) {
+            editor->hideTooltip();
+            editor->popupMenuForContinuous(q);
+        };
+    }
 }
 } // namespace scxt::ui::app
 

--- a/src-ui/app/edit-screen/components/ProcessorPane.h
+++ b/src-ui/app/edit-screen/components/ProcessorPane.h
@@ -119,7 +119,7 @@ struct ProcessorPane : sst::jucegui::components::NamedPanel, HasEditor, juce::Dr
             sst::jucegui::components::Labeled<sst::jucegui::components::ContinuousParamEditor>>();
         auto kn = std::make_unique<T>();
         kn->setSource(at.get());
-        setupWidgetForValueTooltip(kn, at);
+        setupWidgetForValueTooltip(kn.get(), at);
         kn->setTitle(at->getLabel());
         kn->setDescription(at->getLabel());
         getContentAreaComponent()->addAndMakeVisible(*kn);

--- a/src-ui/app/editor-impl/SCXTEditorMenus.cpp
+++ b/src-ui/app/editor-impl/SCXTEditorMenus.cpp
@@ -327,4 +327,33 @@ void SCXTEditor::addUIThemesMenu(juce::PopupMenu &p, bool addTitle)
     }
 }
 
+void SCXTEditor::popupMenuForContinuous(sst::jucegui::components::ContinuousParamEditor *e)
+{
+    auto data = e->continuous();
+    if (!data)
+    {
+        SCLOG("Continuous with no data - no popup to be had");
+        return;
+    }
+
+    if (!e->isEnabled())
+    {
+        SCLOG("No menu on non-enabled widget");
+        return;
+    }
+
+    auto p = juce::PopupMenu();
+    p.addSectionHeader(data->getLabel());
+    p.addSeparator();
+    p.addItem(data->getValueAsString(), []() {});
+    p.addSeparator();
+    p.addItem("Set to Default", [w = juce::Component::SafePointer(e)]() {
+        if (!w)
+            return;
+        w->continuous()->setValueFromGUI(w->continuous()->getDefaultValue());
+    });
+
+    p.showMenuAsync(defaultPopupMenuOptions());
+}
+
 } // namespace scxt::ui::app

--- a/src-ui/app/mixer-screen/components/ChannelStrip.cpp
+++ b/src-ui/app/mixer-screen/components/ChannelStrip.cpp
@@ -114,7 +114,7 @@ ChannelStrip::ChannelStrip(SCXTEditor *e, MixerScreen *m, int bi, BusType t)
             axs->setSource(ava.get());
             addAndMakeVisible(*axs);
             auxAttachments[idx] = std::move(ava);
-            setupWidgetForValueTooltip(axs, auxAttachments[idx]);
+            setupWidgetForValueTooltip(axs.get(), auxAttachments[idx]);
             idx++;
         }
         idx = 0;
@@ -148,14 +148,14 @@ ChannelStrip::ChannelStrip(SCXTEditor *e, MixerScreen *m, int bi, BusType t)
     panKnob = std::make_unique<jcmp::Knob>();
     panKnob->setSource(panAttachment.get());
     addAndMakeVisible(*panKnob);
-    setupWidgetForValueTooltip(panKnob, panAttachment);
+    setupWidgetForValueTooltip(panKnob.get(), panAttachment);
 
     vcaAttachment = std::make_unique<attachment_t>(
         datamodel::pmd().asCubicDecibelAttenuation().withName("Level").withDefault(1.0), onChange,
         mixer->busSendData[busIndex].level);
     vcaSlider = std::make_unique<jcmp::VSlider>();
     vcaSlider->setSource(vcaAttachment.get());
-    setupWidgetForValueTooltip(vcaSlider, vcaAttachment);
+    setupWidgetForValueTooltip(vcaSlider.get(), vcaAttachment);
     addAndMakeVisible(*vcaSlider);
 
     if (t != BusType::MAIN)

--- a/src-ui/app/mixer-screen/components/PartEffectsPane.cpp
+++ b/src-ui/app/mixer-screen/components/PartEffectsPane.cpp
@@ -183,7 +183,7 @@ template <typename T> T *PartEffectsPane::attachWidgetToFloat(int pidx)
         w->setEnabled(true);
     }
 
-    setupWidgetForValueTooltip(w, at);
+    setupWidgetForValueTooltip(w.get(), at);
     addAndMakeVisible(*w);
 
     if constexpr (std::is_same_v<T, jcmp::Knob>)


### PR DESCRIPTION
- Add a popup to all continous controls created by the HasEditor helper (which is all of them except the depth slider)
- Delegate this to the SCXTEditor class.
- Just show the value right now but also add a set to default so we can test edits work (they do)

Addresses #1316