### PR TITLE
RMB allows a typein

### DIFF
--- a/src-ui/CMakeLists.txt
+++ b/src-ui/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(${PROJECT_NAME} STATIC
         app/play-screen/PlayScreen.cpp
 
         app/shared/HeaderRegion.cpp
+        app/shared/MenuValueTypein.cpp
         app/shared/PartSidebarCard.cpp
         app/shared/SingleMacroEditor.cpp
 

--- a/src-ui/app/editor-impl/SCXTEditorMenus.cpp
+++ b/src-ui/app/editor-impl/SCXTEditorMenus.cpp
@@ -40,6 +40,7 @@
 #include "app/shared/HeaderRegion.h"
 #include "app/edit-screen/components/MacroMappingVariantPane.h"
 #include "app/other-screens/AboutScreen.h"
+#include "app/shared/MenuValueTypein.h"
 
 #include <version.h>
 
@@ -345,7 +346,8 @@ void SCXTEditor::popupMenuForContinuous(sst::jucegui::components::ContinuousPara
     auto p = juce::PopupMenu();
     p.addSectionHeader(data->getLabel());
     p.addSeparator();
-    p.addItem(data->getValueAsString(), []() {});
+    p.addCustomItem(
+        -1, std::make_unique<shared::MenuValueTypein>(this, juce::Component::SafePointer(e)));
     p.addSeparator();
     p.addItem("Set to Default", [w = juce::Component::SafePointer(e)]() {
         if (!w)

--- a/src-ui/app/shared/MenuValueTypein.cpp
+++ b/src-ui/app/shared/MenuValueTypein.cpp
@@ -1,0 +1,91 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "MenuValueTypein.h"
+#include "app/SCXTEditor.h"
+
+namespace scxt::ui::app::shared
+{
+
+MenuValueTypein::MenuValueTypein(
+    SCXTEditor *editor,
+    juce::Component::SafePointer<sst::jucegui::components::ContinuousParamEditor> under)
+    : HasEditor(editor), underComp(under), juce::PopupMenu::CustomComponent(false)
+{
+    textEditor = std::make_unique<juce::TextEditor>();
+    textEditor->setText(under->continuous()->getValueAsString(),
+                        juce::NotificationType::dontSendNotification);
+    textEditor->setWantsKeyboardFocus(true);
+    textEditor->addListener(this);
+    textEditor->setIndents(2, 0);
+
+    auto valCol = editor->style()->getColour(
+        sst::jucegui::components::ContinuousParamEditor::Styles::styleClass,
+        sst::jucegui::components::ContinuousParamEditor::Styles::value);
+
+    if (auto styleCon =
+            dynamic_cast<sst::jucegui::style::StyleConsumer *>(underComp.getComponent()))
+    {
+        valCol =
+            styleCon->getColour(sst::jucegui::components::ContinuousParamEditor::Styles::value);
+    }
+
+    textEditor->setColour(juce::TextEditor::ColourIds::backgroundColourId, valCol.withAlpha(0.2f));
+    textEditor->setColour(juce::TextEditor::ColourIds::highlightColourId, valCol.withAlpha(0.32f));
+    textEditor->setJustification(juce::Justification::centredLeft);
+    textEditor->setColour(juce::TextEditor::ColourIds::outlineColourId,
+                          juce::Colours::black.withAlpha(0.f));
+    textEditor->setColour(juce::TextEditor::ColourIds::focusedOutlineColourId,
+                          juce::Colours::black.withAlpha(0.f));
+    textEditor->setBorder(juce::BorderSize<int>(3));
+    textEditor->applyColourToAllText(editor->themeColor(theme::ColorMap::generic_content_high),
+                                     true);
+    textEditor->applyFontToAllText(editor->themeApplier.interMediumFor(13), true);
+
+    addAndMakeVisible(*textEditor);
+}
+
+void MenuValueTypein::textEditorReturnKeyPressed(juce::TextEditor &ed)
+{
+    auto s = ed.getText().toStdString();
+    if (underComp && underComp->continuous())
+    {
+        if (s.empty())
+        {
+            SCLOG("Empty value - setting to default of "
+                  << underComp->continuous()->getDefaultValue());
+            underComp->continuous()->setValueFromGUI(underComp->continuous()->getDefaultValue());
+        }
+        else
+        {
+            underComp->continuous()->setValueAsString(s);
+        }
+    }
+    triggerMenuItem();
+}
+
+} // namespace scxt::ui::app::shared

--- a/src-ui/app/shared/MenuValueTypein.h
+++ b/src-ui/app/shared/MenuValueTypein.h
@@ -1,0 +1,69 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_UI_APP_SHARED_MENUVALUETYPEIN_H
+#define SCXT_SRC_UI_APP_SHARED_MENUVALUETYPEIN_H
+
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <sst/jucegui/components/ContinuousParamEditor.h>
+#include "app/HasEditor.h"
+
+namespace scxt::ui::app::shared
+{
+
+struct MenuValueTypein : HasEditor, juce::PopupMenu::CustomComponent, juce::TextEditor::Listener
+{
+    std::unique_ptr<juce::TextEditor> textEditor;
+    juce::Component::SafePointer<sst::jucegui::components::ContinuousParamEditor> underComp;
+    MenuValueTypein(
+        SCXTEditor *editor,
+        juce::Component::SafePointer<sst::jucegui::components::ContinuousParamEditor> under);
+
+    void getIdealSize(int &w, int &h) override
+    {
+        w = 180;
+        h = 22;
+    }
+    void resized() override { textEditor->setBounds(getLocalBounds().reduced(3, 1)); }
+
+    void visibilityChanged() override
+    {
+        juce::Timer::callAfterDelay(2, [this]() {
+            if (textEditor->isVisible())
+            {
+                textEditor->grabKeyboardFocus();
+                textEditor->selectAll();
+            }
+        });
+    }
+
+    void textEditorReturnKeyPressed(juce::TextEditor &ed) override;
+    void textEditorEscapeKeyPressed(juce::TextEditor &) override { triggerMenuItem(); }
+};
+
+} // namespace scxt::ui::app::shared
+#endif // MENUVALUETYPEIN_H


### PR DESCRIPTION
- RMB has a typein which is focused and allows you to type in a value on all knobs. Some caveats though
- Doesn't work with temposync, #1347
- Bit of an accessible nightmare. Need a switch. #1348.
- Defaulting seems generally inconsistent or broken. #1349

but the core idea of "lets put the typein on the menu" works. So this closes #1316