### PR TITLE
Mod Matrix Smoothing in place (still defaults to off)

### DIFF
--- a/src/engine/group.cpp
+++ b/src/engine/group.cpp
@@ -54,7 +54,7 @@ Group::Group()
 void Group::rePrepareAndBindGroupMatrix()
 {
     endpoints.sources.bind(modMatrix, *this);
-    modMatrix.prepare(routingTable);
+    modMatrix.prepare(routingTable, getSampleRate(), blockSize);
     endpoints.bindTargetBaseValues(modMatrix, *this);
     modMatrix.process();
 

--- a/src/json/modulation_traits.h
+++ b/src/json/modulation_traits.h
@@ -189,8 +189,11 @@ SC_STREAMDEF(scxt::voice::modulation::Matrix::RoutingTable::Routing, SC_FROM({
                  }
                  else
                  {
-                     v = {{"active", t.active}, {"source", t.source}, {"sourceVia", t.sourceVia},
-                          {"target", t.target}, {"curve", t.curve},   {"depth", t.depth}};
+                     v = {{"active", t.active},       {"source", t.source},
+                          {"sourceVia", t.sourceVia}, {"target", t.target},
+                          {"curve", t.curve},         {"depth", t.depth},
+                          {"srcLMS", t.sourceLagMS},  {"srVLMS", t.sourceViaLagMS},
+                          {"srcLE", t.sourceLagExp},  {"srVLE", t.sourceViaLagExp}};
                      if (SC_STREAMING_FOR_IN_PROCESS)
                          addToObject<val_t>(v, "extraPayload", t.extraPayload);
                  }
@@ -204,6 +207,10 @@ SC_STREAMDEF(scxt::voice::modulation::Matrix::RoutingTable::Routing, SC_FROM({
                  findIf(v, "curve", result.curve);
                  findIf(v, "depth", result.depth);
                  findIf(v, "extraPayload", result.extraPayload);
+                 findOrSet(v, "srcLMS", 0, result.sourceLagMS);
+                 findOrSet(v, "srVLMS", 0, result.sourceViaLagMS);
+                 findOrSet(v, "srcLE", true, result.sourceLagExp);
+                 findOrSet(v, "srVLE", true, result.sourceViaLagExp);
              }));
 
 SC_STREAMDEF(scxt::voice::modulation::Matrix::RoutingTable, SC_FROM({

--- a/src/modulation/group_matrix.h
+++ b/src/modulation/group_matrix.h
@@ -72,6 +72,11 @@ struct GroupMatrixConfig
         auto res = multiplicativeTargets.find(ti) != multiplicativeTargets.end();
         return res;
     }
+    static bool supportsLag(const SourceIdentifier &s)
+    {
+        SCLOG_ONCE("Supports Lag says 'yes' for all voice matrix values currently");
+        return true;
+    }
 
     static constexpr bool IsFixedMatrix{true};
     static constexpr size_t FixedMatrixSize{12};

--- a/src/modulation/voice_matrix.h
+++ b/src/modulation/voice_matrix.h
@@ -74,6 +74,12 @@ struct MatrixConfig
         return res;
     }
 
+    static bool supportsLag(const SourceIdentifier &s)
+    {
+        SCLOG_ONCE("Supports Lag says 'yes' for all voice matrix values currently");
+        return true;
+    }
+
     static constexpr bool IsFixedMatrix{true};
     static constexpr size_t FixedMatrixSize{12};
 

--- a/src/selection/selection_manager.cpp
+++ b/src/selection/selection_manager.cpp
@@ -701,7 +701,7 @@ void SelectionManager::configureAndSendZoneModMatrixMetadata(int p, int g, int z
     // routing table. Or maybe even make it a function on zone (that's probably better).
     scxt::voice::modulation::Matrix mat;
     mat.forUIMode = true;
-    mat.prepare(zp->routingTable);
+    mat.prepare(zp->routingTable, engine.getSampleRate(), blockSize);
     scxt::voice::modulation::MatrixEndpoints ep{nullptr};
     ep.bindTargetBaseValues(mat, *zp);
     for (auto &r : zp->routingTable.routes)

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -106,7 +106,7 @@ void Voice::voiceStarted()
 
     // This order matters
     endpoints->sources.bind(modMatrix, *zone, *this);
-    modMatrix.prepare(zone->routingTable);
+    modMatrix.prepare(zone->routingTable, getSampleRate(), blockSize);
     endpoints->bindTargetBaseValues(modMatrix, *zone);
     modMatrix.process();
 


### PR DESCRIPTION
This commit implements smoothing, both linear and exponential, in the mod matrix. It exposes this in the UI as a sub-menu for a source and it is available for every source (except of course for "No Source").

Currently there's no per-source defaults for the matrix. I'll add that as a separate issue but lets use this commit to close #1343