### PR TITLE
Save and Load individual parts.

### DIFF
--- a/src-ui/app/shared/HeaderRegion.h
+++ b/src-ui/app/shared/HeaderRegion.h
@@ -109,6 +109,8 @@ struct HeaderRegion : juce::Component, HasEditor, juce::FileDragAndDropTarget
     void showSaveMenu();
     void doSaveMulti();
     void doLoadMulti();
+    void doSaveSelectedPart();
+    void doLoadIntoSelectedPart();
 
     void showMultiSelectionMenu();
 

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -350,6 +350,7 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     {
         IN_PROCESS,
         FOR_MULTI,
+        FOR_PART,
         FOR_DAW
     };
     static thread_local StreamReason streamReason;

--- a/src/engine/part.cpp
+++ b/src/engine/part.cpp
@@ -84,4 +84,20 @@ Part::zoneMappingSummary_t Part::getZoneMappingSummary()
     }
     return res;
 }
+
+std::vector<SampleID> Part::getSamplesUsedByPart() const
+{
+    std::unordered_set<SampleID> resSet;
+    for (const auto &g : groups)
+    {
+        for (const auto &z : g->getZones())
+        {
+            for (const auto &var : z->variantData.variants)
+            {
+                resSet.insert(var.sampleID);
+            }
+        }
+    }
+    return std::vector<SampleID>(resSet.begin(), resSet.end());
+}
 } // namespace scxt::engine

--- a/src/engine/part.h
+++ b/src/engine/part.h
@@ -195,6 +195,8 @@ struct Part : MoveableOnly<Part>, SampleRateSupport
     groupContainer_t::iterator end() noexcept { return groups.end(); }
     groupContainer_t::const_iterator cend() const noexcept { return groups.cend(); }
 
+    std::vector<SampleID> getSamplesUsedByPart() const;
+
   private:
     groupContainer_t groups;
 };

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -154,10 +154,38 @@ SC_STREAMDEF(
     scxt::engine::Part, SC_FROM({
         // TODO: Do a non-empty part stream with the If variant
         v = {{"config", from.configuration}, {"groups", from.getGroups()}, {"macros", from.macros}};
+        if (SC_STREAMING_FOR_PART)
+        {
+            addToObject<val_t>(v, "streamingVersion", currentStreamingVersion);
+            addToObject<val_t>(v, "streamedForPart", true);
+            assert(from.parentPatch->parentEngine);
+            addToObject<val_t>(
+                v, "samplesUsedByPart",
+                from.parentPatch->parentEngine->getSampleManager()->getSampleAddressesFor(
+                    from.getSamplesUsedByPart()));
+            SCLOG("ToDo - stream sample manager subset");
+        }
     }),
     SC_TO({
         auto &part = to;
         part.clearGroups();
+
+        std::unique_ptr<engine::Engine::UnstreamGuard> sg;
+        bool streamedForPart{false};
+        findOrSet(v, "streamedForPart", false, streamedForPart);
+        if (streamedForPart)
+        {
+            uint64_t partStreamingVersion{0};
+            findIf(v, "streamingVersion", partStreamingVersion);
+            SCLOG("Unstreaming part state. Stream version : "
+                  << scxt::humanReadableVersion(partStreamingVersion));
+
+            scxt::sample::SampleManager::sampleAddressesAndIds_t samples;
+            findIf(v, "samplesUsedByPart", samples);
+            to.parentPatch->parentEngine->getSampleManager()->restoreFromSampleAddressesAndIDs(samples);
+
+            sg = std::make_unique<engine::Engine::UnstreamGuard>(partStreamingVersion);
+        }
 
         if (SC_UNSTREAMING_FROM_PRIOR_TO(0x2024'08'18))
         {

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -182,7 +182,8 @@ SC_STREAMDEF(
 
             scxt::sample::SampleManager::sampleAddressesAndIds_t samples;
             findIf(v, "samplesUsedByPart", samples);
-            to.parentPatch->parentEngine->getSampleManager()->restoreFromSampleAddressesAndIDs(samples);
+            to.parentPatch->parentEngine->getSampleManager()->restoreFromSampleAddressesAndIDs(
+                samples);
 
             sg = std::make_unique<engine::Engine::UnstreamGuard>(partStreamingVersion);
         }

--- a/src/json/scxt_traits.h
+++ b/src/json/scxt_traits.h
@@ -210,6 +210,8 @@ void addUnlessDefault(V &v, const std::string &key, const R &defVal, const R &va
 #define SC_STREAMING_FOR_DAW (engine::Engine::streamReason == engine::Engine::StreamReason::FOR_DAW)
 #define SC_STREAMING_FOR_MULTI                                                                     \
     (engine::Engine::streamReason == engine::Engine::StreamReason::FOR_MULTI)
+#define SC_STREAMING_FOR_PART                                                                      \
+    (engine::Engine::streamReason == engine::Engine::StreamReason::FOR_PART)
 
 #define SC_STREAMING_FOR_DAW_OR_MULTI (SC_STREAMING_FOR_DAW || SC_STREAMING_FOR_MULTI)
 

--- a/src/json/stream.cpp
+++ b/src/json/stream.cpp
@@ -101,4 +101,37 @@ void unstreamEngineState(engine::Engine &e, const std::string &data, bool msgPac
 
     e.sendFullRefreshToClient();
 }
+
+
+void unstreamPartState(engine::Engine &e, int part, const std::string &data, bool msgPack)
+{
+    e.clearAll();
+    if (msgPack)
+    {
+        tao::json::events::transformer<tao::json::events::to_basic_value<scxt_traits>> consumer;
+        tao::json::msgpack::events::from_string(consumer, data);
+        auto jv = std::move(consumer.value);
+        jv.to(*(e.getPatch()->getPart(part)));
+    }
+    else
+    {
+        tao::json::events::transformer<tao::json::events::to_basic_value<scxt_traits>> consumer;
+        tao::json::events::from_string(consumer, data);
+        auto jv = std::move(consumer.value);
+        jv.to(*(e.getPatch()->getPart(part)));
+    }
+
+    if (!e.getSampleManager()->missingList.empty())
+    {
+        std::ostringstream oss;
+        oss << "On load, sample manager could not locate the following files:\n";
+        for (const auto &p : e.getSampleManager()->missingList)
+        {
+            oss << "  " << p.u8string() << "\n";
+        }
+        e.getMessageController()->reportErrorToClient("Missing Samples", oss.str());
+    }
+
+    e.sendFullRefreshToClient();
+}
 } // namespace scxt::json

--- a/src/json/stream.cpp
+++ b/src/json/stream.cpp
@@ -102,7 +102,6 @@ void unstreamEngineState(engine::Engine &e, const std::string &data, bool msgPac
     e.sendFullRefreshToClient();
 }
 
-
 void unstreamPartState(engine::Engine &e, int part, const std::string &data, bool msgPack)
 {
     e.clearAll();

--- a/src/json/stream.h
+++ b/src/json/stream.h
@@ -37,6 +37,7 @@ namespace scxt::json
 std::string streamPatch(const engine::Patch &p, bool pretty = false);
 std::string streamEngineState(const engine::Engine &e, bool pretty = false);
 void unstreamEngineState(engine::Engine &e, const std::string &jsonData, bool msgPack = false);
+void unstreamPartState(engine::Engine &e, int part, const std::string &jsonData, bool msgPack = false);
 } // namespace scxt::json
 
 #endif // SHORTCIRCUIT_STREAM_H

--- a/src/json/stream.h
+++ b/src/json/stream.h
@@ -37,7 +37,8 @@ namespace scxt::json
 std::string streamPatch(const engine::Patch &p, bool pretty = false);
 std::string streamEngineState(const engine::Engine &e, bool pretty = false);
 void unstreamEngineState(engine::Engine &e, const std::string &jsonData, bool msgPack = false);
-void unstreamPartState(engine::Engine &e, int part, const std::string &jsonData, bool msgPack = false);
+void unstreamPartState(engine::Engine &e, int part, const std::string &jsonData,
+                       bool msgPack = false);
 } // namespace scxt::json
 
 #endif // SHORTCIRCUIT_STREAM_H

--- a/src/messaging/client/browser_messages.h
+++ b/src/messaging/client/browser_messages.h
@@ -46,7 +46,7 @@ inline void doAddBrowserDeviceLocation(const fs::path &p, const engine::Engine &
     serializationSendToClient(s2c_refresh_browser, true, cont);
 }
 CLIENT_TO_SERIAL(AddBrowserDeviceLocation, c2s_add_browser_device_location, std::string,
-                 doAddBrowserDeviceLocation(fs::path{payload}, engine, cont));
+                 doAddBrowserDeviceLocation(fs::path(fs::u8path(payload)), engine, cont));
 
 SERIAL_TO_CLIENT(RefreshBrowser, s2c_refresh_browser, bool, onBrowserRefresh)
 

--- a/src/messaging/client/patch_io_messages.h
+++ b/src/messaging/client/patch_io_messages.h
@@ -34,14 +34,33 @@ namespace scxt::messaging::client
 {
 inline void doSaveMulti(const std::string &s, engine::Engine &engine, MessageController &cont)
 {
-    patch_io::saveMulti(fs::path{s}, engine);
+    patch_io::saveMulti(fs::path(fs::u8path(s)), engine);
 
     SCLOG("Remember to update the browser also");
     // engine.getBrowser()->doSomething;
 }
 CLIENT_TO_SERIAL(SaveMulti, c2s_save_multi, std::string, doSaveMulti(payload, engine, cont));
-
 CLIENT_TO_SERIAL(LoadMulti, c2s_load_multi, std::string,
-                 patch_io::loadMulti(fs::path{payload}, engine));
+                 patch_io::loadMulti(fs::path(fs::u8path(payload)), engine));
+
+inline void doSaveSelectedPart(const std::string &s, engine::Engine &engine,
+                               MessageController &cont)
+{
+    SCLOG("Saving part to " << s);
+    patch_io::savePart(fs::path(fs::u8path(s)), engine, engine.getSelectionManager()->selectedPart);
+    // engine.getBrowser()->doSomething;
+}
+CLIENT_TO_SERIAL(SaveSelectedPart, c2s_save_selected_part, std::string,
+                 doSaveSelectedPart(payload, engine, cont));
+
+using loadPartIntoPayload_t = std::tuple<std::string, int16_t>;
+inline void doLoadPartInto(const loadPartIntoPayload_t &payload, engine::Engine &engine,
+                           MessageController &cont)
+{
+    patch_io::loadPartInto(fs::path(fs::u8path(std::get<0>(payload))), engine,
+                           std::get<1>(payload));
+}
+CLIENT_TO_SERIAL(LoadPartInto, c2s_load_part_into, loadPartIntoPayload_t,
+                 doLoadPartInto(payload, engine, cont));
 } // namespace scxt::messaging::client
 #endif // SHORTCIRCUITXT_PATCH_IO_MESSAGES_H

--- a/src/messaging/client/structure_messages.h
+++ b/src/messaging/client/structure_messages.h
@@ -80,7 +80,7 @@ CLIENT_TO_SERIAL(RegisterClient, c2s_register_client, bool, doRegisterClient(eng
 inline void addSample(const std::string &payload, engine::Engine &engine, MessageController &cont)
 {
     assert(cont.threadingChecker.isSerialThread());
-    auto p = fs::path{payload};
+    auto p = fs::path(fs::u8path(payload));
     engine.loadSampleIntoSelectedPartAndGroup(p);
 }
 CLIENT_TO_SERIAL(AddSample, c2s_add_sample, std::string, addSample(payload, engine, cont);)
@@ -106,7 +106,7 @@ inline void addSampleInZone(const addSampleInZone_t &payload, engine::Engine &en
                             MessageController &cont)
 {
     assert(cont.threadingChecker.isSerialThread());
-    auto path = fs::path{std::get<0>(payload)};
+    auto path = fs::path(fs::u8path(std::get<0>(payload)));
     auto part{std::get<1>(payload)};
     auto group{std::get<2>(payload)};
     auto zone{std::get<3>(payload)};

--- a/src/patch_io/patch_io.cpp
+++ b/src/patch_io/patch_io.cpp
@@ -261,7 +261,7 @@ bool loadPartInto(const fs::path &p, scxt::engine::Engine &engine, int part)
             try
             {
                 nonconste.stopAllSounds();
-                 scxt::json::unstreamPartState(nonconste, part, payload, false);
+                scxt::json::unstreamPartState(nonconste, part, payload, false);
                 auto &cont = *e.getMessageController();
                 cont.restartAudioThreadFromSerial();
             }
@@ -276,7 +276,7 @@ bool loadPartInto(const fs::path &p, scxt::engine::Engine &engine, int part)
         try
         {
             engine.stopAllSounds();
-            scxt::json::unstreamPartState(engine,part, payload, false);
+            scxt::json::unstreamPartState(engine, part, payload, false);
         }
         catch (std::exception &err)
         {

--- a/src/patch_io/patch_io.h
+++ b/src/patch_io/patch_io.h
@@ -35,8 +35,8 @@ namespace scxt::patch_io
 {
 bool saveMulti(const fs::path &toFile, const scxt::engine::Engine &);
 bool loadMulti(const fs::path &fromFile, scxt::engine::Engine &);
-bool streamPart(const fs::path &toFile, const scxt::engine::Part &);
-bool unstreamPart(const fs::path &fromFile, scxt::engine::Part &);
+bool savePart(const fs::path &toFile, const scxt::engine::Engine &, int part);
+bool loadPartInto(const fs::path &fromFile, scxt::engine::Engine &, int part);
 
 bool initFromResourceBundle(scxt::engine::Engine &e);
 } // namespace scxt::patch_io

--- a/src/sample/sample_manager.cpp
+++ b/src/sample/sample_manager.cpp
@@ -246,4 +246,24 @@ void SampleManager::updateSampleMemory()
     }
     sampleMemoryInBytes = res;
 }
+
+SampleManager::sampleAddressesAndIds_t
+SampleManager::getSampleAddressesFor(const std::vector<SampleID> &sids) const
+{
+    SampleManager::sampleAddressesAndIds_t res;
+    for (const auto &sid : sids)
+    {
+        auto smp = getSample(sid);
+        if (!smp)
+        {
+            SCLOG("WARNING: Requested non-existant sample at " << sid.to_string());
+        }
+        else
+        {
+            res.emplace_back(sid, smp->getSampleFileAddress());
+        }
+    }
+    return res;
+}
+
 } // namespace scxt::sample

--- a/src/sample/sample_manager.h
+++ b/src/sample/sample_manager.h
@@ -114,6 +114,9 @@ struct SampleManager : MoveableOnly<SampleManager>
         }
         return res;
     }
+
+    sampleAddressesAndIds_t getSampleAddressesFor(const std::vector<SampleID> &) const;
+
     void restoreFromSampleAddressesAndIDs(const sampleAddressesAndIds_t &);
 
     void purgeUnreferencedSamples();


### PR DESCRIPTION
- Streaming with a FOR_PART option includes version and samples with associated API changes
- Menu to save a part.
- Load part plumbing in place through to engine.
- Restore sample manager state *but* there's an ID colliusion issue here. See #1370

Addresses #1014 some more

Actually do the unstream (but still need sample side)

done-one