### PR TITLE
Move SampleID to MD5Sum

### DIFF
--- a/src/engine/zone.cpp
+++ b/src/engine/zone.cpp
@@ -197,6 +197,15 @@ void Zone::setupOnUnstream(const engine::Engine &e)
     auto nbSampleLoaded{getNumSampleLoaded()};
     for (auto i = 0; i < nbSampleLoaded; ++i)
     {
+        auto oid = variantData.variants[i].sampleID;
+        auto nid = e.getSampleManager()->resolveAlias(oid);
+
+        if (nid != oid)
+        {
+            SCLOG("Relabeling zone on change : " << oid.to_string() << " -> " << nid.to_string());
+            variantData.variants[i].sampleID = nid;
+        }
+
         attachToSample(*(e.getSampleManager()), i, Zone::NONE);
     }
     for (int p = 0; p < processorCount; ++p)

--- a/src/json/stream.cpp
+++ b/src/json/stream.cpp
@@ -104,7 +104,7 @@ void unstreamEngineState(engine::Engine &e, const std::string &data, bool msgPac
 
 void unstreamPartState(engine::Engine &e, int part, const std::string &data, bool msgPack)
 {
-    e.clearAll();
+    e.getPatch()->getPart(part)->clearGroups();
     if (msgPack)
     {
         tao::json::events::transformer<tao::json::events::to_basic_value<scxt_traits>> consumer;

--- a/src/json/utils_traits.h
+++ b/src/json/utils_traits.h
@@ -70,5 +70,30 @@ template <int idType> struct scxt_traits<ID<idType>>
         }
     }
 };
+
+SC_STREAMDEF(scxt::SampleID, SC_FROM(v = {{"m", from.md5}, {"a", from.multiAddress}});
+             , SC_TO(
+                   auto vs = v.find("m"); if (vs) {
+                       std::string m5;
+                       vs->to(m5);
+                       strncpy(to.md5, m5.c_str(), scxt::SampleID::md5len + 1);
+                       findIf(v, "a", to.multiAddress);
+                   } else {
+                       std::string legType{"t"}, legID{"i"};
+                       if (SC_UNSTREAMING_FROM_PRIOR_TO(0x2024'08'06))
+                       {
+                           legType = "idType";
+                           legID = "id";
+                       }
+
+                       if (6 != v.at(legType).template as<int32_t>())
+                       {
+                           SCLOG("Unstreamed a non-6 type from legacy");
+                       }
+                       int32_t id;
+                       v.at(legID).to(id);
+                       to.setAsLegacy(id);
+                   }));
+
 } // namespace scxt::json
 #endif // SHORTCIRCUIT_UTILS_TRAITS_H

--- a/src/patch_io/patch_io.cpp
+++ b/src/patch_io/patch_io.cpp
@@ -119,9 +119,7 @@ bool savePart(const fs::path &p, const scxt::engine::Engine &e, int part)
     try
     {
         auto sg = scxt::engine::Engine::StreamGuard(engine::Engine::FOR_PART);
-        // auto msg =
-        // tao::json::msgpack::to_string(json::scxt_value(*(e.getPatch()->getPart(part))));
-        auto msg = tao::json::to_string(json::scxt_value(*(e.getPatch()->getPart(part))));
+        auto msg = tao::json::msgpack::to_string(json::scxt_value(*(e.getPatch()->getPart(part))));
 
         auto f = std::make_unique<RIFF::File>('SCXT');
         f->SetByteOrder(RIFF::endian_little);
@@ -261,7 +259,7 @@ bool loadPartInto(const fs::path &p, scxt::engine::Engine &engine, int part)
             try
             {
                 nonconste.stopAllSounds();
-                scxt::json::unstreamPartState(nonconste, part, payload, false);
+                scxt::json::unstreamPartState(nonconste, part, payload, true);
                 auto &cont = *e.getMessageController();
                 cont.restartAudioThreadFromSerial();
             }
@@ -276,7 +274,7 @@ bool loadPartInto(const fs::path &p, scxt::engine::Engine &engine, int part)
         try
         {
             engine.stopAllSounds();
-            scxt::json::unstreamPartState(engine, part, payload, false);
+            scxt::json::unstreamPartState(engine, part, payload, true);
         }
         catch (std::exception &err)
         {

--- a/src/sample/multisample_support/multisample_import.cpp
+++ b/src/sample/multisample_support/multisample_import.cpp
@@ -119,7 +119,7 @@ bool importMultisample(const fs::path &p, engine::Engine &engine)
                                                   &ssize, 0);
 
         auto lsid = engine.getSampleManager()->setupSampleFromMultifile(
-            p, fileToIndex[fc->Attribute("file")], data, ssize);
+            p, md5, fileToIndex[fc->Attribute("file")], data, ssize);
         free(data);
 
         if (!lsid.has_value())

--- a/src/sample/sample.cpp
+++ b/src/sample/sample.cpp
@@ -70,6 +70,9 @@ bool Sample::load(const fs::path &path)
         mFileName = path;
         displayName = fmt::format("{}", path.filename().u8string());
         type = WAV_FILE;
+
+        id.setAsMD5(md5Sum);
+
         return true;
     }
     else if (extensionMatches(path, ".flac"))
@@ -80,6 +83,9 @@ bool Sample::load(const fs::path &path)
             type = FLAC_FILE;
             mFileName = path;
             displayName = fmt::format("{}", path.filename().u8string());
+
+            id.setAsMD5(md5Sum);
+
             return true;
         }
     }
@@ -91,6 +97,9 @@ bool Sample::load(const fs::path &path)
             type = MP3_FILE;
             mFileName = path;
             displayName = fmt::format("{}", path.filename().u8string());
+
+            id.setAsMD5(md5Sum);
+
             return true;
         }
     }
@@ -108,6 +117,9 @@ bool Sample::load(const fs::path &path)
         sample_loaded = true;
         mFileName = path;
         displayName = fmt::format("{}", path.filename().u8string());
+
+        id.setAsMD5(md5Sum);
+
         return true;
     }
 

--- a/src/sample/sample.h
+++ b/src/sample/sample.h
@@ -46,7 +46,7 @@ struct alignas(16) Sample : MoveableOnly<Sample>
         MULTISAMPLE_FILE,
     } type{WAV_FILE};
 
-    Sample() : id(SampleID::next()) {}
+    Sample() {}
     Sample(const SampleID &sid) : displayName(sid.to_string()), id(sid) {}
     virtual ~Sample();
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -88,10 +88,60 @@ typedef ID<4> GroupID;
 template <> inline const std::string GroupID::display_name() const { return "Group"; }
 typedef ID<5> ZoneID;
 template <> inline const std::string ZoneID::display_name() const { return "Zone"; }
-typedef ID<6> SampleID;
-template <> inline const std::string SampleID::display_name() const { return "Sample"; }
 typedef ID<7> EngineID;
 template <> inline const std::string EngineID::display_name() const { return "Engine"; }
+
+struct SampleID
+{
+    static constexpr size_t md5len{32};
+    char md5[md5len + 1]{};
+    std::array<int, 3> multiAddress{-1, -1, -1};
+
+    SampleID() { setAsInvalid(); }
+
+    std::string to_string() const
+    {
+        if (multiAddress[0] == -1)
+            return fmt::format("SampleID:{}", std::string(md5));
+        else
+            return fmt::format("SampleID:{}@{}/{}/{}", std::string(md5), multiAddress[0],
+                               multiAddress[1], multiAddress[2]);
+    }
+
+    bool operator==(const SampleID &other) const
+    {
+        return strncmp(md5, other.md5, md5len) == 0 && multiAddress[0] == other.multiAddress[0] &&
+               multiAddress[1] == other.multiAddress[1] && multiAddress[2] == other.multiAddress[2];
+    }
+    bool operator!=(const SampleID &other) const { return !(other == *this); }
+
+    bool isValid() const { return md5[0] != 'x' && md5[1] != '\0'; }
+
+    void setAsInvalid()
+    {
+        memset(md5, 0, sizeof(md5));
+        std::fill(multiAddress.begin(), multiAddress.end(), -1);
+        md5[0] = '!';
+    }
+    void setAsMD5(const std::string &m)
+    {
+        strncpy(md5, m.c_str(), md5len + 1);
+        std::fill(multiAddress.begin(), multiAddress.end(), -1);
+    }
+    void setAsLegacy(int oldId)
+    {
+        auto ls = fmt::format("lgcy({})", oldId);
+        setAsMD5(ls);
+    }
+
+    void setAsMD5WithAddress(const std::string &m, int a0, int a1, int a2)
+    {
+        strncpy(md5, m.c_str(), md5len + 1);
+        multiAddress[0] = a0;
+        multiAddress[1] = a1;
+        multiAddress[2] = a2;
+    }
+};
 
 /**
  * A class which forces move semantics and optionally runs a naive leak detector
@@ -291,5 +341,21 @@ inline std::string humanReadableVersion(uint64_t v)
 template <int idType> struct std::hash<scxt::ID<idType>>
 {
     size_t operator()(const scxt::ID<idType> &v) const { return std::hash<int>()(v.id); }
+};
+
+template <> struct std::hash<scxt::SampleID>
+{
+    size_t operator()(const scxt::SampleID &v) const
+    {
+        auto mh = std::hash<std::string>()(v.md5);
+        for (int i = 0; i < 3; ++i)
+        {
+            if (v.multiAddress[i] >= 0)
+            {
+                mh = mh + ((v.multiAddress[i] + 1) << (i * 8));
+            }
+        }
+        return mh;
+    }
 };
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -35,6 +35,7 @@
 #include <functional>
 #include <filesystem>
 #include <thread>
+#include <array>
 
 #include <iostream>
 #include <map>


### PR DESCRIPTION
This commit does a few things

1. Moves the SampleID to be md5sum/a/a/a style rather than id
2. Has a remapping strategy for legacy and non consistent md5sum

Nicely, this will close #1370

Restore multisample support

Also move part to msgpack again