### PR TITLE
Towards basic missing sample resolution

### DIFF
--- a/src-ui/app/edit-screen/components/GroupZoneTreeControl.h
+++ b/src-ui/app/edit-screen/components/GroupZoneTreeControl.h
@@ -33,6 +33,7 @@
 
 #include "sst/jucegui/components/GlyphButton.h"
 #include "sst/jucegui/components/Label.h"
+#include "engine/feature_enums.h"
 
 namespace scxt::ui::app::edit_screen
 {
@@ -53,7 +54,7 @@ template <typename SidebarParent, bool fz> struct GroupZoneListBoxModel : juce::
         auto &pgz = sidebar->partGroupSidebar->pgzStructure;
         thisGroup.clear();
         for (const auto &el : pgz)
-            if (el.first.part == sidebar->editor->selectedPart && el.first.group >= 0)
+            if (el.address.part == sidebar->editor->selectedPart && el.address.group >= 0)
                 thisGroup.push_back(el);
     }
     int getNumRows() override { return thisGroup.size() + 1; /* for the plus */ }
@@ -74,7 +75,7 @@ template <typename SidebarParent, bool fz> struct GroupZoneListBoxModel : juce::
         auto &tgl = thisGroup;
         if (rowNumber < 0 || rowNumber >= tgl.size())
             return {};
-        auto &sad = tgl[rowNumber].first;
+        auto &sad = tgl[rowNumber].address;
         return sad;
     }
 
@@ -112,7 +113,7 @@ template <typename SidebarParent, bool fz> struct GroupZoneListBoxModel : juce::
 
             const auto &sg = tgl[rowNumber];
 
-            bool isLeadZone = isZone() && gsb->isLeadZone(sg.first);
+            bool isLeadZone = isZone() && gsb->isLeadZone(sg.address);
 
             auto editor = gsb->partGroupSidebar->editor;
 
@@ -159,7 +160,7 @@ template <typename SidebarParent, bool fz> struct GroupZoneListBoxModel : juce::
                 }
             }
 
-            if (sg.first.zone < 0)
+            if (sg.address.zone < 0)
             {
                 g.setColour(fillColor);
                 g.fillRect(getLocalBounds());
@@ -170,10 +171,10 @@ template <typename SidebarParent, bool fz> struct GroupZoneListBoxModel : juce::
                 auto bx = getLocalBounds().withWidth(grouplabelPad);
                 auto nb = getLocalBounds().withTrimmedLeft(grouplabelPad);
                 g.setColour(lowTextColor);
-                g.drawText(std::to_string(sg.first.group + 1), bx,
+                g.drawText(std::to_string(sg.address.group + 1), bx,
                            juce::Justification::centredLeft);
                 g.setColour(textColor);
-                g.drawText(sg.second, nb, juce::Justification::centredLeft);
+                g.drawText(sg.name, nb, juce::Justification::centredLeft);
 
                 if (dragOverState == DRAG_OVER)
                 {
@@ -201,7 +202,12 @@ template <typename SidebarParent, bool fz> struct GroupZoneListBoxModel : juce::
                 g.drawLine(zonePad, getHeight(), getWidth(), getHeight());
 
                 g.setColour(textColor);
-                g.drawText(sg.second, getLocalBounds().translated(zonePad + 2, 0),
+                if (sg.features & engine::ZoneFeatures::MISSING_SAMPLE)
+                {
+                    g.setColour(editor->themeColor(theme::ColorMap::warning_1a));
+                }
+
+                g.drawText(sg.name, getLocalBounds().translated(zonePad + 2, 0),
                            juce::Justification::centredLeft);
 
                 if (isLeadZone)
@@ -266,7 +272,7 @@ template <typename SidebarParent, bool fz> struct GroupZoneListBoxModel : juce::
 
                     const auto &sg = tgl[rowNumber];
 
-                    p.addSectionHeader(sg.second);
+                    p.addSectionHeader(sg.name);
                     p.addSeparator();
                     p.addItem("Rename", [w = juce::Component::SafePointer(this)]() {
                         if (!w)
@@ -368,12 +374,12 @@ template <typename SidebarParent, bool fz> struct GroupZoneListBoxModel : juce::
             const auto &tgl = lbm->thisGroup;
 
             const auto &sg = tgl[rowNumber];
-            assert(sg.first.zone < 0);
+            assert(sg.address.zone < 0);
             auto st = gsb->partGroupSidebar->style();
             auto groupFont = gsb->editor->themeApplier.interRegularFor(11);
             renameEditor->setFont(groupFont);
             renameEditor->applyFontToAllText(groupFont);
-            renameEditor->setText(sg.second);
+            renameEditor->setText(sg.name);
             renameEditor->setSelectAllWhenFocused(true);
             renameEditor->setIndents(2, 1);
             renameEditor->setVisible(true);
@@ -389,7 +395,7 @@ template <typename SidebarParent, bool fz> struct GroupZoneListBoxModel : juce::
             auto zoneFont = gsb->editor->themeApplier.interLightFor(11);
             renameEditor->setFont(zoneFont);
             renameEditor->applyFontToAllText(zoneFont);
-            renameEditor->setText(sg.second);
+            renameEditor->setText(sg.name);
             renameEditor->setSelectAllWhenFocused(true);
             renameEditor->setIndents(2, 1);
             renameEditor->setVisible(true);

--- a/src-ui/app/edit-screen/components/PartGroupSidebar.cpp
+++ b/src-ui/app/edit-screen/components/PartGroupSidebar.cpp
@@ -153,7 +153,7 @@ struct GroupZoneSidebarBase : juce::Component, HasEditor, juce::DragAndDropConta
             int selR = -1;
             for (const auto &[i, r] : sst::cpputils::enumerate(listBoxModel->thisGroup))
             {
-                if (r.first == a)
+                if (r.address == a)
                 {
                     rows.addRange({(int)i, (int)(i + 1)});
                 }

--- a/src-ui/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
+++ b/src-ui/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
@@ -313,11 +313,11 @@ void MappingDisplay::setLeadSelection(const selection::SelectionManager::ZoneAdd
     bool foundZone{false};
     for (const auto &s : summary)
     {
-        if (s.first == za)
+        if (s.address == za)
         {
             foundZone = true;
             if (mappingZones)
-                mappingZones->setLeadZoneBounds(s.second);
+                mappingZones->setLeadZoneBounds(s);
         }
     }
 

--- a/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -226,9 +226,9 @@ void SCXTEditor::onGroupZoneMappingSummary(const scxt::engine::Part::zoneMapping
     if constexpr (scxt::log::uiStructure)
     {
         SCLOG("Updated zone mapping summary");
-        for (const auto &[addr, item] : d)
+        for (const auto &z : d)
         {
-            SCLOG("  " << addr << " " << std::get<2>(item));
+            SCLOG("  " << z.address << " " << z.name);
         }
     }
 }

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -54,6 +54,7 @@
 #include <filesystem>
 #include <mutex>
 #include "messaging/client/client_serial.h"
+#include "feature_enums.h"
 
 namespace scxt::engine
 {
@@ -452,7 +453,13 @@ Engine::pgzStructure_t Engine::getPartGroupZoneStructure() const
             int32_t zoneidx{0};
             for (const auto &zone : *group)
             {
-                res.push_back({{partidx, groupidx, zoneidx}, zone->getName()});
+                int32_t zoneFeatures{0};
+                if (zone->missingSampleCount() > 0)
+                {
+                    zoneFeatures |= ZoneFeatures::MISSING_SAMPLE;
+                }
+
+                res.push_back({{partidx, groupidx, zoneidx}, zone->getName(), zoneFeatures});
                 zoneidx++;
             }
 
@@ -466,7 +473,7 @@ Engine::pgzStructure_t Engine::getPartGroupZoneStructure() const
         SCLOG("Returning partgroup structure size " << res.size());
 
         for (const auto &pg : res)
-            SCLOG("   " << pg.first << " @ " << pg.second);
+            SCLOG("   " << pg.address << " @ " << pg.name);
     }
 
     return res;

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -448,8 +448,13 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     const std::optional<dsp::processor::ProcessorStorage>
     getProcessorStorage(const processorAddress_t &addr) const;
 
-    typedef std::vector<std::pair<selection::SelectionManager::ZoneAddress, std::string>>
-        pgzStructure_t;
+    struct PGZStructureBundle
+    {
+        selection::SelectionManager::ZoneAddress address;
+        std::string name;
+        int32_t features{0};
+    };
+    typedef std::vector<PGZStructureBundle> pgzStructure_t;
     /**
      * Get the Part/Group/Zone structure as a set o fzone addreses. A part with
      * no groups will be (p,-1,-1); a group with no zones will be (p,g,-1).

--- a/src/engine/feature_enums.h
+++ b/src/engine/feature_enums.h
@@ -1,0 +1,16 @@
+//
+// Created by Paul Walker on 9/24/24.
+//
+
+#ifndef FEATURE_ENUMS_H
+#define FEATURE_ENUMS_H
+
+namespace scxt::engine
+{
+enum ZoneFeatures
+{
+    MISSING_SAMPLE = 1 << 0,
+};
+}
+
+#endif // FEATURE_ENUMS_H

--- a/src/engine/part.cpp
+++ b/src/engine/part.cpp
@@ -29,6 +29,7 @@
 #include "bus.h"
 #include "patch.h"
 #include "engine.h"
+#include "feature_enums.h"
 
 #include "selection/selection_manager.h"
 
@@ -73,11 +74,16 @@ Part::zoneMappingSummary_t Part::getZoneMappingSummary()
         for (const auto &z : *g)
         {
             // get address for zone
-            auto data =
-                zoneMappingItem_t{z->mapping.keyboardRange, z->mapping.velocityRange, z->getName()};
             auto addr = selection::SelectionManager::ZoneAddress(pidx, gidx, zidx);
+            int32_t features{0};
+            if (z->missingSampleCount() > 0)
+            {
+                features |= ZoneFeatures::MISSING_SAMPLE;
+            }
+            auto data = zoneMappingItem_t{addr, z->mapping.keyboardRange, z->mapping.velocityRange,
+                                          z->getName(), features};
             // res[addr] = data;
-            res.emplace_back(addr, data);
+            res.emplace_back(data);
             zidx++;
         }
         gidx++;

--- a/src/engine/part.h
+++ b/src/engine/part.h
@@ -128,9 +128,16 @@ struct Part : MoveableOnly<Part>, SampleRateSupport
     /**
      * Utility data structures to allow rapid draws and displays of the structure in clients
      */
-    typedef std::tuple<KeyboardRange, VelocityRange, std::string> zoneMappingItem_t;
-    typedef std::vector<std::pair<selection::SelectionManager::ZoneAddress, zoneMappingItem_t>>
-        zoneMappingSummary_t;
+    struct ZoneMappingItem
+    {
+        selection::SelectionManager::ZoneAddress address;
+        KeyboardRange kr;
+        VelocityRange vr;
+        std::string name;
+        int32_t features{0};
+    };
+    using zoneMappingItem_t = ZoneMappingItem; // legacy name from when we were a tuple
+    typedef std::vector<ZoneMappingItem> zoneMappingSummary_t;
     zoneMappingSummary_t getZoneMappingSummary();
 
     // TODO GroupID -> index

--- a/src/engine/zone.cpp
+++ b/src/engine/zone.cpp
@@ -433,5 +433,24 @@ void Zone::onRoutingChanged()
     //                      << SCD(lfosActive[3]) << SCD(egsActive[0]) << SCD(egsActive[1]))
 }
 
+int16_t Zone::missingSampleCount() const
+{
+    int idx{0};
+    int ct{0};
+    for (auto &sv : variantData.variants)
+    {
+        if (sv.active)
+        {
+            auto smp = samplePointers[idx];
+            if (smp && smp->isMissingPlaceholder)
+            {
+                ct++;
+            }
+        }
+        idx++;
+    }
+    return ct;
+}
+
 template struct HasGroupZoneProcessors<Zone>;
 } // namespace scxt::engine

--- a/src/engine/zone.h
+++ b/src/engine/zone.h
@@ -205,6 +205,8 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
     void setNormalizedSampleLevel(bool usePeak = false, int associatedSampleID = -1);
     void clearNormalizedSampleLevel(int associatedSampleID = -1);
 
+    int16_t missingSampleCount() const;
+
     struct ZoneMappingData
     {
         int16_t rootKey{60};

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -56,7 +56,6 @@
 
 namespace scxt::json
 {
-
 SC_STREAMDEF(scxt::engine::Engine, SC_FROM({
                  if (SC_STREAMING_FOR_IN_PROCESS)
                  {
@@ -121,6 +120,15 @@ SC_STREAMDEF(scxt::engine::Patch, SC_FROM({
                  findIf(v, "busses", patch.busses);
              }))
 
+SC_STREAMDEF(scxt::engine::Engine::PGZStructureBundle, SC_FROM({
+                 v = {{"address", t.address}, {"name", t.name}, {"features", t.features}};
+             }),
+             SC_TO({
+                 findIf(v, "address", to.address);
+                 findIf(v, "name", to.name);
+                 findOrSet(v, "features", 0, to.features);
+             }));
+
 SC_STREAMDEF(scxt::engine::Macro, SC_FROM({
                  v = {{"p", t.part}, {"i", t.index}, {"v", t.value}};
 
@@ -149,6 +157,20 @@ SC_STREAMDEF(
         findOrSet(v, "m", false, to.mute);
         findOrSet(v, "s", false, to.solo);
     }));
+
+SC_STREAMDEF(scxt::engine::Part::ZoneMappingItem,
+             SC_FROM(v = {{"a", from.address},
+                          {"kr", from.kr},
+                          {"vr", from.vr},
+                          {"name", from.name},
+                          {"features", from.features}};),
+             SC_TO({
+                 findIf(v, "a", to.address);
+                 findIf(v, "kr", to.kr);
+                 findIf(v, "vr", to.vr);
+                 findIf(v, "name", to.name);
+                 findIf(v, "features", to.features);
+             }))
 
 SC_STREAMDEF(
     scxt::engine::Part, SC_FROM({

--- a/src/sample/sample.cpp
+++ b/src/sample/sample.cpp
@@ -464,4 +464,19 @@ void Sample::dumpInformationToLog()
     }
 }
 
+std::shared_ptr<Sample> Sample::createMissingPlaceholder(const Sample::SampleFileAddress &a)
+{
+    auto res = std::make_shared<Sample>();
+    res->mFileName = a.path;
+    res->md5Sum = a.md5sum;
+    res->type = a.type;
+    res->preset = a.preset;
+    res->instrument = a.instrument;
+    res->region = a.region;
+    res->isMissingPlaceholder = true;
+    res->displayName = fmt::format("Missing {}", a.path.filename().u8string());
+
+    return res;
+}
+
 } // namespace scxt::sample

--- a/src/sample/sample.h
+++ b/src/sample/sample.h
@@ -76,6 +76,9 @@ struct alignas(16) Sample : MoveableOnly<Sample>
         int region{-1};
     };
 
+    bool isMissingPlaceholder{false};
+    static std::shared_ptr<Sample> createMissingPlaceholder(const SampleFileAddress &a);
+
     SampleFileAddress getSampleFileAddress() const
     {
 #if BUILD_IS_DEBUG

--- a/src/sample/sample_manager.cpp
+++ b/src/sample/sample_manager.cpp
@@ -39,6 +39,7 @@ void SampleManager::restoreFromSampleAddressesAndIDs(const sampleAddressesAndIds
         if (!fs::exists(addr.path))
         {
             missingList.push_back(addr.path);
+            addSampleAsMissing(id, addr);
         }
         else
         {
@@ -263,6 +264,20 @@ SampleManager::getSampleAddressesFor(const std::vector<SampleID> &sids) const
         }
     }
     return res;
+}
+
+void SampleManager::addSampleAsMissing(const SampleID &id, const Sample::SampleFileAddress &f)
+{
+    if (samples.find(id) == samples.end())
+    {
+        auto ms = Sample::createMissingPlaceholder(f);
+        ms->id = id;
+
+        SCLOG("Missing : " << f.path.u8string());
+        SCLOG("        : " << id.to_string());
+
+        samples[id] = ms;
+    }
 }
 
 } // namespace scxt::sample

--- a/src/sample/sample_manager.h
+++ b/src/sample/sample_manager.h
@@ -76,6 +76,7 @@ struct SampleManager : MoveableOnly<SampleManager>
     SampleManager(const ThreadingChecker &t) : threadingChecker(t) {}
     ~SampleManager();
 
+    void addSampleAsMissing(const SampleID &id, const Sample::SampleFileAddress &f);
     std::optional<SampleID> loadSampleByFileAddress(const Sample::SampleFileAddress &);
     std::optional<SampleID> loadSampleByFileAddressToID(const Sample::SampleFileAddress &,
                                                         const SampleID &);
@@ -144,6 +145,7 @@ struct SampleManager : MoveableOnly<SampleManager>
         auto ap = idAliases.find(a);
         if (ap == idAliases.end())
             return a;
+        assert(ap->second != a);
         return resolveAlias(ap->second);
     }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -96,16 +96,19 @@ struct SampleID
 {
     static constexpr size_t md5len{32};
     char md5[md5len + 1]{};
-    std::array<int, 3> multiAddress{-1, -1, -1};
+
+    static constexpr int unusedAddress{-1};
+    std::array<int, 3> multiAddress{unusedAddress, unusedAddress, unusedAddress};
 
     SampleID() { setAsInvalid(); }
 
     std::string to_string() const
     {
-        if (multiAddress[0] == -1)
-            return fmt::format("SampleID:{}", std::string(md5));
+        std::string hd{"SampleID"};
+        if (multiAddress[0] == unusedAddress)
+            return fmt::format("{}:{}", hd, std::string(md5));
         else
-            return fmt::format("SampleID:{}@{}/{}/{}", std::string(md5), multiAddress[0],
+            return fmt::format("{}:{}@{}/{}/{}", hd, std::string(md5), multiAddress[0],
                                multiAddress[1], multiAddress[2]);
     }
 
@@ -121,13 +124,13 @@ struct SampleID
     void setAsInvalid()
     {
         memset(md5, 0, sizeof(md5));
-        std::fill(multiAddress.begin(), multiAddress.end(), -1);
+        std::fill(multiAddress.begin(), multiAddress.end(), unusedAddress);
         md5[0] = '!';
     }
     void setAsMD5(const std::string &m)
     {
         strncpy(md5, m.c_str(), md5len + 1);
-        std::fill(multiAddress.begin(), multiAddress.end(), -1);
+        std::fill(multiAddress.begin(), multiAddress.end(), unusedAddress);
     }
     void setAsLegacy(int oldId)
     {

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -591,9 +591,6 @@ void Voice::initializeGenerator()
 {
     if (sampleIndex < 0)
     {
-        // For now we just null out the generator and deal but an alternate
-        // approach in the future would be to have a family of built in generators
-        // which we can run which just do DSP. Because honestly its a sampler.
         Generator = nullptr;
         GD.isFinished = false;
         monoGenerator = true;
@@ -602,8 +599,16 @@ void Voice::initializeGenerator()
 
     // but the default of course is to use the sample index
     auto &s = zone->samplePointers[sampleIndex];
-    auto &variantData = zone->variantData.variants[sampleIndex];
     assert(s);
+    if (s->isMissingPlaceholder)
+    {
+        Generator = nullptr;
+        GD.isFinished = false;
+        monoGenerator = true;
+        return;
+    }
+
+    auto &variantData = zone->variantData.variants[sampleIndex];
 
     GDIO.outputL = output[0];
     GDIO.outputR = output[1];


### PR DESCRIPTION
Missing samlpes get placed in the sample hierarchy as types we can reason about and replace. This allows us to detect which zones have missing samples and beam that to the UI so we can color things at display time as well as just showing the missing list error dialog.

Along the way clean up some pragmatic use of tuples and replace them with some actual structures that stream.

This still doesn't let us *fix* anything. But it lets us identify the problem spots at least in the UI. More to come soon obviously