### PR TITLE
Files and Data structures in place for missing resolution

### DIFF
--- a/src-ui/CMakeLists.txt
+++ b/src-ui/CMakeLists.txt
@@ -25,6 +25,8 @@ add_library(${PROJECT_NAME} STATIC
         app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
         app/edit-screen/components/mapping-pane/ZoneLayoutKeyboard.cpp
 
+        app/missing-resolution/MissingResolutionScreen.cpp
+
         app/mixer-screen/MixerScreen.cpp
         app/mixer-screen/components/BusPane.cpp
         app/mixer-screen/components/ChannelStrip.cpp

--- a/src-ui/app/SCXTEditor.h
+++ b/src-ui/app/SCXTEditor.h
@@ -77,6 +77,10 @@ namespace play_screen
 {
 struct PlayScreen;
 }
+namespace missing_resolution
+{
+struct MissingResolutionScreen;
+}
 namespace other_screens
 {
 struct WelcomeScreen;
@@ -142,6 +146,7 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::DragAndDropCont
     std::unique_ptr<other_screens::AboutScreen> aboutScreen;
     std::unique_ptr<other_screens::WelcomeScreen> welcomeScreen;
     std::unique_ptr<other_screens::LogScreen> logScreen;
+    std::unique_ptr<missing_resolution::MissingResolutionScreen> missingResolutionScreen;
 
     std::unique_ptr<sst::jucegui::components::ToolTip> toolTip;
 
@@ -242,6 +247,8 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::DragAndDropCont
     std::array<std::array<scxt::engine::Macro, scxt::macrosPerPart>, scxt::numParts> macroCache;
     void onMacroFullState(const scxt::messaging::client::macroFullState_t &);
     void onMacroValue(const scxt::messaging::client::macroValue_t &);
+
+    void onMissingResolutionWorkItemList(const std::vector<engine::MissingResolutionWorkItem> &);
 
     // Originate client to serialization messages
     void doSelectionAction(const selection::SelectionManager::ZoneAddress &, bool selecting,

--- a/src-ui/app/editor-impl/SCXTEditor.cpp
+++ b/src-ui/app/editor-impl/SCXTEditor.cpp
@@ -30,6 +30,8 @@
 #include "melatonin_inspector/melatonin_inspector.h"
 #endif
 
+#include "SCXTJuceLookAndFeel.h"
+
 #include "app/SCXTEditor.h"
 
 #include "app/play-screen/PlayScreen.h"
@@ -43,7 +45,7 @@
 #include "app/other-screens/AboutScreen.h"
 #include "app/other-screens/LogScreen.h"
 #include "app/other-screens/WelcomeScreen.h"
-#include "SCXTJuceLookAndFeel.h"
+#include "app/missing-resolution/MissingResolutionScreen.h"
 #include "sst/jucegui/components/ToolTip.h"
 #include <sst/jucegui/components/DiscreteParamMenuBuilder.h>
 
@@ -123,6 +125,9 @@ SCXTEditor::SCXTEditor(messaging::MessageController &e, infrastructure::Defaults
 
     logScreen = std::make_unique<other_screens::LogScreen>(this);
     addChildComponent(*logScreen);
+
+    missingResolutionScreen = std::make_unique<missing_resolution::MissingResolutionScreen>(this);
+    addChildComponent(*missingResolutionScreen);
 
     setStyle(style());
 

--- a/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -39,6 +39,7 @@
 #include "app/other-screens/AboutScreen.h"
 #include "app/browser-ui/BrowserPane.h"
 #include "app/play-screen/PlayScreen.h"
+#include "app/missing-resolution/MissingResolutionScreen.h"
 
 namespace scxt::ui::app
 {

--- a/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -415,4 +415,25 @@ void SCXTEditor::onActivityNotification(
     // SCLOG((idx == 1 ? "Open" : (idx == 0 ? "Close" : "Update")) << " [" << msg << "]");
     SCLOG_ONCE("Update activity messages currently ignored");
 }
+
+void SCXTEditor::onMissingResolutionWorkItemList(
+    const std::vector<engine::MissingResolutionWorkItem> &items)
+{
+    for (const auto &wi : items)
+    {
+        SCLOG("Missing resolution work item");
+        SCLOG("   path  : " << wi.path.u8string());
+        SCLOG("   zone  : " << wi.address);
+        SCLOG("   var   : " << wi.variant);
+        SCLOG("   md5   : " << wi.md5sum);
+    }
+
+    if (!items.empty())
+    {
+        missingResolutionScreen->setWorkItemList(items);
+        missingResolutionScreen->setBounds(getLocalBounds());
+        missingResolutionScreen->setVisible(true);
+        missingResolutionScreen->toFront(true);
+    }
+}
 } // namespace scxt::ui::app

--- a/src-ui/app/missing-resolution/MissingResolutionScreen.cpp
+++ b/src-ui/app/missing-resolution/MissingResolutionScreen.cpp
@@ -26,6 +26,7 @@
  */
 
 #include "MissingResolutionScreen.h"
+#include "app/SCXTEditor.h"
 
 #include <sst/jucegui/components/NamedPanel.h>
 #include <sst/jucegui/components/TextPushButton.h>

--- a/src-ui/app/missing-resolution/MissingResolutionScreen.cpp
+++ b/src-ui/app/missing-resolution/MissingResolutionScreen.cpp
@@ -1,0 +1,96 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "MissingResolutionScreen.h"
+
+#include <sst/jucegui/components/NamedPanel.h>
+#include <sst/jucegui/components/TextPushButton.h>
+
+namespace scxt::ui::app::missing_resolution
+{
+
+struct Contents : juce::Component, HasEditor
+{
+    MissingResolutionScreen *parent{nullptr};
+    std::unique_ptr<sst::jucegui::components::TextPushButton> okButton;
+    Contents(MissingResolutionScreen *p, SCXTEditor *e) : parent(p), HasEditor(e)
+    {
+        okButton = std::make_unique<sst::jucegui::components::TextPushButton>();
+        okButton->setLabel("OK");
+        okButton->setOnCallback([w = juce::Component::SafePointer(parent)]() {
+            if (!w)
+                return;
+            w->setVisible(false);
+        });
+        addAndMakeVisible(*okButton);
+    }
+
+    void resized() override
+    {
+        auto b = getLocalBounds();
+        b = b.withTrimmedTop(b.getHeight() - 22).withTrimmedLeft(b.getWidth() - 100);
+        okButton->setBounds(b);
+    }
+    void paint(juce::Graphics &g) override
+    {
+        int bxH = 40;
+        auto bx = getLocalBounds().reduced(2, 2).withHeight(bxH);
+        for (const auto &i : parent->workItems)
+        {
+            auto bd = bx.reduced(2, 2);
+            g.setFont(editor->themeApplier.interBoldFor(14));
+            g.setColour(editor->themeColor(theme::ColorMap::generic_content_high));
+            g.drawText(i.path.u8string(), bd, juce::Justification::topLeft);
+
+            g.setFont(editor->themeApplier.interMediumFor(12));
+            g.setColour(editor->themeColor(theme::ColorMap::generic_content_medium));
+            g.drawText(i.md5sum, bd, juce::Justification::bottomLeft);
+
+            g.setColour(editor->themeColor(theme::ColorMap::generic_content_low));
+            g.drawRect(bx, 1);
+
+            bx = bx.translated(0, bxH + 4);
+        }
+    }
+};
+
+MissingResolutionScreen::MissingResolutionScreen(SCXTEditor *e) : HasEditor(e)
+{
+    auto ct = std::make_unique<sst::jucegui::components::NamedPanel>("Missing Sample Resolution");
+    addAndMakeVisible(*ct);
+
+    auto contents = std::make_unique<Contents>(this, e);
+    ct->setContentAreaComponent(std::move(contents));
+    contentsArea = std::move(ct);
+}
+
+void MissingResolutionScreen::resized()
+{
+    contentsArea->setBounds(getLocalBounds().reduced(100, 80));
+}
+
+} // namespace scxt::ui::app::missing_resolution

--- a/src-ui/app/missing-resolution/MissingResolutionScreen.h
+++ b/src-ui/app/missing-resolution/MissingResolutionScreen.h
@@ -1,0 +1,62 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_UI_APP_MISSING_RESOLUTION_MISSINGRESOLUTIONSCREEN_H
+#define SCXT_SRC_UI_APP_MISSING_RESOLUTION_MISSINGRESOLUTIONSCREEN_H
+
+#include "app/HasEditor.h"
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <vector>
+#include "engine/missing_resolution.h"
+
+namespace scxt::ui::app::missing_resolution
+{
+
+struct MissingResolutionScreen : juce::Component, HasEditor
+{
+    std::unique_ptr<juce::Component> contentsArea;
+    MissingResolutionScreen(SCXTEditor *e);
+
+    void paint(juce::Graphics &g) override
+    {
+        g.fillAll(juce::Colour(0x90, 0x90, 0x90).withAlpha(0.3f));
+    }
+
+    void resized() override;
+    void mouseUp(const juce::MouseEvent &) override { setVisible(false); }
+
+    void setWorkItemList(const std::vector<engine::MissingResolutionWorkItem> &l)
+    {
+        workItems = l;
+        repaint();
+    }
+
+    std::vector<engine::MissingResolutionWorkItem> workItems;
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MissingResolutionScreen);
+};
+} // namespace scxt::ui::app::missing_resolution
+#endif // MISSINGRESOLUTIONSCREEN_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(${PROJECT_NAME} STATIC
         engine/part.cpp
         engine/patch.cpp
         engine/memory_pool.cpp
+        engine/missing_resolution.cpp
         engine/bus.cpp
         engine/macros.cpp
 

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -55,6 +55,7 @@
 #include <mutex>
 #include "messaging/client/client_serial.h"
 #include "feature_enums.h"
+#include "missing_resolution.h"
 
 namespace scxt::engine
 {
@@ -1083,6 +1084,13 @@ void Engine::sendFullRefreshToClient() const
     getSelectionManager()->sendSelectedZonesToClient();
     getSelectionManager()->sendSelectedPartMacrosToClient();
     getSelectionManager()->sendOtherTabsSelectionToClient();
+
+    auto missing = collectMissingResolutionWorkItems(*this);
+    if (!missing.empty())
+    {
+        serializationSendToClient(messaging::client::s2c_send_missing_resolution_workitem_list,
+                                  missing, *(getMessageController()));
+    }
 }
 
 void Engine::clearAll()

--- a/src/engine/missing_resolution.cpp
+++ b/src/engine/missing_resolution.cpp
@@ -1,0 +1,69 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "missing_resolution.h"
+
+namespace scxt::engine
+{
+std::vector<MissingResolutionWorkItem> collectMissingResolutionWorkItems(const Engine &e)
+{
+    std::vector<MissingResolutionWorkItem> res;
+
+    int pidx{0};
+    for (const auto &p : *(e.getPatch()))
+    {
+        int gidx{0};
+        for (const auto &g : *p)
+        {
+            int zidx{0};
+            for (const auto &z : *g)
+            {
+                int idx{0};
+                for (const auto &v : z->variantData.variants)
+                {
+                    if (v.active && z->samplePointers[idx]->isMissingPlaceholder)
+                    {
+                        auto &sm = z->samplePointers[idx];
+                        MissingResolutionWorkItem wf;
+                        wf.address = {pidx, gidx, zidx};
+                        wf.variant = idx;
+                        wf.path = sm->mFileName;
+                        wf.md5sum = sm->md5Sum;
+                        res.push_back(wf);
+                    }
+                    idx++;
+                }
+                zidx++;
+            }
+            gidx++;
+        }
+        pidx++;
+    }
+
+    return res;
+}
+} // namespace scxt::engine

--- a/src/engine/missing_resolution.h
+++ b/src/engine/missing_resolution.h
@@ -25,15 +25,24 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_ENGINE_FEATURE_ENUMS_H
-#define SCXT_SRC_ENGINE_FEATURE_ENUMS_H
+#ifndef SCXT_SRC_ENGINE_MISSING_RESOLUTION_H
+#define SCXT_SRC_ENGINE_MISSING_RESOLUTION_H
+
+#include "selection/selection_manager.h"
+#include "engine.h"
 
 namespace scxt::engine
 {
-enum ZoneFeatures
+struct MissingResolutionWorkItem
 {
-    MISSING_SAMPLE = 1 << 0,
+    selection::SelectionManager::ZoneAddress address;
+    int16_t variant;
+    fs::path path;
+    std::string md5sum;
 };
-}
 
-#endif // FEATURE_ENUMS_H
+std::vector<MissingResolutionWorkItem> collectMissingResolutionWorkItems(const Engine &e);
+
+} // namespace scxt::engine
+
+#endif // MISSING_RESOLUTION_H

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -51,6 +51,8 @@
 #include "modulation_traits.h"
 #include "datamodel_traits.h"
 #include "selection_traits.h"
+#include "missing_resolution_traits.h"
+
 #include "engine/bus.h"
 #include "messaging/messaging.h"
 
@@ -88,7 +90,6 @@ SC_STREAMDEF(scxt::engine::Engine, SC_FROM({
                  // Order matters here. Samples need to be there before the patch and patch
                  // before selection
 
-                 to.getSampleManager()->resetMissingList();
                  findIf(v, "sampleManager", *(to.getSampleManager()));
                  findIf(v, "patch", *(to.getPatch()));
                  findIf(v, "selectionManager", *(to.getSelectionManager()));

--- a/src/json/missing_resolution_traits.h
+++ b/src/json/missing_resolution_traits.h
@@ -25,15 +25,34 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_ENGINE_FEATURE_ENUMS_H
-#define SCXT_SRC_ENGINE_FEATURE_ENUMS_H
+#ifndef SCXT_SRC_JSON_MISSING_RESOLUTION_TRAITS_H
+#define SCXT_SRC_JSON_MISSING_RESOLUTION_TRAITS_H
 
-namespace scxt::engine
-{
-enum ZoneFeatures
-{
-    MISSING_SAMPLE = 1 << 0,
-};
-}
+#include <tao/json/to_string.hpp>
+#include <tao/json/from_string.hpp>
+#include <tao/json/contrib/traits.hpp>
 
-#endif // FEATURE_ENUMS_H
+#include "stream.h"
+#include "extensions.h"
+
+#include "engine/missing_resolution.h"
+
+namespace scxt::json
+{
+SC_STREAMDEF(scxt::engine::MissingResolutionWorkItem, SC_FROM({
+                 v = {{"a", from.address},
+                      {"v", from.variant},
+                      {"p", from.path.u8string()},
+                      {"md5", from.md5sum}};
+             }),
+             SC_TO({
+                 findIf(v, "a", to.address);
+                 findIf(v, "v", to.variant);
+                 findIf(v, "md5", to.md5sum);
+                 std::string fp;
+                 findIf(v, "p", fp);
+                 to.path = fs::path(fs::u8path(fp));
+             }));
+} // namespace scxt::json
+
+#endif // MISSING_RESOLUTION_TRAITS_H

--- a/src/json/stream.cpp
+++ b/src/json/stream.cpp
@@ -88,17 +88,6 @@ void unstreamEngineState(engine::Engine &e, const std::string &data, bool msgPac
         jv.to(e);
     }
 
-    if (!e.getSampleManager()->missingList.empty())
-    {
-        std::ostringstream oss;
-        oss << "On load, sample manager could not locate the following files:\n";
-        for (const auto &p : e.getSampleManager()->missingList)
-        {
-            oss << "  " << p.u8string() << "\n";
-        }
-        e.getMessageController()->reportErrorToClient("Missing Samples", oss.str());
-    }
-
     e.sendFullRefreshToClient();
 }
 
@@ -118,17 +107,6 @@ void unstreamPartState(engine::Engine &e, int part, const std::string &data, boo
         tao::json::events::from_string(consumer, data);
         auto jv = std::move(consumer.value);
         jv.to(*(e.getPatch()->getPart(part)));
-    }
-
-    if (!e.getSampleManager()->missingList.empty())
-    {
-        std::ostringstream oss;
-        oss << "On load, sample manager could not locate the following files:\n";
-        for (const auto &p : e.getSampleManager()->missingList)
-        {
-            oss << "  " << p.u8string() << "\n";
-        }
-        e.getMessageController()->reportErrorToClient("Missing Samples", oss.str());
     }
 
     e.sendFullRefreshToClient();

--- a/src/messaging/client/client_messages.h
+++ b/src/messaging/client/client_messages.h
@@ -43,5 +43,6 @@
 #include "debug_messages.h"
 #include "patch_io_messages.h"
 #include "macro_messages.h"
+#include "missing_resolution_messages.h"
 
 #endif // SHORTCIRCUIT_CLIENT_MESSAGE_IMPLS_H

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -193,6 +193,8 @@ enum SerializationToClientMessageIds
     s2c_update_macro_full_state,
     s2c_update_macro_value,
 
+    s2c_send_missing_resolution_workitem_list,
+
     num_serializationToClientMessages
 };
 

--- a/src/messaging/client/missing_resolution_messages.h
+++ b/src/messaging/client/missing_resolution_messages.h
@@ -25,15 +25,20 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#ifndef SCXT_SRC_ENGINE_FEATURE_ENUMS_H
-#define SCXT_SRC_ENGINE_FEATURE_ENUMS_H
+#ifndef SCXT_SRC_MESSAGING_CLIENT_MISSING_RESOLUTION_MESSAGES_H
+#define SCXT_SRC_MESSAGING_CLIENT_MISSING_RESOLUTION_MESSAGES_H
 
-namespace scxt::engine
+#include "messaging/client/client_serial.h"
+#include "messaging/client/detail/client_json_details.h"
+#include "json/engine_traits.h"
+#include "json/datamodel_traits.h"
+#include "selection/selection_manager.h"
+#include "engine/missing_resolution.h"
+#include "client_macros.h"
+
+namespace scxt::messaging::client
 {
-enum ZoneFeatures
-{
-    MISSING_SAMPLE = 1 << 0,
-};
+SERIAL_TO_CLIENT(SendMissingResolutionWorkItemList, s2c_send_missing_resolution_workitem_list,
+                 std::vector<engine::MissingResolutionWorkItem>, onMissingResolutionWorkItemList);
 }
-
-#endif // FEATURE_ENUMS_H
+#endif // MISSING_RESOLUTION_MESSAGES_H

--- a/src/sample/sample_manager.cpp
+++ b/src/sample/sample_manager.cpp
@@ -38,7 +38,6 @@ void SampleManager::restoreFromSampleAddressesAndIDs(const sampleAddressesAndIds
     {
         if (!fs::exists(addr.path))
         {
-            missingList.push_back(addr.path);
             addSampleAsMissing(id, addr);
         }
         else

--- a/src/sample/sample_manager.h
+++ b/src/sample/sample_manager.h
@@ -131,9 +131,6 @@ struct SampleManager : MoveableOnly<SampleManager>
         updateSampleMemory();
     }
 
-    std::vector<fs::path> missingList;
-    void resetMissingList() { missingList.clear(); }
-
     uint64_t streamingVersion{0x2112'01'01}; // see comment in patch.h
 
     std::atomic<uint64_t> sampleMemoryInBytes{0};


### PR DESCRIPTION
1. Add missing resolution headers, workitem objects, streaming, messages, and ui screen
2. Implement a version of that which sends a structured readonly list of missing workitems to the UI on startup
3. Implement a screen which does a read only render of that structure

Still no "resolve" button. That's next, but maybe not today