### PR TITLE
An unacceptable workflow which allows missing sample resolution

### DIFF
--- a/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -423,15 +423,18 @@ void SCXTEditor::onMissingResolutionWorkItemList(
     for (const auto &wi : items)
     {
         SCLOG("Missing resolution work item");
-        SCLOG("   path  : " << wi.path.u8string());
-        SCLOG("   zone  : " << wi.address);
-        SCLOG("   var   : " << wi.variant);
-        SCLOG("   md5   : " << wi.md5sum);
+        SCLOG("   path : " << wi.path.u8string());
+        SCLOG("   id   : " << wi.missingID.to_string());
     }
 
-    if (!items.empty())
+    missingResolutionScreen->setWorkItemList(items);
+
+    if (items.empty())
     {
-        missingResolutionScreen->setWorkItemList(items);
+        missingResolutionScreen->setVisible(false);
+    }
+    else
+    {
         missingResolutionScreen->setBounds(getLocalBounds());
         missingResolutionScreen->setVisible(true);
         missingResolutionScreen->toFront(true);

--- a/src-ui/app/missing-resolution/MissingResolutionScreen.h
+++ b/src-ui/app/missing-resolution/MissingResolutionScreen.h
@@ -55,6 +55,11 @@ struct MissingResolutionScreen : juce::Component, HasEditor
         repaint();
     }
 
+    void resolveItem(int idx);
+    void applyResolution(int idx, const fs::path &toThis);
+
+    std::unique_ptr<juce::FileChooser> fileChooser;
+
     std::vector<engine::MissingResolutionWorkItem> workItems;
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MissingResolutionScreen);
 };

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -1086,11 +1086,9 @@ void Engine::sendFullRefreshToClient() const
     getSelectionManager()->sendOtherTabsSelectionToClient();
 
     auto missing = collectMissingResolutionWorkItems(*this);
-    if (!missing.empty())
-    {
-        serializationSendToClient(messaging::client::s2c_send_missing_resolution_workitem_list,
-                                  missing, *(getMessageController()));
-    }
+    // send missing even if empty. An empty missing flags dont show dialog
+    serializationSendToClient(messaging::client::s2c_send_missing_resolution_workitem_list, missing,
+                              *(getMessageController()));
 }
 
 void Engine::clearAll()

--- a/src/engine/missing_resolution.cpp
+++ b/src/engine/missing_resolution.cpp
@@ -33,35 +33,16 @@ std::vector<MissingResolutionWorkItem> collectMissingResolutionWorkItems(const E
 {
     std::vector<MissingResolutionWorkItem> res;
 
-    int pidx{0};
-    for (const auto &p : *(e.getPatch()))
+    const auto &sm = e.getSampleManager();
+    auto it = sm->samplesBegin();
+    while (it != sm->samplesEnd())
     {
-        int gidx{0};
-        for (const auto &g : *p)
+        const auto &[id, s] = *it;
+        if (s->isMissingPlaceholder)
         {
-            int zidx{0};
-            for (const auto &z : *g)
-            {
-                int idx{0};
-                for (const auto &v : z->variantData.variants)
-                {
-                    if (v.active && z->samplePointers[idx]->isMissingPlaceholder)
-                    {
-                        auto &sm = z->samplePointers[idx];
-                        MissingResolutionWorkItem wf;
-                        wf.address = {pidx, gidx, zidx};
-                        wf.variant = idx;
-                        wf.path = sm->mFileName;
-                        wf.md5sum = sm->md5Sum;
-                        res.push_back(wf);
-                    }
-                    idx++;
-                }
-                zidx++;
-            }
-            gidx++;
+            res.push_back({id, s->mFileName});
         }
-        pidx++;
+        it++;
     }
 
     return res;

--- a/src/engine/missing_resolution.h
+++ b/src/engine/missing_resolution.h
@@ -35,10 +35,8 @@ namespace scxt::engine
 {
 struct MissingResolutionWorkItem
 {
-    selection::SelectionManager::ZoneAddress address;
-    int16_t variant;
+    SampleID missingID;
     fs::path path;
-    std::string md5sum;
 };
 
 std::vector<MissingResolutionWorkItem> collectMissingResolutionWorkItems(const Engine &e);

--- a/src/engine/zone.cpp
+++ b/src/engine/zone.cpp
@@ -202,7 +202,8 @@ void Zone::setupOnUnstream(const engine::Engine &e)
 
         if (nid != oid)
         {
-            SCLOG("Relabeling zone on change : " << oid.to_string() << " -> " << nid.to_string());
+            SCLOG(getName() << " : Relabeling zone on change : " << oid.to_string() << " -> "
+                            << nid.to_string());
             variantData.variants[i].sampleID = nid;
         }
 
@@ -442,6 +443,8 @@ int16_t Zone::missingSampleCount() const
         if (sv.active)
         {
             auto smp = samplePointers[idx];
+            // SCLOG("Checking missing sample at " << sv.sampleID.to_string() << " " << smp.get());
+
             if (smp && smp->isMissingPlaceholder)
             {
                 ct++;

--- a/src/json/missing_resolution_traits.h
+++ b/src/json/missing_resolution_traits.h
@@ -40,15 +40,13 @@
 namespace scxt::json
 {
 SC_STREAMDEF(scxt::engine::MissingResolutionWorkItem, SC_FROM({
-                 v = {{"a", from.address},
-                      {"v", from.variant},
-                      {"p", from.path.u8string()},
-                      {"md5", from.md5sum}};
+                 v = {
+                     {"i", from.missingID},
+                     {"p", from.path.u8string()},
+                 };
              }),
              SC_TO({
-                 findIf(v, "a", to.address);
-                 findIf(v, "v", to.variant);
-                 findIf(v, "md5", to.md5sum);
+                 findIf(v, "i", to.missingID);
                  std::string fp;
                  findIf(v, "p", fp);
                  to.path = fs::path(fs::u8path(fp));

--- a/src/json/utils_traits.h
+++ b/src/json/utils_traits.h
@@ -71,13 +71,15 @@ template <int idType> struct scxt_traits<ID<idType>>
     }
 };
 
-SC_STREAMDEF(scxt::SampleID, SC_FROM(v = {{"m", from.md5}, {"a", from.multiAddress}});
+SC_STREAMDEF(scxt::SampleID,
+             SC_FROM(v = {{"m", from.md5}, {"a", from.multiAddress}, {"p", from.pathHash}});
              , SC_TO(
                    auto vs = v.find("m"); if (vs) {
                        std::string m5;
                        vs->to(m5);
                        strncpy(to.md5, m5.c_str(), scxt::SampleID::md5len + 1);
                        findIf(v, "a", to.multiAddress);
+                       findIf(v, "p", to.pathHash);
                    } else {
                        std::string legType{"t"}, legID{"i"};
                        if (SC_UNSTREAMING_FROM_PRIOR_TO(0x2024'08'06))

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -152,6 +152,8 @@ enum ClientToSerializationMessagesIds
 
     c2s_send_full_part_config,
 
+    c2s_resolve_sample,
+
     num_clientToSerializationMessages
 };
 

--- a/src/sample/sample.cpp
+++ b/src/sample/sample.cpp
@@ -52,6 +52,7 @@ bool Sample::load(const fs::path &path)
         return false;
 
     md5Sum = infrastructure::createMD5SumFromFile(path);
+    id.setPathHash(path.u8string().c_str());
 
     // If you add a type here add it in Browser::isLoadableFile also to stay in sync
     if (extensionMatches(path, ".wav"))

--- a/src/sample/sample_manager.h
+++ b/src/sample/sample_manager.h
@@ -141,15 +141,24 @@ struct SampleManager : MoveableOnly<SampleManager>
     {
         auto ap = idAliases.find(a);
         if (ap == idAliases.end())
+        {
             return a;
+        }
         assert(ap->second != a);
         return resolveAlias(ap->second);
     }
 
+    using sampleMap_t = std::unordered_map<SampleID, std::shared_ptr<Sample>>;
+
+    // You can do a const interation but not a non-const one
+    sampleMap_t::const_iterator samplesBegin() const { return samples.cbegin(); }
+    sampleMap_t::const_iterator samplesEnd() const { return samples.cend(); }
+
   private:
     void updateSampleMemory();
     std::unordered_map<SampleID, SampleID> idAliases;
-    std::unordered_map<SampleID, std::shared_ptr<Sample>> samples;
+
+    sampleMap_t samples;
 
     std::unordered_map<std::string, std::tuple<std::unique_ptr<RIFF::File>,
                                                std::unique_ptr<sf2::File>>>


### PR DESCRIPTION
1. If samples are missing at load time the screen has a 'resolve first' button which lets you pick the first in the list. If two are missing, press the button again after you resolve the first. obviously bad ui. But
2. If you do that the sample gets resolved and replaced and remapped
3. To do this added a path hash to the sample id and also did quite a bit of work cleaning up aliasing, loading, purging, api etc to make sure the right stuff happens at the right time
4. Along the way make the find-missing to be all samples in the sample db which are missing and not purged as opposed to traversing tree looking for attachment to same