### PR TITLE
Absolute minimal acceptable sample resolution

### DIFF
--- a/src-ui/app/SCXTEditor.h
+++ b/src-ui/app/SCXTEditor.h
@@ -147,6 +147,8 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::DragAndDropCont
     std::unique_ptr<other_screens::WelcomeScreen> welcomeScreen;
     std::unique_ptr<other_screens::LogScreen> logScreen;
     std::unique_ptr<missing_resolution::MissingResolutionScreen> missingResolutionScreen;
+    bool hasMissingSamples{false};
+    void showMissingResolutionScreen();
 
     std::unique_ptr<sst::jucegui::components::ToolTip> toolTip;
 

--- a/src-ui/app/edit-screen/components/GroupZoneTreeControl.h
+++ b/src-ui/app/edit-screen/components/GroupZoneTreeControl.h
@@ -295,6 +295,18 @@ template <typename SidebarParent, bool fz> struct GroupZoneListBoxModel : juce::
 
                               w->gsb->sendToSerialization(cmsg::ClearPart(za.part));
                           });
+
+                if (gsb->editor->hasMissingSamples)
+                {
+                    p.addSeparator();
+                    p.addItem("Resolve Missing Samples",
+                              [w = juce::Component::SafePointer(this)]() {
+                                  if (!w)
+                                      return;
+                                  w->gsb->editor->showMissingResolutionScreen();
+                              });
+                }
+
                 isPopup = true;
                 p.showMenuAsync(gsb->editor->defaultPopupMenuOptions());
             }

--- a/src-ui/app/edit-screen/components/mapping-pane/SampleWaveform.cpp
+++ b/src-ui/app/edit-screen/components/mapping-pane/SampleWaveform.cpp
@@ -407,6 +407,20 @@ void SampleWaveform::paint(juce::Graphics &g)
         return;
     }
 
+    if (samp->isMissingPlaceholder)
+    {
+        g.setColour(editor->themeColor(theme::ColorMap::generic_content_high));
+        g.setFont(editor->themeApplier.interMediumFor(14));
+        g.drawText("Missing Sample - Please Run Resolution", r.withTrimmedBottom(45),
+                   juce::Justification::centred);
+        g.setColour(editor->themeColor(theme::ColorMap::generic_content_medium));
+        g.setFont(editor->themeApplier.interMediumFor(11));
+        g.drawText("Right mouse on group zone part to launch for now", r,
+                   juce::Justification::centred);
+        g.drawText(samp->mFileName.u8string(), r.withTrimmedTop(30), juce::Justification::centred);
+        return;
+    }
+
     g.setColour(editor->themeColor(theme::ColorMap::grid_secondary));
     if (usedChannels == 2)
     {

--- a/src-ui/app/editor-impl/SCXTEditor.cpp
+++ b/src-ui/app/editor-impl/SCXTEditor.cpp
@@ -486,4 +486,6 @@ std::function<void()> SCXTEditor::makeComingSoon(const std::string &feature) con
                                                f + " is not yet implemented", "OK");
     };
 }
+
+void SCXTEditor::showMissingResolutionScreen() { missingResolutionScreen->setVisible(true); }
 } // namespace scxt::ui::app

--- a/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -431,10 +431,12 @@ void SCXTEditor::onMissingResolutionWorkItemList(
 
     if (items.empty())
     {
+        hasMissingSamples = false;
         missingResolutionScreen->setVisible(false);
     }
     else
     {
+        hasMissingSamples = true;
         missingResolutionScreen->setBounds(getLocalBounds());
         missingResolutionScreen->setVisible(true);
         missingResolutionScreen->toFront(true);

--- a/src-ui/app/missing-resolution/MissingResolutionScreen.h
+++ b/src-ui/app/missing-resolution/MissingResolutionScreen.h
@@ -32,14 +32,16 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <vector>
 #include "engine/missing_resolution.h"
+#include "sst/jucegui/components/NamedPanel.h"
 
 namespace scxt::ui::app::missing_resolution
 {
 
 struct MissingResolutionScreen : juce::Component, HasEditor
 {
-    std::unique_ptr<juce::Component> contentsArea;
+    std::unique_ptr<sst::jucegui::components::NamedPanel> contentsArea;
     MissingResolutionScreen(SCXTEditor *e);
+    ~MissingResolutionScreen();
 
     void paint(juce::Graphics &g) override
     {
@@ -49,11 +51,7 @@ struct MissingResolutionScreen : juce::Component, HasEditor
     void resized() override;
     void mouseUp(const juce::MouseEvent &) override { setVisible(false); }
 
-    void setWorkItemList(const std::vector<engine::MissingResolutionWorkItem> &l)
-    {
-        workItems = l;
-        repaint();
-    }
+    void setWorkItemList(const std::vector<engine::MissingResolutionWorkItem> &l);
 
     void resolveItem(int idx);
     void applyResolution(int idx, const fs::path &toThis);


### PR DESCRIPTION
1. The missing sample screen shows information less grossly
2. Each sample has its own resolve button
3. If you close the resolver you can open it again with RMB on the group screen
4. Sample view of a missing sample says it is missing