### PR TITLE
Allow output amplitude boost

### DIFF
--- a/src/engine/group.h
+++ b/src/engine/group.h
@@ -255,7 +255,8 @@ struct Group : MoveableOnly<Group>,
 } // namespace scxt::engine
 
 SC_DESCRIBE(scxt::engine::Group::GroupOutputInfo,
-            SC_FIELD(amplitude, pmd().asCubicDecibelAttenuation().withName("Amplitude"));
+            SC_FIELD(amplitude,
+                     pmd().asCubicDecibelAttenuationWithUpperDBBound(12).withName("Amplitude"));
             SC_FIELD(pan, pmd().asPercentBipolar().withName("Pan"));
             SC_FIELD(procRouting, pmd().asInt().withRange(0, 1));
             SC_FIELD(oversample, pmd().asBool().withName("Oversample"));

--- a/src/engine/zone.h
+++ b/src/engine/zone.h
@@ -269,7 +269,8 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
 } // namespace scxt::engine
 
 SC_DESCRIBE(scxt::engine::Zone::ZoneOutputInfo,
-            SC_FIELD(amplitude, pmd().asCubicDecibelAttenuation().withName("Amplitude"));
+            SC_FIELD(amplitude,
+                     pmd().asCubicDecibelAttenuationWithUpperDBBound(12).withName("Amplitude"));
             SC_FIELD(pan, pmd().asPercentBipolar().withName("Pan"));
             SC_FIELD(procRouting, pmd().asInt().withRange(0, 1));)
 


### PR DESCRIPTION
1. A PMD which is cubic attenuation and gain both in codebase
2. use it to set zone and group output from -inf to 12db to couple with mod-clamping