### PR TITLE
Voice Optimization: No processors, sample done, terminate

### DIFF
--- a/src/engine/group_and_zone_impl.h
+++ b/src/engine/group_and_zone_impl.h
@@ -73,7 +73,6 @@ void HasGroupZoneProcessors<T>::setProcessorType(int whichProcessor,
         ps.streamingVersion = 0;
     }
 
-    SCLOG("STREAMING VERSION IS " << ps.streamingVersion);
     asT()->onProcessorTypeChanged(whichProcessor, type);
 }
 

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -549,10 +549,14 @@ template <bool OS> bool Voice::processWithOS()
     /*
      * Finally do voice state update
      */
-    if (isAEGRunning)
+    if (isAEGRunning && (hasProcs || isGeneratorRunning))
+    {
         isVoicePlaying = true;
+    }
     else
+    {
         isVoicePlaying = false;
+    }
 
     return true;
 }


### PR DESCRIPTION
The voice lifetime was gated by the AEG in the past but in the case of no processors and a sample which is finished (as in non looping played through etc...) you can early terminate the voice.

Closes #379 (which is a pretty ancient issue)