### PR TITLE
Restructure SF2 to not over-load

### DIFF
--- a/src-ui/app/SCXTEditor.h
+++ b/src-ui/app/SCXTEditor.h
@@ -263,7 +263,6 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::DragAndDropCont
     selection::SelectionManager::selectedZones_t allGroupSelections;
     int16_t selectedPart{0};
 
-    // TODO: Do we allow part multi-select? I think we don't
     std::set<int> groupsWithSelectedZones;
     bool isAnyZoneFromGroupSelected(int groupIdx)
     {

--- a/src/engine/engine_voice_responder.cpp
+++ b/src/engine/engine_voice_responder.cpp
@@ -37,7 +37,6 @@ int32_t Engine::VoiceManagerResponder::beginVoiceCreationTransaction(uint16_t po
     SCLOG_IF(voiceResponder, "begin voice transaction " << SCD(port) << SCD(channel) << SCD(key)
                                                         << SCD(noteId) << SCD(velocity));
     assert(!transactionValid);
-    // TODO: We can optimize this so we don't have to find twice in the future
     auto useKey = engine.midikeyRetuner.remapKeyTo(channel, key);
     auto nts = engine.findZone(channel, useKey, noteId, std::clamp((int)(velocity * 128), 0, 127),
                                findZoneWorkingBuffer);

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -86,7 +86,6 @@ SC_STREAMDEF(scxt::engine::Engine, SC_FROM({
 
                  engine::Engine::UnstreamGuard sg(sv);
 
-                 // TODO: engine gets a SV? Guess maybe
                  // Order matters here. Samples need to be there before the patch and patch
                  // before selection
 
@@ -175,7 +174,6 @@ SC_STREAMDEF(scxt::engine::Part::ZoneMappingItem,
 
 SC_STREAMDEF(
     scxt::engine::Part, SC_FROM({
-        // TODO: Do a non-empty part stream with the If variant
         v = {{"config", from.configuration}, {"groups", from.getGroups()}, {"macros", from.macros}};
         if (SC_STREAMING_FOR_PART)
         {
@@ -273,7 +271,6 @@ SC_STREAMDEF(scxt::engine::Group, SC_FROM({
                      if (group.parentPart && group.parentPart->parentPatch &&
                          group.parentPart->parentPatch->parentEngine)
                      {
-                         // TODO: MOve this somewhere more intelligent
                          group.getZone(idx)->setupOnUnstream(
                              *(group.parentPart->parentPatch->parentEngine));
                      }

--- a/src/sample/sample.cpp
+++ b/src/sample/sample.cpp
@@ -127,30 +127,17 @@ bool Sample::load(const fs::path &path)
     return false;
 }
 
-bool Sample::loadFromSF2(const fs::path &p, sf2::File *f, int presetNum, int inst, int reg)
+bool Sample::loadFromSF2(const fs::path &p, sf2::File *f, int sampleIndex)
 {
     mFileName = p;
-    preset = presetNum;
-    instrument = inst;
-    region = reg;
+    preset = -1;
+    instrument = -1;
+    region = sampleIndex;
     type = SF2_FILE;
 
-    auto *preset = f->GetPreset(presetNum);
-
-    auto *presetRegion = preset->GetRegion(inst);
-    sf2::Instrument *instr = presetRegion->pInstrument;
-
-    if (instr->pGlobalRegion)
-    {
-        // TODO: Global Region
-    }
-
-    auto sfsample = instr->GetRegion(region)->GetSample();
+    auto sfsample = f->GetSample(sampleIndex);
     if (!sfsample)
         return false;
-
-    SCLOG("Loading individual sf2 sample '" << sfsample->Name << "' " << SCD(presetNum)
-                                            << SCD(instrument) << SCD(region) << SCD(p.u8string()));
 
     auto frameSize = sfsample->GetFrameSize();
     channels = sfsample->GetChannelCount();
@@ -160,8 +147,7 @@ bool Sample::loadFromSF2(const fs::path &p, sf2::File *f, int presetNum, int ins
     auto s = sfsample;
 
     auto fnp = fs::path{f->GetRiffFile()->GetFileName()};
-    displayName = fmt::format("{} - {} ({} @ {}.{})", f->GetInstrument(inst)->GetName(), s->Name,
-                              fnp.filename().u8string(), inst, region);
+    displayName = fmt::format("{} - ({} @ {})", s->Name, fnp.filename().u8string(), sampleIndex);
 
     if (frameSize == 2 && channels == 1 && sfsample->SampleType == sf2::Sample::MONO_SAMPLE)
     {

--- a/src/sample/sample.h
+++ b/src/sample/sample.h
@@ -55,7 +55,7 @@ struct alignas(16) Sample : MoveableOnly<Sample>
     std::string displayName{};
     std::string getDisplayName() const { return displayName; }
     bool load(const fs::path &path);
-    bool loadFromSF2(const fs::path &path, sf2::File *f, int preset, int inst, int region);
+    bool loadFromSF2(const fs::path &path, sf2::File *f, int sampleIndex);
 
     const fs::path &getPath() const { return mFileName; }
     std::string md5Sum{};

--- a/src/sample/sample_manager.h
+++ b/src/sample/sample_manager.h
@@ -86,6 +86,7 @@ struct SampleManager : MoveableOnly<SampleManager>
     std::optional<SampleID> loadSampleFromSF2(const fs::path &,
                                               sf2::File *f, // if this is null I will re-open it
                                               int preset, int instrument, int region);
+    int findSF2SampleIndexFor(sf2::File *, int preset, int instrument, int region);
 
     std::optional<SampleID> setupSampleFromMultifile(const fs::path &, const std::string &md5,
                                                      int idx, void *data, size_t dataSize);

--- a/src/utils.h
+++ b/src/utils.h
@@ -218,7 +218,6 @@ struct SampleRateSupport
 
 struct ThreadingChecker
 {
-    // TODO: Remove this workaround once I have startup working
     std::atomic<bool> bypassThreadChecks{false};
 
     std::thread::id clientThreadId{}, serialThreadId{}, audioThreadId{};


### PR DESCRIPTION
The SF2 indexes samples by the preset/instrument/region but that resolves to a sample index. Since I was using P/I/R as SampleID that meant identical samples had different IDs and thus loaded multiple times. Defacto this made a 3MB SF2 with lots of instruments load as 90MB and stuff. Ugh.

So fix this in two ways

1. Make loadeFromSF2 (p,i,r) remap the sample to index if needed
2. Change the sample->load to be index based

and voila