### PR TITLE
Fix two AEG problems in oversample and 0 rate mode

### DIFF
--- a/src/engine/group.cpp
+++ b/src/engine/group.cpp
@@ -474,6 +474,8 @@ void Group::onSampleRateChanged()
 
     for (auto &z : zones)
         z->setSampleRate(getSampleRate(), getSampleRateInv());
+
+    this->setHasModulatorsSampleRate(getSampleRate(), getSampleRateInv());
 }
 
 void Group::onProcessorTypeChanged(int w, dsp::processor::ProcessorType t)

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -794,4 +794,7 @@ void Voice::updateTransportPhasors()
         mul = mul / 2;
     }
 }
+
+void Voice::onSampleRateChanged() { setHasModulatorsSampleRate(samplerate, samplerate_inv); }
+
 } // namespace scxt::voice

--- a/src/voice/voice.h
+++ b/src/voice/voice.h
@@ -199,6 +199,8 @@ struct alignas(16) Voice : MoveableOnly<Voice>,
     }
     void release() { isGated = false; }
     void cleanupVoice();
+
+    void onSampleRateChanged() override;
 };
 } // namespace scxt::voice
 


### PR DESCRIPTION
- In 0 rate mode we would improperly skip sectinos nw I have fixed the exp timing blowing out the behavior. Do a variety of things to skip ahead properly to the first active stage

- The OS AEG had the wrong sample rate. This meant with OS on the AEG went twice as fast.

Fix both and close #1389