### PR TITLE
Handle monophonic midi messages (CC, Channel Bend) better

### DIFF
--- a/clients/clap-first/scxt-juce-standalone/scxt-juce-standalone.cpp
+++ b/clients/clap-first/scxt-juce-standalone/scxt-juce-standalone.cpp
@@ -255,8 +255,7 @@ struct SCXTApplicationWindow : juce::DocumentWindow, juce::Button::Listener
                         {
                             auto msg = (scope.blockSize1 == 1) ? midiBuffer[scope.startIndex1]
                                                                : midiBuffer[scope.startIndex2];
-                            sst::voicemanager::applyMidi1Message(window.engine->voiceManager, 0,
-                                                                 msg.getRawData());
+                            window.engine->processMIDI1Event(0, msg.getRawData());
                         }
                     }
                     // Drain thread safe midi queue

--- a/clients/clap-first/scxt-plugin/scxt-plugin.cpp
+++ b/clients/clap-first/scxt-plugin/scxt-plugin.cpp
@@ -32,8 +32,6 @@
 #include "version.h"
 #include "app/SCXTEditor.h"
 
-#include "sst/voicemanager/midi1_to_voicemanager.h"
-
 namespace scxt::clap_first::scxt_plugin
 {
 const clap_plugin_descriptor *getDescription()
@@ -418,24 +416,23 @@ bool SCXTPlugin::handleEvent(const clap_event_header_t *nextEvent)
         case CLAP_EVENT_MIDI:
         {
             auto mevt = reinterpret_cast<const clap_event_midi *>(nextEvent);
-            sst::voicemanager::applyMidi1Message(engine->voiceManager, mevt->port_index,
-                                                 mevt->data);
+            engine->processMIDI1Event(mevt->port_index, mevt->data);
         }
         break;
 
         case CLAP_EVENT_NOTE_ON:
         {
             auto nevt = reinterpret_cast<const clap_event_note *>(nextEvent);
-            engine->voiceManager.processNoteOnEvent(nevt->port_index, nevt->channel, nevt->key,
-                                                    nevt->note_id, nevt->velocity, 0.f);
+            engine->processNoteOnEvent(nevt->port_index, nevt->channel, nevt->key, nevt->note_id,
+                                       nevt->velocity, 0.f);
         }
         break;
 
         case CLAP_EVENT_NOTE_OFF:
         {
             auto nevt = reinterpret_cast<const clap_event_note *>(nextEvent);
-            engine->voiceManager.processNoteOffEvent(nevt->port_index, nevt->channel, nevt->key,
-                                                     nevt->note_id, nevt->velocity);
+            engine->processNoteOffEvent(nevt->port_index, nevt->channel, nevt->key, nevt->note_id,
+                                        nevt->velocity);
         }
 
         case CLAP_EVENT_PARAM_VALUE:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(${PROJECT_NAME} STATIC
         engine/missing_resolution.cpp
         engine/bus.cpp
         engine/macros.cpp
+        engine/group_triggers.cpp
 
         json/stream.cpp
 

--- a/src/engine/engine_voice_responder.cpp
+++ b/src/engine/engine_voice_responder.cpp
@@ -212,21 +212,6 @@ void Engine::VoiceManagerResponder::endVoiceCreationTransaction(uint16_t port, u
 
 void Engine::VoiceManagerResponder::releaseVoice(voice::Voice *v, float velocity) { v->release(); }
 
-void Engine::VoiceManagerResponder::setVoiceMIDIPitchBend(voice::Voice *v, uint16_t pb14bit)
-{
-    auto fv = (pb14bit - 8192) / 8192.f;
-    auto part = v->zone->parentGroup->parentPart;
-    part->pitchBendValue = fv;
-}
-
-void Engine::VoiceManagerResponder::setMIDI1CC(voice::Voice *v, int8_t controller, int8_t val)
-{
-    assert(controller >= 0);
-    auto fv = val / 127.0;
-    auto part = v->zone->parentGroup->parentPart;
-    part->midiCCValues[controller] = fv;
-}
-
 void Engine::VoiceManagerResponder::setNoteExpression(voice::Voice *v, int32_t expression,
                                                       double value)
 {

--- a/src/engine/group_triggers.cpp
+++ b/src/engine/group_triggers.cpp
@@ -1,0 +1,28 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "group_triggers.h"

--- a/src/engine/group_triggers.h
+++ b/src/engine/group_triggers.h
@@ -1,0 +1,65 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_ENGINE_GROUP_TRIGGERS_H
+#define SCXT_SRC_ENGINE_GROUP_TRIGGERS_H
+
+#include <memory>
+
+#include "datamodel/metadata.h"
+
+namespace scxt::engine
+{
+
+struct Group;
+
+/**
+ * Maintain the state of keys ccs etc... for a particular instrument
+ */
+struct GroupTriggerInstrumentState
+{
+};
+
+/**
+ * Calculate if a group is triggered
+ */
+struct GroupTrigger
+{
+    GroupTriggerInstrumentState &state;
+    GroupTrigger(GroupTriggerInstrumentState &onState) : state(onState) {}
+    virtual ~GroupTrigger() = default;
+    virtual bool value(const std::unique_ptr<Group> &) const = 0;
+
+    datamodel::pmd argMetadata(int argNo) const;
+    std::string displayName;
+};
+
+std::unique_ptr<GroupTrigger> makeMacroGroupTrigger(GroupTriggerInstrumentState &);
+std::unique_ptr<GroupTrigger> makeMIDI1CCGroupTrigger(GroupTriggerInstrumentState &);
+
+} // namespace scxt::engine
+#endif // GROUP_TRIGGERS_H

--- a/src/engine/part.h
+++ b/src/engine/part.h
@@ -68,6 +68,12 @@ struct Part : MoveableOnly<Part>, SampleRateSupport
     int16_t partNumber;
     Patch *parentPatch{nullptr};
 
+    bool respondsToMIDIChannel(int16_t channel) const
+    {
+        return channel < 0 || configuration.channel == PartConfiguration::omniChannel ||
+               channel == configuration.channel;
+    }
+
     struct PartConfiguration
     {
         static constexpr int16_t omniChannel{-1};


### PR DESCRIPTION
Monophonic messages used to come through the voice manager to each voice which would find the right spot. Refactor the voice manager so this is more reasonably sent less frequently etc... and have a new monophonic midi signal handler.