### PR TITLE
Get MIDI CCs in the mod matrix

### DIFF
--- a/src/modulation/group_matrix.cpp
+++ b/src/modulation/group_matrix.cpp
@@ -134,6 +134,7 @@ void GroupMatrixEndpoints::OutputTarget::bind(scxt::modulation::GroupMatrix &m, 
 void GroupMatrixEndpoints::Sources::bind(scxt::modulation::GroupMatrix &m, engine::Group &g)
 {
     lfoSources.bind(m, g, zeroSource);
+    midiCCSources.bind(m, *(g.parentPart));
 
     int idx{0};
 

--- a/src/modulation/group_matrix.h
+++ b/src/modulation/group_matrix.h
@@ -247,7 +247,7 @@ struct GroupMatrixEndpoints
     struct Sources
     {
         Sources(engine::Engine *e)
-            : lfoSources(e), egSource{{'greg', 'eg1 ', 0}, {'greg', 'eg2 ', 0}},
+            : lfoSources(e), midiCCSources(e), egSource{{'greg', 'eg1 ', 0}, {'greg', 'eg2 ', 0}},
               transportSources(e), macroSources(e)
         {
             registerGroupModSource(e, egSource[0], "", "EG1");
@@ -255,6 +255,8 @@ struct GroupMatrixEndpoints
         }
 
         LFOSourceBase<SR, 'grlf', lfosPerGroup, registerGroupModSource> lfoSources;
+        MIDICCBase<GroupMatrixConfig, SR, 'zncc', registerGroupModSource> midiCCSources;
+
         SR egSource[2];
         TransportSourceBase<SR, 'gtsp', false, registerGroupModSource> transportSources;
 

--- a/src/modulation/matrix_shared.h
+++ b/src/modulation/matrix_shared.h
@@ -409,4 +409,30 @@ struct LFOSourceBase
     }
 };
 
+template <typename CF, typename SR, uint32_t gid,
+          void (*registerSource)(scxt::engine::Engine *, const SR &, const std::string &,
+                                 const std::string &)>
+struct MIDICCBase
+{
+    static constexpr int numMidiCC{128};
+    MIDICCBase(scxt::engine::Engine *e)
+    {
+        for (uint32_t i = 0; i < numMidiCC; ++i)
+        {
+            sources[i] = SR{gid, 'm1cc', i};
+            registerSource(e, sources[i], "MIDI CCs", fmt::format("CC {:03}", i));
+        }
+    }
+    std::array<SR, 128> sources;
+
+    template <typename M, typename P> void bind(M &m, P &p)
+    {
+        for (int i = 0; i < numMidiCC; ++i)
+        {
+            m.bindSourceValue(sources[i], p.midiCCValues[i]);
+            CF::setDefaultLagFor(sources[i], 50);
+        }
+    }
+};
+
 #endif // SHORTCIRCUITXT_MATRIX_SHARED_H

--- a/src/modulation/voice_matrix.cpp
+++ b/src/modulation/voice_matrix.cpp
@@ -128,6 +128,7 @@ void MatrixEndpoints::Sources::bind(scxt::voice::modulation::Matrix &m, engine::
                                     voice::Voice &v)
 {
     lfoSources.bind(m, v, zeroSource);
+    midiCCSources.bind(m, *(z.parentGroup->parentPart));
 
     m.bindSourceValue(aegSource, v.aeg.outBlock0);
     m.bindSourceValue(eg2Source, v.eg2.outBlock0);

--- a/src/modulation/voice_matrix.h
+++ b/src/modulation/voice_matrix.h
@@ -224,14 +224,16 @@ struct MatrixEndpoints
     struct Sources
     {
         Sources(engine::Engine *e)
-            : lfoSources(e), midiSources(e), noteExpressions(e), aegSource{'zneg', 'aeg ', 0},
-              eg2Source{'zneg', 'eg2 ', 0}, transportSources(e), rngSources(e), macroSources(e)
+            : lfoSources(e), midiCCSources(e), midiSources(e), noteExpressions(e),
+              aegSource{'zneg', 'aeg ', 0}, eg2Source{'zneg', 'eg2 ', 0}, transportSources(e),
+              rngSources(e), macroSources(e)
         {
             registerVoiceModSource(e, aegSource, "", "AEG");
             registerVoiceModSource(e, eg2Source, "", "EG2");
         }
 
         LFOSourceBase<SR, 'znlf', lfosPerZone, registerVoiceModSource> lfoSources;
+        MIDICCBase<MatrixConfig, SR, 'zncc', registerVoiceModSource> midiCCSources;
 
         struct MIDISources
         {


### PR DESCRIPTION
The UI is terrible, there's no learn, the menus not nested, it doesn't show the standard midi names, so this only addresses #401 since there's more to do to finish it, but this also shows the path for how to get there and is useful already despite all those shortcomings.