### PR TITLE
Fix disapearing group sidebar; start UI messages

### DIFF
--- a/src-ui/app/SCXTEditor.h
+++ b/src-ui/app/SCXTEditor.h
@@ -213,6 +213,8 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::DragAndDropCont
     void onGroupMatrixMetadata(const scxt::modulation::groupMatrixMetadata_t &);
     void onGroupMatrix(const scxt::modulation::GroupMatrix::RoutingTable &);
 
+    void onGroupTriggerConditions(const scxt::engine::GroupTriggerConditions &);
+
     void onGroupOrZoneModulatorStorageUpdated(
         const scxt::messaging::client::indexedModulatorStorageUpdate_t &);
     void onZoneOutputInfoUpdated(const scxt::messaging::client::zoneOutputInfoUpdate_t &p);

--- a/src-ui/app/edit-screen/components/PartGroupSidebar.cpp
+++ b/src-ui/app/edit-screen/components/PartGroupSidebar.cpp
@@ -250,6 +250,7 @@ struct GroupSidebar : GroupZoneSidebarBase<GroupSidebar, false>
         auto dividerHeight = 8;
 
         auto lb = b.withTrimmedBottom(trigHeight + settingsHeight + 2 * dividerHeight);
+        listBox->setBounds(lb);
         auto tb = b.withY(lb.getBottom()).withHeight(dividerHeight);
         triggersDivider->setBounds(tb);
         tb = tb.translated(0, dividerHeight).withHeight(trigHeight);

--- a/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -444,4 +444,9 @@ void SCXTEditor::onMissingResolutionWorkItemList(
         missingResolutionScreen->toFront(true);
     }
 }
+
+void SCXTEditor::onGroupTriggerConditions(scxt::engine::GroupTriggerConditions const &g)
+{
+    SCLOG_ONCE("Implement: On Group Trigger Conditions");
+}
 } // namespace scxt::ui::app

--- a/src/engine/group_triggers.cpp
+++ b/src/engine/group_triggers.cpp
@@ -71,7 +71,8 @@ std::string GroupTriggerConditions::toStringGroupConditionsConjunction(const Con
     }
     return "a";
 }
-GroupTriggerConditions::Conjunction fromStringConditionsConjunction(const std::string &s)
+GroupTriggerConditions::Conjunction
+GroupTriggerConditions::fromStringConditionsConjunction(const std::string &s)
 {
     static auto inverse =
         makeEnumInverse<GroupTriggerConditions::Conjunction,
@@ -85,7 +86,6 @@ GroupTriggerConditions::Conjunction fromStringConditionsConjunction(const std::s
 
 struct GTMacro : GroupTrigger
 {
-
     GTMacro(GroupTriggerInstrumentState &onState, GroupTriggerStorage &onStorage)
         : GroupTrigger(onState, onStorage)
     {

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -182,6 +182,8 @@ enum SerializationToClientMessageIds
     s2c_update_zone_output_info,
     s2c_update_group_output_info,
 
+    s2c_send_group_trigger_conditions,
+
     s2c_respond_single_processor_metadata_and_data,
     s2c_notify_mismatched_processors_for_zone,
 

--- a/src/messaging/client/group_messages.h
+++ b/src/messaging/client/group_messages.h
@@ -40,6 +40,9 @@ using groupOutputInfoUpdate_t = std::pair<bool, engine::Group::GroupOutputInfo>;
 SERIAL_TO_CLIENT(GroupOutputInfoUpdated, s2c_update_group_output_info, groupOutputInfoUpdate_t,
                  onGroupOutputInfoUpdated);
 
+SERIAL_TO_CLIENT(SendGroupTriggerConditions, s2c_send_group_trigger_conditions,
+                 scxt::engine::GroupTriggerConditions, onGroupTriggerConditions)
+
 CLIENT_TO_SERIAL_CONSTRAINED(UpdateGroupOutputFloatValue, c2s_update_group_output_float_value,
                              detail::diffMsg_t<float>, engine::Group::GroupOutputInfo,
                              detail::updateGroupMemberValue(&engine::Group::outputInfo, payload,

--- a/src/selection/selection_manager.cpp
+++ b/src/selection/selection_manager.cpp
@@ -627,6 +627,9 @@ void SelectionManager::sendDisplayDataForSingleGroup(int part, int group)
                               modulation::getGroupMatrixMetadata(*g),
                               *(engine.getMessageController()));
     serializationSendToClient(cms::s2c_update_group_matrix, rt, *(engine.getMessageController()));
+
+    serializationSendToClient(cms::s2c_send_group_trigger_conditions, g->triggerConditions,
+                              *(engine.getMessageController()));
 }
 
 void SelectionManager::sendDisplayDataForNoGroupSelected()


### PR DESCRIPTION
Start the UI message for group triggers but along the way realize my last commit removed the group sidebar selection tree Ooops! So do a quick merge to fix it.