### PR TITLE
Voice Stealing and Termination Improvements

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -53,7 +53,7 @@ static constexpr uint16_t numPluginOutputs{numNonMainPluginOutputs + 1};
 
 static constexpr size_t numTransportPhasors{7}; // double whole -> 32
 
-static constexpr uint16_t maxVoices{256};
+static constexpr uint16_t maxVoices{512};
 
 // some battles are not worth it
 static constexpr uint16_t BLOCK_SIZE{blockSize};

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -207,6 +207,7 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
                                          int32_t noteId, float velocity);
 
         void releaseVoice(voice::Voice *v, float velocity);
+        void terminateVoice(voice::Voice *v);
         void retriggerVoiceWithNewNoteID(voice::Voice *v, int32_t noteid, float velocity)
         {
             SCLOG("Retrigger Voice Unimplemented")

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -494,6 +494,12 @@ template <bool OS> bool Voice::processWithOS()
 
     pao *= velKeyFade;
 
+    if (terminationSequence > 0)
+    {
+        terminationSequence--;
+        pao *= terminationSequence / blocksToTerminate;
+    }
+
     if constexpr (OS)
     {
         outputAmpOS.set_target(pao * pao * pao * noteExpressions[(int)ExpressionIDs::VOLUME]);
@@ -558,6 +564,10 @@ template <bool OS> bool Voice::processWithOS()
         isVoicePlaying = false;
     }
 
+    if (terminationSequence == 0)
+    {
+        isVoicePlaying = false;
+    }
     return true;
 }
 

--- a/src/voice/voice.h
+++ b/src/voice/voice.h
@@ -186,6 +186,10 @@ struct alignas(16) Voice : MoveableOnly<Voice>,
     bool isVoicePlaying{false};
     bool isVoiceAssigned{false};
 
+    int16_t terminationSequence{-1};
+    // how many blocks is the early-terminate/steal fade
+    static constexpr int blocksToTerminate{8};
+
     void attack()
     {
         isGated = true;
@@ -198,6 +202,7 @@ struct alignas(16) Voice : MoveableOnly<Voice>,
         voiceStarted();
     }
     void release() { isGated = false; }
+    void beginTerminationSequence() { terminationSequence = blocksToTerminate; }
     void cleanupVoice();
 
     void onSampleRateChanged() override;


### PR DESCRIPTION
Handle a voice stealing API which, for now, steals only at the hard limit, but has been tested at both hard and soft limit at this commit with a different configuration. Closes #1392 

At the same time, add a voice termination fade for soft terminates which keeps the voice alive for 8 blocks with a fade during the period. Closes #801