### PR TITLE
Unison as single voice

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -76,6 +76,8 @@ static constexpr uint16_t processorsPerZoneAndGroup{4};
 
 static constexpr uint16_t triggerConditionsPerGroup{4};
 
+static constexpr uint16_t maxGeneratorsPerVoice{64};
+
 /*
  * This namespace guards some very useful debugging guards and logs in the code.
  */
@@ -86,6 +88,7 @@ static constexpr bool uiStructure{false};
 static constexpr bool groupZoneMutation{false};
 static constexpr bool memoryPool{false};
 static constexpr bool voiceResponder{false};
+static constexpr bool generatorInitialization{false};
 } // namespace log
 
 } // namespace scxt

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -386,7 +386,7 @@ bool Engine::processAudio()
                 itm.group = v->zonePath.group;
                 itm.zone = v->zonePath.zone;
                 itm.sample = v->sampleIndex;
-                itm.samplePos = v->GD.samplePos;
+                itm.samplePos = v->GD[0].samplePos;
                 itm.midiNote = v->originalMidiKey;
                 itm.midiChannel = v->channel;
                 itm.gated = v->isGated;


### PR DESCRIPTION
Unison used to be implemented in the voice manager as spanning voices but for a varieyt of reasons (including but not limited to polyphony) you kinda want them stacked before a single processor chain. So move Unison from voice-cretion to bundle-of-generators in-the-voice pattern.