### PR TITLE
Add a data cache; add a cross-editor subscription

### DIFF
--- a/src-ui/CMakeLists.txt
+++ b/src-ui/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(${PROJECT_NAME} STATIC
         app/editor-impl/SCXTEditor.cpp
         app/editor-impl/SCXTEditorMenus.cpp
         app/editor-impl/SCXTEditorResponseHandlers.cpp
+        app/editor-impl/SCXTEditorDataCache.cpp
 
         app/edit-screen/EditScreen.cpp
         app/edit-screen/components/AdsrPane.cpp

--- a/src-ui/app/HasEditor.h
+++ b/src-ui/app/HasEditor.h
@@ -57,6 +57,8 @@ struct HasEditor
     template <typename T> void updateValueTooltip(const T &attachment);
     template <typename W, typename A>
     void setupWidgetForValueTooltip(W *widget, const A &attachment);
+
+    template <typename P, typename A> void addSubscription(const P &, A &);
 };
 } // namespace scxt::ui::app
 #endif // SHORTCIRCUIT_HASEDITOR_H

--- a/src-ui/app/SCXTEditorDataCache.h
+++ b/src-ui/app/SCXTEditorDataCache.h
@@ -1,0 +1,91 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_UI_APP_SCXTEDITORDATACACHE_H
+#define SCXT_SRC_UI_APP_SCXTEDITORDATACACHE_H
+
+#include <unordered_map>
+#include <unordered_set>
+
+#include "engine/bus.h"
+#include "engine/part.h"
+#include "engine/group.h"
+#include "engine/zone.h"
+#include "engine/patch.h"
+
+#include "sst/jucegui/data/Continuous.h"
+#include "sst/jucegui/data/Discrete.h"
+
+namespace scxt::ui::app
+{
+/**
+ * The iriginal design of the SC UI (which is still partly that way) has local copies
+ * of the data cache right next to the particular panel. This works well until you want
+ * to share data across more than one panel, and then it gets clumsy, or if your heirarchy
+ * gets deep.
+ *
+ * So this class exists to have a place for the SCXTEditorResonder thingy to push data
+ * copies and for hte UI to bind to, since the UI will reliably be components which
+ * haveeditor.
+ */
+struct SCXTEditorDataCache
+{
+    // Displayed group tab output info
+    scxt::engine::Group::GroupOutputInfo groupOutputInfo;
+    // Displayed zone tab output info
+    scxt::engine::Zone::ZoneOutputInfo zoneOutputInfo;
+
+    void addSubscription(void *el, sst::jucegui::data::Continuous *);
+    void addSubscription(void *el, sst::jucegui::data::Discrete *);
+    void fireSubscription(void *el, sst::jucegui::data::Continuous *);
+    void fireSubscription(void *el, sst::jucegui::data::Discrete *);
+
+  private:
+    std::unordered_map<void *, std::unordered_set<sst::jucegui::data::Continuous *>> csubs;
+    std::unordered_map<void *, std::unordered_set<sst::jucegui::data::Discrete *>> dsubs;
+
+    struct CListener : sst::jucegui::data::Continuous::DataListener
+    {
+        SCXTEditorDataCache &cache;
+        CListener(SCXTEditorDataCache &dc) : cache(dc){};
+        virtual ~CListener() = default;
+        void dataChanged() override{};
+        void sourceVanished(sst::jucegui::data::Continuous *c) override;
+    } clistener{*this};
+
+    struct DListener : sst::jucegui::data::Discrete::DataListener
+    {
+        SCXTEditorDataCache &cache;
+        DListener(SCXTEditorDataCache &dc) : cache(dc){};
+        virtual ~DListener() = default;
+        void dataChanged() override{};
+        void sourceVanished(sst::jucegui::data::Discrete *c) override;
+    } dlistener{*this};
+};
+} // namespace scxt::ui::app
+
+#endif // SCXTEDITORDATACACHE_H

--- a/src-ui/app/edit-screen/components/GroupSettingsCard.cpp
+++ b/src-ui/app/edit-screen/components/GroupSettingsCard.cpp
@@ -27,14 +27,16 @@
 
 #include "GroupSettingsCard.h"
 #include "app/SCXTEditor.h"
-#include "connectors/PayloadDataAttachment.h"
 
 namespace scxt::ui::app::edit_screen
 {
 namespace jcmp = sst::jucegui::components;
 
-GroupSettingsCard::GroupSettingsCard(SCXTEditor *e) : HasEditor(e)
+GroupSettingsCard::GroupSettingsCard(SCXTEditor *e)
+    : HasEditor(e), info(e->editorDataCache.groupOutputInfo)
 {
+    using fac = connectors::SingleValueFactory<attachment_t, floatMsg_t>;
+
     auto mkg = [this](auto gl) {
         auto res = std::make_unique<jcmp::GlyphPainter>(gl);
         addAndMakeVisible(*res);
@@ -67,9 +69,10 @@ GroupSettingsCard::GroupSettingsCard(SCXTEditor *e) : HasEditor(e)
     glideDrag = mkd('gdrg', "Glide");
 
     volGlyph = mkg(jcmp::GlyphPainter::GlyphType::VOLUME);
-    volDrag = mkd('grvl', "Volume");
+    fac::attachAndAdd(info, info.amplitude, this, volAttachment, volDrag);
     panGlyph = mkg(jcmp::GlyphPainter::GlyphType::PAN);
-    panDrag = mkd('grpn', "Pan");
+    fac::attachAndAdd(info, info.pan, this, panAttachment, panDrag);
+
     tuneGlyph = mkg(jcmp::GlyphPainter::GlyphType::TUNING);
     tuneDrag = mkd('grtn', "Tune");
 }

--- a/src-ui/app/edit-screen/components/GroupSettingsCard.h
+++ b/src-ui/app/edit-screen/components/GroupSettingsCard.h
@@ -35,6 +35,9 @@
 #include "sst/jucegui/components/Label.h"
 #include "sst/jucegui/components/GlyphButton.h"
 
+#include "messaging/messaging.h"
+#include "connectors/PayloadDataAttachment.h"
+
 #include "app/HasEditor.h"
 
 namespace scxt::ui::app::edit_screen
@@ -52,6 +55,13 @@ struct GroupSettingsCard : juce::Component, HasEditor
         glideMenu, srcMenu;
     std::unique_ptr<sst::jucegui::components::DraggableTextEditableValue> pbDnVal, pbUpDrag,
         glideDrag, volDrag, panDrag, tuneDrag;
+
+    using floatMsg_t = scxt::messaging::client::UpdateGroupOutputFloatValue;
+    typedef connectors::PayloadDataAttachment<engine::Group::GroupOutputInfo> attachment_t;
+
+    std::unique_ptr<attachment_t> volAttachment, panAttachment;
+
+    engine::Group::GroupOutputInfo &info;
 };
 } // namespace scxt::ui::app::edit_screen
 #endif // GROUPSETTINGSCARD_H

--- a/src-ui/app/edit-screen/components/OutputPane.h
+++ b/src-ui/app/edit-screen/components/OutputPane.h
@@ -47,6 +47,8 @@ struct OutPaneZoneTraits
 
     using floatMsg_t = scxt::messaging::client::UpdateZoneOutputFloatValue;
     using int16Msg_t = scxt::messaging::client::UpdateZoneOutputInt16TValue;
+
+    static engine::Zone::ZoneOutputInfo &outputInfo(SCXTEditor *e);
 };
 
 struct OutPaneGroupTraits
@@ -58,6 +60,8 @@ struct OutPaneGroupTraits
 
     using floatMsg_t = scxt::messaging::client::UpdateGroupOutputFloatValue;
     using int16Msg_t = scxt::messaging::client::UpdateGroupOutputInt16TValue;
+
+    static engine::Group::GroupOutputInfo &outputInfo(SCXTEditor *e);
 };
 template <typename OTTraits> struct OutputTab;
 template <typename OTTraits> struct ProcTab;
@@ -69,7 +73,8 @@ template <typename OTTraits> struct OutputPane : sst::jucegui::components::Named
 
     void resized() override;
     void setActive(bool);
-    void setOutputData(const typename OTTraits::info_t &);
+
+    void updateFromOutputInfo();
 
     std::unique_ptr<OutputTab<OTTraits>> output;
     std::unique_ptr<ProcTab<OTTraits>> proc;

--- a/src-ui/app/editor-impl/SCXTEditorDataCache.cpp
+++ b/src-ui/app/editor-impl/SCXTEditorDataCache.cpp
@@ -76,18 +76,9 @@ void SCXTEditorDataCache::CListener::sourceVanished(sst::jucegui::data::Continuo
 {
     for (auto &cs : cache.csubs)
     {
-        auto sb = cs.second.begin();
-        while (sb != cs.second.end())
-        {
-            if (*sb == c)
-            {
-                sb = cs.second.erase(sb);
-            }
-            else
-            {
-                ++sb;
-            }
-        }
+        auto p = cs.second.find(c);
+        if (p != cs.second.end())
+            cs.second.erase(p);
     }
 }
 
@@ -95,18 +86,9 @@ void SCXTEditorDataCache::DListener::sourceVanished(sst::jucegui::data::Discrete
 {
     for (auto &cs : cache.dsubs)
     {
-        auto sb = cs.second.begin();
-        while (sb != cs.second.end())
-        {
-            if (*sb == c)
-            {
-                sb = cs.second.erase(sb);
-            }
-            else
-            {
-                ++sb;
-            }
-        }
+        auto p = cs.second.find(c);
+        if (p != cs.second.end())
+            cs.second.erase(p);
     }
 }
 

--- a/src-ui/app/editor-impl/SCXTEditorDataCache.cpp
+++ b/src-ui/app/editor-impl/SCXTEditorDataCache.cpp
@@ -1,0 +1,113 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "app/SCXTEditorDataCache.h"
+#include "utils.h"
+
+namespace scxt::ui::app
+{
+
+void SCXTEditorDataCache::addSubscription(void *el, sst::jucegui::data::Continuous *c)
+{
+    csubs[el].insert(c);
+    c->addGUIDataListener(&clistener);
+}
+void SCXTEditorDataCache::addSubscription(void *el, sst::jucegui::data::Discrete *d)
+{
+    dsubs[el].insert(d);
+    d->addGUIDataListener(&dlistener);
+}
+
+void SCXTEditorDataCache::fireSubscription(void *el, sst::jucegui::data::Continuous *c)
+{
+    auto cp = csubs.find(el);
+    if (cp != csubs.end())
+    {
+        for (auto &ca : cp->second)
+        {
+            if (ca != c)
+            {
+                ca->setValueFromModel(c->getValue());
+            }
+        }
+    }
+}
+
+void SCXTEditorDataCache::fireSubscription(void *el, sst::jucegui::data::Discrete *c)
+{
+    auto cp = dsubs.find(el);
+    if (cp != dsubs.end())
+    {
+        for (auto &ca : cp->second)
+        {
+            if (ca != c)
+            {
+                ca->setValueFromModel(c->getValue());
+            }
+        }
+    }
+}
+
+void SCXTEditorDataCache::CListener::sourceVanished(sst::jucegui::data::Continuous *c)
+{
+    for (auto &cs : cache.csubs)
+    {
+        auto sb = cs.second.begin();
+        while (sb != cs.second.end())
+        {
+            if (*sb == c)
+            {
+                sb = cs.second.erase(sb);
+            }
+            else
+            {
+                ++sb;
+            }
+        }
+    }
+}
+
+void SCXTEditorDataCache::DListener::sourceVanished(sst::jucegui::data::Discrete *c)
+{
+    for (auto &cs : cache.dsubs)
+    {
+        auto sb = cs.second.begin();
+        while (sb != cs.second.end())
+        {
+            if (*sb == c)
+            {
+                sb = cs.second.erase(sb);
+            }
+            else
+            {
+                ++sb;
+            }
+        }
+    }
+}
+
+} // namespace scxt::ui::app

--- a/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -203,20 +203,22 @@ void SCXTEditor::onGroupOrZoneModulatorStorageUpdated(
 void SCXTEditor::onZoneOutputInfoUpdated(const scxt::messaging::client::zoneOutputInfoUpdate_t &p)
 {
     auto [active, inf] = p;
+    editorDataCache.zoneOutputInfo = inf;
     editScreen->getZoneElements()->outPane->setActive(active);
     if (active)
     {
-        editScreen->getZoneElements()->outPane->setOutputData(inf);
+        editScreen->getZoneElements()->outPane->updateFromOutputInfo();
     }
 }
 
 void SCXTEditor::onGroupOutputInfoUpdated(const scxt::messaging::client::groupOutputInfoUpdate_t &p)
 {
     auto [active, inf] = p;
+    editorDataCache.groupOutputInfo = inf;
     editScreen->getGroupElements()->outPane->setActive(active);
     if (active)
     {
-        editScreen->getGroupElements()->outPane->setOutputData(inf);
+        editScreen->getGroupElements()->outPane->updateFromOutputInfo();
     }
 }
 

--- a/src-ui/connectors/PayloadDataAttachment.h
+++ b/src-ui/connectors/PayloadDataAttachment.h
@@ -231,6 +231,9 @@ struct PayloadDataAttachment : sst::jucegui::data::Continuous
     {
         prevValue = value;
         value = (ValueType)f;
+
+        for (auto *l : guilisteners)
+            l->dataChanged();
     }
 
     float getMin() const override { return description.minVal; }
@@ -309,6 +312,9 @@ struct DiscretePayloadDataAttachment : sst::jucegui::data::Discrete
     {
         prevValue = value;
         value = (ValueType)f;
+
+        for (auto *l : guilisteners)
+            l->dataChanged();
     }
 
     int getMin() const override { return (int)description.minVal; }
@@ -403,7 +409,12 @@ struct DirectBooleanPayloadDataAttachment : sst::jucegui::data::Discrete
         value = f;
         callback(f);
     }
-    void setValueFromModel(const int &f) override { value = f; }
+    void setValueFromModel(const int &f) override
+    {
+        value = f;
+        for (auto *l : guilisteners)
+            l->dataChanged();
+    }
 
     int getMin() const override { return (int)0; }
     int getMax() const override { return (int)1; }
@@ -448,7 +459,12 @@ struct SamplePointDataAttachment : sst::jucegui::data::Continuous
     float getMin() const override { return -1; }
     float getMax() const override { return sampleCount; }
     float getDefaultValue() const override { return 0; }
-    void setValueFromModel(const float &f) override { value = (int64_t)f; }
+    void setValueFromModel(const float &f) override
+    {
+        value = (int64_t)f;
+        for (auto *l : guilisteners)
+            l->dataChanged();
+    }
 };
 
 template <typename A, typename Msg, typename ABase = A> struct SingleValueFactory
@@ -470,6 +486,7 @@ template <typename A, typename Msg, typename ABase = A> struct SingleValueFactor
         {
             e->setupWidgetForValueTooltip(wid.get(), att.get());
         }
+        e->addSubscription(val, att);
         return {std::move(att), std::move(wid)};
     }
 

--- a/src/engine/group.h
+++ b/src/engine/group.h
@@ -260,7 +260,7 @@ struct Group : MoveableOnly<Group>,
 SC_DESCRIBE(scxt::engine::Group::GroupOutputInfo,
             SC_FIELD(amplitude,
                      pmd().asCubicDecibelAttenuationWithUpperDBBound(12).withName("Amplitude"));
-            SC_FIELD(pan, pmd().asPercentBipolar().withName("Pan"));
+            SC_FIELD(pan, pmd().asPercentBipolar().withName("Pan").withDecimalPlaces(0));
             SC_FIELD(procRouting, pmd().asInt().withRange(0, 1));
             SC_FIELD(oversample, pmd().asBool().withName("Oversample"));
             SC_FIELD(velocitySensitivity,


### PR DESCRIPTION
Basically make it so shared ui data has a place to live and that editors on it can detect they are multiple and show you the changes.

Applied right now to group pan and amplitude only but its all generalizable.