### PR TITLE
MPE Support

### DIFF
--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -1166,28 +1166,13 @@ void Engine::processNoteOffEvent(int16_t port, int16_t channel, int16_t key, int
     voiceManager.processNoteOffEvent(port, channel, key, note_id, velocity);
 }
 
-void Engine::MonoVoiceManagerResponder::setMIDIPitchBend(int16_t channel, int16_t pb14bit)
+void Engine::onPartConfigurationUpdated()
 {
-    auto fv = (pb14bit - 8192) / 8192.f;
-    for (const auto &p : engine.getPatch()->getParts())
-    {
-        if (p->configuration.active && p->respondsToMIDIChannel(channel))
-        {
-            p->pitchBendValue = fv;
-        }
-    }
-}
-void Engine::MonoVoiceManagerResponder::setMIDI1CC(int16_t channel, int16_t cc, int16_t val)
-{
-    auto fv = val / 127.0;
+    auto midiM = voiceManager_t::MIDI1Dialect::MIDI1;
+    for (auto &p : *getPatch())
+        if (p->configuration.channel == Part::PartConfiguration::mpeChannel)
+            midiM = voiceManager_t::MIDI1Dialect::MIDI1_MPE;
 
-    for (const auto &p : engine.getPatch()->getParts())
-    {
-        if (p->configuration.active && p->respondsToMIDIChannel(channel))
-        {
-            p->midiCCValues[cc] = fv;
-        }
-    }
+    voiceManager.dialect = midiM;
 }
-void Engine::MonoVoiceManagerResponder::setMIDIChannelPressure(int16_t channel, int16_t pres) {}
 } // namespace scxt::engine

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -166,6 +166,8 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
         return idx;
     }
 
+    void onPartConfigurationUpdated();
+
     tuning::MidikeyRetuner midikeyRetuner;
 
     // new voice manager style
@@ -213,7 +215,9 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
             SCLOG("Retrigger Voice Unimplemented")
         }
 
-        void setVoiceMIDIMPEChannelPitchBend(voice::Voice *v, uint16_t pb14bit) {}
+        void setVoiceMIDIMPEChannelPitchBend(voice::Voice *v, uint16_t pb14bit);
+        void setVoiceMIDIMPEChannelPressure(voice::Voice *v, int8_t val);
+        void setVoiceMIDIMPETimbre(voice::Voice *v, int8_t val);
 
         void setVoicePolyphonicParameterModulation(voice::Voice *v, uint32_t parameter,
                                                    double value)

--- a/src/engine/group.h
+++ b/src/engine/group.h
@@ -82,8 +82,15 @@ struct Group : MoveableOnly<Group>,
         float amplitude{1.f}, pan{0.f}, velocitySensitivity{0.6f};
         bool muted{false};
         bool oversample{true};
+
         ProcRoutingPath procRouting{procRoute_linear};
         BusAddress routeTo{DEFAULT_BUS};
+
+        bool hasIndependentPolyLimit{false};
+        bool polyLimitIsVoices{true};
+        int32_t polyLimit{0};
+
+        bool isMonoLegato{false};
     } outputInfo;
 
     GroupTriggerConditions triggerConditions;

--- a/src/engine/part.h
+++ b/src/engine/part.h
@@ -72,17 +72,29 @@ struct Part : MoveableOnly<Part>, SampleRateSupport
     bool respondsToMIDIChannel(int16_t channel) const
     {
         return channel < 0 || configuration.channel == PartConfiguration::omniChannel ||
+               configuration.channel == PartConfiguration::mpeChannel ||
                channel == configuration.channel;
+    }
+    bool isMPEVoiceChannel(int16_t channel) const
+    {
+        return configuration.channel == PartConfiguration::mpeChannel &&
+               channel != configuration.mpeGlobalChannel;
     }
 
     struct PartConfiguration
     {
         static constexpr int16_t omniChannel{-1};
+        static constexpr int16_t mpeChannel{-2};
+
+        int mpePitchBendRange{24};
+        int mpeGlobalChannel{0};
 
         bool active{false};
         int16_t channel{omniChannel}; // a midi channel or a special value like omni
         bool mute{false};
         bool solo{false};
+
+        bool polyLimitVoices{0}; // poly limit. 0 means unlimited.
 
         BusAddress routeTo{DEFAULT_BUS};
     } configuration;

--- a/src/messaging/client/part_messages.h
+++ b/src/messaging/client/part_messages.h
@@ -48,6 +48,7 @@ inline void updatePartFullConfig(const partConfigurationPayload_t &p, const engi
     auto [pt, conf] = p;
     cont.scheduleAudioThreadCallback([part = pt, configuration = conf](auto &eng) {
         eng.getPatch()->getPart(part)->configuration = configuration;
+        eng.onPartConfigurationUpdated();
     });
 }
 CLIENT_TO_SERIAL(UpdatePartFullConfig, c2s_send_full_part_config, partConfigurationPayload_t,

--- a/src/modulation/voice_matrix.cpp
+++ b/src/modulation/voice_matrix.cpp
@@ -135,8 +135,13 @@ void MatrixEndpoints::Sources::bind(scxt::voice::modulation::Matrix &m, engine::
 
     m.bindSourceValue(midiSources.modWheelSource, z.parentGroup->parentPart->midiCCValues[1]);
     m.bindSourceValue(midiSources.velocitySource, v.velocity);
+    m.bindSourceValue(midiSources.releaseVelocitySource, v.releaseVelocity);
     m.bindSourceValue(midiSources.keytrackSource, v.keytrackPerOct);
     m.bindSourceValue(midiSources.polyATSource, v.polyAT);
+
+    m.bindSourceValue(mpeSources.mpePressure, v.mpePressure);
+    m.bindSourceValue(mpeSources.mpeTimbre, v.mpeTimbre);
+    m.bindSourceValue(mpeSources.mpeBend, v.mpePitchBend);
 
     m.bindSourceValue(noteExpressions.volume, v.noteExpressions[(int)Voice::ExpressionIDs::VOLUME]);
     m.bindSourceValue(noteExpressions.pan, v.noteExpressions[(int)Voice::ExpressionIDs::PAN]);

--- a/src/modulation/voice_matrix.h
+++ b/src/modulation/voice_matrix.h
@@ -226,7 +226,7 @@ struct MatrixEndpoints
         Sources(engine::Engine *e)
             : lfoSources(e), midiCCSources(e), midiSources(e), noteExpressions(e),
               aegSource{'zneg', 'aeg ', 0}, eg2Source{'zneg', 'eg2 ', 0}, transportSources(e),
-              rngSources(e), macroSources(e)
+              rngSources(e), macroSources(e), mpeSources(e)
         {
             registerVoiceModSource(e, aegSource, "", "AEG");
             registerVoiceModSource(e, eg2Source, "", "EG2");
@@ -239,17 +239,32 @@ struct MatrixEndpoints
         {
             MIDISources(engine::Engine *e)
                 : modWheelSource{'zmid', 'modw'}, velocitySource{'zmid', 'velo'},
-                  keytrackSource{'zmid', 'ktrk'}
+                  releaseVelocitySource{'zmid', 'rvel'}, keytrackSource{'zmid', 'ktrk'}
             {
                 registerVoiceModSource(e, modWheelSource, "MIDI", "Mod Wheel");
                 MatrixConfig::setDefaultLagFor(modWheelSource, 25);
                 registerVoiceModSource(e, velocitySource, "MIDI", "Velocity");
+                registerVoiceModSource(e, releaseVelocitySource, "MIDI", "Release Vel");
                 registerVoiceModSource(e, keytrackSource, "MIDI", "KeyTrack");
                 registerVoiceModSource(e, polyATSource, "MIDI", "Poly AT");
                 MatrixConfig::setDefaultLagFor(polyATSource, 100);
             }
-            SR modWheelSource, velocitySource, keytrackSource, polyATSource;
+            SR modWheelSource, velocitySource, releaseVelocitySource, keytrackSource, polyATSource;
         } midiSources;
+
+        struct MPESources
+        {
+            MPESources(engine::Engine *e)
+                : mpeBend{'zmpe', 'bend'}, mpeTimbre{'zmpe', 'timb'}, mpePressure{'zmpe', 'pres'}
+            {
+                registerVoiceModSource(e, mpeBend, "MPE", "Voice Pitch Bend");
+                registerVoiceModSource(e, mpeTimbre, "MPE", "Timbre");
+                MatrixConfig::setDefaultLagFor(mpeTimbre, 50);
+                registerVoiceModSource(e, mpePressure, "MPE", "Pressure");
+                MatrixConfig::setDefaultLagFor(mpePressure, 50);
+            }
+            SR mpeBend, mpeTimbre, mpePressure;
+        } mpeSources;
 
         struct NoteExpressionSources
         {

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -759,6 +759,7 @@ float Voice::calculateVoicePitch()
 
     fpitch += retuner;
     fpitch += noteExpressions[(int)ExpressionIDs::TUNING];
+    fpitch += mpePitchBend;
 
     keytrackPerOct = (key + retuner - zone->mapping.rootKey) / 12.0;
 

--- a/src/voice/voice.h
+++ b/src/voice/voice.h
@@ -74,9 +74,14 @@ struct alignas(16) Voice : MoveableOnly<Voice>,
     uint8_t originalMidiKey{
         60}; // the actual physical key pressed not the one I resolved to after tuning
     float velocity{1.f};
+    float releaseVelocity{0.f};
     float velKeyFade{1.f};
     float keytrackPerOct{0.f}; // resolvee key - pitch cnter / 12
     float polyAT{0.f};
+    float mpePitchBend{0.f}; // in semis
+    float mpeTimbre{0.f};    // 0..1 normalized
+    float mpePressure{0.f};  // 0..1 normalized
+
     static constexpr size_t noteExpressionCount{7};
     float noteExpressions[noteExpressionCount]{};
     // These are the same as teh CLAP expression IDs but I dont want to include
@@ -202,6 +207,8 @@ struct alignas(16) Voice : MoveableOnly<Voice>,
 
         isVoicePlaying = true;
         isVoiceAssigned = true;
+
+        releaseVelocity = 0.f;
 
         voiceStarted();
     }


### PR DESCRIPTION
1. MPE, Omni, part channels all working fine. Closes #240
2. MPE mode routes pitch, timbre, channel pressure and bend
3. MPE settable bend ranges
4. Release velocity as a modulator

Closes #437