### PR TITLE
Fix a startup order refresh problem

### DIFF
--- a/src-ui/app/editor-impl/SCXTEditor.cpp
+++ b/src-ui/app/editor-impl/SCXTEditor.cpp
@@ -95,16 +95,6 @@ SCXTEditor::SCXTEditor(messaging::MessageController &e, infrastructure::Defaults
     toolTip = std::make_unique<sst::jucegui::components::ToolTip>();
     addChildComponent(*toolTip);
 
-    namespace cmsg = scxt::messaging::client;
-    msgCont.registerClient("SCXTEditor", [this](auto &s) {
-        {
-            // Remember this runs on the serialization thread so needs to be thread safe
-            std::lock_guard<std::mutex> g(callbackMutex);
-            callbackQueue.push(s);
-        }
-        juce::MessageManager::callAsync([this]() { drainCallbackQueue(); });
-    });
-
     headerRegion = std::make_unique<shared::HeaderRegion>(this);
     addAndMakeVisible(*headerRegion);
 
@@ -139,6 +129,16 @@ SCXTEditor::SCXTEditor(messaging::MessageController &e, infrastructure::Defaults
 
     focusDebugger = std::make_unique<sst::jucegui::accessibility::FocusDebugger>(*this);
     focusDebugger->setDoFocusDebug(false);
+
+    namespace cmsg = scxt::messaging::client;
+    msgCont.registerClient("SCXTEditor", [this](auto &s) {
+        {
+            // Remember this runs on the serialization thread so needs to be thread safe
+            std::lock_guard<std::mutex> g(callbackMutex);
+            callbackQueue.push(s);
+        }
+        juce::MessageManager::callAsync([this]() { drainCallbackQueue(); });
+    });
 }
 
 SCXTEditor::~SCXTEditor() noexcept

--- a/src/messaging/client/structure_messages.h
+++ b/src/messaging/client/structure_messages.h
@@ -71,6 +71,8 @@ inline void doRegisterClient(engine::Engine &engine, MessageController &cont)
         engine.getSelectionManager()->selectAction(sac);
     }
     engine.getSelectionManager()->sendSelectedPartMacrosToClient();
+
+    engine.sendFullRefreshToClient();
 }
 CLIENT_TO_SERIAL(RegisterClient, c2s_register_client, bool, doRegisterClient(engine, cont));
 


### PR DESCRIPTION
The startup order and initialization sequence means that the standalone juce which creates the ui before the first message showed parts, and the plugin and clap-first did not. Fix this by having a full refresh on editor, which is appropriate anyway.