### PR TITLE
Fix a delete-zone-playing-voice crash

### DIFF
--- a/src/engine/group.h
+++ b/src/engine/group.h
@@ -166,8 +166,9 @@ struct Group : MoveableOnly<Group>,
 
         auto res = std::move(zones[idx]);
         zones.erase(zones.begin() + idx);
-        // REPACK WEAK REFS TODO
         res->parentGroup = nullptr;
+
+        postZoneTraversalRemoveHandler();
         return res;
     }
 


### PR DESCRIPTION
I actually had a 'TODO repack zones' in teh code, so replace that with a call to the repack zone weak ref operator on delete.

Closes #1445