### PR TITLE
Browser auto-preview

### DIFF
--- a/src-ui/app/browser-ui/BrowserPane.h
+++ b/src-ui/app/browser-ui/BrowserPane.h
@@ -42,6 +42,7 @@ namespace scxt::ui::app::browser_ui // a bit clumsy to distinguis from scxt::bro
 struct DevicesPane;
 struct FavoritesPane;
 struct SearchPane;
+struct BrowserPaneFooter;
 struct BrowserPane : public app::HasEditor, sst::jucegui::components::NamedPanel
 {
     std::unique_ptr<sst::jucegui::components::ToggleButtonRadioGroup> selectedFunction;
@@ -57,9 +58,12 @@ struct BrowserPane : public app::HasEditor, sst::jucegui::components::NamedPanel
     std::unique_ptr<DevicesPane> devicesPane;
     std::unique_ptr<FavoritesPane> favoritesPane;
     std::unique_ptr<SearchPane> searchPane;
+    std::unique_ptr<BrowserPaneFooter> footerArea;
 
     void selectPane(int);
     int selectedPane{0};
+
+    bool autoPreviewEnabled{true};
 };
 } // namespace scxt::ui::app::browser_ui
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(${PROJECT_NAME} STATIC
         selection/selection_manager.cpp
 
         voice/voice.cpp
+        voice/preview_voice.cpp
 
         patch_io/patch_io.cpp
 

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -62,7 +62,8 @@
 namespace scxt::voice
 {
 struct Voice;
-}
+struct PreviewVoice;
+} // namespace scxt::voice
 namespace scxt::messaging
 {
 struct MessageController;
@@ -251,6 +252,8 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     } monoVoiceManagerResponder{*this};
     using voiceManager_t =
         sst::voicemanager::VoiceManager<VMConfig, VoiceManagerResponder, MonoVoiceManagerResponder>;
+    static_assert(sst::voicemanager::constraints::ConstraintsChecker<
+                  VMConfig, VoiceManagerResponder, MonoVoiceManagerResponder>::satisfies());
     voiceManager_t voiceManager{voiceManagerResponder, monoVoiceManagerResponder};
 
     void onSampleRateChanged() override;
@@ -269,6 +272,8 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     // TODO: All this gets ripped out when voice management is fixed
     void assertActiveVoiceCount();
     std::atomic<uint32_t> activeVoices{0};
+
+    std::unique_ptr<voice::PreviewVoice> previewVoice;
 
     const std::unique_ptr<messaging::MessageController> &getMessageController() const
     {

--- a/src/engine/group.cpp
+++ b/src/engine/group.cpp
@@ -402,16 +402,17 @@ void Group::postZoneTraversalRemoveHandler()
     /*
      * Go backwards down the weak refs removing inactive ones
      */
-    assert(rescanWeakRefs);
-    assert(activeZones);
     assert(activeZones >= rescanWeakRefs);
-    for (int i = activeZones - 1; i >= 0; --i)
+    if (activeZones != 0)
     {
-        if (!activeZoneWeakRefs[i]->isActive())
+        for (int i = activeZones - 1; i >= 0; --i)
         {
-            rescanWeakRefs--;
-            activeZoneWeakRefs[i] = activeZoneWeakRefs[activeZones - 1];
-            activeZones--;
+            if (!activeZoneWeakRefs[i]->isActive())
+            {
+                rescanWeakRefs--;
+                activeZoneWeakRefs[i] = activeZoneWeakRefs[activeZones - 1];
+                activeZones--;
+            }
         }
     }
     assert(rescanWeakRefs == 0);

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -141,7 +141,9 @@ enum ClientToSerializationMessagesIds
     c2s_set_mixer_effect_storage,
     c2s_set_mixer_send_storage,
 
+    // Browser functions
     c2s_add_browser_device_location,
+    c2s_preview_browser_sample,
 
     c2s_request_debug_action,
 

--- a/src/voice/preview_voice.cpp
+++ b/src/voice/preview_voice.cpp
@@ -1,0 +1,121 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "sst/basic-blocks/mechanics/block-ops.h"
+#include "preview_voice.h"
+#include "dsp/generator.h"
+
+namespace mech = sst::basic_blocks::mechanics;
+
+namespace scxt::voice
+{
+struct PreviewVoice::Details
+{
+    dsp::GeneratorState GD;
+    dsp::GeneratorIO GDIO;
+    dsp::GeneratorFPtr Generator;
+
+    PreviewVoice *parent{nullptr};
+    Details(PreviewVoice *p) : parent(p) {}
+    std::shared_ptr<sample::Sample> sample;
+
+    void initiateGD()
+    {
+        GDIO.outputL = parent->output[0];
+        GDIO.outputR = parent->output[1];
+        if (sample->bitDepth == sample::Sample::BD_I16)
+        {
+            GDIO.sampleDataL = sample->GetSamplePtrI16(0);
+            GDIO.sampleDataR = sample->GetSamplePtrI16(1);
+        }
+        else if (sample->bitDepth == sample::Sample::BD_F32)
+        {
+            GDIO.sampleDataL = sample->GetSamplePtrF32(0);
+            GDIO.sampleDataR = sample->GetSamplePtrF32(1);
+        }
+        else
+        {
+            assert(false);
+        }
+        GDIO.waveSize = sample->sample_length;
+
+        GD.samplePos = 0;
+        GD.sampleSubPos = 0;
+        GD.loopLowerBound = 0;
+        GD.loopUpperBound = sample->sample_length;
+        GD.loopFade = 0;
+        GD.playbackLowerBound = 0;
+        GD.playbackUpperBound = sample->sample_length;
+        GD.direction = 1;
+        GD.isFinished = false;
+        GD.directionAtOutset = GD.direction;
+        GD.gated = true;
+
+        GD.ratio = (int32_t)((double)(1 << 24) * sample->sample_rate * parent->samplerate_inv);
+
+        Generator = dsp::GetFPtrGeneratorSample(
+            sample->channels != 1, sample->bitDepth == sample::Sample::BD_F32, false, false, false);
+        assert(Generator);
+    }
+};
+
+PreviewVoice::PreviewVoice() { details = std::make_unique<Details>(this); }
+PreviewVoice::~PreviewVoice() {}
+
+bool PreviewVoice::attachAndStart(const std::shared_ptr<sample::Sample> &s)
+{
+    SCLOG("Starting Preview : " << s->mFileName.u8string());
+    details->sample = s;
+    details->initiateGD();
+    isActive = true;
+    return true;
+}
+bool PreviewVoice::detatchAndStop()
+{
+    details->sample = nullptr;
+    // TODO : Fade
+    isActive = false;
+    return true;
+}
+
+void PreviewVoice::processBlock()
+{
+    if (details->GD.isFinished)
+    {
+        detatchAndStop();
+        return;
+    }
+    assert(details->Generator);
+    details->Generator(&details->GD, &details->GDIO);
+    if (details->sample->channels == 1)
+    {
+        mech::copy_from_to<blockSize>(output[0], output[1]);
+    }
+    // SCLOG(output[0][0] << " " << output[1][0]);
+}
+
+} // namespace scxt::voice

--- a/src/voice/preview_voice.h
+++ b/src/voice/preview_voice.h
@@ -1,0 +1,56 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_VOICE_PREVIEW_VOICE_H
+#define SCXT_SRC_VOICE_PREVIEW_VOICE_H
+
+#include <memory>
+
+#include "utils.h"
+#include "configuration.h"
+#include "sample/sample.h"
+
+namespace scxt::voice
+{
+struct PreviewVoice : SampleRateSupport
+{
+    float output alignas(16)[2][blockSize];
+
+    struct Details;
+    PreviewVoice();
+    ~PreviewVoice();
+
+    bool attachAndStart(const std::shared_ptr<sample::Sample> &);
+    void processBlock();
+    bool detatchAndStop();
+
+    bool isActive{false};
+    std::unique_ptr<Details> details;
+};
+} // namespace scxt::voice
+
+#endif // PREVIEW_VOICE_H


### PR DESCRIPTION
This activates preview-without-zone DSP from the browser UI if the toggle is on and you long hold a single file sample.