### PR TITLE
Some fixes when switching legato or reordering grup letago

### DIFF
--- a/src/engine/engine_voice_responder.cpp
+++ b/src/engine/engine_voice_responder.cpp
@@ -236,6 +236,8 @@ void Engine::VoiceManagerResponder::setPolyphonicAftertouch(voice::Voice *v, int
 
 void Engine::VoiceManagerResponder::terminateVoice(voice::Voice *v)
 {
+    SCLOG_IF(voiceResponder, "terminateVoice " << v << " " << (int)v->key);
+    ;
     if (!v->isVoicePlaying)
         return;
     if (v->isGated)

--- a/src/engine/group.cpp
+++ b/src/engine/group.cpp
@@ -624,10 +624,16 @@ void Group::resetPolyAndPlaymode(engine::Engine &e)
     }
     else
     {
+        auto pgrp = (uint64_t)this;
+        SCLOG_IF(voiceResponder, "Setting up poly group " << pgrp);
+
+        e.voiceManager.setPlaymode(pgrp, Engine::voiceManager_t::PlayMode::POLY_VOICES,
+                                   outputInfo.vmPlayModeFeaturesInt);
         assert(outputInfo.vmPlayModeInt == (uint32_t)Engine::voiceManager_t::PlayMode::POLY_VOICES);
         if (!outputInfo.hasIndependentPolyLimit)
         {
             // TODO we really want a 'clear'
+            e.voiceManager.setPolyphonyGroupVoiceLimit((uint64_t)this, maxVoices);
         }
         else
         {


### PR DESCRIPTION
there was a bug in VM basically which made the legato application order of group dependent in one case. Fix that and also make sure that swithcing to poly actually switches us to poly (which wasnt that bug but could have been)