### PR TITLE
Browser expand into multi-files

### DIFF
--- a/src-ui/app/SCXTEditorDataCache.h
+++ b/src-ui/app/SCXTEditorDataCache.h
@@ -38,6 +38,7 @@
 #include "engine/group.h"
 #include "engine/zone.h"
 #include "engine/patch.h"
+#include "sample/compound_file.h"
 
 #include "sst/jucegui/data/Continuous.h"
 #include "sst/jucegui/data/Discrete.h"
@@ -98,6 +99,7 @@ struct SCXTEditorDataCache
         void sourceVanished(sst::jucegui::data::Discrete *c) override;
     } dlistener{*this};
 };
+
 } // namespace scxt::ui::app
 
 #endif // SCXTEDITORDATACACHE_H

--- a/src-ui/app/browser-ui/BrowserPaneInterfaces.h
+++ b/src-ui/app/browser-ui/BrowserPaneInterfaces.h
@@ -1,0 +1,32 @@
+//
+// Created by Paul Walker on 1/28/25.
+//
+
+#ifndef BROWSERPANEINTERFACES_H
+#define BROWSERPANEINTERFACES_H
+
+#include <optional>
+#include "filesystem/import.h"
+#include "sample/compound_file.h"
+
+namespace scxt::ui::app::browser_ui
+{
+struct WithSampleInfo
+{
+    virtual ~WithSampleInfo() {}
+    virtual std::optional<fs::directory_entry> getDirEnt() const = 0;
+    virtual std::optional<sample::compound::CompoundElement> getCompoundElement() const = 0;
+};
+
+template <typename T> static bool hasSampleInfo(const T &t)
+{
+    return dynamic_cast<const WithSampleInfo *>(t.get()) != nullptr;
+}
+
+template <typename T> static WithSampleInfo *asSampleInfo(const T &t)
+{
+    return dynamic_cast<WithSampleInfo *>(t.get());
+}
+
+} // namespace scxt::ui::app::browser_ui
+#endif // BROWSERPANEINTERFACES_H

--- a/src-ui/app/edit-screen/components/mapping-pane/MappingDisplay.h
+++ b/src-ui/app/edit-screen/components/mapping-pane/MappingDisplay.h
@@ -164,9 +164,6 @@ struct MappingDisplay : juce::Component,
 
     int voiceCountFor(const selection::SelectionManager::ZoneAddress &z);
 
-    std::optional<std::string>
-    sourceDetailsDragAndDropSample(const SourceDetails &dragSourceDetails);
-
     bool isInterestedInDragSource(const SourceDetails &dragSourceDetails) override;
     void itemDropped(const SourceDetails &dragSourceDetails) override;
     bool isUndertakingDrop{false};

--- a/src-ui/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
+++ b/src-ui/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
@@ -29,6 +29,7 @@
 #include "app/SCXTEditor.h"
 #include "messaging/client/client_serial.h"
 #include "SampleWaveform.h"
+#include "app/browser-ui/BrowserPaneInterfaces.h"
 
 namespace scxt::ui::app::edit_screen
 {

--- a/src-ui/app/edit-screen/components/mapping-pane/VariantDisplay.h
+++ b/src-ui/app/edit-screen/components/mapping-pane/VariantDisplay.h
@@ -105,9 +105,6 @@ struct VariantDisplay : juce::Component, HasEditor
         void currentTabChanged(int newCurrentTabIndex,
                                const juce::String &newCurrentTabName) override;
 
-        std::optional<std::string>
-        sourceDetailsDragAndDropSample(const SourceDetails &dragSourceDetails);
-
         bool isInterestedInDragSource(const SourceDetails &dragSourceDetails) override;
 
         bool isInterestedInFileDrag(const juce::StringArray &files) override;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(${PROJECT_NAME} STATIC
 
         sample/exs_support/exs_import.cpp
         sample/multisample_support/multisample_import.cpp
+        sample/sf2_support/sf2_compound_file_impl.cpp
         sample/sfz_support/sfz_parse.cpp
         sample/sfz_support/sfz_import.cpp
 

--- a/src/browser/browser.cpp
+++ b/src/browser/browser.cpp
@@ -28,6 +28,7 @@
 #include "browser.h"
 #include "browser_db.h"
 #include "utils.h"
+#include "sample/compound_file.h"
 
 namespace scxt::browser
 {
@@ -110,5 +111,18 @@ void Browser::removeRootPathForDeviceView(const fs::path &p)
 {
     browserDb.addRemoveDeviceLocation(p, false);
     browserDb.waitForJobsOutstandingComplete(100);
+}
+
+std::vector<sample::compound::CompoundElement> Browser::expandForBrowser(const fs::path &p)
+{
+    if (extensionMatches(p, ".sf2"))
+    {
+        auto inst = sample::compound::getSF2InstrumentAddresses(p);
+        auto smp = sample::compound::getSF2SampleAddresses(p);
+        inst.insert(inst.end(), smp.begin(), smp.end());
+
+        return inst;
+    }
+    return {};
 }
 } // namespace scxt::browser

--- a/src/browser/browser.h
+++ b/src/browser/browser.h
@@ -33,6 +33,7 @@
 #include <utility>
 #include <functional>
 #include "filesystem/import.h"
+#include "sample/compound_file.h"
 
 namespace scxt::infrastructure
 {
@@ -85,6 +86,9 @@ struct Browser
     static bool isLoadableSingleSample(const fs::path &);
     static bool isLoadableMultiSample(const fs::path &);
     static bool isShortCircuitFormatFile(const fs::path &);
+
+    static bool isExpandableInBrowser(const fs::path &p) { return isLoadableMultiSample(p); }
+    static std::vector<sample::compound::CompoundElement> expandForBrowser(const fs::path &p);
 
     struct LoadableFile
     {

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -39,6 +39,7 @@
 #include "configuration.h"
 
 #include "sample/sample.h"
+#include "sample/compound_file.h"
 #include "sample/sample_manager.h"
 
 #include <filesystem>
@@ -438,12 +439,18 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
                                             KeyboardRange krange = {48, 72},
                                             VelocityRange vrange = {0, 127});
 
+    void loadCompoundElementIntoSelectedPartAndGroup(
+        const scxt::sample::compound::CompoundElement &, int16_t rootKey = 60,
+        KeyboardRange krange = {48, 72}, VelocityRange vrange = {0, 127});
+
     /*
      * Serialization thread originated mutation apis
      */
     void loadSampleIntoZone(const fs::path &, int16_t part, int16_t group, int16_t zone,
-                            int sampleID, int16_t rootKey = 60, KeyboardRange krange = {48, 72},
-                            VelocityRange vrange = {0, 127});
+                            int variantID);
+
+    void loadCompoundElementIntoZone(const sample::compound::CompoundElement &, int16_t part,
+                                     int16_t group, int16_t zone, int variantID);
 
     void createEmptyZone(KeyboardRange krange = {48, 72}, VelocityRange vrange = {0, 127});
     void duplicateZone(const selection::SelectionManager::ZoneAddress &);

--- a/src/json/sample_traits.h
+++ b/src/json/sample_traits.h
@@ -35,6 +35,7 @@
 #include "stream.h"
 
 #include "sample/sample_manager.h"
+#include "sample/compound_file.h"
 #include "browser/browser.h"
 #include "scxt_traits.h"
 
@@ -140,5 +141,17 @@ SC_STREAMDEF(scxt::sample::SampleManager, SC_FROM({
                  findIf(v, "sampleAddresses", res);
                  to.restoreFromSampleAddressesAndIDs(res);
              }));
+
+SC_STREAMDEF(
+    scxt::sample::compound::CompoundElement, SC_FROM({
+        v = {{"type", (int32_t)from.type}, {"name", from.name}, {"addr", from.sampleAddress}};
+    }),
+    SC_TO({
+        int t;
+        findOrSet(v, "type", 0, t);
+        to.type = (scxt::sample::compound::CompoundElement::Type)t;
+        findIf(v, "name", to.name);
+        findIf(v, "addr", to.sampleAddress);
+    }));
 } // namespace scxt::json
 #endif // SHORTCIRCUIT_SAMPLE_TRAITS_H

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -125,6 +125,8 @@ enum ClientToSerializationMessagesIds
     c2s_add_sample,
     c2s_add_sample_with_range,
     c2s_add_sample_in_zone,
+    c2s_add_compound_element_with_range,
+    c2s_add_compound_element_in_zone,
     c2s_create_group,
     c2s_move_zone,
     c2s_delete_zone,

--- a/src/messaging/client/structure_messages.h
+++ b/src/messaging/client/structure_messages.h
@@ -102,6 +102,21 @@ inline void addSampleWithRange(const addSampleWithRange_t &payload, engine::Engi
 CLIENT_TO_SERIAL(AddSampleWithRange, c2s_add_sample_with_range, addSampleWithRange_t,
                  addSampleWithRange(payload, engine, cont);)
 
+using addCompoundElementWithRange_t =
+    std::tuple<sample::compound::CompoundElement, int, int, int, int, int>;
+inline void addCompoundElementWithRange(const addCompoundElementWithRange_t &payload,
+                                        engine::Engine &engine, MessageController &cont)
+{
+    assert(cont.threadingChecker.isSerialThread());
+    auto el = std::get<0>(payload);
+    auto rk = std::get<1>(payload);
+    auto kr = engine::KeyboardRange(std::get<2>(payload), std::get<3>(payload));
+    auto vr = engine::VelocityRange(std::get<4>(payload), std::get<5>(payload));
+    engine.loadCompoundElementIntoSelectedPartAndGroup(el, rk, kr, vr);
+}
+CLIENT_TO_SERIAL(AddCompoundElementWithRange, c2s_add_compound_element_with_range,
+                 addCompoundElementWithRange_t, addCompoundElementWithRange(payload, engine, cont);)
+
 // sample, part, group, wone, sampleid
 using addSampleInZone_t = std::tuple<std::string, int, int, int, int>;
 inline void addSampleInZone(const addSampleInZone_t &payload, engine::Engine &engine,
@@ -118,6 +133,24 @@ inline void addSampleInZone(const addSampleInZone_t &payload, engine::Engine &en
 }
 CLIENT_TO_SERIAL(AddSampleInZone, c2s_add_sample_in_zone, addSampleInZone_t,
                  addSampleInZone(payload, engine, cont);)
+
+// sample, part, group, wone, sampleid
+using addCompoundElementInZone_t =
+    std::tuple<sample::compound::CompoundElement, int, int, int, int>;
+inline void addCompoundElementInZone(const addCompoundElementInZone_t &payload,
+                                     engine::Engine &engine, MessageController &cont)
+{
+    assert(cont.threadingChecker.isSerialThread());
+    auto el = std::get<0>(payload);
+    auto part{std::get<1>(payload)};
+    auto group{std::get<2>(payload)};
+    auto zone{std::get<3>(payload)};
+    auto sampleID{std::get<4>(payload)};
+
+    engine.loadCompoundElementIntoZone(el, part, group, zone, sampleID);
+}
+CLIENT_TO_SERIAL(AddCompoundElementInZone, c2s_add_compound_element_in_zone,
+                 addCompoundElementInZone_t, addCompoundElementInZone(payload, engine, cont);)
 
 inline void createGroupIn(int partNumber, engine::Engine &engine, MessageController &cont)
 {

--- a/src/sample/compound_file.h
+++ b/src/sample/compound_file.h
@@ -1,0 +1,33 @@
+//
+// Created by Paul Walker on 1/26/25.
+//
+
+#ifndef COMPOUND_FILE_H
+#define COMPOUND_FILE_H
+
+#include "sample/sample.h"
+
+namespace scxt::engine
+{
+struct Engine;
+}
+
+namespace scxt::sample::compound
+{
+struct CompoundElement
+{
+    enum Type : int32_t
+    {
+        SAMPLE,
+        INSTRUMENT
+    } type{SAMPLE};
+
+    std::string name;
+    Sample::SampleFileAddress sampleAddress;
+};
+
+std::vector<CompoundElement> getSF2SampleAddresses(const fs::path &);
+std::vector<CompoundElement> getSF2InstrumentAddresses(const fs::path &);
+
+} // namespace scxt::sample::compound
+#endif // COMPOUND_FILE_H

--- a/src/sample/sample_manager.cpp
+++ b/src/sample/sample_manager.cpp
@@ -42,31 +42,7 @@ void SampleManager::restoreFromSampleAddressesAndIDs(const sampleAddressesAndIds
         }
         else
         {
-            std::optional<SampleID> nid;
-            switch (addr.type)
-            {
-            case Sample::WAV_FILE:
-            case Sample::FLAC_FILE:
-            case Sample::MP3_FILE:
-            case Sample::AIFF_FILE:
-            {
-                nid = loadSampleByPath(addr.path);
-            }
-            break;
-            case Sample::SF2_FILE:
-            {
-                nid = loadSampleFromSF2(addr.path, nullptr, addr.preset, addr.instrument,
-                                        addr.region);
-            }
-            break;
-            case Sample::MULTISAMPLE_FILE:
-            {
-                nid = loadSampleFromMultiSample(addr.path, addr.region, id);
-            }
-            break;
-                // add something here? don't forget to add it in the multi resolver too in
-                // resolveSingleFileMissingWorkItem
-            }
+            auto nid = loadSampleByFileAddress(addr, id);
 
             if (nid.has_value())
             {
@@ -80,6 +56,37 @@ void SampleManager::restoreFromSampleAddressesAndIDs(const sampleAddressesAndIds
 }
 
 SampleManager::~SampleManager() { SCLOG("Destroying Sample Manager"); }
+
+std::optional<SampleID>
+SampleManager::loadSampleByFileAddress(const Sample::SampleFileAddress &addr, const SampleID &id)
+{
+    std::optional<SampleID> nid;
+    switch (addr.type)
+    {
+    case Sample::WAV_FILE:
+    case Sample::FLAC_FILE:
+    case Sample::MP3_FILE:
+    case Sample::AIFF_FILE:
+    {
+        nid = loadSampleByPath(addr.path);
+    }
+    break;
+    case Sample::SF2_FILE:
+    {
+        nid = loadSampleFromSF2(addr.path, nullptr, addr.preset, addr.instrument, addr.region);
+    }
+    break;
+    case Sample::MULTISAMPLE_FILE:
+    {
+        nid = loadSampleFromMultiSample(addr.path, addr.region, id);
+    }
+    break;
+        // add something here? don't forget to add it in the multi resolver too in
+        // resolveSingleFileMissingWorkItem
+    }
+
+    return nid;
+}
 
 std::optional<SampleID> SampleManager::loadSampleByPath(const fs::path &p)
 {

--- a/src/sample/sample_manager.h
+++ b/src/sample/sample_manager.h
@@ -77,9 +77,8 @@ struct SampleManager : MoveableOnly<SampleManager>
     ~SampleManager();
 
     void addSampleAsMissing(const SampleID &id, const Sample::SampleFileAddress &f);
-    std::optional<SampleID> loadSampleByFileAddress(const Sample::SampleFileAddress &);
-    std::optional<SampleID> loadSampleByFileAddressToID(const Sample::SampleFileAddress &,
-                                                        const SampleID &);
+    std::optional<SampleID> loadSampleByFileAddress(const Sample::SampleFileAddress &,
+                                                    const SampleID &);
 
     std::optional<SampleID> loadSampleByPath(const fs::path &);
 

--- a/src/sample/sf2_support/sf2_compound_file_impl.cpp
+++ b/src/sample/sf2_support/sf2_compound_file_impl.cpp
@@ -1,0 +1,51 @@
+//
+// Created by Paul Walker on 1/26/25.
+//
+
+#include "sample/compound_file.h"
+
+namespace scxt::sample::compound
+{
+std::vector<CompoundElement> getSF2SampleAddresses(const fs::path &p)
+{
+    auto riff = std::make_unique<RIFF::File>(p.u8string());
+    auto sf = std::make_unique<sf2::File>(riff.get());
+
+    auto sc = sf->GetSampleCount();
+    std::vector<CompoundElement> result;
+    result.reserve(sc);
+    for (int i = 0; i < sc; ++i)
+    {
+        auto s = sf->GetSample(i);
+
+        CompoundElement res;
+        res.type = CompoundElement::Type::SAMPLE;
+        res.name = s->GetName();
+        res.sampleAddress = {Sample::SF2_FILE, p, "", -1, -1, i};
+        result.push_back(res);
+    }
+    return result;
+}
+
+std::vector<CompoundElement> getSF2InstrumentAddresses(const fs::path &p)
+{
+    auto riff = std::make_unique<RIFF::File>(p.u8string());
+    auto sf = std::make_unique<sf2::File>(riff.get());
+
+    auto ic = sf->GetInstrumentCount();
+    std::vector<CompoundElement> result;
+    result.reserve(ic);
+    for (int i = 0; i < ic; ++i)
+    {
+        auto in = sf->GetInstrument(i);
+
+        CompoundElement res;
+        res.type = CompoundElement::Type::INSTRUMENT;
+        res.name = in->GetName();
+        res.sampleAddress = {Sample::SF2_FILE, p, "", -1, i, -1};
+        result.push_back(res);
+    }
+
+    return result;
+}
+} // namespace scxt::sample::compound


### PR DESCRIPTION
- Have an isExpandable
- Have the browser sidebar have a toggle icon which toggles
- Add an interface rather than a prop for drag dat
- Add 'CompoundElement/compound_file' type with streaming
- Load SF2 Sub-Sample into New Zone or Variant works

So good checkpoint here. Still a lot to do including other formats and instruments.