### PR TITLE
A crude multi-resolver

### DIFF
--- a/src-ui/app/SCXTEditor.h
+++ b/src-ui/app/SCXTEditor.h
@@ -310,6 +310,10 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::DragAndDropCont
 
     std::function<void()> makeComingSoon(const std::string &feature = "This feature") const;
 
+    void promptOKCancel(
+        const std::string &title, const std::string &message, std::function<void()> onOK,
+        std::function<void()> onCancel = []() {});
+
     /*
      * Items to deal with the shared memory reads
      */

--- a/src-ui/app/editor-impl/SCXTEditor.cpp
+++ b/src-ui/app/editor-impl/SCXTEditor.cpp
@@ -499,4 +499,22 @@ void SCXTEditor::onStyleChanged()
     if (lnf)
         lnf->setStyle(style());
 }
+
+void SCXTEditor::promptOKCancel(const std::string &title, const std::string &message,
+                                std::function<void()> onOK, std::function<void()> onCancel)
+{
+    juce::AlertWindow::showAsync(juce::MessageBoxOptions()
+                                     .withIconType(juce::MessageBoxIconType::QuestionIcon)
+                                     .withTitle(title)
+                                     .withMessage(message)
+                                     .withButton("OK")
+                                     .withButton("Cancel"),
+                                 [onOK, onCancel](auto x) {
+                                     if (x == 1)
+                                         onOK();
+                                     if (x == 0 && onCancel)
+                                         onCancel();
+                                 });
+}
+
 } // namespace scxt::ui::app

--- a/src-ui/app/missing-resolution/MissingResolutionScreen.h
+++ b/src-ui/app/missing-resolution/MissingResolutionScreen.h
@@ -55,6 +55,8 @@ struct MissingResolutionScreen : juce::Component, HasEditor
 
     void resolveItem(int idx);
     void applyResolution(int idx, const fs::path &toThis);
+    void applyDirectoryResolution(std::vector<engine::MissingResolutionWorkItem> indexes,
+                                  const fs::path &newParent);
 
     std::unique_ptr<juce::FileChooser> fileChooser;
 


### PR DESCRIPTION
When you resolve a sample foo.wav in /x/y/z to /a/b/c, if there are other existant unresolved samples form /x/y/z which also exist in /a/b/c, prompt and allow you to bulk resolve them.