### PR TITLE
More than 2 egsPerZone - part one

### DIFF
--- a/src/engine/group.cpp
+++ b/src/engine/group.cpp
@@ -47,7 +47,7 @@ namespace scxt::engine
 
 Group::Group()
     : id(GroupID::next()), name(id.to_string()), endpoints{nullptr},
-      modulation::shared::HasModulators<Group>(this), osDownFilter(6, true)
+      modulation::shared::HasModulators<Group, egsPerGroup>(this), osDownFilter(6, true)
 {
 }
 

--- a/src/engine/group.h
+++ b/src/engine/group.h
@@ -56,7 +56,7 @@ constexpr int lfosPerGroup{scxt::lfosPerGroup};
 
 struct Group : MoveableOnly<Group>,
                HasGroupZoneProcessors<Group>,
-               modulation::shared::HasModulators<Group>,
+               modulation::shared::HasModulators<Group, egsPerGroup>,
                SampleRateSupport
 {
     Group();

--- a/src/engine/zone.h
+++ b/src/engine/zone.h
@@ -249,7 +249,7 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
     std::array<bool, egsPerZone> egsActive{};
 
     // 0 is the AEG, 1 is EG2
-    std::array<modulation::modulators::AdsrStorage, 2> egStorage;
+    std::array<modulation::modulators::AdsrStorage, egsPerZone> egStorage;
 
     void onProcessorTypeChanged(int, dsp::processor::ProcessorType) {}
 

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -40,7 +40,7 @@ namespace scxt::voice
 {
 
 Voice::Voice(engine::Engine *e, engine::Zone *z)
-    : scxt::modulation::shared::HasModulators<Voice>(this), engine(e), zone(z),
+    : scxt::modulation::shared::HasModulators<Voice, egsPerZone>(this), engine(e), zone(z),
       sampleIndex(zone->sampleIndex), halfRate(6, true), endpoints(nullptr) // see comment
 {
     assert(zone);

--- a/src/voice/voice.h
+++ b/src/voice/voice.h
@@ -46,7 +46,7 @@ namespace scxt::voice
 {
 struct alignas(16) Voice : MoveableOnly<Voice>,
                            SampleRateSupport,
-                           scxt::modulation::shared::HasModulators<Voice>
+                           scxt::modulation::shared::HasModulators<Voice, egsPerZone>
 {
     float output alignas(16)[2][blockSize << 2];
     // I do *not* own these. The engine guarantees it outlives the voice


### PR DESCRIPTION
More than 2 egs per zone. Part one

1. Allow hasModulation to be eg count parameterized
2. Make sure to use egsPerZone consistently
3. Check compilation with egsPerZone = 4, but in this commit leave it as 2 as a checkpoint

Addresses #1211