### PR TITLE
Support SF2 cracking in browser more comprehensively

### DIFF
--- a/src-ui/app/browser-ui/BrowserPane.cpp
+++ b/src-ui/app/browser-ui/BrowserPane.cpp
@@ -563,6 +563,8 @@ struct DriveFSRowComponent : public juce::Component, WithSampleInfo
             else
             {
                 // This is a hack and should be a drag and drop gesture really I guess
+                auto &entry = data[rowNumber];
+
                 namespace cmsg = scxt::messaging::client;
                 auto &d = data[rowNumber];
                 if (d.expandableAddress.has_value())
@@ -571,6 +573,18 @@ struct DriveFSRowComponent : public juce::Component, WithSampleInfo
                         cmsg::AddCompoundElementWithRange(
                             {*(d.expandableAddress), 60, 48, 72, 0, 127}),
                         browserPane->editor->msgCont);
+                }
+                else if (browser::Browser::isExpandableInBrowser(entry.dirent.path()))
+                {
+                    if (entry.isExpanded)
+                    {
+                        browserPane->devicesPane->driveFSArea->collapsMultifile(rowNumber);
+                    }
+                    else
+                    {
+                        browserPane->devicesPane->driveFSArea->expandMultifile(rowNumber);
+                    }
+                    repaint();
                 }
                 else
                 {

--- a/src-ui/app/browser-ui/BrowserPane.cpp
+++ b/src-ui/app/browser-ui/BrowserPane.cpp
@@ -564,9 +564,20 @@ struct DriveFSRowComponent : public juce::Component, WithSampleInfo
             {
                 // This is a hack and should be a drag and drop gesture really I guess
                 namespace cmsg = scxt::messaging::client;
-                scxt::messaging::client::clientSendToSerialization(
-                    cmsg::AddSample(data[rowNumber].dirent.path().u8string()),
-                    browserPane->editor->msgCont);
+                auto &d = data[rowNumber];
+                if (d.expandableAddress.has_value())
+                {
+                    cmsg::clientSendToSerialization(
+                        cmsg::AddCompoundElementWithRange(
+                            {*(d.expandableAddress), 60, 48, 72, 0, 127}),
+                        browserPane->editor->msgCont);
+                }
+                else
+                {
+                    scxt::messaging::client::clientSendToSerialization(
+                        cmsg::AddSample(data[rowNumber].dirent.path().u8string()),
+                        browserPane->editor->msgCont);
+                }
             }
         }
     }
@@ -652,6 +663,7 @@ struct DriveFSRowComponent : public juce::Component, WithSampleInfo
                 }
                 else
                 {
+                    auto &sa = entry.expandableAddress->sampleAddress;
                     jcmp::GlyphPainter::paintGlyph(g, gr, jcmp::GlyphPainter::FILE_MUSIC,
                                                    textColor.withAlpha(isSelected ? 1.f : 0.5f));
                 }

--- a/src-ui/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
+++ b/src-ui/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
@@ -853,6 +853,7 @@ void VariantDisplay::MyTabbedComponent::itemDropped(
                                               dragSourceDetails.localPosition.y)};
         if (wsi->getCompoundElement().has_value())
         {
+            auto ce = *wsi->getCompoundElement();
             sendToSerialization(cmsg::AddCompoundElementInZone(
                 {*wsi->getCompoundElement(), za->part, za->group, za->zone, sampleID}));
         }

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -463,7 +463,7 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     void pasteZone(const selection::SelectionManager::ZoneAddress &);
     std::string zoneClipboard;
 
-    void loadSf2MultiSampleIntoSelectedPart(const fs::path &);
+    void loadSf2MultiSampleIntoSelectedPart(const fs::path &, int instrument = -1);
 
     /*
      * OnRegister generate and send all the metdata the client needs


### PR DESCRIPTION
Addresses #1526

- Address UI gestures so dbl click or drag a componund element goes down the right code path.
- Filter SF2 by instrument at load time.
- Open question: What's the preset / instrument hierarchy