### PR TITLE
Part Blurb

### DIFF
--- a/clients/clap-first/scxt-plugin/scxt-plugin.cpp
+++ b/clients/clap-first/scxt-plugin/scxt-plugin.cpp
@@ -70,7 +70,7 @@ SCXTPlugin::SCXTPlugin(const clap_host *h) : plugHelper_t(getDescription(), h)
     engine->getMessageController()->requestHostCallback = [this, h](uint64_t flag) {
         if (h)
         {
-            SCLOG("Request Host CallbacK");
+            SCLOG("Request Host CallbacK " << flag);
             // FIXME - atomics better here
             this->nextMainThreadAction |= flag;
             h->request_callback(h);

--- a/src-ui/app/edit-screen/components/PartGroupSidebar.h
+++ b/src-ui/app/edit-screen/components/PartGroupSidebar.h
@@ -61,6 +61,8 @@ struct PartGroupSidebar : sst::jucegui::components::NamedPanel, HasEditor
     void partConfigurationChanged(int i);
     void groupTriggerConditionChanged(const scxt::engine::GroupTriggerConditions &);
 
+    void showHamburgerMenu();
+
     void resized() override;
 };
 } // namespace scxt::ui::app::edit_screen

--- a/src-ui/app/play-screen/PlayScreen.cpp
+++ b/src-ui/app/play-screen/PlayScreen.cpp
@@ -68,6 +68,7 @@ struct ViewportComponent : juce::Component, HasEditor
 
 PlayScreen::PlayScreen(SCXTEditor *e) : HasEditor(e)
 {
+    visibilityWatcher = std::make_unique<sst::jucegui::util::VisibilityParentWatcher>(this);
     browser = std::make_unique<browser_ui::BrowserPane>(editor);
     addAndMakeVisible(*browser);
 
@@ -158,7 +159,9 @@ void PlayScreen::rebuildPositionsAndVisibilites()
 
     for (int p = 0; p < scxt::numParts; ++p)
     {
+        partSidebars[p]->resetFromEditorCache();
         partSidebars[p]->setVisible(viz(p));
+        partSidebars[p]->setTallMode(tallMode);
     }
 
     if (isVisible())
@@ -208,6 +211,10 @@ void PlayScreen::visibilityChanged()
             }
         }
 
+        tallMode = (bool)editor->defaultsProvider.getUserDefaultValue(
+            infrastructure::DefaultKeys::playModeExpanded, true);
+        rebuildPositionsAndVisibilites();
+
         repaint();
     }
 }
@@ -233,7 +240,8 @@ void PlayScreen::resized()
         auto rb = rectangleForPart(i);
 
         partSidebars[i]->setBounds(rb.withWidth(shared::PartSidebarCard::width)
-                                       .withHeight(shared::PartSidebarCard::height));
+                                       .withHeight(tallMode ? shared::PartSidebarCard::tallHeight
+                                                            : shared::PartSidebarCard::height));
     }
 
     int pt{0};

--- a/src-ui/app/play-screen/PlayScreen.h
+++ b/src-ui/app/play-screen/PlayScreen.h
@@ -38,6 +38,7 @@
 #include "sst/jucegui/components/NamedPanel.h"
 #include "sst/jucegui/components/MultiSwitch.h"
 #include "sst/jucegui/component-adapters/DiscreteToReference.h"
+#include "sst/jucegui/util/VisibilityParentWatcher.h"
 #include "app/shared/PartSidebarCard.h"
 #include "app/shared/SingleMacroEditor.h"
 
@@ -68,6 +69,7 @@ struct PlayScreen : juce::Component, HasEditor
 
     std::unique_ptr<sst::jucegui::components::NamedPanel> playNamedPanel;
     std::unique_ptr<browser_ui::BrowserPane> browser;
+    std::unique_ptr<sst::jucegui::util::VisibilityParentWatcher> visibilityWatcher;
 
     PlayScreen(SCXTEditor *e);
     ~PlayScreen();

--- a/src-ui/app/shared/PartSidebarCard.cpp
+++ b/src-ui/app/shared/PartSidebarCard.cpp
@@ -299,7 +299,10 @@ void PartSidebarCard::resetFromEditorCache()
 
 void PartSidebarCard::textEditorTextChanged(juce::TextEditor &e)
 {
-    editor->partConfigurations[part].blurb = e.getText().toStdString();
+    memset(editor->partConfigurations[part].blurb, 0,
+           engine::Part::PartConfiguration::maxDescription);
+    strncpy(editor->partConfigurations[part].blurb, e.getText().toStdString().c_str(),
+            engine::Part::PartConfiguration::maxDescription - 1);
     sendToSerialization(cmsg::UpdatePartFullConfig({part, editor->partConfigurations[part]}));
 }
 
@@ -307,7 +310,7 @@ void PartSidebarCard::showPartBlurbTooltip()
 {
     if (!tallMode)
     {
-        auto b = editor->partConfigurations[part].blurb;
+        std::string b = editor->partConfigurations[part].blurb;
 
         if (!b.empty())
         {

--- a/src-ui/app/shared/PartSidebarCard.h
+++ b/src-ui/app/shared/PartSidebarCard.h
@@ -32,6 +32,7 @@
 #include "sst/jucegui/components/MenuButton.h"
 #include "sst/jucegui/components/ToggleButton.h"
 #include "sst/jucegui/components/TextPushButton.h"
+#include "sst/jucegui/components/TextEditor.h"
 #include "sst/jucegui/components/HSliderFilled.h"
 #include "app/HasEditor.h"
 #include "connectors/PayloadDataAttachment.h"
@@ -39,7 +40,10 @@
 
 namespace scxt::ui::app::shared
 {
-struct PartSidebarCard : juce::Component, HasEditor
+struct PartSidebarCard : juce::Component,
+                         HasEditor,
+                         sst::jucegui::components::WithIdleTimer,
+                         juce::TextEditor::Listener
 {
     int part;
 
@@ -48,21 +52,38 @@ struct PartSidebarCard : juce::Component, HasEditor
 
     static constexpr int row0{2}, rowHeight{20}, rowMargin{2};
 
-    static constexpr int height{88}, width{172};
+    static constexpr int height{88}, tallHeight{176}, width{172};
 
     std::unique_ptr<sst::jucegui::components::ToggleButton> solo, mute;
     std::unique_ptr<boolattachment_t> muteAtt, soloAtt;
     std::unique_ptr<sst::jucegui::components::MenuButton> patchName;
     std::unique_ptr<sst::jucegui::components::TextPushButton> midiMode, outBus, polyCount;
     std::unique_ptr<sst::jucegui::components::HSliderFilled> level, pan, tuning;
+    std::unique_ptr<sst::jucegui::components::TextEditor> partBlurb;
+
     bool selfAccent{true};
     PartSidebarCard(int p, SCXTEditor *e);
     void paint(juce::Graphics &g) override;
 
     void showMidiModeMenu();
 
+    bool tallMode{false};
+    void setTallMode(bool b)
+    {
+        tallMode = b;
+        partBlurb->setVisible(tallMode);
+    }
+
+    void showPartBlurbTooltip();
+    void hidePartBlurbTooltip();
+
     void mouseDown(const juce::MouseEvent &e) override;
+    void mouseEnter(const juce::MouseEvent &event) override { beginTimer(); }
+    void mouseExit(const juce::MouseEvent &event) override { endTimer(); }
+
     void resized() override;
+
+    void textEditorTextChanged(juce::TextEditor &) override;
 
     void showPopup();
 

--- a/src/engine/part.h
+++ b/src/engine/part.h
@@ -97,6 +97,8 @@ struct Part : MoveableOnly<Part>, SampleRateSupport
         bool polyLimitVoices{0}; // poly limit. 0 means unlimited.
 
         BusAddress routeTo{DEFAULT_BUS};
+
+        std::string blurb;
     } configuration;
     void process(Engine &onto);
 

--- a/src/engine/part.h
+++ b/src/engine/part.h
@@ -101,7 +101,7 @@ struct Part : MoveableOnly<Part>, SampleRateSupport
         // This needs to be a standard object, and windows msvc doesn't like
         // std::strings in those objects, so use a char*
         static constexpr int maxDescription{2048};
-        char blurb[maxDescription];
+        char blurb[maxDescription]{0};
     } configuration;
     void process(Engine &onto);
 

--- a/src/engine/part.h
+++ b/src/engine/part.h
@@ -98,6 +98,8 @@ struct Part : MoveableOnly<Part>, SampleRateSupport
 
         BusAddress routeTo{DEFAULT_BUS};
 
+        // This needs to be a standard object, and windows msvc doesn't like
+        // std::strings in those objects, so use a char*
         static constexpr int maxDescription{2048};
         char blurb[maxDescription];
     } configuration;

--- a/src/engine/part.h
+++ b/src/engine/part.h
@@ -98,7 +98,8 @@ struct Part : MoveableOnly<Part>, SampleRateSupport
 
         BusAddress routeTo{DEFAULT_BUS};
 
-        std::string blurb;
+        static constexpr int maxDescription{2048};
+        char blurb[maxDescription];
     } configuration;
     void process(Engine &onto);
 

--- a/src/infrastructure/user_defaults.h
+++ b/src/infrastructure/user_defaults.h
@@ -42,6 +42,7 @@ enum DefaultKeys
     colormapPathIfFile,
     welcomeScreenSeen,
     playModeExpanded,
+    partSidebarPartExpanded,
     browserAutoPreviewEnabled,
     useSoftwareRenderer,
 
@@ -69,6 +70,8 @@ inline std::string defaultKeyToString(DefaultKeys k)
         return "welcomeScreenSeen";
     case playModeExpanded:
         return "playModeExpanded";
+    case partSidebarPartExpanded:
+        return "partSidebarPartExpanded";
     case browserAutoPreviewEnabled:
         return "browserAutoPreviewEnabled";
     case useSoftwareRenderer:

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -158,7 +158,7 @@ SC_STREAMDEF(scxt::engine::Part::PartConfiguration,
                           {"s", from.solo},
                           {"pl", from.polyLimitVoices},
                           {"mbr", from.mpePitchBendRange},
-                          {"bl", from.blurb}};),
+                          {"bl", std::string(from.blurb)}};),
              SC_TO({
                  findOrSet(v, "c", scxt::engine::Part::PartConfiguration::omniChannel, to.channel);
                  findOrSet(v, "a", true, to.active);
@@ -166,7 +166,10 @@ SC_STREAMDEF(scxt::engine::Part::PartConfiguration,
                  findOrSet(v, "s", false, to.solo);
                  findOrSet(v, "pl", 0, to.polyLimitVoices);
                  findOrSet(v, "mbr", 24, to.mpePitchBendRange);
-                 findOrSet(v, "bl", "", to.blurb);
+                 std::string bStr;
+                 findOrSet(v, "bl", "", bStr);
+                 memset(to.blurb, 0, sizeof(to.blurb));
+                 strncpy(to.blurb, bStr.c_str(), sizeof(to.blurb) - 1);
              }));
 
 SC_STREAMDEF(scxt::engine::Part::ZoneMappingItem,

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -157,7 +157,8 @@ SC_STREAMDEF(scxt::engine::Part::PartConfiguration,
                           {"m", from.mute},
                           {"s", from.solo},
                           {"pl", from.polyLimitVoices},
-                          {"mbr", from.mpePitchBendRange}};),
+                          {"mbr", from.mpePitchBendRange},
+                          {"bl", from.blurb}};),
              SC_TO({
                  findOrSet(v, "c", scxt::engine::Part::PartConfiguration::omniChannel, to.channel);
                  findOrSet(v, "a", true, to.active);
@@ -165,6 +166,7 @@ SC_STREAMDEF(scxt::engine::Part::PartConfiguration,
                  findOrSet(v, "s", false, to.solo);
                  findOrSet(v, "pl", 0, to.polyLimitVoices);
                  findOrSet(v, "mbr", 24, to.mpePitchBendRange);
+                 findOrSet(v, "bl", "", to.blurb);
              }));
 
 SC_STREAMDEF(scxt::engine::Part::ZoneMappingItem,

--- a/src/utils.h
+++ b/src/utils.h
@@ -223,21 +223,9 @@ struct ThreadingChecker
 
     std::thread::id serialThreadId{}, audioThreadId{};
     std::set<std::thread::id> clientThreadIds{};
-    void addAsAClientThread()
-    {
-        std::cout << "Add " << std::endl;
-        clientThreadIds.insert(std::this_thread::get_id());
-    }
-    void addAsAClientThread(std::thread::id tid)
-    {
-        std::cout << "Add2 " << std::endl;
-        clientThreadIds.insert(tid);
-    }
-    void removeAsAClientThread()
-    {
-        std::cout << "Rem " << std::endl;
-        clientThreadIds.erase(std::this_thread::get_id());
-    }
+    void addAsAClientThread() { clientThreadIds.insert(std::this_thread::get_id()); }
+    void addAsAClientThread(std::thread::id tid) { clientThreadIds.insert(tid); }
+    void removeAsAClientThread() { clientThreadIds.erase(std::this_thread::get_id()); }
     inline bool isClientThread() const
     {
 #if BUILD_IS_DEBUG


### PR DESCRIPTION
Closes #1117

- SSTJG gets text editor
- Part sidecard gets a tooltip
- share expanded state
- blurb stored in model and editable in UI
- Separate prefs for PGZ and Play
- Tooltip if closed works as expected
- Sync PGZ and Play values properly in the UI on viz changes