### PR TITLE
Show playing zones in PGZ sidebar

### DIFF
--- a/src-ui/app/edit-screen/EditScreen.cpp
+++ b/src-ui/app/edit-screen/EditScreen.cpp
@@ -77,7 +77,23 @@ void EditScreen::layout()
     groupElements->layoutInto(mainRect);
 }
 
-void EditScreen::onVoiceInfoChanged() { mappingPane->repaint(); }
+void EditScreen::onVoiceInfoChanged()
+{
+    voiceCountByZoneAddress.clear();
+    for (const auto &v : editor->sharedUiMemoryState.voiceDisplayItems)
+    {
+        if (v.active)
+        {
+            auto sa = selection::SelectionManager::ZoneAddress(v.part, v.group, v.zone);
+            if (voiceCountByZoneAddress.find(sa) == voiceCountByZoneAddress.end())
+                voiceCountByZoneAddress[sa] = 0;
+            voiceCountByZoneAddress[sa]++;
+        }
+    }
+
+    mappingPane->repaint();
+    partSidebar->repaint();
+}
 
 void EditScreen::updateSamplePlaybackPosition(size_t sampleIndex, int64_t samplePos)
 {

--- a/src-ui/app/edit-screen/EditScreen.h
+++ b/src-ui/app/edit-screen/EditScreen.h
@@ -34,6 +34,7 @@
 #include "app/HasEditor.h"
 #include "app/browser-ui/BrowserPane.h"
 #include "sst/jucegui/components/NamedPanel.h"
+#include "selection/selection_manager.h"
 
 namespace scxt::ui::app
 {
@@ -118,6 +119,7 @@ struct EditScreen : juce::Component, HasEditor
     void resized() override { layout(); }
 
     void layout();
+    std::map<selection::SelectionManager::ZoneAddress, size_t> voiceCountByZoneAddress;
     void onVoiceInfoChanged();
     void updateSamplePlaybackPosition(size_t sampleIndex, int64_t samplePos);
 

--- a/src-ui/app/edit-screen/components/GroupZoneTreeControl.h
+++ b/src-ui/app/edit-screen/components/GroupZoneTreeControl.h
@@ -207,6 +207,13 @@ template <typename SidebarParent, bool fz> struct GroupZoneListBoxModel : juce::
                     g.setColour(editor->themeColor(theme::ColorMap::warning_1a));
                 }
 
+                size_t voiceCount{0};
+                auto p = editor->editScreen->voiceCountByZoneAddress.find(sg.address);
+                if (p != editor->editScreen->voiceCountByZoneAddress.end())
+                {
+                    voiceCount = p->second;
+                }
+
                 g.drawText(sg.name, getLocalBounds().translated(zonePad + 2, 0),
                            juce::Justification::centredLeft);
 
@@ -217,6 +224,15 @@ template <typename SidebarParent, bool fz> struct GroupZoneListBoxModel : juce::
                     b = b.withTrimmedTop(q / 2).withTrimmedBottom(q / 2);
                     jcmp::GlyphPainter::paintGlyph(g, b, jcmp::GlyphPainter::JOG_RIGHT,
                                                    textColor.withAlpha(0.5f));
+                }
+
+                if (voiceCount > 0)
+                {
+                    auto b = getLocalBounds()
+                                 .withWidth(zonePad)
+                                 .translated(getWidth() - zonePad, 0)
+                                 .reduced(2);
+                    jcmp::GlyphPainter::paintGlyph(g, b, jcmp::GlyphPainter::SPEAKER, textColor);
                 }
 
                 if (dragOverState == DRAG_OVER)

--- a/src-ui/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
+++ b/src-ui/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
@@ -31,6 +31,8 @@
 #include "ZoneLayoutDisplay.h"
 #include "ZoneLayoutKeyboard.h"
 
+#include <app/edit-screen/EditScreen.h>
+
 namespace scxt::ui::app::edit_screen
 {
 namespace cmsg = scxt::messaging::client;
@@ -329,15 +331,11 @@ void MappingDisplay::setLeadSelection(const selection::SelectionManager::ZoneAdd
 
 int MappingDisplay::voiceCountFor(const selection::SelectionManager::ZoneAddress &z)
 {
-    int res{0};
-    for (const auto &v : editor->sharedUiMemoryState.voiceDisplayItems)
-    {
-        if (v.active && v.part == z.part && v.group == z.group && v.zone == z.zone)
-        {
-            res++;
-        }
-    }
-    return res;
+    auto p = editor->editScreen->voiceCountByZoneAddress.find(z);
+    if (p != editor->editScreen->voiceCountByZoneAddress.end())
+        return p->second;
+
+    return 0;
 }
 
 bool MappingDisplay::isInterestedInDragSource(


### PR DESCRIPTION
Show playing zones in the PGZ sidebar
While at it, make the lookup of playing zones and voice count way more efficient by caching when changed, and update mapping view to use that data structure also

Closes #1550