### PR TITLE
New interpolation mode for lo-fi style sample playback

### DIFF
--- a/src-ui/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
+++ b/src-ui/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
@@ -396,7 +396,7 @@ void VariantDisplay::resized()
     }
 
     addGap(10);
-    if (v.loopMode == engine::Zone::LOOP_FOR_COUNT)
+    if (v.loopMode == engine::Zone::LOOP_COUNT)
     {
         ofRow(loopModeButton, 84);
         ofRow(loopCnt, 26);
@@ -503,7 +503,7 @@ void VariantDisplay::rebuild()
     case engine::Zone::LOOP_WHILE_GATED:
         loopModeButton->setLabel("LOOP UNTIL REL" + dirExtra);
         break;
-    case engine::Zone::LOOP_FOR_COUNT:
+    case engine::Zone::LOOP_COUNT:
         loopModeButton->setLabel("COUNT");
         break;
     }
@@ -532,7 +532,7 @@ void VariantDisplay::rebuild()
     case dsp::InterpolationTypes::Linear:
         srcButton->setLabel("LIN");
         break;
-    case dsp::InterpolationTypes::ZeroOrderHoldAA:
+    case dsp::InterpolationTypes::ZOHAA:
         srcButton->setLabel("ZAA");
         break;
     case dsp::InterpolationTypes::ZeroOrderHold:
@@ -570,7 +570,7 @@ void VariantDisplay::rebuild()
     glyphLabels[curve]->setVisible(hasLoop);
 
     loopCnt->setVisible(variantView.variants[selectedVariation].loopMode ==
-                        engine::Zone::LoopMode::LOOP_FOR_COUNT);
+                        engine::Zone::LoopMode::LOOP_COUNT);
 
     waveforms[selectedVariation].waveform->rebuildHotZones();
 
@@ -739,9 +739,9 @@ void VariantDisplay::showLoopModeMenu()
     };
     add(engine::Zone::LoopMode::LOOP_DURING_VOICE, false, "Loop");
     add(engine::Zone::LoopMode::LOOP_DURING_VOICE, true, "Loop Alternate");
-    add(engine::Zone::LoopMode::LOOP_WHILE_GATED, false, "Loop Untiqgitql Release");
+    add(engine::Zone::LoopMode::LOOP_WHILE_GATED, false, "Loop Until Release");
     add(engine::Zone::LoopMode::LOOP_WHILE_GATED, true, "Loop Alternate Until Release");
-    add(engine::Zone::LoopMode::LOOP_FOR_COUNT, false, "Loop For Count");
+    add(engine::Zone::LoopMode::LOOP_COUNT, false, "Loop For Count");
 
     p.showMenuAsync(editor->defaultPopupMenuOptions(loopModeButton.get()));
 }
@@ -763,8 +763,8 @@ void VariantDisplay::showSRCMenu()
     };
     add(dsp::InterpolationTypes::Sinc, "Sinc");
     add(dsp::InterpolationTypes::Linear, "Linear");
-    add(dsp::InterpolationTypes::ZeroOrderHoldAA, "Zero-Order Hold (Anti-Aliased)");
-    add(dsp::InterpolationTypes::ZeroOrderHold, "Zero-order Hold");
+    add(dsp::InterpolationTypes::ZOHAA, "Zero-Order Hold (Anti-Aliased)");
+    add(dsp::InterpolationTypes::ZeroOrderHold, "Zero Order Hold");
 
     p.showMenuAsync(editor->defaultPopupMenuOptions());
 }

--- a/src-ui/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
+++ b/src-ui/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
@@ -532,6 +532,9 @@ void VariantDisplay::rebuild()
     case dsp::InterpolationTypes::Linear:
         srcButton->setLabel("LIN");
         break;
+    case dsp::InterpolationTypes::ZeroOrderHoldAA:
+        srcButton->setLabel("ZAA");
+        break;
     case dsp::InterpolationTypes::ZeroOrderHold:
         srcButton->setLabel("ZOH");
         break;
@@ -760,6 +763,7 @@ void VariantDisplay::showSRCMenu()
     };
     add(dsp::InterpolationTypes::Sinc, "Sinc");
     add(dsp::InterpolationTypes::Linear, "Linear");
+    add(dsp::InterpolationTypes::ZeroOrderHoldAA, "Zero-order Hold with antialiasing");
     add(dsp::InterpolationTypes::ZeroOrderHold, "Zero-order Hold");
 
     p.showMenuAsync(editor->defaultPopupMenuOptions());

--- a/src-ui/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
+++ b/src-ui/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
@@ -763,7 +763,7 @@ void VariantDisplay::showSRCMenu()
     };
     add(dsp::InterpolationTypes::Sinc, "Sinc");
     add(dsp::InterpolationTypes::Linear, "Linear");
-    add(dsp::InterpolationTypes::ZeroOrderHoldAA, "Zero-order Hold with antialiasing");
+    add(dsp::InterpolationTypes::ZeroOrderHoldAA, "Zero-Order Hold (Anti-Aliased)");
     add(dsp::InterpolationTypes::ZeroOrderHold, "Zero-order Hold");
 
     p.showMenuAsync(editor->defaultPopupMenuOptions());

--- a/src/dsp/generator.cpp
+++ b/src/dsp/generator.cpp
@@ -119,36 +119,26 @@ template <InterpolationTypes KT, typename T> struct KernelOp
 {
 };
 
-template <InterpolationTypes KT, typename T, int NUM_CHANNELS, bool LOOP_ACTIVE>
+/* These all have that defaulted bool argument
+ so that we can avoid duplicating the whole sinc code another two times for the anti-aliased
+ zero-order hold version. Nothing ever actually sets it except for the KernelProcessor.
+ See comment in the definition below.
+ */
+
+template <InterpolationTypes KT, typename T, int NUM_CHANNELS, bool LOOP_ACTIVE, bool ZOH = false>
 struct KernelProcessor;
 
 template <typename T> struct KernelOp<InterpolationTypes::ZeroOrderHold, T>
 {
-    template <int NUM_CHANNELS, bool LOOP_ACTIVE>
+    template <int NUM_CHANNELS, bool LOOP_ACTIVE, bool ZOH = false>
     static void
     Process(GeneratorState *__restrict GD,
             KernelProcessor<InterpolationTypes::ZeroOrderHold, T, NUM_CHANNELS, LOOP_ACTIVE> &ks);
 };
 
-template <> struct KernelOp<InterpolationTypes::ZeroOrderHoldAA, float>
-{
-    template <int NUM_CHANNELS, bool LOOP_ACTIVE>
-    static void Process(
-        GeneratorState *__restrict GD,
-        KernelProcessor<InterpolationTypes::ZeroOrderHoldAA, float, NUM_CHANNELS, LOOP_ACTIVE> &ks);
-};
-
-template <> struct KernelOp<InterpolationTypes::ZeroOrderHoldAA, int16_t>
-{
-    template <int NUM_CHANNELS, bool LOOP_ACTIVE>
-    static void Process(GeneratorState *__restrict GD,
-                        KernelProcessor<InterpolationTypes::ZeroOrderHoldAA, int16_t, NUM_CHANNELS,
-                                        LOOP_ACTIVE> &ks);
-};
-
 template <typename T> struct KernelOp<InterpolationTypes::Linear, T>
 {
-    template <int NUM_CHANNELS, bool LOOP_ACTIVE>
+    template <int NUM_CHANNELS, bool LOOP_ACTIVE, bool ZOH = false>
     static void
     Process(GeneratorState *__restrict GD,
             KernelProcessor<InterpolationTypes::Linear, T, NUM_CHANNELS, LOOP_ACTIVE> &ks);
@@ -156,21 +146,21 @@ template <typename T> struct KernelOp<InterpolationTypes::Linear, T>
 
 template <> struct KernelOp<InterpolationTypes::Sinc, float>
 {
-    template <int NUM_CHANNELS, bool LOOP_ACTIVE>
+    template <int NUM_CHANNELS, bool LOOP_ACTIVE, bool ZOH = false>
     static void
     Process(GeneratorState *__restrict GD,
-            KernelProcessor<InterpolationTypes::Sinc, float, NUM_CHANNELS, LOOP_ACTIVE> &ks);
+            KernelProcessor<InterpolationTypes::Sinc, float, NUM_CHANNELS, LOOP_ACTIVE, ZOH> &ks);
 };
 
 template <> struct KernelOp<InterpolationTypes::Sinc, int16_t>
 {
-    template <int NUM_CHANNELS, bool LOOP_ACTIVE>
+    template <int NUM_CHANNELS, bool LOOP_ACTIVE, bool ZOH = false>
     static void
     Process(GeneratorState *__restrict GD,
-            KernelProcessor<InterpolationTypes::Sinc, int16_t, NUM_CHANNELS, LOOP_ACTIVE> &ks);
+            KernelProcessor<InterpolationTypes::Sinc, int16_t, NUM_CHANNELS, LOOP_ACTIVE, ZOH> &ks);
 };
 
-template <InterpolationTypes KT, typename T, int NUM_CHANNELS, bool LOOP_ACTIVE>
+template <InterpolationTypes KT, typename T, int NUM_CHANNELS, bool LOOP_ACTIVE, bool ZOH>
 struct KernelProcessor
 {
     int32_t SamplePos, SampleSubPos;
@@ -188,7 +178,41 @@ struct KernelProcessor
 
     void ProcessKernel(GeneratorState *__restrict GD)
     {
-        return KernelOp<KT, T>::Process(GD, *this);
+        if constexpr (KT == InterpolationTypes::ZOHAA)
+        {
+            // Declare another KernelProcessor with sinc specialization and the
+            // aforementioned bool argument set to true
+            // Return the new objects process function, which will call the sinc method with
+            // ZOH=true
+            if constexpr (NUM_CHANNELS == 2)
+            {
+                KernelProcessor<InterpolationTypes::Sinc, T, NUM_CHANNELS, LOOP_ACTIVE, true>
+                    SincWithZoh{SamplePos,
+                                SampleSubPos,
+                                m0,
+                                i,
+                                {ReadSample[0], ReadSample[1]},
+                                {ReadFadeSample[0], ReadFadeSample[1]},
+                                fadeActive,
+                                loopFade,
+                                {Output[0], Output[1]},
+                                IO};
+
+                return SincWithZoh.ProcessKernel(GD);
+            }
+            else
+            {
+                KernelProcessor<InterpolationTypes::Sinc, T, NUM_CHANNELS, LOOP_ACTIVE, true>
+                    SincWithZoh{SamplePos,         SampleSubPos, m0,       i,         ReadSample[0],
+                                ReadFadeSample[0], fadeActive,   loopFade, Output[0], IO};
+
+                return SincWithZoh.ProcessKernel(GD);
+            }
+        }
+        else
+        {
+            return KernelOp<KT, T>::Process(GD, *this);
+        }
     }
 };
 
@@ -197,7 +221,7 @@ float NormalizeSampleToF32(float val) { return val; }
 float NormalizeSampleToF32(int16_t val) { return val * I16InvScale2; }
 
 template <typename T>
-template <int NUM_CHANNELS, bool LOOP_ACTIVE>
+template <int NUM_CHANNELS, bool LOOP_ACTIVE, bool ZOH>
 void KernelOp<InterpolationTypes::ZeroOrderHold, T>::Process(
     GeneratorState *__restrict GD,
     KernelProcessor<InterpolationTypes::ZeroOrderHold, T, NUM_CHANNELS, LOOP_ACTIVE> &ks)
@@ -248,266 +272,8 @@ void KernelOp<InterpolationTypes::ZeroOrderHold, T>::Process(
     }
 }
 
-template <int NUM_CHANNELS, bool LOOP_ACTIVE>
-void KernelOp<InterpolationTypes::ZeroOrderHoldAA, float>::Process(
-    GeneratorState *__restrict GD,
-    KernelProcessor<InterpolationTypes::ZeroOrderHoldAA, float, NUM_CHANNELS, LOOP_ACTIVE> &ks)
-{
-    auto readSampleL{ks.ReadSample[0]};
-    auto readFadeSampleL{ks.ReadFadeSample[0]};
-    auto OutputL{ks.Output[0]};
-    auto m0{ks.m0};
-    auto i{ks.i};
-
-#if DEBUG_CODE_I_WANT_TO_RETAIN
-    /* This code only works if theres no loop etc but please leave it here
-     * since it is useful when debugging in the future
-     */
-    {
-        ptrdiff_t space = (float *)readSampleL - (float *)ks.IO->sampleDataL;
-        float above = space - ks.IO->waveSize + FIRipol_N;
-
-        if (space < -(int64_t)FIRoffset || above > FIRoffset)
-            SCLOG(SCD(ks.IO->sampleDataL)
-                  << SCD(readSampleL) << SCD(space) << SCD(above) << SCD(ks.IO->waveSize));
-
-        assert(space >= -(int64_t)FIRoffset && above <= FIRoffset);
-    }
-#endif
-
-    auto finalSubPos = ks.SampleSubPos;
-    auto subSubPos = (float)(finalSubPos) / (float)(1 << 24);
-    auto subRatio = std::abs((float)(GD->ratio) / (float)(1 << 24));
-    if (subRatio <= 0.5f)
-    {
-        subSubPos = std::pow(subSubPos, 1.0f / subRatio);
-        finalSubPos = (int)(subSubPos * (1 << 24));
-        m0 = ((finalSubPos >> 12) & 0xff0);
-    }
-
-    // float32 path (SSE)
-    SIMD_M128 lipol0, tmp[4], sL4, sR4;
-    lipol0 = SIMD_MM(setzero_ps)();
-    lipol0 = SIMD_MM(cvtsi32_ss)(lipol0, finalSubPos & 0xffff);
-    lipol0 = SIMD_MM(shuffle_ps)(lipol0, lipol0, SIMD_MM_SHUFFLE(0, 0, 0, 0));
-    tmp[0] = SIMD_MM(add_ps)(SIMD_MM(mul_ps)(*((SIMD_M128 *)&sincTable.SincOffsetF32[m0]), lipol0),
-                             *((SIMD_M128 *)&sincTable.SincTableF32[m0]));
-    tmp[1] =
-        SIMD_MM(add_ps)(SIMD_MM(mul_ps)(*((SIMD_M128 *)&sincTable.SincOffsetF32[m0 + 4]), lipol0),
-                        *((SIMD_M128 *)&sincTable.SincTableF32[m0 + 4]));
-    tmp[2] =
-        SIMD_MM(add_ps)(SIMD_MM(mul_ps)(*((SIMD_M128 *)&sincTable.SincOffsetF32[m0 + 8]), lipol0),
-                        *((SIMD_M128 *)&sincTable.SincTableF32[m0 + 8]));
-    tmp[3] =
-        SIMD_MM(add_ps)(SIMD_MM(mul_ps)(*((SIMD_M128 *)&sincTable.SincOffsetF32[m0 + 12]), lipol0),
-                        *((SIMD_M128 *)&sincTable.SincTableF32[m0 + 12]));
-    sL4 = SIMD_MM(mul_ps)(tmp[0], SIMD_MM(loadu_ps)(readSampleL));
-    sL4 = SIMD_MM(add_ps)(sL4, SIMD_MM(mul_ps)(tmp[1], SIMD_MM(loadu_ps)(readSampleL + 4)));
-    sL4 = SIMD_MM(add_ps)(sL4, SIMD_MM(mul_ps)(tmp[2], SIMD_MM(loadu_ps)(readSampleL + 8)));
-    sL4 = SIMD_MM(add_ps)(sL4, SIMD_MM(mul_ps)(tmp[3], SIMD_MM(loadu_ps)(readSampleL + 12)));
-    // sL4 = sst::basic_blocks::mechanics::sum_ps_to_ss(sL4);
-    sL4 = SIMD_MM(hadd_ps)(sL4, sL4);
-    sL4 = SIMD_MM(hadd_ps)(sL4, sL4);
-
-    SIMD_MM(store_ss)(&OutputL[i], sL4);
-
-    if constexpr (LOOP_ACTIVE)
-    {
-        if (ks.fadeActive)
-        {
-            sR4 = SIMD_MM(mul_ps)(tmp[0], SIMD_MM(loadu_ps)(readFadeSampleL));
-            sR4 = SIMD_MM(add_ps)(sR4,
-                                  SIMD_MM(mul_ps)(tmp[1], SIMD_MM(loadu_ps)(readFadeSampleL + 4)));
-            sR4 = SIMD_MM(add_ps)(sR4,
-                                  SIMD_MM(mul_ps)(tmp[2], SIMD_MM(loadu_ps)(readFadeSampleL + 8)));
-            sR4 = SIMD_MM(add_ps)(sR4,
-                                  SIMD_MM(mul_ps)(tmp[3], SIMD_MM(loadu_ps)(readFadeSampleL + 12)));
-            // sR4 = sst::basic_blocks::mechanics::sum_ps_to_ss(sR4);
-            sR4 = SIMD_MM(hadd_ps)(sR4, sR4);
-            sR4 = SIMD_MM(hadd_ps)(sR4, sR4);
-
-            float fadeVal{0.f};
-            SIMD_MM(store_ss)(&fadeVal, sR4);
-            auto fadeGain(
-                getFadeGain(ks.SamplePos, GD->loopUpperBound - ks.loopFade, GD->loopUpperBound));
-            auto aOut = getFadeGainToAmp(1.f - fadeGain);
-            fadeGain = getFadeGainToAmp(fadeGain);
-
-            OutputL[i] = OutputL[i] * aOut + fadeVal * fadeGain;
-        }
-    }
-
-    if constexpr (NUM_CHANNELS == 2)
-    {
-        auto readSampleR{ks.ReadSample[1]};
-        auto readFadeSampleR{ks.ReadFadeSample[1]};
-        auto OutputR{ks.Output[1]};
-
-        sR4 = SIMD_MM(mul_ps)(tmp[0], SIMD_MM(loadu_ps)(readSampleR));
-        sR4 = SIMD_MM(add_ps)(sR4, SIMD_MM(mul_ps)(tmp[1], SIMD_MM(loadu_ps)(readSampleR + 4)));
-        sR4 = SIMD_MM(add_ps)(sR4, SIMD_MM(mul_ps)(tmp[2], SIMD_MM(loadu_ps)(readSampleR + 8)));
-        sR4 = SIMD_MM(add_ps)(sR4, SIMD_MM(mul_ps)(tmp[3], SIMD_MM(loadu_ps)(readSampleR + 12)));
-        // sR4 = sst::basic_blocks::mechanics::sum_ps_to_ss(sR4);
-        sR4 = SIMD_MM(hadd_ps)(sR4, sR4);
-        sR4 = SIMD_MM(hadd_ps)(sR4, sR4);
-
-        SIMD_MM(store_ss)(&OutputR[i], sR4);
-
-        if constexpr (LOOP_ACTIVE)
-        {
-            if (ks.fadeActive)
-            {
-                sR4 = SIMD_MM(mul_ps)(tmp[0], SIMD_MM(loadu_ps)(readFadeSampleR));
-                sR4 = SIMD_MM(add_ps)(
-                    sR4, SIMD_MM(mul_ps)(tmp[1], SIMD_MM(loadu_ps)(readFadeSampleR + 4)));
-                sR4 = SIMD_MM(add_ps)(
-                    sR4, SIMD_MM(mul_ps)(tmp[2], SIMD_MM(loadu_ps)(readFadeSampleR + 8)));
-                sR4 = SIMD_MM(add_ps)(
-                    sR4, SIMD_MM(mul_ps)(tmp[3], SIMD_MM(loadu_ps)(readFadeSampleR + 12)));
-                // sR4 = sst::basic_blocks::mechanics::sum_ps_to_ss(sR4);
-                sR4 = SIMD_MM(hadd_ps)(sR4, sR4);
-                sR4 = SIMD_MM(hadd_ps)(sR4, sR4);
-
-                float fadeVal{0.f};
-                SIMD_MM(store_ss)(&fadeVal, sR4);
-                auto fadeGain(getFadeGain(ks.SamplePos, GD->loopUpperBound - ks.loopFade,
-                                          GD->loopUpperBound));
-                auto aOut = getFadeGainToAmp(1.f - fadeGain);
-                fadeGain = getFadeGainToAmp(fadeGain);
-
-                OutputR[i] = OutputR[i] * aOut + fadeVal * fadeGain;
-            }
-        }
-    }
-}
-
-template <int NUM_CHANNELS, bool LOOP_ACTIVE>
-void KernelOp<InterpolationTypes::ZeroOrderHoldAA, int16_t>::Process(
-    GeneratorState *__restrict GD,
-    KernelProcessor<InterpolationTypes::ZeroOrderHoldAA, int16_t, NUM_CHANNELS, LOOP_ACTIVE> &ks)
-{
-    auto readSampleL{ks.ReadSample[0]};
-    auto readFadeSampleL{ks.ReadFadeSample[0]};
-    auto OutputL{ks.Output[0]};
-    auto m0{ks.m0};
-    auto i{ks.i};
-    constexpr auto stereo = NUM_CHANNELS == 2;
-
-    int16_t *readSampleR{nullptr};
-    float *OutputR{nullptr};
-    if constexpr (stereo)
-    {
-        readSampleR = ks.ReadSample[1];
-        OutputR = ks.Output[1];
-    }
-
-    auto finalSubPos = ks.SampleSubPos;
-    auto subSubPos = (float)(finalSubPos) / (float)(1 << 24);
-    auto subRatio = std::abs((float)(GD->ratio) / (float)(1 << 24));
-    if (subRatio <= 0.5f)
-    {
-        subSubPos = std::pow(subSubPos, 1.0f / subRatio);
-        finalSubPos = (int)(subSubPos * (1 << 24));
-        m0 = ((finalSubPos >> 12) & 0xff0);
-    }
-
-    // int16
-    // SSE2 path
-    SIMD_M128I lipol0, tmp, sL8A, sR8A, tmp2, sL8B, sR8B;
-    auto fL = SIMD_MM(setzero_ps)(), fR = SIMD_MM(setzero_ps)();
-    lipol0 = SIMD_MM(set1_epi16)(finalSubPos & 0xffff);
-
-    tmp = SIMD_MM(add_epi16)(
-        SIMD_MM(mulhi_epi16)(*((SIMD_M128I *)&sincTable.SincOffsetI16[m0]), lipol0),
-        *((SIMD_M128I *)&sincTable.SincTableI16[m0]));
-    sL8A = SIMD_MM(madd_epi16)(tmp, SIMD_MM(loadu_si128)((SIMD_M128I *)readSampleL));
-    if constexpr (stereo)
-        sR8A = SIMD_MM(madd_epi16)(tmp, SIMD_MM(loadu_si128)((SIMD_M128I *)readSampleR));
-
-    tmp2 = SIMD_MM(add_epi16)(
-        SIMD_MM(mulhi_epi16)(*((SIMD_M128I *)&sincTable.SincOffsetI16[m0 + 8]), lipol0),
-        *((SIMD_M128I *)&sincTable.SincTableI16[m0 + 8]));
-    sL8B = SIMD_MM(madd_epi16)(tmp2, SIMD_MM(loadu_si128)((SIMD_M128I *)(readSampleL + 8)));
-    if constexpr (stereo)
-        sR8B = SIMD_MM(madd_epi16)(tmp2, SIMD_MM(loadu_si128)((SIMD_M128I *)(readSampleR + 8)));
-
-    sL8A = SIMD_MM(add_epi32)(sL8A, sL8B);
-    if constexpr (stereo)
-        sR8A = SIMD_MM(add_epi32)(sR8A, sR8B);
-
-    int l alignas(16)[4], r alignas(16)[4];
-    SIMD_MM(store_si128)((SIMD_M128I *)&l, sL8A);
-    if constexpr (stereo)
-        SIMD_MM(store_si128)((SIMD_M128I *)&r, sR8A);
-    l[0] = (l[0] + l[1]) + (l[2] + l[3]);
-    if constexpr (stereo)
-        r[0] = (r[0] + r[1]) + (r[2] + r[3]);
-
-    fL = SIMD_MM(mul_ss)(SIMD_MM(cvtsi32_ss)(fL, l[0]), I16InvScale_m128);
-    if constexpr (stereo)
-        fR = SIMD_MM(mul_ss)(SIMD_MM(cvtsi32_ss)(fR, r[0]), I16InvScale_m128);
-
-    SIMD_MM(store_ss)(&OutputL[i], fL);
-    if constexpr (stereo)
-        SIMD_MM(store_ss)(&OutputR[i], fR);
-
-    if constexpr (LOOP_ACTIVE)
-    {
-        if (ks.fadeActive)
-        {
-            int16_t *readFadeSampleR{nullptr};
-            if constexpr (stereo)
-            {
-                readFadeSampleR = ks.ReadFadeSample[1];
-            }
-
-            sL8A = SIMD_MM(madd_epi16)(tmp, SIMD_MM(loadu_si128)((SIMD_M128I *)readFadeSampleL));
-            if constexpr (stereo)
-                sR8A =
-                    SIMD_MM(madd_epi16)(tmp, SIMD_MM(loadu_si128)((SIMD_M128I *)readFadeSampleR));
-            sL8B = SIMD_MM(madd_epi16)(tmp2,
-                                       SIMD_MM(loadu_si128)((SIMD_M128I *)(readFadeSampleL + 8)));
-            if constexpr (stereo)
-                sR8B = SIMD_MM(madd_epi16)(
-                    tmp2, SIMD_MM(loadu_si128)((SIMD_M128I *)(readFadeSampleR + 8)));
-
-            sL8A = SIMD_MM(add_epi32)(sL8A, sL8B);
-            if constexpr (stereo)
-                sR8A = SIMD_MM(add_epi32)(sR8A, sR8B);
-
-            int l alignas(16)[4], r alignas(16)[4];
-            SIMD_MM(store_si128)((SIMD_M128I *)&l, sL8A);
-            if constexpr (stereo)
-                SIMD_MM(store_si128)((SIMD_M128I *)&r, sR8A);
-            l[0] = (l[0] + l[1]) + (l[2] + l[3]);
-            if constexpr (stereo)
-                r[0] = (r[0] + r[1]) + (r[2] + r[3]);
-
-            fL = SIMD_MM(mul_ss)(SIMD_MM(cvtsi32_ss)(fL, l[0]), I16InvScale_m128);
-            if constexpr (stereo)
-                fR = SIMD_MM(mul_ss)(SIMD_MM(cvtsi32_ss)(fR, r[0]), I16InvScale_m128);
-
-            float fadeValL{0.f};
-            float fadeValR{0.f};
-            SIMD_MM(store_ss)(&fadeValL, fL);
-            if constexpr (stereo)
-                SIMD_MM(store_ss)(&fadeValR, fR);
-
-            auto fadeGain(
-                getFadeGain(ks.SamplePos, GD->loopUpperBound - ks.loopFade, GD->loopUpperBound));
-
-            auto aOut = getFadeGainToAmp(1.f - fadeGain);
-            fadeGain = getFadeGainToAmp(fadeGain);
-
-            OutputL[i] = OutputL[i] * aOut + fadeValL * fadeGain;
-            if constexpr (stereo)
-                OutputR[i] = OutputR[i] * aOut + fadeValR * fadeGain;
-        }
-    }
-}
-
 template <typename T>
-template <int NUM_CHANNELS, bool LOOP_ACTIVE>
+template <int NUM_CHANNELS, bool LOOP_ACTIVE, bool ZOH>
 void KernelOp<InterpolationTypes::Linear, T>::Process(
     GeneratorState *__restrict GD,
     KernelProcessor<InterpolationTypes::Linear, T, NUM_CHANNELS, LOOP_ACTIVE> &ks)
@@ -574,10 +340,10 @@ void KernelOp<InterpolationTypes::Linear, T>::Process(
     }
 }
 
-template <int NUM_CHANNELS, bool LOOP_ACTIVE>
+template <int NUM_CHANNELS, bool LOOP_ACTIVE, bool ZOH>
 void KernelOp<InterpolationTypes::Sinc, float>::Process(
     GeneratorState *__restrict GD,
-    KernelProcessor<InterpolationTypes::Sinc, float, NUM_CHANNELS, LOOP_ACTIVE> &ks)
+    KernelProcessor<InterpolationTypes::Sinc, float, NUM_CHANNELS, LOOP_ACTIVE, ZOH> &ks)
 {
     auto readSampleL{ks.ReadSample[0]};
     auto readFadeSampleL{ks.ReadFadeSample[0]};
@@ -585,7 +351,7 @@ void KernelOp<InterpolationTypes::Sinc, float>::Process(
     auto m0{ks.m0};
     auto i{ks.i};
 
-#if DEBUG_CODE_I_WANT_TO_RETAIN
+#if DEBUG_GENERATOR
     /* This code only works if theres no loop etc but please leave it here
      * since it is useful when debugging in the future
      */
@@ -600,6 +366,16 @@ void KernelOp<InterpolationTypes::Sinc, float>::Process(
         assert(space >= -(int64_t)FIRoffset && above <= FIRoffset);
     }
 #endif
+
+    if constexpr (ZOH) // ZOH-AA
+    {
+        auto finalSubPos = ks.SampleSubPos;
+        auto subSubPos = (float)(finalSubPos) / (float)(1 << 24);
+        auto subRatio = std::abs((float)(GD->ratio) / (float)(1 << 24));
+        subSubPos = std::pow(subSubPos, 1.0f / subRatio);
+        finalSubPos = (int)(subSubPos * (1 << 24));
+        m0 = ((finalSubPos >> 12) & 0xff0);
+    }
 
     // float32 path (SSE)
     SIMD_M128 lipol0, tmp[4], sL4, sR4;
@@ -697,10 +473,10 @@ void KernelOp<InterpolationTypes::Sinc, float>::Process(
     }
 }
 
-template <int NUM_CHANNELS, bool LOOP_ACTIVE>
+template <int NUM_CHANNELS, bool LOOP_ACTIVE, bool ZOH>
 void KernelOp<InterpolationTypes::Sinc, int16_t>::Process(
     GeneratorState *__restrict GD,
-    KernelProcessor<InterpolationTypes::Sinc, int16_t, NUM_CHANNELS, LOOP_ACTIVE> &ks)
+    KernelProcessor<InterpolationTypes::Sinc, int16_t, NUM_CHANNELS, LOOP_ACTIVE, ZOH> &ks)
 {
     auto readSampleL{ks.ReadSample[0]};
     auto readFadeSampleL{ks.ReadFadeSample[0]};
@@ -715,6 +491,16 @@ void KernelOp<InterpolationTypes::Sinc, int16_t>::Process(
     {
         readSampleR = ks.ReadSample[1];
         OutputR = ks.Output[1];
+    }
+
+    if constexpr (ZOH) // ZOH-AA
+    {
+        auto finalSubPos = ks.SampleSubPos;
+        auto subSubPos = (float)(finalSubPos) / (float)(1 << 24);
+        auto subRatio = std::abs((float)(GD->ratio) / (float)(1 << 24));
+        subSubPos = std::pow(subSubPos, 1.0f / subRatio);
+        finalSubPos = (int)(subSubPos * (1 << 24));
+        m0 = ((finalSubPos >> 12) & 0xff0);
     }
 
     // int16
@@ -1032,10 +818,10 @@ void GeneratorSample(GeneratorState *__restrict GD, GeneratorIO *__restrict IO)
                          readFadeR);
                 break;
             }
-            case InterpolationTypes::ZeroOrderHoldAA:
+            case InterpolationTypes::ZOHAA:
             {
-                KPStereo(InterpolationTypes::ZeroOrderHoldAA, type_from_cond, 2, readL, readR,
-                         readFadeL, readFadeR);
+                KPStereo(InterpolationTypes::ZOHAA, type_from_cond, 2, readL, readR, readFadeL,
+                         readFadeR);
                 break;
             }
             case InterpolationTypes::ZeroOrderHold:
@@ -1060,9 +846,9 @@ void GeneratorSample(GeneratorState *__restrict GD, GeneratorIO *__restrict IO)
                 KPMono(InterpolationTypes::Linear, type_from_cond, 1, readL, readFadeL);
                 break;
             }
-            case InterpolationTypes::ZeroOrderHoldAA:
+            case InterpolationTypes::ZOHAA:
             {
-                KPMono(InterpolationTypes::ZeroOrderHoldAA, type_from_cond, 1, readL, readFadeL);
+                KPMono(InterpolationTypes::ZOHAA, type_from_cond, 1, readL, readFadeL);
                 break;
             }
             case InterpolationTypes::ZeroOrderHold:

--- a/src/dsp/generator.cpp
+++ b/src/dsp/generator.cpp
@@ -133,17 +133,17 @@ template <typename T> struct KernelOp<InterpolationTypes::ZeroOrderHold, T>
 template <> struct KernelOp<InterpolationTypes::ZeroOrderHoldAA, float>
 {
     template <int NUM_CHANNELS, bool LOOP_ACTIVE>
-    static void
-    Process(GeneratorState *__restrict GD,
-            KernelProcessor<InterpolationTypes::ZeroOrderHoldAA, float, NUM_CHANNELS, LOOP_ACTIVE> &ks);
+    static void Process(
+        GeneratorState *__restrict GD,
+        KernelProcessor<InterpolationTypes::ZeroOrderHoldAA, float, NUM_CHANNELS, LOOP_ACTIVE> &ks);
 };
 
 template <> struct KernelOp<InterpolationTypes::ZeroOrderHoldAA, int16_t>
 {
     template <int NUM_CHANNELS, bool LOOP_ACTIVE>
-    static void
-    Process(GeneratorState *__restrict GD,
-            KernelProcessor<InterpolationTypes::ZeroOrderHoldAA, int16_t, NUM_CHANNELS, LOOP_ACTIVE> &ks);
+    static void Process(GeneratorState *__restrict GD,
+                        KernelProcessor<InterpolationTypes::ZeroOrderHoldAA, int16_t, NUM_CHANNELS,
+                                        LOOP_ACTIVE> &ks);
 };
 
 template <typename T> struct KernelOp<InterpolationTypes::Linear, T>
@@ -279,9 +279,11 @@ void KernelOp<InterpolationTypes::ZeroOrderHoldAA, float>::Process(
     auto subSubPos = (float)(finalSubPos) / (float)(1 << 24);
     auto subRatio = std::abs((float)(GD->ratio) / (float)(1 << 24));
     if (subRatio <= 0.5f)
-        subSubPos = std::pow(subSubPos, std::pow(2.0f / subRatio, 1.0f));
+    {
+        subSubPos = std::pow(subSubPos, 1.0f / subRatio);
         finalSubPos = (int)(subSubPos * (1 << 24));
         m0 = ((finalSubPos >> 12) & 0xff0);
+    }
 
     // float32 path (SSE)
     SIMD_M128 lipol0, tmp[4], sL4, sR4;
@@ -403,9 +405,11 @@ void KernelOp<InterpolationTypes::ZeroOrderHoldAA, int16_t>::Process(
     auto subSubPos = (float)(finalSubPos) / (float)(1 << 24);
     auto subRatio = std::abs((float)(GD->ratio) / (float)(1 << 24));
     if (subRatio <= 0.5f)
-        subSubPos = std::pow(subSubPos, std::pow(0.5f / subRatio, 1.0f));
+    {
+        subSubPos = std::pow(subSubPos, 1.0f / subRatio);
         finalSubPos = (int)(subSubPos * (1 << 24));
         m0 = ((finalSubPos >> 12) & 0xff0);
+    }
 
     // int16
     // SSE2 path
@@ -501,7 +505,6 @@ void KernelOp<InterpolationTypes::ZeroOrderHoldAA, int16_t>::Process(
         }
     }
 }
-
 
 template <typename T>
 template <int NUM_CHANNELS, bool LOOP_ACTIVE>

--- a/src/dsp/generator.h
+++ b/src/dsp/generator.h
@@ -40,6 +40,7 @@ enum InterpolationTypes
 {
     Sinc,
     Linear,
+    ZeroOrderHoldAA,
     ZeroOrderHold
 };
 DECLARE_ENUM_STRING(InterpolationTypes);
@@ -52,6 +53,8 @@ inline std::string toStringInterpolationTypes(const InterpolationTypes &p)
         return "sinc";
     case Linear:
         return "lin";
+    case ZeroOrderHoldAA:
+        return "zaa";
     case ZeroOrderHold:
         return "zho";
     }

--- a/src/dsp/generator.h
+++ b/src/dsp/generator.h
@@ -40,7 +40,7 @@ enum InterpolationTypes
 {
     Sinc,
     Linear,
-    ZeroOrderHoldAA,
+    ZOHAA,
     ZeroOrderHold
 };
 DECLARE_ENUM_STRING(InterpolationTypes);
@@ -53,10 +53,10 @@ inline std::string toStringInterpolationTypes(const InterpolationTypes &p)
         return "sinc";
     case Linear:
         return "lin";
-    case ZeroOrderHoldAA:
+    case ZOHAA:
         return "zaa";
     case ZeroOrderHold:
-        return "zho";
+        return "zoh";
     }
     return "sinc";
 }

--- a/src/engine/zone.cpp
+++ b/src/engine/zone.cpp
@@ -323,7 +323,7 @@ std::string Zone::toStringLoopMode(const LoopMode &p)
         return "during_voice";
     case LOOP_WHILE_GATED:
         return "while_gated";
-    case LOOP_FOR_COUNT:
+    case LOOP_COUNT:
         return "for_count";
     }
     return "during_voice";
@@ -332,7 +332,7 @@ std::string Zone::toStringLoopMode(const LoopMode &p)
 Zone::LoopMode Zone::fromStringLoopMode(const std::string &s)
 {
     static auto inverse = makeEnumInverse<Zone::LoopMode, Zone::toStringLoopMode>(
-        Zone::LoopMode::LOOP_DURING_VOICE, Zone::LoopMode::LOOP_FOR_COUNT);
+        Zone::LoopMode::LOOP_DURING_VOICE, Zone::LoopMode::LOOP_COUNT);
     auto p = inverse.find(s);
     if (p == inverse.end())
         return LOOP_DURING_VOICE;

--- a/src/engine/zone.h
+++ b/src/engine/zone.h
@@ -93,7 +93,7 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
     {
         LOOP_DURING_VOICE, // If a loop begins, stay in it for the life of teh voice
         LOOP_WHILE_GATED,  // If a loop begins, loop while gated
-        LOOP_FOR_COUNT     // Loop exactly (n) times
+        LOOP_COUNT         // Loop exactly (n) times
     };
     DECLARE_ENUM_STRING(LoopMode);
 

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -387,7 +387,7 @@ template <bool OS> bool Voice::processWithOS()
                 /*
                  * We implement loop for count by gating on loop count
                  */
-                if (variantData.loopMode == engine::Zone::LOOP_FOR_COUNT)
+                if (variantData.loopMode == engine::Zone::LOOP_COUNT)
                 {
                     // first loop is zero so don't skip -1
                     GD[gidx].gated = GD[gidx].loopCount < variantData.loopCountWhenCounted - 1;
@@ -856,7 +856,7 @@ void Voice::initializeGenerator()
 
             // We doo loop count by gating on loopCount < maxLoopCount
             variantData.loopMode == engine::Zone::LOOP_WHILE_GATED ||
-                variantData.loopMode == engine::Zone::LOOP_FOR_COUNT);
+                variantData.loopMode == engine::Zone::LOOP_COUNT);
         SCLOG_IF(generatorInitialization,
                  "Generator : " << SCD(currGen) << SCD((size_t)Generator[currGen]));
         SCLOG_IF(generatorInitialization, "     SMP  : " << SCD(GDIO[currGen].sampleDataL)


### PR DESCRIPTION
Implemented a new interpolation mode for Shortcircuit XT. A variation of the custom interpolation used in my sfizz fork: sonically, it sounds pretty passable for an early variable-clock DAC sampler: it's like piecewise interpolation but without the excessive aliasing, hence, the title I gave it in the code, but functionally, this additional mode is a modified version of the included sinc interpolation. My changes are rough around the edges, most likely, so revision suggestions from others are welcome.