### PR TITLE
Refactor the Zone RMB to share between mapping pane and tree

### DIFF
--- a/src-ui/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
+++ b/src-ui/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
@@ -428,4 +428,9 @@ void MappingDisplay::filesDropped(const juce::StringArray &files, int x, int y)
     repaint();
 }
 
+void MappingDisplay::doZoneRename(const selection::SelectionManager::ZoneAddress &z)
+{
+    editor->showComingSoon("Rename from Mapping Pane");
+}
+
 } // namespace scxt::ui::app::edit_screen

--- a/src-ui/app/edit-screen/components/mapping-pane/MappingDisplay.h
+++ b/src-ui/app/edit-screen/components/mapping-pane/MappingDisplay.h
@@ -179,6 +179,8 @@ struct MappingDisplay : juce::Component,
     void fileDragExit(const juce::StringArray &files) override;
     void filesDropped(const juce::StringArray &files, int x, int y) override;
 
+    void doZoneRename(const selection::SelectionManager::ZoneAddress &z);
+
     engine::Part::zoneMappingSummary_t summary{};
 };
 

--- a/src-ui/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
+++ b/src-ui/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
@@ -29,6 +29,7 @@
 #include "ZoneLayoutKeyboard.h"
 #include "MappingDisplay.h"
 #include "engine/feature_enums.h"
+#include "app/shared/ZoneRightMouseMenu.h"
 
 namespace scxt::ui::app::edit_screen
 {
@@ -285,48 +286,21 @@ void ZoneLayoutDisplay::showZoneMenu(const selection::SelectionManager::ZoneAddr
     auto p = juce::PopupMenu();
 
     bool added{false};
+    int part{-1};
     for (auto &s : display->summary)
     {
+        part = s.address.part;
         if (s.address == za)
         {
-            namespace cmsg = scxt::messaging::client;
-
+            app::shared::populateZoneRightMouseMenuForZone(display, display, p, za, s.name);
             added = true;
-            p.addSectionHeader(s.name);
-            p.addItem("Rename", [w = juce::Component::SafePointer(this), s]() {
-                if (!w)
-                    return;
-                w->editor->showComingSoon("Rename from Mapping Pane");
-            });
-            p.addItem("Copy", [w = juce::Component::SafePointer(this), s]() {
-                if (!w)
-                    return;
-                w->display->sendToSerialization(cmsg::CopyZone(s.address));
-            });
-            p.addItem("Paste", [w = juce::Component::SafePointer(this), s]() {
-                if (!w)
-                    return;
-                w->display->sendToSerialization(cmsg::PasteZone(s.address));
-            });
-            p.addItem("Duplicate", [w = juce::Component::SafePointer(this), s]() {
-                if (!w)
-                    return;
-                w->display->sendToSerialization(cmsg::DuplicateZone(s.address));
-            });
-            p.addItem("Delete", [w = juce::Component::SafePointer(this), s]() {
-                if (!w)
-                    return;
-                w->display->sendToSerialization(cmsg::DeleteZone(s.address));
-            });
         }
     }
 
     if (added)
         p.addSeparator();
 
-    p.addSectionHeader("All Selected Zones");
-    p.addSeparator();
-    p.addItem("Coming Soon", []() {});
+    app::shared::populateZoneRightMouseMenuForSelectedZones(display, p, part);
 
     p.showMenuAsync(editor->defaultPopupMenuOptions());
 }

--- a/src-ui/app/shared/ZoneRightMouseMenu.h
+++ b/src-ui/app/shared/ZoneRightMouseMenu.h
@@ -1,0 +1,88 @@
+//
+// Created by Paul Walker on 4/4/25.
+//
+
+#ifndef ZONERIGHTMOUSEMENU_H
+#define ZONERIGHTMOUSEMENU_H
+
+#include <juce_gui_basics/juce_gui_basics.h>
+#include "selection/selection_manager.h"
+#include "messaging/client/client_messages.h"
+
+namespace scxt::ui::app::shared
+{
+template <typename SendingComp, typename RenamingComp> // COMP is a HasEditor and a few other things
+void populateZoneRightMouseMenuForZone(SendingComp *that, RenamingComp *rnThat, juce::PopupMenu &p,
+                                       const selection::SelectionManager::ZoneAddress &forZone,
+                                       const std::string &zoneSectionName)
+{
+    namespace cmsg = scxt::messaging::client;
+
+    p.addSectionHeader(zoneSectionName);
+    p.addItem("Rename", [w = juce::Component::SafePointer(rnThat), forZone]() {
+        if (!w)
+            return;
+        w->doZoneRename(forZone);
+    });
+    p.addItem("Copy", [w = juce::Component::SafePointer(that), forZone]() {
+        if (!w)
+            return;
+        w->sendToSerialization(cmsg::CopyZone(forZone));
+    });
+    p.addItem("Paste", [w = juce::Component::SafePointer(that), forZone]() {
+        if (!w)
+            return;
+        w->sendToSerialization(cmsg::PasteZone(forZone));
+    });
+    p.addItem("Duplicate", [w = juce::Component::SafePointer(that), forZone]() {
+        if (!w)
+            return;
+        w->sendToSerialization(cmsg::DuplicateZone(forZone));
+    });
+    p.addItem("Delete", [w = juce::Component::SafePointer(that), forZone]() {
+        if (!w)
+            return;
+        w->sendToSerialization(cmsg::DeleteZone(forZone));
+    });
+}
+
+template <typename SendingComp>
+void populateZoneRightMouseMenuForSelectedZones(SendingComp *that, juce::PopupMenu &p, int part,
+                                                const std::string &name = "")
+{
+    namespace cmsg = scxt::messaging::client;
+
+    if (name.empty())
+        p.addSectionHeader("Selected Zones");
+    else
+        p.addSectionHeader(name);
+
+    p.addItem("Delete All", [w = juce::Component::SafePointer(that)]() {
+        if (!w)
+            return;
+
+        w->sendToSerialization(cmsg::DeleteAllSelectedZones(true));
+    });
+
+    p.addSeparator();
+    p.addSectionHeader("Current Part");
+    p.addItem("Delete All Zones and Groups", [w = juce::Component::SafePointer(that), part]() {
+        if (!w)
+            return;
+
+        w->sendToSerialization(cmsg::ClearPart(part));
+    });
+
+    if (that->editor->hasMissingSamples)
+    {
+        p.addSeparator();
+        p.addItem("Resolve Missing Samples", [w = juce::Component::SafePointer(that)]() {
+            if (!w)
+                return;
+            w->editor->showMissingResolutionScreen();
+        });
+    }
+}
+} // namespace scxt::ui::app::shared
+
+#endif // ZONERIGHTMOUSEMENU_H


### PR DESCRIPTION
Basically put that menu generation in one place. No functional change, unless I got it wrong.