### PR TITLE
Add multifile-browser-preview. Start browser multi-sel

### DIFF
--- a/src/messaging/client/browser_messages.h
+++ b/src/messaging/client/browser_messages.h
@@ -90,15 +90,16 @@ CLIENT_TO_SERIAL(BrowserQueueRefresh, c2s_browser_queue_refresh, browserQueueRef
 SERIAL_TO_CLIENT(SendBrowserQueueLength, s2c_send_browser_queuelength, browserQueueRefreshPayload_t,
                  onBrowserQueueLengthRefresh)
 
-using previewBrowserSamplePayload_t = std::tuple<bool, std::string>;
+using previewBrowserSamplePayload_t = std::tuple<bool, sample::Sample::SampleFileAddress>;
 inline void doPreviewBrowserSample(const previewBrowserSamplePayload_t &p,
                                    const engine::Engine &engine, MessageController &cont)
 {
-    auto [startstop, pathString] = p;
-    auto path = fs::path(fs::u8path(pathString));
+    auto [startstop, sampleAddress] = p;
+
     if (startstop)
     {
-        auto sid = engine.getSampleManager()->loadSampleByPath(path);
+        auto sid = engine.getSampleManager()->loadSampleByFileAddress(sampleAddress, {});
+
         if (sid.has_value())
         {
             auto smp = engine.getSampleManager()->getSample(*sid);
@@ -109,7 +110,8 @@ inline void doPreviewBrowserSample(const previewBrowserSamplePayload_t &p,
         else
         {
             cont.reportErrorToClient("Unable to launch preview",
-                                     "Sample file preview load failed for " + path.u8string());
+                                     "Sample file preview load failed for " +
+                                         sampleAddress.path.u8string());
         }
     }
     else

--- a/src/sample/sample.cpp
+++ b/src/sample/sample.cpp
@@ -526,4 +526,28 @@ std::shared_ptr<Sample> Sample::createMissingPlaceholder(const Sample::SampleFil
     return res;
 }
 
+Sample::SourceType Sample::sourceTypeFromPath(const fs::path &path)
+{
+    if (extensionMatches(path, ".wav"))
+        return SourceType::WAV_FILE;
+    if (extensionMatches(path, ".sf2"))
+        return SourceType::SF2_FILE;
+    if (extensionMatches(path, ".sfz"))
+        return SourceType::SFZ_FILE;
+    if (extensionMatches(path, ".flac"))
+        return SourceType::FLAC_FILE;
+    if (extensionMatches(path, ".mp3"))
+        return SourceType::MP3_FILE;
+    if (extensionMatches(path, ".aif") || extensionMatches(path, ".aiff"))
+        return SourceType::AIFF_FILE;
+    if (extensionMatches(path, ".multisample"))
+        return SourceType::MULTISAMPLE_FILE;
+    if (extensionMatches(path, ".gig"))
+        return SourceType::GIG_FILE;
+
+    SCLOG("Unmatched extension : " << path.u8string());
+    return WAV_FILE;
+    ;
+}
+
 } // namespace scxt::sample

--- a/src/sample/sample.h
+++ b/src/sample/sample.h
@@ -50,6 +50,8 @@ struct alignas(16) Sample : MoveableOnly<Sample>
         GIG_FILE,
     } type{WAV_FILE};
 
+    static SourceType sourceTypeFromPath(const fs::path &path);
+
     Sample() {}
     Sample(const SampleID &sid) : displayName(sid.to_string()), id(sid) {}
     virtual ~Sample();


### PR DESCRIPTION
1. Browser can preview a sample inside a 'cracked' file by the sample address. Basically per sample preview inside gig, sf2, etc... Closes #1585

2. Browser multi-select active and has same mouse behaviour as mac finder. Can't do anything with multi-selected samples yet so only addresses #1541