### PR TITLE
Monoliths for .wav and .aif files

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -92,6 +92,7 @@ static constexpr bool voiceLifecycle{false};
 static constexpr bool generatorInitialization{false};
 static constexpr bool sampleLoadAndPurge{false};
 static constexpr bool missingResolution{false};
+static constexpr bool patchIO{false};
 } // namespace log
 
 } // namespace scxt

--- a/src/patch_io/patch_io.h
+++ b/src/patch_io/patch_io.h
@@ -46,6 +46,28 @@ bool savePart(const fs::path &toFile, const scxt::engine::Engine &, int part,
 bool loadPartInto(const fs::path &fromFile, scxt::engine::Engine &, int part);
 
 bool initFromResourceBundle(scxt::engine::Engine &e, const std::string &file);
+
+struct SCMonolithSampleReader
+{
+    SCMonolithSampleReader(RIFF::File *f);
+    ~SCMonolithSampleReader();
+
+    size_t getSampleCount();
+
+    struct SampleData
+    {
+        std::string filename;
+        std::vector<uint8_t> data;
+    };
+    // Lets avoid copying around that data vector; return bool and populate the ref
+    bool getSampleData(size_t index, SampleData &data);
+
+  private:
+    RIFF::File *file;
+    int version;
+    size_t cacheSampleCount{0};
+    bool cacheSampleCountDone{false};
+};
 } // namespace scxt::patch_io
 
 #endif // SHORTCIRCUITXT_PATCH_IO_H

--- a/src/sample/sample.h
+++ b/src/sample/sample.h
@@ -64,6 +64,7 @@ struct alignas(16) Sample : MoveableOnly<Sample>
     bool load(const fs::path &path);
     bool loadFromSF2(const fs::path &path, sf2::File *f, int sampleIndex);
     bool loadFromGIG(const fs::path &path, gig::File *f, int sampleIndex);
+    bool loadFromSCXTMonolith(const fs::path &path, RIFF::File *f, int sampleIndex);
 
     const fs::path &getPath() const { return mFileName; }
     std::string md5Sum{};

--- a/src/sample/sample_manager.h
+++ b/src/sample/sample_manager.h
@@ -92,6 +92,11 @@ struct SampleManager : MoveableOnly<SampleManager>
                                               gig::File *f, // if this is null I will re-open it
                                               int preset, int instrument, int region);
 
+    std::optional<SampleID>
+    loadSampleFromSCXTMonolith(const fs::path &,
+                               RIFF::File *f, // if this is null I will re-open it
+                               int preset, int instrument, int region);
+
     std::optional<SampleID> setupSampleFromMultifile(const fs::path &, const std::string &md5,
                                                      int idx, void *data, size_t dataSize);
     std::optional<SampleID> loadSampleFromMultiSample(const fs::path &, int idx,
@@ -122,6 +127,26 @@ struct SampleManager : MoveableOnly<SampleManager>
     fs::path relativeRoot;
     void setRelativeRoot(const fs::path &p) { relativeRoot = p; }
     void clearRelativeRoot() { relativeRoot = fs::path{}; }
+
+    std::map<fs::path, int> monolithIndex;
+    fs::path monolithPath;
+
+    void setMonolithBinaryIndex(const fs::path &p, const std::vector<fs::path> &idx)
+    {
+        monolithPath = p;
+        monolithIndex.clear();
+        int fi{0};
+        for (auto &p : idx)
+        {
+            monolithIndex[p] = fi;
+            fi++;
+        }
+    }
+    void clearMonolithBinaryIndex()
+    {
+        monolithPath = fs::path{};
+        monolithIndex.clear();
+    }
 
     typedef std::vector<std::pair<SampleID, Sample::SampleFileAddress>> sampleAddressesAndIds_t;
     sampleAddressesAndIds_t getSampleAddressesAndIDs() const
@@ -193,6 +218,10 @@ struct SampleManager : MoveableOnly<SampleManager>
                                                std::unique_ptr<gig::File>>>
         gigFilesByPath; // last is the md5sum
     std::unordered_map<std::string, std::string> gigMD5ByPath;
+
+    std::unordered_map<std::string, std::unique_ptr<RIFF::File>>
+        scxtMonolithFilesByPath; // last is the md5sum
+    std::unordered_map<std::string, std::string> scxtMonolithMD5ByPath;
 
     std::unordered_map<std::string, std::unique_ptr<ZipArchiveHolder>> zipArchives;
 };

--- a/src/utils.h
+++ b/src/utils.h
@@ -370,9 +370,8 @@ inline std::unordered_map<std::string, E> makeEnumInverse(const E &from, const E
 
 void printStackTrace(int frameDepth = -1);
 
-inline bool extensionMatches(const fs::path &p, const std::string &s)
+inline bool extensionStringMatches(const std::string &pes, const std::string &s)
 {
-    auto pes = p.extension().u8string();
     if (pes.size() != s.size())
         return false;
 
@@ -384,6 +383,12 @@ inline bool extensionMatches(const fs::path &p, const std::string &s)
         return false;
     };
     return std::equal(pes.begin(), pes.end(), s.begin(), cic);
+}
+
+inline bool extensionMatches(const fs::path &p, const std::string &s)
+{
+    auto pes = p.extension().u8string();
+    return extensionStringMatches(pes, s);
 }
 
 inline std::string humanReadableVersion(uint64_t v)


### PR DESCRIPTION
- Store single files in the RIFF as a list
- Load from monolith and remap the sample id
- Retain monolith pointer in subsequent state
- Support wav and aiff

Closes #1014 but begets a collection of other issues