### PR TITLE
Some memory cleanups in FLAC; Mac Standalone improvements

### DIFF
--- a/src/sample/loaders/load_flac.cpp
+++ b/src/sample/loaders/load_flac.cpp
@@ -26,6 +26,8 @@
  */
 #include "sample/sample.h"
 
+#include <memory>
+
 #if SCXT_USE_FLAC
 #include <fstream>
 #include "FLAC++/decoder.h"
@@ -316,6 +318,7 @@ bool Sample::parseFlac(const fs::path &p)
                             meta.playmode = pm_forward_loop;
                     }
                 }
+                delete a;
             }
             else if (si->get_block_type() == FLAC__METADATA_TYPE_STREAMINFO)
             {
@@ -334,6 +337,7 @@ bool Sample::parseFlac(const fs::path &p)
                     auto c = a->get_comment(q);
                     // SCLOG("Field: " << c.get_field_name());
                 }
+                delete a;
             }
             else
             {

--- a/src/sample/sample_manager.h
+++ b/src/sample/sample_manager.h
@@ -159,8 +159,8 @@ struct SampleManager : MoveableOnly<SampleManager>
             {
                 auto prior = sfa.path;
                 sfa.path = reparentPath / sfa.path.filename();
-                SCLOG("SampleManager::getSampleAddressesAndIDs: reparenting " << prior << " to "
-                                                                              << sfa.path);
+                SCLOG_IF(sampleLoadAndPurge, "SampleManager::getSampleAddressesAndIDs: reparenting "
+                                                 << prior << " to " << sfa.path);
             }
             res.emplace_back(k, sfa);
         }


### PR DESCRIPTION
Also do the  (optional) ReleaseChunkMemeory earlier when parsing to avoid having read memory lagging around in the riff reader in patch io

Closes #1600