### PR TITLE
Final tweaks for octave number preference

### DIFF
--- a/src-ui/app/editor-impl/SCXTEditorMenus.cpp
+++ b/src-ui/app/editor-impl/SCXTEditorMenus.cpp
@@ -318,14 +318,16 @@ void SCXTEditor::addUIThemesMenu(juce::PopupMenu &p, bool addTitle)
 
     p.addSeparator();
     p.addSectionHeader("MIDI Octave");
+    auto cv = defaultsProvider.getUserDefaultValue(infrastructure::octave0, 0);
     for (int i = -1; i <= 1; ++i)
     {
-        p.addItem(fmt::format("C{} is MIDI 60", 4 + i),
+        p.addItem(fmt::format("C{} is MIDI 60", 4 + i), true, i == cv,
                   [w = juce::Component::SafePointer(this), i]() {
                       if (w)
                       {
                           w->defaultsProvider.updateUserDefaultValue(infrastructure::octave0, i);
                           sst::basic_blocks::params::ParamMetaData::defaultMidiNoteOctaveOffset = i;
+                          w->repaint();
                       }
                   });
     }


### PR DESCRIPTION
Octave number was in the code base but (1) the menu didn't have a check, (2) it didn't repaint when swapped, and (3) none of that was in #416

So fix 1 and 2 and closes #416