### PR TITLE
Fix state error with variant and sample display

### DIFF
--- a/src-ui/app/edit-screen/components/MacroMappingVariantPane.cpp
+++ b/src-ui/app/edit-screen/components/MacroMappingVariantPane.cpp
@@ -140,6 +140,8 @@ void MacroMappingVariantPane::editorSelectionChanged()
 {
     if (editor->currentLeadZoneSelection.has_value())
         mappingDisplay->setLeadSelection(*(editor->currentLeadZoneSelection));
+
+    sampleDisplay->rebuildForSelectedVariation(sampleDisplay->selectedVariation, true);
     repaint();
 }
 

--- a/src-ui/app/edit-screen/components/mapping-pane/VariantDisplay.h
+++ b/src-ui/app/edit-screen/components/mapping-pane/VariantDisplay.h
@@ -195,6 +195,8 @@ struct VariantDisplay : juce::Component, HasEditor
     std::unique_ptr<sst::jucegui::components::MenuButton> srcButton;
     std::unique_ptr<sst::jucegui::components::GlyphButton> zoomButton;
 
+    std::unique_ptr<juce::Component> noSelectionOverlay;
+
     struct FileInfos : juce::Component, HasEditor
     {
         FileInfos(HasEditor *e) : HasEditor(e->editor) { setInterceptsMouseClicks(false, false); }


### PR DESCRIPTION
basically if no zones are selected sample display did something wonky and if you made an empty zone after selecting a high tab in another variant sample display could crash. Closes #1612