### PR TITLE
Modulator Presets; Browser SCM/SCP phase one

### DIFF
--- a/src-ui/app/edit-screen/components/LFOPane.h
+++ b/src-ui/app/edit-screen/components/LFOPane.h
@@ -88,13 +88,16 @@ struct LfoPane : sst::jucegui::components::NamedPanel, app::HasEditor
     void resized() override;
     void rebuildPanelComponents(); // entirely new components
 
+    void showModulatorShapeMenu();
+    std::string getShapeMenuLabel();
+
     void setActive(int index, bool active);
     void setModulatorStorage(int index, const modulation::ModulatorStorage &mod);
 
     void repositionContentAreaComponents();
 
     std::unique_ptr<shapeAttachment_t> modulatorShapeA;
-    std::unique_ptr<sst::jucegui::components::MenuButtonDiscreteEditor> modulatorShape;
+    std::unique_ptr<sst::jucegui::components::MenuButton> modulatorShape;
 
     std::unique_ptr<triggerAttachment_t> triggerModeA;
     std::unique_ptr<sst::jucegui::components::MultiSwitch> triggerMode;
@@ -103,9 +106,14 @@ struct LfoPane : sst::jucegui::components::NamedPanel, app::HasEditor
     std::unique_ptr<boolAttachment_t> tempoSyncA;
     template <typename T> void setAttachmentAsTemposync(T &t);
 
-    std::array<modulation::ModulatorStorage, engine::lfosPerZone> modulatorStorageData;
+    void doSavePreset();
+    void doLoadPreset();
 
-    void pickPresets();
+    std::string streamToJSON() const;
+    void unstreamFromJSON(const std::string &);
+
+    std::array<modulation::ModulatorStorage, engine::lfosPerZone> modulatorStorageData;
+    std::unique_ptr<juce::FileChooser> fileChooser;
 };
 } // namespace scxt::ui::app::edit_screen
 

--- a/src-ui/connectors/PayloadDataAttachment.h
+++ b/src-ui/connectors/PayloadDataAttachment.h
@@ -513,6 +513,19 @@ template <typename A, typename Msg, typename ABase = A> struct SingleValueFactor
         return {std::move(att), std::move(wid)};
     }
 
+    template <typename... Args>
+    static std::unique_ptr<A> attachOnly(const typename A::payload_t &p, typename A::value_t &val,
+                                         app::HasEditor *e, Args... args)
+    {
+        auto md = scxt::datamodel::describeValue(p, val);
+
+        auto att = std::make_unique<A>(md, val);
+        configureUpdater<Msg, A, ABase>(*att, p, e, std::forward<Args>(args)...);
+
+        e->addSubscription(val, att);
+        return std::move(att);
+    }
+
     template <typename W, typename... Args>
     static void attach(const typename A::payload_t &p, typename A::value_t &val, app::HasEditor *e,
                        std::unique_ptr<A> &aRes, std::unique_ptr<W> &wRes, Args... args)

--- a/src/browser/browser.cpp
+++ b/src/browser/browser.cpp
@@ -54,6 +54,7 @@ Browser::Browser(BrowserDB &db, const infrastructure::DefaultsProvider &dp, cons
     };
     patchIODirectory = create("Patches");
     themeDirectory = create("Themes");
+    modulatorPresetDirectory = create("Modulator Presets");
 }
 
 std::vector<Browser::indexedRootPath_t> Browser::getRootPathsForDeviceView() const
@@ -63,6 +64,7 @@ std::vector<Browser::indexedRootPath_t> Browser::getRootPathsForDeviceView() con
     std::vector<Browser::indexedRootPath_t> res;
     for (const auto &[p, s] : osdef)
         res.emplace_back(p, s, false);
+    res.emplace_back(patchIODirectory, "User Patches", true);
     auto fav = browserDb.getBrowserLocations();
     for (const auto &p : fav)
         res.emplace_back(p.first, p.first.filename().u8string(), p.second);

--- a/src/browser/browser.h
+++ b/src/browser/browser.h
@@ -70,9 +70,10 @@ struct Browser
     /*
      * Paths for user content
      */
-    fs::path userDirectory;    // like "Documents"/Shortcircuit XT
-    fs::path patchIODirectory; // user/Patches
-    fs::path themeDirectory;   // user/Themes
+    fs::path userDirectory;            // like "Documents"/Shortcircuit XT
+    fs::path patchIODirectory;         // user/Patches
+    fs::path themeDirectory;           // user/Themes
+    fs::path modulatorPresetDirectory; // user/Modulator\ Presets
 
     /*
      * Filesystem Views: Very simple. The Browser gives you a set of

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -781,6 +781,16 @@ void Engine::loadSampleIntoSelectedPartAndGroup(const fs::path &p, int16_t rootK
         });
         return;
     }
+    if (extensionMatches(p, ".scm"))
+    {
+        patch_io::loadMulti(p, *this);
+        return;
+    }
+    if (extensionMatches(p, ".scp"))
+    {
+        patch_io::loadPartInto(p, *this, getSelectionManager()->selectedPart);
+        return;
+    }
 
     // OK so what we want to do now is
     // 1. Load this sample on this thread

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -84,6 +84,8 @@ enum ClientToSerializationMessagesIds
     c2s_update_zone_or_group_modstorage_bool_value,
     c2s_update_zone_or_group_modstorage_int16_t_value,
 
+    c2s_update_full_modstorage_for_groups_or_zones,
+
     c2s_update_lead_zone_mapping,
     c2s_update_zone_mapping_float,
     c2s_update_zone_mapping_int16_t,

--- a/src/modulation/modulator_storage.h
+++ b/src/modulation/modulator_storage.h
@@ -170,25 +170,24 @@ SC_DESCRIBE(scxt::modulation::modulators::AdsrStorage, {
 // We describe modulator storage as a compound since we address
 // it that way. Maybe revisit this in the future and split it out
 SC_DESCRIBE(scxt::modulation::ModulatorStorage, {
-    SC_FIELD(modulatorShape,
-             pmd()
-                 .asInt()
-                 .withName("Modulator Shape")
-                 .withRange(modulation::ModulatorStorage::STEP,
-                            modulation::ModulatorStorage::MSEG -
-                                1) /* This -1 turns off MSEG in the menu */
-                 .withUnorderedMapFormatting({
-                     {modulation::ModulatorStorage::STEP, "STEP"},
-                     {modulation::ModulatorStorage::MSEG, "MSEG"},
-                     {modulation::ModulatorStorage::LFO_SINE, "SINE"},
-                     {modulation::ModulatorStorage::LFO_RAMP, "RAMP"},
-                     {modulation::ModulatorStorage::LFO_TRI, "TRI"},
-                     {modulation::ModulatorStorage::LFO_SAW_TRI_RAMP, "SAW-TRI-RMP"},
-                     {modulation::ModulatorStorage::LFO_PULSE, "PULSE"},
-                     {modulation::ModulatorStorage::LFO_SMOOTH_NOISE, "NOISE"},
-                     {modulation::ModulatorStorage::LFO_ENV, "ENV"},
-                     {modulation::ModulatorStorage::LFO_SH_NOISE, "S&H"},
-                 }));
+    SC_FIELD(modulatorShape, pmd()
+                                 .asInt()
+                                 .withName("Modulator Shape")
+                                 .withRange(modulation::ModulatorStorage::STEP,
+                                            modulation::ModulatorStorage::MSEG -
+                                                1) /* This -1 turns off MSEG in the menu */
+                                 .withUnorderedMapFormatting({
+                                     {modulation::ModulatorStorage::STEP, "STEP"},
+                                     {modulation::ModulatorStorage::MSEG, "MSEG"},
+                                     {modulation::ModulatorStorage::LFO_SINE, "SINE"},
+                                     {modulation::ModulatorStorage::LFO_RAMP, "RAMP"},
+                                     {modulation::ModulatorStorage::LFO_TRI, "TRI"},
+                                     {modulation::ModulatorStorage::LFO_SAW_TRI_RAMP, "SAW-RMP"},
+                                     {modulation::ModulatorStorage::LFO_PULSE, "SQR-TRI"},
+                                     {modulation::ModulatorStorage::LFO_SMOOTH_NOISE, "NOISE"},
+                                     {modulation::ModulatorStorage::LFO_ENV, "ENV"},
+                                     {modulation::ModulatorStorage::LFO_SH_NOISE, "S&H"},
+                                 }));
     SC_FIELD(triggerMode, pmd()
                               .asInt()
                               .withName("Trigger")


### PR DESCRIPTION
- Load SCM and SCP from sidebar (no chicken box yet)
- Save scmod and load scmod presets but load doesn't update engine yet
- Re-work the LFO shape menu to be anticipating of preset mode

Addresses a bunch of #778; we also didn't have an issue for this but i will probably just polish it off without one.