### PR TITLE
The MISC (phasor/random) panel; BREAKING change

### DIFF
--- a/src-ui/app/SCXTEditor.h
+++ b/src-ui/app/SCXTEditor.h
@@ -227,6 +227,7 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::DragAndDropCont
 
     void onGroupOrZoneModulatorStorageUpdated(
         const scxt::messaging::client::indexedModulatorStorageUpdate_t &);
+    void onGroupOrZoneMiscModStorageUpdated(const scxt::messaging::client::gzMiscStorageUpdate_t &);
     void onZoneOutputInfoUpdated(const scxt::messaging::client::zoneOutputInfoUpdate_t &p);
     void onGroupOutputInfoUpdated(const scxt::messaging::client::groupOutputInfoUpdate_t &p);
 

--- a/src-ui/app/edit-screen/EditScreen.cpp
+++ b/src-ui/app/edit-screen/EditScreen.cpp
@@ -172,9 +172,7 @@ EditScreen::ZoneOrGroupElements<ZGTrait>::ZoneOrGroupElements(EditScreen *parent
     }
     else
     {
-        lfo->tabNames = {"GLFO 1", "GLFO 2", "GLFO 3", "GLFO 4"};
-        assert(lfo->tabNames.size() == scxt::lfosPerGroup);
-        lfo->resetTabState();
+        lfo->setTabsForGLFO();
         eg[0]->setName("GRP EG1");
         eg[1]->setName("GRP EG2");
 
@@ -248,14 +246,14 @@ void EditScreen::onOtherTabSelection()
     if (!gts.empty())
     {
         auto gt = std::atoi(gts.c_str());
-        if (gt >= 0 && gt < lfosPerGroup)
+        if (gt >= 0 && gt < lfosPerGroup + 1) // for misc
             groupElements->lfo->selectTab(gt);
     }
     auto zts = editor->queryTabSelection(tabKey("multi.zone.lfo"));
     if (!zts.empty())
     {
         auto zt = std::atoi(zts.c_str());
-        if (zt >= 0 && zt < lfosPerZone)
+        if (zt >= 0 && zt < lfosPerZone + 1) // for misc
             zoneElements->lfo->selectTab(zt);
     }
 
@@ -263,14 +261,14 @@ void EditScreen::onOtherTabSelection()
     if (!gts.empty())
     {
         auto gt = std::atoi(gts.c_str());
-        if (gt >= 0 && gt < lfosPerGroup)
+        if (gt >= 0 && gt < 2)
             groupElements->outPane->selectTab(gt);
     }
     zts = editor->queryTabSelection(tabKey("multi.zone.output"));
     if (!zts.empty())
     {
         auto zt = std::atoi(zts.c_str());
-        if (zt >= 0 && zt < lfosPerZone)
+        if (zt >= 0 && zt < 2)
             zoneElements->outPane->selectTab(zt);
     }
     auto mts = editor->queryTabSelection(tabKey("multi.mapping"));

--- a/src-ui/app/edit-screen/components/LFOPane.cpp
+++ b/src-ui/app/edit-screen/components/LFOPane.cpp
@@ -1064,8 +1064,9 @@ struct MiscPanel : juce::Component, HasEditor
         p.addSectionHeader("Phasor Synch Mode");
         p.addSeparator();
         auto gen = [&p, i, this](auto v, auto l) {
+            auto that = this; // grrrr msvc
             p.addItem(l, true, v == ms.phasors[i].syncMode,
-                      [i, w = juce::Component::SafePointer(this), v] {
+                      [i, w = juce::Component::SafePointer(that), v] {
                           if (!w)
                               return;
                           w->ms.phasors[i].syncMode = v;
@@ -1086,8 +1087,9 @@ struct MiscPanel : juce::Component, HasEditor
         p.addSectionHeader("Phasor Division");
         p.addSeparator();
         auto gen = [&p, i, this](auto v, auto l) {
+            auto that = this;
             p.addItem(l, true, v == ms.phasors[i].division,
-                      [i, w = juce::Component::SafePointer(this), v] {
+                      [i, w = juce::Component::SafePointer(that), v] {
                           if (!w)
                               return;
                           w->ms.phasors[i].division = v;
@@ -1108,8 +1110,9 @@ struct MiscPanel : juce::Component, HasEditor
         p.addSectionHeader("Random Distribution");
         p.addSeparator();
         auto gen = [&p, i, this](auto v, auto l) {
+            auto that = this;
             p.addItem(l, true, v == ms.randoms[i].style,
-                      [i, w = juce::Component::SafePointer(this), v] {
+                      [i, w = juce::Component::SafePointer(that), v] {
                           if (!w)
                               return;
                           w->ms.randoms[i].style = v;

--- a/src-ui/app/edit-screen/components/LFOPane.h
+++ b/src-ui/app/edit-screen/components/LFOPane.h
@@ -53,6 +53,7 @@ struct CurveLFOPane;
 struct ENVLFOPane;
 struct MSEGLFOPane;
 struct ConsistencyLFOPane;
+struct MiscPanel;
 
 struct LfoPane : sst::jucegui::components::NamedPanel, app::HasEditor
 {
@@ -79,6 +80,7 @@ struct LfoPane : sst::jucegui::components::NamedPanel, app::HasEditor
     std::unique_ptr<ENVLFOPane> envLfoPane;
     std::unique_ptr<MSEGLFOPane> msegLfoPane;
     std::unique_ptr<ConsistencyLFOPane> consistencyLfoPane;
+    std::unique_ptr<MiscPanel> miscPanel;
 
     bool forZone{true};
 
@@ -94,6 +96,7 @@ struct LfoPane : sst::jucegui::components::NamedPanel, app::HasEditor
 
     void setActive(int index, bool active);
     void setModulatorStorage(int index, const modulation::ModulatorStorage &mod);
+    void setMiscModStorage(const modulation::MiscSourceStorage &mm);
 
     void repositionContentAreaComponents();
 
@@ -113,7 +116,10 @@ struct LfoPane : sst::jucegui::components::NamedPanel, app::HasEditor
     std::optional<std::string> streamToJSON() const;
     void unstreamFromJSON(const std::string &);
 
+    void setTabsForGLFO();
+
     std::array<modulation::ModulatorStorage, engine::lfosPerZone> modulatorStorageData;
+    modulation::MiscSourceStorage miscStorageData;
     std::unique_ptr<juce::FileChooser> fileChooser;
 };
 } // namespace scxt::ui::app::edit_screen

--- a/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -213,6 +213,20 @@ void SCXTEditor::onGroupOrZoneModulatorStorageUpdated(
     }
 }
 
+void SCXTEditor::onGroupOrZoneMiscModStorageUpdated(
+    const scxt::messaging::client::gzMiscStorageUpdate_t &payload)
+{
+    const auto &[forZone, mm] = payload;
+    if (forZone)
+    {
+        editScreen->getZoneElements()->lfo->setMiscModStorage(mm);
+    }
+    else
+    {
+        editScreen->getGroupElements()->lfo->setMiscModStorage(mm);
+    }
+}
+
 void SCXTEditor::onZoneOutputInfoUpdated(const scxt::messaging::client::zoneOutputInfoUpdate_t &p)
 {
     auto [active, inf] = p;

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -51,8 +51,6 @@ static constexpr size_t macrosPerPart{16};
 static constexpr uint16_t numNonMainPluginOutputs{20};
 static constexpr uint16_t numPluginOutputs{numNonMainPluginOutputs + 1};
 
-static constexpr size_t numTransportPhasors{7}; // double whole -> 32
-
 static constexpr uint16_t maxVoices{512};
 
 // some battles are not worth it
@@ -73,6 +71,9 @@ static constexpr uint16_t maxVariantsPerZone{16};
 static constexpr uint16_t lfosPerGroup{4};
 static constexpr uint16_t egsPerGroup{2};
 static constexpr uint16_t processorsPerZoneAndGroup{4};
+
+static constexpr uint16_t phasorsPerGroupOrZone{4};
+static constexpr uint16_t randomsPerGroupOrZone{4};
 
 static constexpr uint16_t triggerConditionsPerGroup{4};
 

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -1029,6 +1029,7 @@ void Engine::onTransportUpdated()
 
 void Engine::updateTransportPhasors()
 {
+#if 0
     float mul = 1 << ((numTransportPhasors - 1) / 2);
     for (int i = 0; i < numTransportPhasors; ++i)
     {
@@ -1036,6 +1037,7 @@ void Engine::updateTransportPhasors()
         transportPhasors[i] = std::modf((float)(transport.timeInBeats) * mul, &rawBeat);
         mul = mul / 2;
     }
+#endif
 }
 
 std::optional<fs::path> Engine::setupUserStorageDirectory()

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -113,7 +113,6 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
 
     sst::basic_blocks::modulators::Transport transport;
     void onTransportUpdated();
-    std::array<float, numTransportPhasors> transportPhasors{};
     void updateTransportPhasors();
 
     /**

--- a/src/engine/group.cpp
+++ b/src/engine/group.cpp
@@ -195,6 +195,7 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
         {
         }
     }
+    phasorEvaluator.step(e.transport, miscSourceStorage);
 
     bool envGate = gated;
     for (int i = 0; i < egsPerGroup; ++i)
@@ -640,6 +641,9 @@ void Group::resetLFOs(int whichLFO)
             SCLOG("Unimplemented modulator shape " << ms.modulatorShape);
         }
     }
+
+    randomEvaluator.evaluate(getEngine()->rng, miscSourceStorage);
+    phasorEvaluator.attack(getEngine()->transport, miscSourceStorage);
 }
 
 bool Group::isActive() const

--- a/src/engine/group.h
+++ b/src/engine/group.h
@@ -202,7 +202,7 @@ struct Group : MoveableOnly<Group>,
     std::array<modulation::modulators::AdsrStorage, egsPerGroup> gegStorage{};
 
     std::array<modulation::ModulatorStorage, lfosPerGroup> modulatorStorage;
-    std::array<modulation::modulators::StepLFO, lfosPerGroup> stepLfos;
+    modulation::MiscSourceStorage miscSourceStorage;
     bool initializedLFOs{false};
 
     modulation::GroupMatrix modMatrix;

--- a/src/engine/zone.cpp
+++ b/src/engine/zone.cpp
@@ -391,6 +391,7 @@ void Zone::onRoutingChanged()
     for (int i = 0; i < egsPerZone; ++i)
         egsActive[i] = false;
     egsActive[0] = true; // the AEG always runs
+    phasorsActive = false;
     auto doCheck = [this, &usedForScanning](const voice::modulation::MatrixEndpoints::SR &src) {
         for (int i = 0; i < lfosPerZone; ++i)
         {
@@ -405,6 +406,14 @@ void Zone::onRoutingChanged()
             if (src == usedForScanning.egSources[i])
             {
                 egsActive[i] = true;
+            }
+        }
+
+        for (int i = 0; i < phasorsPerGroupOrZone; ++i)
+        {
+            if (src == usedForScanning.transportSources.phasors[i])
+            {
+                phasorsActive = true;
             }
         }
     };

--- a/src/engine/zone.h
+++ b/src/engine/zone.h
@@ -244,9 +244,11 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
     void onRoutingChanged();
 
     std::array<modulation::ModulatorStorage, lfosPerZone> modulatorStorage;
+    modulation::MiscSourceStorage miscSourceStorage;
 
     std::array<bool, lfosPerZone> lfosActive{};
     std::array<bool, egsPerZone> egsActive{};
+    bool phasorsActive{};
 
     // 0 is the AEG, 1 is EG2
     std::array<modulation::modulators::AdsrStorage, egsPerZone> egStorage;

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -101,6 +101,7 @@ SC_STREAMDEF(scxt::engine::Engine, SC_FROM({
 
                  // and finally set the sample rate
                  to.getPatch()->setSampleRate(to.getSampleRate());
+                 SCLOG("Unstream and Setup Complete");
              }))
 
 SC_STREAMDEF(scxt::engine::Patch, SC_FROM({
@@ -393,6 +394,7 @@ SC_STREAMDEF(scxt::engine::Group, SC_FROM({
                       {"routingTable", t.routingTable},
                       {"gegStorage", t.gegStorage},
                       {"modulatorStorage", t.modulatorStorage},
+                      {"miscSourceStorage", t.miscSourceStorage},
                       {"processorStorage", t.processorStorage},
                       {"triggerConditions", t.triggerConditions}};
              }),
@@ -405,6 +407,7 @@ SC_STREAMDEF(scxt::engine::Group, SC_FROM({
                  findIf(v, "routingTable", group.routingTable);
                  findIf(v, "triggerConditions", group.triggerConditions);
                  findIfArray(v, "modulatorStorage", group.modulatorStorage);
+                 findIf(v, "miscSourceStorage", group.miscSourceStorage);
                  group.clearZones();
 
                  auto vzones = v.at("zones").get_array();
@@ -586,6 +589,7 @@ SC_STREAMDEF(scxt::engine::Zone, SC_FROM({
                       {"processorStorage", t.processorStorage},
                       {"routingTable", t.routingTable},
                       {"modulatorStorage", t.modulatorStorage},
+                      {"miscSourceStorage", t.miscSourceStorage},
                       {"egs", t.egStorage},
                       {"givenName", useGivenName}};
              }),
@@ -599,6 +603,7 @@ SC_STREAMDEF(scxt::engine::Zone, SC_FROM({
 
                  findIf(v, "routingTable", zone.routingTable);
                  findIfArray(v, "modulatorStorage", zone.modulatorStorage);
+                 findIf(v, "miscSourceStorage", zone.miscSourceStorage);
                  if (v.find("aegStorage"))
                  {
                      findOrDefault(v, "aegStorage", zone.egStorage[0]);

--- a/src/json/modulation_traits.h
+++ b/src/json/modulation_traits.h
@@ -130,6 +130,52 @@ SC_STREAMDEF(modulation::modulators::AdsrStorage, SC_FROM({
                  findOrSet(v, "rShape", 0.f, result.rShape);
              }))
 
+STREAM_ENUM(modulation::modulators::PhasorStorage::Division,
+            modulation::modulators::PhasorStorage::toStringDivision,
+            modulation::modulators::PhasorStorage::fromStringDivision);
+
+STREAM_ENUM(modulation::modulators::PhasorStorage::SyncMode,
+            modulation::modulators::PhasorStorage::toStringSyncMode,
+            modulation::modulators::PhasorStorage::fromStringSyncMode);
+
+SC_STREAMDEF(modulation::modulators::PhasorStorage, SC_FROM({
+                 v = tao::json::empty_object;
+                 using ps = modulation::modulators::PhasorStorage;
+                 addUnlessDefault<val_t>(v, "di", ps::Division::NOTE, from.division);
+                 addUnlessDefault<val_t>(v, "sy", ps::SyncMode::VOICEPOS, from.syncMode);
+                 addUnlessDefault<val_t>(v, "nu", 1, from.numerator);
+                 addUnlessDefault<val_t>(v, "de", 4, from.denominator);
+             }),
+             SC_TO({
+                 using ps = modulation::modulators::PhasorStorage;
+                 findOrSet(v, "di", ps::Division::NOTE, to.division);
+                 findOrSet(v, "sy", ps::SyncMode::VOICEPOS, to.syncMode);
+                 findOrSet(v, "nu", 1, to.numerator);
+                 findOrSet(v, "de", 4, to.denominator);
+             }));
+
+STREAM_ENUM(modulation::modulators::RandomStorage::Style,
+            modulation::modulators::RandomStorage::toStringStyle,
+            modulation::modulators::RandomStorage::fromStringStyle);
+
+SC_STREAMDEF(modulation::modulators::RandomStorage, SC_FROM({
+                 v = tao::json::empty_object;
+                 addUnlessDefault<val_t>(
+                     v, "st", modulation::modulators::RandomStorage::Style::UNIFORM_01, from.style);
+             }),
+             SC_TO({
+                 findOrSet(v, "st", modulation::modulators::RandomStorage::Style::UNIFORM_01,
+                           to.style);
+             }));
+
+SC_STREAMDEF(modulation::MiscSourceStorage, SC_FROM({
+                 v = {{"rs", t.randoms}, {"ps", t.phasors}};
+             }),
+             SC_TO({
+                 findIfArray(v, "rs", to.randoms);
+                 findIfArray(v, "ps", to.phasors);
+             }));
+
 STREAM_ENUM(modulation::ModulatorStorage::ModulatorShape,
             modulation::ModulatorStorage::toStringModulatorShape,
             modulation::ModulatorStorage::fromStringModulatorShape);

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -85,6 +85,7 @@ enum ClientToSerializationMessagesIds
     c2s_update_zone_or_group_modstorage_int16_t_value,
 
     c2s_update_full_modstorage_for_groups_or_zones,
+    c2s_update_miscmod_storage_for_groups_or_zones,
 
     c2s_update_lead_zone_mapping,
     c2s_update_zone_mapping_float,
@@ -200,6 +201,7 @@ enum SerializationToClientMessageIds
     s2c_update_group_matrix_metadata,
     s2c_update_group_matrix,
     s2c_update_group_or_zone_individual_modulator_storage,
+    s2c_update_group_or_zone_miscmod_storage,
     s2c_update_zone_output_info,
     s2c_update_group_output_info,
 

--- a/src/modulation/group_matrix.cpp
+++ b/src/modulation/group_matrix.cpp
@@ -203,11 +203,13 @@ void GroupMatrixEndpoints::Sources::bind(scxt::modulation::GroupMatrix &m, engin
 
     int idx{0};
 
+#if 0
     for (int i = 0; i < scxt::numTransportPhasors; ++i)
     {
         assert(g.getEngine());
         m.bindSourceValue(transportSources.phasors[i], g.getEngine()->transportPhasors[i]);
     }
+#endif
 
     auto *part = g.parentPart;
     for (int i = 0; i < macrosPerPart; ++i)
@@ -217,6 +219,16 @@ void GroupMatrixEndpoints::Sources::bind(scxt::modulation::GroupMatrix &m, engin
 
     m.bindSourceValue(egSource[0], g.eg[0].outBlock0);
     m.bindSourceValue(egSource[1], g.eg[1].outBlock0);
+
+    for (int i = 0; i < scxt::randomsPerGroupOrZone; ++i)
+    {
+        m.bindSourceValue(rngSources.randoms[i], g.randomEvaluator.outputs[i]);
+    }
+
+    for (int i = 0; i < scxt::phasorsPerGroupOrZone; ++i)
+    {
+        m.bindSourceValue(transportSources.phasors[i], g.phasorEvaluator.outputs[i]);
+    }
 }
 
 void GroupMatrixEndpoints::registerGroupModTarget(
@@ -298,7 +310,7 @@ groupMatrixMetadata_t getGroupMatrixMetadata(const engine::Group &g)
     {
         tg.emplace_back(t, identifierDisplayName_t{std::get<0>(fns)(g, t), std::get<1>(fns)(g, t)},
                         std::get<2>(fns)(g, t),
-                        std::get<2>(fns)(g, t)); // GroupMatrixConfig::getIsMultiplicative(t));
+                        std::get<3>(fns)(g, t)); // GroupMatrixConfig::getIsMultiplicative(t));
     }
     std::sort(tg.begin(), tg.end(), tgtCmp);
 

--- a/src/modulation/group_matrix.h
+++ b/src/modulation/group_matrix.h
@@ -245,7 +245,7 @@ struct GroupMatrixEndpoints
     {
         Sources(engine::Engine *e)
             : lfoSources(e), midiCCSources(e), egSource{{'greg', 'eg1 ', 0}, {'greg', 'eg2 ', 0}},
-              transportSources(e), macroSources(e)
+              transportSources(e), rngSources(e), macroSources(e)
         {
             registerGroupModSource(e, egSource[0], "", "EG1");
             registerGroupModSource(e, egSource[1], "", "EG2");
@@ -257,8 +257,9 @@ struct GroupMatrixEndpoints
             midiCCSources;
 
         SR egSource[2];
-        scxt::modulation::shared::TransportSourceBase<SR, 'gtsp', false, registerGroupModSource>
+        scxt::modulation::shared::TransportSourceBase<SR, 'gtsp', registerGroupModSource>
             transportSources;
+        scxt::modulation::shared::RNGSourceBase<SR, 'grng', registerGroupModSource> rngSources;
 
         struct MacroSources
         {

--- a/src/modulation/has_modulators.h
+++ b/src/modulation/has_modulators.h
@@ -35,6 +35,8 @@
 #include "modulation/modulators/steplfo.h"
 #include "modulation/modulators/curvelfo.h"
 #include "modulation/modulators/envlfo.h"
+#include "modulation/modulators/random_evaluator.h"
+#include "modulation/modulators/phasor_evaluator.h"
 #include "sst/cpputils/constructors.h"
 
 namespace scxt::modulation::shared
@@ -76,6 +78,8 @@ template <typename T, size_t egsPerObject> struct HasModulators
     scxt::modulation::modulators::StepLFO stepLfos[lfosPerObject];
     scxt::modulation::modulators::CurveLFO curveLfos[lfosPerObject];
     scxt::modulation::modulators::EnvLFO envLfos[lfosPerObject];
+    scxt::modulation::modulators::RandomEvaluator randomEvaluator;
+    scxt::modulation::modulators::PhasorEvaluator phasorEvaluator;
 
     typedef sst::basic_blocks::modulators::AHDSRShapedSC<
         T, blockSize, sst::basic_blocks::modulators::TwentyFiveSecondExp>
@@ -90,6 +94,7 @@ template <typename T, size_t egsPerObject> struct HasModulators
 
     std::array<bool, lfosPerObject> lfosActive{};
     std::array<bool, egsPerObject> egsActive{};
+    bool phasorsActive;
 
     void setHasModulatorsSampleRate(double sr, double sri) { doubleRate.resetRates(); }
 

--- a/src/modulation/matrix_shared.h
+++ b/src/modulation/matrix_shared.h
@@ -332,35 +332,42 @@ inline void LFOTargetEndpointData<TG, gn>::baseBind(M &m, Z &z)
     bindEl(m, ms, env.rateMulT, ms.envLfoStorage.rateMul, env.rateMulP);
 }
 
-template <typename SR, uint32_t gid, bool includeVoice,
+template <typename SR, uint32_t gid,
           void (*registerSource)(scxt::engine::Engine *, const SR &, const std::string &,
                                  const std::string &)>
 struct TransportSourceBase
 {
     TransportSourceBase(scxt::engine::Engine *e)
     {
-        auto ctr = (scxt::numTransportPhasors - 1) / 2;
-        for (uint32_t i = 0; i < scxt::numTransportPhasors; ++i)
+        for (uint32_t i = 0; i < scxt::phasorsPerGroupOrZone; ++i)
         {
-            std::string name = "Beat";
-            if (i < ctr)
-                name = std::string("Beat / ") + std::to_string(1 << (ctr - i));
-            if (i > ctr)
-                name = std::string("Beat x ") + std::to_string(1 << (i - ctr));
-
             phasors[i] = SR{gid, 'phsr', i};
-            registerSource(e, phasors[i], "Transport", name);
-
-            if constexpr (includeVoice)
-            {
-                voicePhasors[i] = SR{gid, 'vphr', i};
-                registerSource(e, voicePhasors[i], "Transport", "Voice " + name);
-            }
+            std::string lab = "A";
+            lab[0] += i;
+            registerSource(e, phasors[i], "Phasors", "Phasor " + lab);
         }
     }
 
-    std::array<SR, scxt::numTransportPhasors> phasors;
-    std::conditional_t<includeVoice, std::array<SR, scxt::numTransportPhasors>, char> voicePhasors;
+    std::array<SR, scxt::phasorsPerGroupOrZone> phasors;
+};
+
+template <typename SR, uint32_t gid,
+          void (*registerSource)(scxt::engine::Engine *, const SR &, const std::string &,
+                                 const std::string &)>
+struct RNGSourceBase
+{
+    RNGSourceBase(scxt::engine::Engine *e)
+    {
+        for (uint32_t i = 0; i < scxt::phasorsPerGroupOrZone; ++i)
+        {
+            randoms[i] = SR{gid, 'rnds', i};
+            std::string lab = "A";
+            lab[0] += i;
+            registerSource(e, randoms[i], "Random", "Random " + lab);
+        }
+    }
+
+    std::array<SR, scxt::randomsPerGroupOrZone> randoms;
 };
 
 template <typename SR, uint32_t gid, size_t numLfo,

--- a/src/modulation/modulator_storage.cpp
+++ b/src/modulation/modulator_storage.cpp
@@ -29,6 +29,83 @@
 
 namespace scxt::modulation
 {
+namespace modulators
+{
+
+std::string PhasorStorage::toStringDivision(const Division &s)
+{
+    switch (s)
+    {
+    case Division::NOTE:
+        return "n";
+    case Division::TRIPLET:
+        return "t";
+    case Division::DOTTED:
+        return "d";
+    }
+    return "ERR";
+}
+
+PhasorStorage::Division PhasorStorage::fromStringDivision(const std::string &s)
+{
+    static auto inverse = makeEnumInverse<PhasorStorage::Division, PhasorStorage::toStringDivision>(
+        PhasorStorage::Division::NOTE, PhasorStorage::Division::DOTTED);
+    auto p = inverse.find(s);
+    if (p == inverse.end())
+        return PhasorStorage::Division::NOTE;
+    return p->second;
+}
+
+std::string PhasorStorage::toStringSyncMode(const SyncMode &s)
+{
+    switch (s)
+    {
+    case SyncMode::SONGPOS:
+        return "sp";
+    case SyncMode::VOICEPOS:
+        return "vp";
+    }
+    return "ERR";
+}
+
+PhasorStorage::SyncMode PhasorStorage::fromStringSyncMode(const std::string &s)
+{
+    static auto inverse = makeEnumInverse<PhasorStorage::SyncMode, PhasorStorage::toStringSyncMode>(
+        PhasorStorage::SyncMode::SONGPOS, PhasorStorage::SyncMode::VOICEPOS);
+    auto p = inverse.find(s);
+    if (p == inverse.end())
+        return PhasorStorage::SyncMode::VOICEPOS;
+    return p->second;
+}
+
+std::string RandomStorage::toStringStyle(const Style &s)
+{
+    switch (s)
+    {
+    case RandomStorage::Style::UNIFORM_01:
+        return "u01";
+    case RandomStorage::Style::HALF_NORMAL:
+        return "hfn";
+    case RandomStorage::Style::NORMAL:
+        return "nm";
+    case RandomStorage::Style::UNIFORM_BIPOLAR:
+        return "ubp";
+    }
+    return "ERR";
+}
+
+RandomStorage::Style RandomStorage::fromStringStyle(const std::string &s)
+{
+    static auto inverse = makeEnumInverse<RandomStorage::Style, RandomStorage::toStringStyle>(
+        RandomStorage::Style::UNIFORM_01, RandomStorage::Style::HALF_NORMAL);
+    auto p = inverse.find(s);
+    if (p == inverse.end())
+        return RandomStorage::Style::UNIFORM_01;
+    return p->second;
+}
+
+} // namespace modulators
+
 std::string ModulatorStorage::toStringModulatorShape(
     const scxt::modulation::ModulatorStorage::ModulatorShape &ms)
 {

--- a/src/modulation/modulator_storage.h
+++ b/src/modulation/modulator_storage.h
@@ -72,6 +72,38 @@ struct EnvLFOStorage
     float rateMul{0.f};
     bool loop{false};
 };
+
+struct PhasorStorage
+{
+    enum SyncMode
+    {
+        SONGPOS,
+        VOICEPOS
+    } syncMode{VOICEPOS};
+    DECLARE_ENUM_STRING(SyncMode);
+
+    enum Division
+    {
+        NOTE,
+        TRIPLET,
+        DOTTED
+    } division{NOTE};
+    DECLARE_ENUM_STRING(Division);
+
+    int32_t numerator{1}, denominator{4};
+};
+
+struct RandomStorage
+{
+    enum Style
+    {
+        UNIFORM_01,
+        UNIFORM_BIPOLAR,
+        NORMAL,
+        HALF_NORMAL
+    } style{UNIFORM_01};
+    DECLARE_ENUM_STRING(Style);
+};
 } // namespace modulators
 
 struct ModulatorStorage
@@ -123,6 +155,12 @@ struct ModulatorStorage
     inline bool isCurve() const { return !isStep() && !isEnv() && !isMSEG(); }
 
     bool modulatorConsistent{true};
+};
+
+struct MiscSourceStorage
+{
+    std::array<modulators::PhasorStorage, scxt::phasorsPerGroupOrZone> phasors;
+    std::array<modulators::RandomStorage, scxt::randomsPerGroupOrZone> randoms;
 };
 
 inline double secondsToNormalizedEnvTime(double s)
@@ -253,6 +291,20 @@ SC_DESCRIBE(scxt::modulation::ModulatorStorage, {
                                         .withFeature(pmd::Features::ALLOW_FRACTIONAL_TYPEINS)
                                         .withName("Rate Multiplier"));
     SC_FIELD(envLfoStorage.loop, pmd().asBool().withDefault(0.0).withName("Loop"));
-})
+});
+
+SC_DESCRIBE(scxt::modulation::modulators::PhasorStorage,
+            SC_FIELD(numerator, pmd()
+                                    .asInt()
+                                    .withLinearScaleFormatting("")
+                                    .withDefault(1)
+                                    .withName("Numerator")
+                                    .withRange(1, 64));
+            SC_FIELD(denominator, pmd()
+                                      .asInt()
+                                      .withLinearScaleFormatting("")
+                                      .withDefault(4)
+                                      .withName("Denominator")
+                                      .withRange(1, 64));)
 
 #endif // SHORTCIRCUITXT_MODULATOR_STORAGE_H

--- a/src/modulation/modulators/phasor_evaluator.h
+++ b/src/modulation/modulators/phasor_evaluator.h
@@ -1,0 +1,81 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_MODULATION_MODULATORS_PHASOR_EVALUATOR_H
+#define SCXT_SRC_MODULATION_MODULATORS_PHASOR_EVALUATOR_H
+
+#include <array>
+#include "configuration.h"
+#include "sst/basic-blocks/dsp/RNG.h"
+#include "modulation/modulator_storage.h"
+
+namespace scxt::modulation::modulators
+{
+struct PhasorEvaluator
+{
+    std::array<float, scxt::phasorsPerGroupOrZone> outputs;
+
+    double lastAttackTime{0};
+
+    void attack(sst::basic_blocks::modulators::Transport &transport,
+                modulation::MiscSourceStorage &rs)
+    {
+        lastAttackTime = transport.timeInBeats;
+    }
+
+    void step(sst::basic_blocks::modulators::Transport &transport,
+              modulation::MiscSourceStorage &rs)
+    {
+        for (int i = 0; i < scxt::phasorsPerGroupOrZone; i++)
+        {
+            auto ps = rs.phasors[i];
+            // this is upside down to spare a divide later
+            auto rat = 0.25 * ps.denominator / ps.numerator;
+            switch (ps.division)
+            {
+            case PhasorStorage::TRIPLET:
+                rat *= 3.0 / 2.0; // 1/8 node triplet is 1/3 of a beta not 1/2 a beat
+                break;
+            case PhasorStorage::DOTTED:
+                rat *= 2.0 / 3.0;
+                break;
+            case PhasorStorage::NOTE:
+                break;
+            }
+            auto tm = transport.timeInBeats;
+            if (ps.syncMode == PhasorStorage::VOICEPOS)
+            {
+                tm -= lastAttackTime;
+            }
+
+            auto pr = tm * rat;
+            outputs[i] = pr - std::floor(pr);
+        }
+    }
+};
+} // namespace scxt::modulation::modulators
+#endif // PHASOR_EVALUATOR_H

--- a/src/modulation/modulators/random_evaluator.h
+++ b/src/modulation/modulators/random_evaluator.h
@@ -1,0 +1,64 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_MODULATION_MODULATORS_RANDOM_EVALUATOR_H
+#define SCXT_SRC_MODULATION_MODULATORS_RANDOM_EVALUATOR_H
+
+#include <array>
+#include "configuration.h"
+#include "sst/basic-blocks/dsp/RNG.h"
+#include "modulation/modulator_storage.h"
+
+namespace scxt::modulation::modulators
+{
+struct RandomEvaluator
+{
+    std::array<float, scxt::randomsPerGroupOrZone> outputs;
+    void evaluate(sst::basic_blocks::dsp::RNG &rng, const modulation::MiscSourceStorage &rs)
+    {
+        for (int i = 0; i < scxt::randomsPerGroupOrZone; i++)
+        {
+            switch (rs.randoms[i].style)
+            {
+            case modulation::modulators::RandomStorage::UNIFORM_01:
+                outputs[i] = rng.unif01();
+                break;
+            case modulation::modulators::RandomStorage::UNIFORM_BIPOLAR:
+                outputs[i] = rng.unifPM1();
+                break;
+            case modulation::modulators::RandomStorage::NORMAL:
+                outputs[i] = rng.normPM1();
+                break;
+            case modulation::modulators::RandomStorage::HALF_NORMAL:
+                outputs[i] = rng.half01();
+                break;
+            }
+        }
+    }
+};
+} // namespace scxt::modulation::modulators
+#endif

--- a/src/modulation/voice_matrix.cpp
+++ b/src/modulation/voice_matrix.cpp
@@ -163,17 +163,14 @@ void MatrixEndpoints::Sources::bind(scxt::voice::modulation::Matrix &m, engine::
     m.bindSourceValue(voiceSources.samplePercentage, v.currentSamplePercentageF);
     m.bindSourceValue(voiceSources.loopPercentage, v.currentLoopPercentageF);
 
-    for (int i = 0; i < scxt::numTransportPhasors; ++i)
+    for (int i = 0; i < scxt::phasorsPerGroupOrZone; ++i)
     {
-        m.bindSourceValue(transportSources.phasors[i], z.getEngine()->transportPhasors[i]);
-        m.bindSourceValue(transportSources.voicePhasors[i], v.transportPhasors[i]);
+        m.bindSourceValue(transportSources.phasors[i], v.phasorEvaluator.outputs[i]);
     }
 
-    for (int i = 0; i < 8; ++i)
+    for (int i = 0; i < scxt::randomsPerGroupOrZone; ++i)
     {
-        bool bip = (i % 4 > 1) ? false : true;
-        int dist = (i < 4) ? 0 : 1;
-        m.bindSourceConstantValue(rngSources.randoms[i], randomRoll(bip, dist));
+        m.bindSourceValue(rngSources.randoms[i], v.randomEvaluator.outputs[i]);
     }
 
     auto *part = z.parentGroup->parentPart;

--- a/src/modulation/voice_matrix.h
+++ b/src/modulation/voice_matrix.h
@@ -328,26 +328,9 @@ struct MatrixEndpoints
             SR isLooping, loopPercentage, samplePercentage;
         } voiceSources;
 
-        scxt::modulation::shared::TransportSourceBase<SR, 'ztsp', true, registerVoiceModSource>
+        scxt::modulation::shared::TransportSourceBase<SR, 'ztsp', registerVoiceModSource>
             transportSources;
-
-        struct RNGSources
-        {
-            RNGSources(engine::Engine *e)
-            {
-                for (uint32_t i = 0; i < 8; ++i)
-                {
-                    std::string name = "";
-                    name = (i % 4 > 1) ? "Unipolar " : "Bipolar ";
-                    name += (i < 4) ? "Even " : "Gaussian ";
-                    name += std::to_string(i % 2 + 1);
-
-                    randoms[i] = SR{'zrng', 'rnds', i};
-                    registerVoiceModSource(e, randoms[i], "Random", name);
-                }
-            }
-            SR randoms[8];
-        } rngSources;
+        scxt::modulation::shared::RNGSourceBase<SR, 'zrng', registerVoiceModSource> rngSources;
 
         struct MacroSources
         {

--- a/src/selection/selection_manager.cpp
+++ b/src/selection/selection_manager.cpp
@@ -539,6 +539,9 @@ void SelectionManager::sendDisplayDataForZonesBasedOnLead(int p, int g, int z)
             cms::indexedModulatorStorageUpdate_t{true, true, i, zp->modulatorStorage[i]},
             *(engine.getMessageController()));
     }
+    serializationSendToClient(cms::s2c_update_group_or_zone_miscmod_storage,
+                              cms::gzMiscStorageUpdate_t{true, zp->miscSourceStorage},
+                              *(engine.getMessageController()));
 
     /*
      * Processors, Output and ModMatrix have multi-select merge rules which are different
@@ -651,6 +654,9 @@ void SelectionManager::sendDisplayDataForSingleGroup(int part, int group)
             cms::indexedModulatorStorageUpdate_t{false, true, i, g->modulatorStorage[i]},
             *(engine.getMessageController()));
     }
+    serializationSendToClient(cms::s2c_update_group_or_zone_miscmod_storage,
+                              cms::gzMiscStorageUpdate_t{false, g->miscSourceStorage},
+                              *(engine.getMessageController()));
 
     for (int i = 0; i < engine::processorCount; ++i)
     {

--- a/src/voice/voice.h
+++ b/src/voice/voice.h
@@ -118,7 +118,6 @@ struct alignas(16) Voice : MoveableOnly<Voice>,
         return dsp::twoToTheXTable;
     }
 
-    float transportPhasors[scxt::numTransportPhasors];
     double startBeat{0.f};
     void updateTransportPhasors();
 


### PR DESCRIPTION
Closes #1278
This is a BREAKING change for folks who used random or transport before.

Add a phasor and random pane to the modulator section Add appropriate data messages and UI to handle and stream Add engines internally which evaluate both for group and zone Group random is wierdly impacted by attack. Will open a separate issue for that.