### PR TITLE
"MOve Selected Groups To New Group" RMB

### DIFF
--- a/src-ui/app/shared/ZoneRightMouseMenu.h
+++ b/src-ui/app/shared/ZoneRightMouseMenu.h
@@ -34,6 +34,9 @@
 
 namespace scxt::ui::app::shared
 {
+inline void findOtherGroups(SCXTEditor *e, const selection::SelectionManager::ZoneAddress &forZone)
+{
+}
 template <typename SendingComp, typename RenamingComp> // COMP is a HasEditor and a few other things
 void populateZoneRightMouseMenuForZone(SendingComp *that, RenamingComp *rnThat, juce::PopupMenu &p,
                                        const selection::SelectionManager::ZoneAddress &forZone,
@@ -67,6 +70,17 @@ void populateZoneRightMouseMenuForZone(SendingComp *that, RenamingComp *rnThat, 
             return;
         w->sendToSerialization(cmsg::DeleteZone(forZone));
     });
+
+    auto moveMenu = juce::PopupMenu();
+    moveMenu.addItem("New Group", [w = juce::Component::SafePointer(that), forZone]() {
+        if (!w)
+            return;
+        w->sendToSerialization(cmsg::MoveZonesFromTo(
+            {{forZone},
+             selection::SelectionManager::ZoneAddress{w->editor->selectedPart, -1, -1}}));
+    });
+    moveMenu.addItem("New Duplicate Group", false, false, []() {});
+    p.addSubMenu("Move to", moveMenu);
 }
 
 template <typename SendingComp>
@@ -86,6 +100,16 @@ void populateZoneRightMouseMenuForSelectedZones(SendingComp *that, juce::PopupMe
 
         w->sendToSerialization(cmsg::DeleteAllSelectedZones(true));
     });
+
+    auto moveMenu = juce::PopupMenu();
+    moveMenu.addItem("New Group", [w = juce::Component::SafePointer(that)]() {
+        if (!w)
+            return;
+        w->sendToSerialization(cmsg::MoveZonesFromTo(
+            {{}, selection::SelectionManager::ZoneAddress{w->editor->selectedPart, -1, -1}}));
+    });
+    moveMenu.addItem("New Duplicate Group", false, false, []() {});
+    p.addSubMenu("Move All to", moveMenu);
 
     p.addSeparator();
     p.addSectionHeader("Current Part");

--- a/src/messaging/client/structure_messages.h
+++ b/src/messaging/client/structure_messages.h
@@ -331,16 +331,14 @@ using zoneAddressFromTo_t = std::pair<std::set<selection::SelectionManager::Zone
 inline void moveZonesFromTo(const zoneAddressFromTo_t &payload, engine::Engine &engine,
                             MessageController &cont)
 {
-    auto &src = payload.first;
+    auto src = payload.first;
     auto &tgt = payload.second;
 
     if (src.empty())
     {
-        cont.reportErrorToClient(
-            "Software Error: Emtpy set moved",
-            "Somehow MoveSoneFromTo had an empty source set. Please report this error condition "
-            "to the develoeprs along with an idea of what you did to get here (if possible).");
-        return;
+        auto sz = engine.getSelectionManager()->currentlySelectedZones();
+        src = std::set<selection::SelectionManager::ZoneAddress>(sz.begin(), sz.end());
+        SCLOG("Empty src so we populated it with " << src.size() << " zones");
     }
     assert(src.begin()->part == tgt.part);
 
@@ -410,7 +408,7 @@ inline void moveZonesFromTo(const zoneAddressFromTo_t &payload, engine::Engine &
             {
                 // they've all been added at the end
                 auto zc = engine.getPatch()->getPart(t.part)->getGroup(t.group)->getZones().size() -
-                          1 - ss.size();
+                          -ss.size();
                 for (int i = 0; i < ss.size(); i++)
                 {
                     // retain the selection set


### PR DESCRIPTION
As part of restructuring these move and sidebar messages I can just pop in a quicl proof of concept for move to new group in the RMB on both sidebar and mapping pane.

Closes #1201
Addresses #1653 (which really subsumes #1201)

This is just a tiny subset of the RMB but it lets me close off that issue and ship the feature at least.