### PR TITLE
Fix Noise LFO; Warn on non-formatted processors

### DIFF
--- a/src/dsp/processor/processor_impl.h
+++ b/src/dsp/processor/processor_impl.h
@@ -301,6 +301,12 @@ template <typename T> struct SSTVoiceEffectShim : T
         {
             res.supportsTemposync =
                 res.supportsTemposync || res.floatControlDescriptions[i].canTemposync;
+            if (!res.floatControlDescriptions[i].supportsStringConversion)
+            {
+                SCLOG("Warning: processor param " << i << " "
+                                                  << res.floatControlDescriptions[i].name
+                                                  << " does not support string conversion");
+            }
         }
 
         if constexpr (HasMemFn_checkParameterConsistency<T>::value)


### PR DESCRIPTION
1. Fix a problem where dPhase and noise LFO conlicted. Addresses #1021
2. Log when a processor is missing a string formattable param, which leads to bad ui experience in various spots. Addresses #1678