### PR TITLE
Fix drag non-sel row in sidebar with multi enabled

### DIFF
--- a/src-ui/app/edit-screen/components/GroupZoneTreeControl.h
+++ b/src-ui/app/edit-screen/components/GroupZoneTreeControl.h
@@ -360,7 +360,7 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
             {
                 if (auto *container = juce::DragAndDropContainer::findParentDragContainerFor(this))
                 {
-                    if (lbm->selectedZones.size() > 1 && !e.mods.isShiftDown())
+                    if (isSelected && lbm->selectedZones.size() > 1 && !e.mods.isShiftDown())
                     {
                         isDragMulti = true;
                     }

--- a/src/modulation/has_modulators.h
+++ b/src/modulation/has_modulators.h
@@ -30,7 +30,6 @@
 
 #include "configuration.h"
 
-#include "sst/basic-blocks/modulators/ADSREnvelope.h"
 #include "sst/basic-blocks/modulators/AHDSRShapedSC.h"
 #include "modulation/modulators/steplfo.h"
 #include "modulation/modulators/curvelfo.h"
@@ -49,9 +48,9 @@ template <typename T, size_t egsPerObject> struct HasModulators
 {
     struct DoubleRate
     {
-        double sampleRate, sampleRateInv;
+        double sampleRate{1}, sampleRateInv{1};
         T *that{nullptr};
-        DoubleRate(T *that) : that(that) { resetRates(); }
+        explicit DoubleRate(T *that) : that(that) { resetRates(); }
         void resetRates()
         {
             sampleRate = that->sampleRate * 2;
@@ -75,11 +74,11 @@ template <typename T, size_t egsPerObject> struct HasModulators
         ENV,
         MSEG
     } lfoEvaluator[lfosPerObject]{};
-    scxt::modulation::modulators::StepLFO stepLfos[lfosPerObject];
-    scxt::modulation::modulators::CurveLFO curveLfos[lfosPerObject];
-    scxt::modulation::modulators::EnvLFO envLfos[lfosPerObject];
-    scxt::modulation::modulators::RandomEvaluator randomEvaluator;
-    scxt::modulation::modulators::PhasorEvaluator phasorEvaluator;
+    std::array<scxt::modulation::modulators::StepLFO, lfosPerObject> stepLfos{};
+    std::array<scxt::modulation::modulators::CurveLFO, lfosPerObject> curveLfos{};
+    std::array<scxt::modulation::modulators::EnvLFO, lfosPerObject> envLfos{};
+    scxt::modulation::modulators::RandomEvaluator randomEvaluator{};
+    scxt::modulation::modulators::PhasorEvaluator phasorEvaluator{};
 
     typedef sst::basic_blocks::modulators::AHDSRShapedSC<
         T, blockSize, sst::basic_blocks::modulators::TwentyFiveSecondExp>
@@ -94,7 +93,7 @@ template <typename T, size_t egsPerObject> struct HasModulators
 
     std::array<bool, lfosPerObject> lfosActive{};
     std::array<bool, egsPerObject> egsActive{};
-    bool phasorsActive;
+    bool phasorsActive{false};
 
     void setHasModulatorsSampleRate(double sr, double sri) { doubleRate.resetRates(); }
 


### PR DESCRIPTION
Dragging a single non selected row when multiple were selected would drigger the multi-drag improperly. Fix. Closes #1654

Also some cleanups from clang-tidy on has_modulators