### PR TITLE
Don't use auto-oversampling in ZOH modes

### DIFF
--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -872,6 +872,10 @@ void Voice::initializeGenerator()
         useOversampling = std::abs(GD[currGen].ratio) > 18000000 || forceOversample;
         GD[currGen].blockSize = blockSize * (useOversampling ? 2 : 1);
 
+        if (!forceOversample && (variantData.interpolationType == dsp::ZeroOrderHold ||
+                                 variantData.interpolationType == dsp::ZOHAA))
+            useOversampling = false;
+
         Generator[currGen] = nullptr;
 
         monoGenerator[currGen] = s->channels == 1;


### PR DESCRIPTION
but still respoect the force oversampling at group level

Closes #1285