### PR TITLE
Refresh browser list before select on expand

### DIFF
--- a/src-ui/app/browser-ui/BrowserPane.cpp
+++ b/src-ui/app/browser-ui/BrowserPane.cpp
@@ -353,11 +353,13 @@ struct DriveFSArea : juce::Component, HasEditor
                 after = contents.insert(after, {contents[row].dirent, false, c});
                 after++;
             }
-
-            listView->rowSelected(row + 1, true);
         }
         ent.isExpanded = true;
         listView->refresh();
+        if (!ct.empty())
+        {
+            listView->rowSelected(row + 1, true);
+        }
     }
     void collapsMultifile(int row)
     {


### PR DESCRIPTION
Which basically fixes an expand-last-row crash.
Closes #1540