### PR TITLE
Slice-point detents in loop and start/end drag

### DIFF
--- a/src-ui/app/edit-screen/components/mapping-pane/SampleWaveform.h
+++ b/src-ui/app/edit-screen/components/mapping-pane/SampleWaveform.h
@@ -58,6 +58,8 @@ struct SampleWaveform : juce::Component, HasEditor, sst::jucegui::components::Zo
     }
 
     juce::Rectangle<int> startSampleHZ, endSampleHZ, startLoopHZ, endLoopHZ, fadeLoopHz;
+    std::vector<std::pair<int, int>> slicePixelAndSamplePositions;
+    static constexpr int sliceSnapZoneInPixels{4};
     void rebuildHotZones();
 
     // Anticipating future drag and so forth gestures


### PR DESCRIPTION
In the samplewaveform, if there are slices, add a small (4px) radius detent / stop around slice points.

Closes #513