### PR TITLE
Replace juce::AlertWindow with a jucegui overlay

### DIFF
--- a/src-ui/app/SCXTEditor.h
+++ b/src-ui/app/SCXTEditor.h
@@ -41,6 +41,7 @@
 #include "sst/jucegui/components/ToolTip.h"
 #include "sst/jucegui/accessibility/FocusDebugger.h"
 #include "sst/jucegui/components/WindowPanel.h"
+#include "sst/jucegui/screens/ScreenHolder.h"
 #include "sst/jucegui/style/JUCELookAndFeelAdapter.h"
 #include "sst/basic-blocks/dsp/RNG.h"
 #include "messaging/client/zone_messages.h"
@@ -91,7 +92,9 @@ struct AboutScreen;
 struct LogScreen;
 } // namespace other_screens
 
-struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::DragAndDropContainer
+struct SCXTEditor : sst::jucegui::components::WindowPanel,
+                    juce::DragAndDropContainer,
+                    sst::jucegui::screens::ScreenHolder<SCXTEditor>
 {
     // The message controller is needed to communicate
     messaging::MessageController &msgCont;
@@ -312,8 +315,7 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel, juce::DragAndDropCont
     std::queue<std::string> callbackQueue;
     engine::Engine::EngineStatusMessage engineStatus;
 
-    std::function<void()> makeComingSoon(const std::string &feature = "This feature") const;
-    void showComingSoon(const std::string &feature = "This feature") const;
+    std::function<void()> makeComingSoon(const std::string &feature = "This feature");
 
     void promptOKCancel(
         const std::string &title, const std::string &message, std::function<void()> onOK,

--- a/src-ui/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
+++ b/src-ui/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
@@ -439,7 +439,7 @@ void MappingDisplay::filesDropped(const juce::StringArray &files, int x, int y)
 
 void MappingDisplay::doZoneRename(const selection::SelectionManager::ZoneAddress &z)
 {
-    editor->showComingSoon("Rename from Mapping Pane");
+    editor->makeComingSoon("Rename from Mapping Pane")();
 }
 
 } // namespace scxt::ui::app::edit_screen

--- a/src/messaging/client/interaction_messages.h
+++ b/src/messaging/client/interaction_messages.h
@@ -42,7 +42,11 @@ SERIAL_TO_CLIENT(ReportError, s2c_report_error, s2cError_t, onErrorFromEngine);
 
 inline void raiseDebugError(MessageController &c)
 {
-    c.reportErrorToClient("A Dummy Error", "This is a dummy error");
+    c.reportErrorToClient("A Dummy Error",
+                          "This is a dummy error. I chose to have it have "
+                          "a very long message like this one so I can test multiline "
+                          "string rendering in the error box. So this one has details like "
+                          "this and that");
 }
 CLIENT_TO_SERIAL(RaiseDebugError, c2s_raise_debug_error, bool, raiseDebugError(cont))
 


### PR DESCRIPTION
which could be better of course but at least now we have it controlled and coherent and have a strategy for future modal and non-modal overlays. Closes #1145 