### PR TITLE
Fix a streaming nomralization regression

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -33,7 +33,7 @@
 
 namespace scxt
 {
-static constexpr uint64_t currentStreamingVersion{0x2024'08'18};
+static constexpr uint64_t currentStreamingVersion{0x2025'06'19};
 
 static constexpr uint16_t blockSize{16};
 static constexpr uint16_t blockSizeQuad{16 >> 2};

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -563,9 +563,25 @@ SC_STREAMDEF(scxt::engine::Zone::SingleVariant, SC_FROM({
                      findOrSet(v, "interpolationType", dsp::InterpolationTypes::Sinc,
                                s.interpolationType);
                      findOrSet(v, "loopCountWhenCounted", 0, s.loopCountWhenCounted);
-                     findOrSet(v, "normalizationAmplitude", 0.f, s.normalizationAmplitude);
+
+                     findOrSet(v, "normalizationAmplitude", 1.f, s.normalizationAmplitude);
+                     findOrSet(v, "amplitude", 1.f, s.amplitude);
+                     if (SC_UNSTREAMING_FROM_PRIOR_TO(0x2025'06'19))
+                     {
+                         /*
+                          * These versions were streamed as zeros when unimplemented.
+                          * When I implemented them I implemented them as amplitude not
+                          * db in the engine, so fix. But there was a week or two where
+                          * the old version had the correc stream so level check before
+                          * whacking.
+                          */
+                         if (s.normalizationAmplitude < 1e-3)
+                             s.normalizationAmplitude = 1;
+                         if (s.amplitude < 1e-3)
+                             s.amplitude = 1;
+                     }
+
                      findOrSet(v, "pitchOffset", 0.f, s.pitchOffset);
-                     findOrSet(v, "amplitude", 0.f, s.amplitude);
                      findOrSet(v, "pan", 0.f, s.pan);
                  }
                  else


### PR DESCRIPTION
in  d7ca5de5 I introduced active normalization and amplitude per variant but these values had been streamed with placeholder zero. When I implemented I used amplitude not db as the in-engine value. So I need to set them to 1, not zero, when unstreaming old systems.

Closes #1703