### PR TITLE
Unused Busses optimization, Hotel California edition

### DIFF
--- a/src/engine/part.cpp
+++ b/src/engine/part.cpp
@@ -97,7 +97,7 @@ void Part::process(Engine &e)
             }
             else
             {
-                auto &obus = e.getPatch()->busses.busByAddress(bi);
+                auto &obus = e.getPatch()->getBusForOutput(bi);
 
                 blk::accumulate_from_to<blockSize>(g->output[0], obus.output[0]);
                 blk::accumulate_from_to<blockSize>(g->output[1], obus.output[1]);
@@ -120,7 +120,7 @@ void Part::process(Engine &e)
             }
         }
 
-        auto &obus = e.getPatch()->busses.busByAddress(bi);
+        auto &obus = e.getPatch()->getBusForOutput(bi);
 
         blk::accumulate_from_to<blockSize>(defOut[0], obus.output[0]);
         blk::accumulate_from_to<blockSize>(defOut[1], obus.output[1]);

--- a/src/engine/patch.cpp
+++ b/src/engine/patch.cpp
@@ -52,6 +52,10 @@ void Patch::process(Engine &e)
 
     for (auto &b : busses.partBusses)
     {
+        if (!busses.busUsed[b.address])
+        {
+            continue;
+        }
         b.process();
         if (b.busSendStorage.supportsSends && b.busSendStorage.hasSends)
         {
@@ -59,6 +63,7 @@ void Patch::process(Engine &e)
             {
                 if (b.busSendStorage.sendLevels[i] != 0.f)
                 {
+                    busses.busUsed[i + AUX_0] = true;
                     switch (b.busSendStorage.auxLocation[i])
                     {
                     case Bus::BusSendStorage::PRE_FX:

--- a/src/engine/patch.h
+++ b/src/engine/patch.h
@@ -46,6 +46,7 @@ struct Patch : MoveableOnly<Patch>, SampleRateSupport
         Busses() : mainBus(MAIN_0) { initialize(); }
         void initialize()
         {
+            std::fill(busUsed.begin(), busUsed.end(), false);
             std::fill(partToVSTRouting.begin(), partToVSTRouting.end(), 0);
             std::fill(auxToVSTRouting.begin(), auxToVSTRouting.end(), 0);
             int adr = PART_0;
@@ -161,7 +162,15 @@ struct Patch : MoveableOnly<Patch>, SampleRateSupport
             }
         }
         std::array<bool, numPluginOutputs> usesOutput{};
+
+        std::array<bool, busCount> busUsed;
     } busses;
+
+    Bus &getBusForOutput(BusAddress &ba)
+    {
+        busses.busUsed[(int)ba] = true;
+        return busses.busByAddress(ba);
+    }
 
     void process(Engine &e);
 

--- a/src/engine/zone.cpp
+++ b/src/engine/zone.cpp
@@ -78,8 +78,7 @@ template <bool OS> void Zone::processWithOS(scxt::engine::Engine &onto)
                 }
                 else if (outputInfo.routeTo >= 0)
                 {
-                    auto &bs = getEngine()->getPatch()->busses;
-                    auto &tb = bs.busByAddress(outputInfo.routeTo);
+                    auto &tb = getEngine()->getPatch()->getBusForOutput(outputInfo.routeTo);
                     blk::accumulate_from_to<osBlock>(v->output[0],
                                                      OS ? tb.outputOS[0] : tb.output[0]);
                     blk::accumulate_from_to<osBlock>(v->output[1],


### PR DESCRIPTION
This adds an optimization where unused busses don't process. An unused bus is one in this sense which has *never* been written to since the patch reset. Hence the name
"Hotel California". You can check into the audio graph any time you want, but you can never leave.

So what we need to do, and what I'll change #1223 to be, is to instead have a tail calculation based on the active effects and whenever written (that is when we do busUsed to true) we set busUsed to the tail length and then count down.

So this only addresses #1223, but it does the plumbing so we can do the rest.