### PR TITLE
Adjust user directory location

### DIFF
--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -1073,9 +1073,15 @@ std::optional<fs::path> Engine::setupUserStorageDirectory()
 
     try
     {
+        // Check for old documents path
         auto res = sst::plugininfra::paths::bestDocumentsFolderPathFor(productName);
         if (!fs::is_directory(res))
-            fs::create_directories(res);
+        {
+            res = sst::plugininfra::paths::bestDocumentsVendorFolderPathFor("Surge Synth Team",
+                                                                            productName);
+            if (!fs::is_directory(res))
+                fs::create_directories(res);
+        }
         if (fs::is_directory(res))
         {
             SCLOG("Using system user directory: " << res.u8string());


### PR DESCRIPTION
Closes #1685

If there is no user directory, use '~/Documents/Surge Synth Team/Shortcircuit XT` but if the prior "Shortcircuit XT" exists continue to use it for continunity.