### PR TITLE
Fix an asan alignment error in widget subscription

### DIFF
--- a/src-ui/app/SCXTEditor.h
+++ b/src-ui/app/SCXTEditor.h
@@ -415,7 +415,8 @@ template <typename P, typename A> void HasEditor::addSubscription(const P &p, A 
         connectors::addGuiStep(*a, [edCopy, vp, f = a.get()](auto &) {
             edCopy->editorDataCache.fireSubscription(vp, f);
         });
-        editor->editorDataCache.addSubscription(vp, a.get());
+        editor->editorDataCache.addSubscription(vp, sizeof(typename A::element_type::value_t),
+                                                a.get());
     }
 }
 } // namespace scxt::ui::app

--- a/src-ui/app/SCXTEditorDataCache.h
+++ b/src-ui/app/SCXTEditorDataCache.h
@@ -62,8 +62,8 @@ struct SCXTEditorDataCache
     // Displayed zone tab output info
     scxt::engine::Zone::ZoneOutputInfo zoneOutputInfo;
 
-    void addSubscription(void *el, sst::jucegui::data::Continuous *);
-    void addSubscription(void *el, sst::jucegui::data::Discrete *);
+    void addSubscription(void *el, size_t soel, sst::jucegui::data::Continuous *);
+    void addSubscription(void *el, size_t soel, sst::jucegui::data::Discrete *);
     void fireSubscription(void *el, sst::jucegui::data::Continuous *);
     void fireSubscription(void *el, sst::jucegui::data::Discrete *);
 
@@ -79,6 +79,7 @@ struct SCXTEditorDataCache
     void fireAllNotificationsBetween(void *st, void *end);
     std::unordered_map<void *, std::unordered_set<sst::jucegui::data::Continuous *>> csubs;
     std::unordered_map<void *, std::unordered_set<sst::jucegui::data::Discrete *>> dsubs;
+    std::unordered_map<void *, size_t> dsizes;
     std::unordered_map<void *, std::vector<std::function<void()>>> fsubs;
 
     struct CListener : sst::jucegui::data::Continuous::DataListener


### PR DESCRIPTION
The widget intercommunication cache subscription mechanism lets things like two widgets be in sync on screen ui side. But it had assumed for discrete values that all discretes were ints, so asan gave a non-aligned read error. And the result was probably wrong (but unused so far).

Fix this by having discrete items know their size.

Closes #1724