### PR TITLE
LFO has a modulatable amplitude

### DIFF
--- a/src/engine/group.cpp
+++ b/src/engine/group.cpp
@@ -164,6 +164,7 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
                 stepLfos[i].retrigger();
             }
             stepLfos[i].process(blockSize);
+            stepLfos[i].output *= *(endpoints.lfo[i].amplitudeP);
         }
         else if (lfoEvaluator[i] == CURVE)
         {
@@ -178,6 +179,8 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
                                  *lp.curve.attackP, *lp.curve.releaseP,
                                  modulatorStorage[i].curveLfoStorage.useenv,
                                  modulatorStorage[i].curveLfoStorage.unipolar, gated);
+
+            curveLfos[i].output *= *(endpoints.lfo[i].amplitudeP);
         }
         else if (lfoEvaluator[i] == ENV)
         {
@@ -203,6 +206,8 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
             envLfos[i].process(*lp.delayP, *lp.attackP, *lp.holdP, *lp.decayP, *lp.sustainP,
                                *lp.releaseP, *lp.aShapeP, *lp.dShapeP, *lp.rShapeP, *lp.rateMulP,
                                useGate);
+
+            envLfos[i].output *= *(endpoints.lfo[i].amplitudeP);
         }
         else
         {

--- a/src/modulation/group_matrix.cpp
+++ b/src/modulation/group_matrix.cpp
@@ -165,6 +165,7 @@ GroupMatrixEndpoints::LFOTarget::LFOTarget(engine::Engine *e, uint32_t p)
         auto nm = [&ms](auto &v) { return datamodel::describeValue(ms, v).name; };
 
         registerGroupModTarget(e, rateT, ptFn, notEnvLabel(nm(ms.rate)));
+        registerGroupModTarget(e, amplitudeT, ptFn, allLabel(nm(ms.amplitude)), true);
         registerGroupModTarget(e, retriggerT, ptFn, allLabel("Retrigger"));
         registerGroupModTarget(e, curve.deformT, ptFn, curveLabel(nm(ms.curveLfoStorage.deform)));
         registerGroupModTarget(e, curve.angleT, ptFn, curveLabel(nm(ms.curveLfoStorage.angle)));

--- a/src/modulation/matrix_shared.h
+++ b/src/modulation/matrix_shared.h
@@ -137,13 +137,15 @@ template <typename TG, uint32_t gn> struct EGTargetEndpointData
 template <typename TG, uint32_t gn> struct LFOTargetEndpointData
 {
     LFOTargetEndpointData(uint32_t p)
-        : index(p), rateT{gn, 'rate', p}, retriggerT{gn, 'rtrg', p}, curve(p), step(p), env(p)
+        : index(p), rateT{gn, 'rate', p}, amplitudeT{gn, 'ampl', p}, retriggerT{gn, 'rtrg', p},
+          curve(p), step(p), env(p)
     {
     }
     uint32_t index{0};
 
-    TG rateT, retriggerT;
+    TG rateT, amplitudeT, retriggerT;
     const float *rateP{nullptr};
+    const float *amplitudeP{nullptr};
     const float *retriggerP{nullptr};
     float zeroBase{0.f};
     struct Curve
@@ -309,6 +311,7 @@ inline void LFOTargetEndpointData<TG, gn>::baseBind(M &m, Z &z)
     auto &ms = z.modulatorStorage[index];
 
     bindEl(m, ms, rateT, ms.rate, rateP);
+    bindEl(m, ms, amplitudeT, ms.amplitude, amplitudeP);
     bindEl(m, ms, retriggerT, zeroBase, retriggerP,
            datamodel::pmd().withName("Retrigger").asPercent());
 

--- a/src/modulation/modulator_storage.h
+++ b/src/modulation/modulator_storage.h
@@ -138,6 +138,7 @@ struct ModulatorStorage
 
     float rate{0.f};
     float start_phase{0.f};
+    float amplitude{1.f}; // linear - and mod target only
     bool temposync{false};
 
     modulators::StepLFOStorage stepLfoStorage;
@@ -241,6 +242,8 @@ SC_DESCRIBE(scxt::modulation::ModulatorStorage, {
                               }));
     SC_FIELD(temposync, pmd().asBool().withName("Temposync"));
     SC_FIELD(rate, pmd().asLfoRate().withName("Rate"));
+    SC_FIELD(amplitude,
+             pmd().asPercent().withName("Amplitude").withSupportsMultiplicativeModulation());
     SC_FIELD(start_phase, pmd().asPercent().withName("Phase"));
 
     SC_FIELD(stepLfoStorage.smooth, pmd()

--- a/src/modulation/voice_matrix.cpp
+++ b/src/modulation/voice_matrix.cpp
@@ -378,6 +378,7 @@ MatrixEndpoints::LFOTarget::LFOTarget(engine::Engine *e, uint32_t p)
         auto nm = [&ms](auto &v) { return datamodel::describeValue(ms, v).name; };
 
         registerVoiceModTarget(e, rateT, ptFn, notEnvLabel(nm(ms.rate)));
+        registerVoiceModTarget(e, amplitudeT, ptFn, allLabel(nm(ms.amplitude)), true);
         registerVoiceModTarget(e, retriggerT, ptFn, allLabel("Retrigger"));
         registerVoiceModTarget(e, curve.deformT, ptFn, curveLabel(nm(ms.curveLfoStorage.deform)));
         registerVoiceModTarget(e, curve.angleT, ptFn, curveLabel(nm(ms.curveLfoStorage.angle)));

--- a/src/voice/voice.cpp
+++ b/src/voice/voice.cpp
@@ -241,6 +241,7 @@ template <bool OS> bool Voice::processWithOS()
                 stepLfos[i].retrigger();
             }
             stepLfos[i].process(blockSize);
+            stepLfos[i].output *= *(endpoints->lfo[i].amplitudeP);
         }
         else if (lfoEvaluator[i] == CURVE)
         {
@@ -256,6 +257,7 @@ template <bool OS> bool Voice::processWithOS()
                                  *lp.curve.attackP, *lp.curve.releaseP,
                                  zone->modulatorStorage[i].curveLfoStorage.useenv,
                                  zone->modulatorStorage[i].curveLfoStorage.unipolar, isGated);
+            curveLfos[i].output *= *(endpoints->lfo[i].amplitudeP);
         }
         else if (lfoEvaluator[i] == ENV)
         {
@@ -281,6 +283,7 @@ template <bool OS> bool Voice::processWithOS()
             envLfos[i].process(*lp.delayP, *lp.attackP, *lp.holdP, *lp.decayP, *lp.sustainP,
                                *lp.releaseP, *lp.aShapeP, *lp.dShapeP, *lp.rShapeP, *lp.rateMulP,
                                useGate);
+            envLfos[i].output *= *(endpoints->lfo[i].amplitudeP);
         }
         else
         {


### PR DESCRIPTION
The LFO has a non-displayed but modulatable amplitude field which can be additively or multiplicatively
modulated. Useful of you want a macro to turn down an LFO which is applied multiple places and already consumes via or some such.

Closes #777