### PR TITLE
Correct the playback display cursor on the sample waveform

### DIFF
--- a/src-ui/app/edit-screen/EditScreen.cpp
+++ b/src-ui/app/edit-screen/EditScreen.cpp
@@ -102,10 +102,12 @@ void EditScreen::onVoiceInfoChanged()
     partSidebar->repaint();
 }
 
-void EditScreen::updateSamplePlaybackPosition(size_t sampleIndex, int64_t samplePos)
+void EditScreen::addSamplePlaybackPosition(size_t sampleIndex, int64_t samplePos)
 {
-    mappingPane->updateSamplePlaybackPosition(sampleIndex, samplePos);
+    mappingPane->addSamplePlaybackPosition(sampleIndex, samplePos);
 }
+
+void EditScreen::clearSamplePlaybackPositions() { mappingPane->clearSamplePlaybackPositions(); }
 
 void EditScreen::setSelectionMode(EditScreen::SelectionMode m)
 {

--- a/src-ui/app/edit-screen/EditScreen.h
+++ b/src-ui/app/edit-screen/EditScreen.h
@@ -126,7 +126,8 @@ struct EditScreen : juce::Component, HasEditor
     void layout();
     std::map<selection::SelectionManager::ZoneAddress, size_t> voiceCountByZoneAddress;
     void onVoiceInfoChanged();
-    void updateSamplePlaybackPosition(size_t sampleIndex, int64_t samplePos);
+    void addSamplePlaybackPosition(size_t sampleIndex, int64_t samplePos);
+    void clearSamplePlaybackPositions();
 
     void selectedPartChanged();
     void macroDataChanged(int part, int index);

--- a/src-ui/app/edit-screen/components/MacroMappingVariantPane.cpp
+++ b/src-ui/app/edit-screen/components/MacroMappingVariantPane.cpp
@@ -155,11 +155,17 @@ void MacroMappingVariantPane::invertScroll(bool invert)
     }
 }
 
-void MacroMappingVariantPane::updateSamplePlaybackPosition(size_t sampleIndex, int64_t samplePos)
+void MacroMappingVariantPane::addSamplePlaybackPosition(size_t sampleIndex, int64_t samplePos)
 {
     if (sampleDisplay->isVisible() && sampleIndex == sampleDisplay->selectedVariation)
         sampleDisplay->waveforms[sampleDisplay->selectedVariation]
-            .waveform->updateSamplePlaybackPosition(samplePos);
+            .waveform->addSamplePlaybackPosition(samplePos);
+}
+
+void MacroMappingVariantPane::clearSamplePlaybackPositions()
+{
+    sampleDisplay->waveforms[sampleDisplay->selectedVariation]
+        .waveform->clearSamplePlaybackPositions();
 }
 
 void MacroMappingVariantPane::selectedPartChanged() { macroDisplay->selectedPartChanged(); }

--- a/src-ui/app/edit-screen/components/MacroMappingVariantPane.h
+++ b/src-ui/app/edit-screen/components/MacroMappingVariantPane.h
@@ -63,7 +63,8 @@ struct MacroMappingVariantPane : sst::jucegui::components::NamedPanel, HasEditor
     engine::Zone::ZoneMappingData mappingView;
     engine::Zone::Variants sampleView;
 
-    void updateSamplePlaybackPosition(size_t sampleIndex, int64_t samplePos);
+    void addSamplePlaybackPosition(size_t sampleIndex, int64_t samplePos);
+    void clearSamplePlaybackPositions();
 
     void invertScroll(bool invert);
     bool invertScroll() const;

--- a/src-ui/app/edit-screen/components/mapping-pane/SampleWaveform.cpp
+++ b/src-ui/app/edit-screen/components/mapping-pane/SampleWaveform.cpp
@@ -33,10 +33,7 @@
 namespace scxt::ui::app::edit_screen
 {
 
-SampleWaveform::SampleWaveform(VariantDisplay *d) : display(d), HasEditor(d->editor)
-{
-    addAndMakeVisible(samplePlaybackPosition);
-}
+SampleWaveform::SampleWaveform(VariantDisplay *d) : display(d), HasEditor(d->editor) {}
 
 void SampleWaveform::rebuildHotZones()
 {
@@ -671,17 +668,47 @@ void SampleWaveform::paint(juce::Graphics &g)
         g.drawText(fmt::format("Norm: {} dB", db), 10, 2, getWidth(), 40,
                    juce::Justification::topLeft);
     }
+
+    for (auto &pb : playbackPositions)
+    {
+        auto px = xPixelForSample(pb);
+        if (px >= 0 && px < getWidth())
+        {
+            static constexpr int ellipseRad{2};
+            g.setColour(editor->themeColor(theme::ColorMap::generic_content_low));
+            g.drawVerticalLine(px, 0, getHeight());
+            g.setColour(editor->themeColor(theme::ColorMap::generic_content_high));
+            if (usedChannels == 1)
+            {
+                g.fillEllipse(px - ellipseRad, getHeight() / 2 - ellipseRad, 2 * ellipseRad + 1,
+                              2 * ellipseRad + 1);
+            }
+            else
+            {
+                g.fillEllipse(px - ellipseRad, getHeight() / 4 - ellipseRad, 2 * ellipseRad + 1,
+                              2 * ellipseRad + 1);
+                g.fillEllipse(px - ellipseRad, 3 * getHeight() / 4 - ellipseRad, 2 * ellipseRad + 1,
+                              2 * ellipseRad + 1);
+            }
+        }
+    }
 }
 
-void SampleWaveform::resized()
+void SampleWaveform::resized() { rebuildHotZones(); }
+
+void SampleWaveform::addSamplePlaybackPosition(int64_t samplePos)
 {
-    rebuildHotZones();
-    samplePlaybackPosition.setSize(1, getHeight());
+    playbackPositions.insert(samplePos);
+    repaint();
 }
 
-void SampleWaveform::updateSamplePlaybackPosition(int64_t samplePos)
+void SampleWaveform::clearSamplePlaybackPositions()
 {
-    // auto x = xPixelForSample(samplePos);
-    // samplePlaybackPosition.setTopLeftPosition(x, 0);
+    if (!playbackPositions.empty())
+    {
+        playbackPositions.clear();
+        repaint();
+    }
 }
+
 } // namespace scxt::ui::app::edit_screen

--- a/src-ui/app/edit-screen/components/mapping-pane/SampleWaveform.h
+++ b/src-ui/app/edit-screen/components/mapping-pane/SampleWaveform.h
@@ -72,13 +72,9 @@ struct SampleWaveform : juce::Component, HasEditor, sst::jucegui::components::Zo
         HZ_DRAG_LOOPEND,
     } mouseState{MouseState::NONE};
 
-    struct PlaybackCursor : juce::Component
-    {
-        void paint(juce::Graphics &g) override
-        { /*g.fillAll(juce::Colours::white);*/
-        }
-    } samplePlaybackPosition;
-    void updateSamplePlaybackPosition(int64_t samplePos);
+    std::set<int64_t> playbackPositions;
+    void addSamplePlaybackPosition(int64_t samplePos);
+    void clearSamplePlaybackPositions();
 
     void rebuildPaths();
 

--- a/src-ui/app/editor-impl/SCXTEditor.cpp
+++ b/src-ui/app/editor-impl/SCXTEditor.cpp
@@ -46,6 +46,9 @@
 #include "app/missing-resolution/MissingResolutionScreen.h"
 #include "sst/jucegui/components/ToolTip.h"
 #include "sst/jucegui/screens/AlertOrPrompt.h"
+
+#include <app/edit-screen/components/MacroMappingVariantPane.h>
+#include <app/edit-screen/components/mapping-pane/VariantDisplay.h>
 #include <sst/jucegui/components/DiscreteParamMenuBuilder.h>
 
 #if MAC
@@ -238,31 +241,27 @@ void SCXTEditor::idle()
         }
     }
 
-#if 0
     /*
      * This basically doesn't work.
      */
-    if (editScreen->isVisible())
+    if (editScreen->isVisible() && editScreen->mappingPane->sampleDisplay->isVisible())
     {
         if (currentLeadZoneSelection.has_value())
         {
             bool anyActive{false};
+            editScreen->clearSamplePlaybackPositions();
             for (const auto &v : sharedUiMemoryState.voiceDisplayItems)
             {
                 if (v.active && v.group == currentLeadZoneSelection->group &&
                     v.part == currentLeadZoneSelection->part &&
                     v.zone == currentLeadZoneSelection->zone)
                 {
-                    editScreen->updateSamplePlaybackPosition(v.sample, v.samplePos);
+                    anyActive = true;
+                    editScreen->addSamplePlaybackPosition(v.sample, v.samplePos);
                 }
-            }
-            if (!anyActive)
-            {
-                editScreen->hideSamplePlaybackPosition();
             }
         }
     }
-#endif
 
     if (headerRegion)
     {

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -300,7 +300,7 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
         setSampleRate(sampleRate);
         sharedUIMemoryState.voiceDisplayStateWriteCounter = 0;
 
-        const double updateFrequencyHz{15.0};
+        const double updateFrequencyHz{30.0};
 
         updateVoiceDisplayStateEvery = (int)std::floor(sampleRate / updateFrequencyHz / blockSize);
         lastUpdateVoiceDisplayState = updateVoiceDisplayStateEvery;


### PR DESCRIPTION
basically don't overpaint, have it be off if no playing, and so on.

Closes #1237