### PR TITLE
Group lifecycle fix

### DIFF
--- a/src/engine/group.cpp
+++ b/src/engine/group.cpp
@@ -142,7 +142,7 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
     float *lOut = output[0];
     float *rOut = output[1];
 
-    bool gated{attackInThisBlock};
+    gated = attackInThisBlock;
     attackInThisBlock = false;
     for (const auto &z : zones)
     {
@@ -240,6 +240,7 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
         auto z = activeZoneWeakRefs[i];
         assert(z->isActive());
         z->process(e);
+
         assert(z->isActive() || rescanWeakRefs > 0);
         assert(oAZ == activeZones);
 

--- a/src/engine/group.h
+++ b/src/engine/group.h
@@ -238,8 +238,8 @@ struct Group : MoveableOnly<Group>,
     bool inRingout() const { return ringoutTime < ringoutMax; }
     bool hasActiveEGs() const
     {
-        const auto eg0A = (int)eg[0].stage <= (int)ahdsrenv_t::s_release;
-        const auto eg1A = (int)eg[1].stage <= (int)ahdsrenv_t::s_release;
+        const auto eg0A = egsActive[0] && ((int)eg[0].stage <= (int)ahdsrenv_t::s_release);
+        const auto eg1A = egsActive[1] && ((int)eg[1].stage <= (int)ahdsrenv_t::s_release);
         return eg0A || eg1A;
     }
 
@@ -260,10 +260,13 @@ struct Group : MoveableOnly<Group>,
     zoneContainer_t::iterator end() noexcept { return zones.end(); }
     zoneContainer_t::const_iterator cend() const noexcept { return zones.cend(); }
 
+    bool gated{false};
+
   private:
     zoneContainer_t zones;
     std::vector<Zone *> activeZoneWeakRefs;
     uint32_t rescanWeakRefs{0};
+
     void postZoneTraversalRemoveHandler();
 };
 } // namespace scxt::engine


### PR DESCRIPTION
Fix a problem with hasActiveEGS in group which meant all unused EGs were always active. This means groups properly stop processing when their subordinate zones re finished and their ringout and local envelopes are done.

Addreses #1638
Addreses #852