### PR TITLE
Add KeyBinding Manager; some KeyBindings

### DIFF
--- a/src-ui/CMakeLists.txt
+++ b/src-ui/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(${PROJECT_NAME} STATIC
         app/editor-impl/SCXTEditorMenus.cpp
         app/editor-impl/SCXTEditorResponseHandlers.cpp
         app/editor-impl/SCXTEditorDataCache.cpp
+        app/editor-impl/KeyBindings.cpp
 
         app/edit-screen/EditScreen.cpp
         app/edit-screen/components/AdsrPane.cpp
@@ -70,6 +71,7 @@ set_target_properties(scxtui_json_layouts PROPERTIES UNITY_BUILD FALSE)
 target_link_libraries(${PROJECT_NAME} PRIVATE
         fmt
         sst-plugininfra::strnatcmp
+        sst-plugininfra
         scxt-resources
         scxtui_json_layouts
         clap_juce_shim

--- a/src-ui/app/SCXTEditor.h
+++ b/src-ui/app/SCXTEditor.h
@@ -43,6 +43,7 @@
 #include "sst/jucegui/components/WindowPanel.h"
 #include "sst/jucegui/screens/ScreenHolder.h"
 #include "sst/jucegui/style/JUCELookAndFeelAdapter.h"
+
 #include "sst/basic-blocks/dsp/RNG.h"
 #include "messaging/client/zone_messages.h"
 #include "browser/browser.h"
@@ -64,6 +65,8 @@ struct HasDiscreteParamMenuBuilder;
 }
 namespace scxt::ui::app
 {
+
+struct KeyBindings;
 
 namespace shared
 {
@@ -329,6 +332,12 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel,
     float lastProcessMemoryInMegabytes{0};
 
     friend struct HasEditor;
+
+    // Keyboard shortcuts
+    std::unique_ptr<KeyBindings> keyBindings;
+    bool keyPressed(const juce::KeyPress &key) override;
+
+    void switchGroupOrZoneFocus();
 
   protected:
     template <typename T> void sendToSerialization(const T &msg)

--- a/src-ui/app/edit-screen/EditScreen.h
+++ b/src-ui/app/edit-screen/EditScreen.h
@@ -33,6 +33,7 @@
 #include <variant>
 #include "app/HasEditor.h"
 #include "app/browser-ui/BrowserPane.h"
+#include "components/PartGroupSidebar.h"
 #include "sst/jucegui/components/NamedPanel.h"
 #include "selection/selection_manager.h"
 
@@ -140,6 +141,22 @@ struct EditScreen : juce::Component, HasEditor
         PART
     } selectionMode{SelectionMode::NONE};
     void setSelectionMode(SelectionMode m);
+    void viewZone() { partSidebar->setSelectedTab(2); }
+    void viewGroup() { partSidebar->setSelectedTab(1); }
+    void viewPart() { partSidebar->setSelectedTab(0); }
+    void swapGroupZone()
+    {
+        if (partSidebar->selectedTab == 2)
+        {
+            // zone to group
+            partSidebar->setSelectedTab(1);
+        }
+        else
+        {
+            // alwyas to zone
+            partSidebar->setSelectedTab(2);
+        }
+    }
 
     void onOtherTabSelection();
     // This allows us, in the future, to make this return s + selected part to have

--- a/src-ui/app/editor-impl/KeyBindings.cpp
+++ b/src-ui/app/editor-impl/KeyBindings.cpp
@@ -1,8 +1,32 @@
-//
-// Created by Paul Walker on 7/28/25.
-//
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
 
 #include "KeyBindings.h"
+#include "app/SCXTEditor.h"
 
 namespace scxt::ui::app
 {

--- a/src-ui/app/editor-impl/KeyBindings.cpp
+++ b/src-ui/app/editor-impl/KeyBindings.cpp
@@ -1,0 +1,55 @@
+//
+// Created by Paul Walker on 7/28/25.
+//
+
+#include "KeyBindings.h"
+
+namespace scxt::ui::app
+{
+KeyBindings::KeyBindings(SCXTEditor *e) : HasEditor(e)
+{
+    manager = std::make_unique<manager_t>(
+        e->browser.userDirectory, "ShortcircuitXT", [this](auto f) { return commandToString(f); },
+        [this](auto &t, auto &m) { editor->displayError(t, m); });
+
+    setupKeyBindings();
+
+    manager->unstreamFromXML();
+}
+KeyBindings::~KeyBindings(){};
+
+void KeyBindings::setupKeyBindings()
+{
+    manager->addBinding(SWITCH_GROUP_ZONE_SELECTION,
+                        {(uint32_t)manager_t::Modifiers::ALT, (int)'G'});
+
+    manager->addBinding(FOCUS_ZONES, {(uint32_t)manager_t::Modifiers::COMMAND, (int)'1'});
+    manager->addBinding(FOCUS_GROUPS, {(uint32_t)manager_t::Modifiers::COMMAND, (int)'2'});
+    manager->addBinding(FOCUS_PARTS, {(uint32_t)manager_t::Modifiers::COMMAND, (int)'3'});
+    manager->addBinding(FOCUS_MIXER, {(uint32_t)manager_t::Modifiers::COMMAND, (int)'4'});
+    manager->addBinding(FOCUS_PLAY, {(uint32_t)manager_t::Modifiers::COMMAND, (int)'5'});
+}
+
+std::string KeyBindings::commandToString(KeyCommands c)
+{
+    switch (c)
+    {
+    case SWITCH_GROUP_ZONE_SELECTION:
+        return "switchGroupZoneSelection";
+    case FOCUS_PARTS:
+        return "focusParts";
+    case FOCUS_GROUPS:
+        return "focusGroups";
+    case FOCUS_ZONES:
+        return "focusZones";
+    case FOCUS_PLAY:
+        return "focusPlay";
+    case FOCUS_MIXER:
+        return "focusMixer";
+    case numKeyCommands:
+        SCLOG("LOGIC ERROR Unstreaming Key Command");
+    }
+    return "LOGIC ERROR";
+}
+
+} // namespace scxt::ui::app

--- a/src-ui/app/editor-impl/KeyBindings.h
+++ b/src-ui/app/editor-impl/KeyBindings.h
@@ -1,0 +1,40 @@
+//
+// Created by Paul Walker on 7/28/25.
+//
+
+#ifndef KEYBINDINGS_H
+#define KEYBINDINGS_H
+
+#include <juce_gui_basics/juce_gui_basics.h>
+#include "app/HasEditor.h"
+#include "sst/plugininfra/keybindings.h"
+
+namespace scxt::ui::app
+{
+enum KeyCommands : uint32_t
+{
+    SWITCH_GROUP_ZONE_SELECTION,
+
+    FOCUS_PARTS,
+    FOCUS_GROUPS,
+    FOCUS_ZONES,
+    FOCUS_MIXER,
+    FOCUS_PLAY,
+
+    numKeyCommands
+};
+struct KeyBindings : HasEditor
+{
+    using manager_t = sst::plugininfra::KeyMapManager<KeyCommands, (int)KeyCommands::numKeyCommands,
+                                                      juce::KeyPress>;
+    KeyBindings(SCXTEditor *);
+    ~KeyBindings();
+
+    void setupKeyBindings();
+
+    std::string commandToString(KeyCommands);
+
+    std::unique_ptr<manager_t> manager;
+};
+};     // namespace scxt::ui::app
+#endif // KEYBINDINGS_H

--- a/src-ui/app/editor-impl/KeyBindings.h
+++ b/src-ui/app/editor-impl/KeyBindings.h
@@ -1,9 +1,32 @@
-//
-// Created by Paul Walker on 7/28/25.
-//
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
 
-#ifndef KEYBINDINGS_H
-#define KEYBINDINGS_H
+#ifndef SCXT_SRC_UI_APP_EDITOR_IMPL_KEYBINDINGS_H
+#define SCXT_SRC_UI_APP_EDITOR_IMPL_KEYBINDINGS_H
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include "app/HasEditor.h"

--- a/src-ui/app/editor-impl/SCXTEditor.cpp
+++ b/src-ui/app/editor-impl/SCXTEditor.cpp
@@ -39,6 +39,7 @@
 
 #include "app/shared/HeaderRegion.h"
 #include "app/edit-screen/EditScreen.h"
+#include "app/editor-impl/KeyBindings.h"
 #include "app/mixer-screen/MixerScreen.h"
 #include "app/other-screens/AboutScreen.h"
 #include "app/other-screens/LogScreen.h"
@@ -115,6 +116,8 @@ SCXTEditor::SCXTEditor(messaging::MessageController &e, infrastructure::Defaults
 
     focusDebugger = std::make_unique<sst::jucegui::accessibility::FocusDebugger>(*this);
     focusDebugger->setDoFocusDebug(false);
+
+    keyBindings = std::make_unique<KeyBindings>(this);
 
     idleTimer = std::make_unique<IdleTimer>(this);
     idleTimer->startTimer(1000 / 60);
@@ -531,6 +534,59 @@ void SCXTEditor::displayError(const std::string &title, const std::string &messa
 {
 
     displayModalOverlay(sst::jucegui::screens::AlertOrPrompt::Alert(title, message));
+}
+
+bool SCXTEditor::keyPressed(const juce::KeyPress &key)
+{
+    auto m = keyBindings->manager->matches(key);
+    ;
+    if (m.has_value())
+    {
+        switch (*m)
+        {
+        case SWITCH_GROUP_ZONE_SELECTION:
+            switchGroupOrZoneFocus();
+            return true;
+            break;
+        // DONT ADD A DEFAULT
+        case FOCUS_ZONES:
+            setActiveScreen(ActiveScreen::MULTI);
+            editScreen->viewZone();
+            return true;
+        case FOCUS_GROUPS:
+            setActiveScreen(ActiveScreen::MULTI);
+            editScreen->viewGroup();
+            return true;
+        case FOCUS_PARTS:
+            setActiveScreen(ActiveScreen::MULTI);
+            editScreen->viewPart();
+            return true;
+        case FOCUS_MIXER:
+            setActiveScreen(ActiveScreen::MIXER);
+            return true;
+        case FOCUS_PLAY:
+            setActiveScreen(ActiveScreen::PLAY);
+            return true;
+
+        case numKeyCommands:
+            break;
+        }
+    }
+    return false;
+}
+
+void SCXTEditor::switchGroupOrZoneFocus()
+{
+    if (activeScreen != ActiveScreen::MULTI)
+    {
+        // Not on multi - go to it
+        setActiveScreen(ActiveScreen::MULTI);
+        editScreen->viewZone();
+    }
+    else
+    {
+        editScreen->swapGroupZone();
+    }
 }
 
 } // namespace scxt::ui::app


### PR DESCRIPTION
1. Add the sst plugininfra key binding manager, which allows in the future custom keybind edits. (That screen isnt' ported from surge yet). CLoses #1746

2. Add key bindings Cmd 1-5 for zone, group, part, mixer, and play

3. Add key binding Alt G for toggle group zone

Closes #1742

Of course we can redesign these key bindings any time we want in the future. This is more a proof of concept and infra and first pass commit.