### PR TITLE
Continued test refactoring; show simplest selection test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,13 +1,17 @@
 # And finally the test suite
 add_executable(scxt-test
-	test_main.cpp
+		test_main.cpp
+		console_ui.cpp
+		test_utilities.cpp
+
 		sfz_parse.cpp
         streaming.cpp
 		sample_analytics.cpp
 		processors_and_fx.cpp
 
-		console_ui.cpp
 		ui_basics.cpp
+
+		selection_manager.cpp
 )
 
 target_link_libraries(scxt-test

--- a/tests/console_ui.cpp
+++ b/tests/console_ui.cpp
@@ -85,42 +85,4 @@ void ConsoleUI::drainQueue()
 
 ConsoleUI::~ConsoleUI() { msgCont.unregisterClient(); }
 
-bool TestHarness::start(double sampleRate)
-{
-    engine = std::make_unique<scxt::engine::Engine>();
-    engine->runningEnvironment = "SCXT Test Harness";
-
-    engine->setSampleRate(sampleRate);
-
-    editor = std::make_unique<ConsoleUI>(*(engine->getMessageController()), *(engine->defaults),
-                                         *(engine->getSampleManager()), *(engine->getBrowser()),
-                                         engine->sharedUIMemoryState);
-
-    keepProcessing = true;
-    audioThread = std::make_unique<std::thread>([this]() { runAudioThread(); });
-    return true;
-}
-
-TestHarness::~TestHarness()
-{
-    keepProcessing.store(false);
-    audioThread->join();
-    editor.reset();
-    engine.reset();
-}
-
-void TestHarness::runAudioThread()
-{
-    auto sr = engine->getSampleRate();
-    auto sleepTime = (uint32_t)(scxt::blockSize / sr * 1000000 * 0.5);
-
-    while (keepProcessing)
-    {
-        engine->processAudio();
-        engine->transport.timeInBeats +=
-            (double)scxt::blockSize * 120 * engine->getSampleRateInv() / 60.f;
-        std::this_thread::sleep_for(std::chrono::microseconds(sleepTime));
-    }
-}
-
 } // namespace scxt::tests

--- a/tests/console_ui.h
+++ b/tests/console_ui.h
@@ -42,6 +42,8 @@ namespace scxt::tests
 {
 struct ConsoleUI
 {
+    bool logMessages{false};
+
     messaging::MessageController &msgCont;
     const sample::SampleManager &sampleManager;
     infrastructure::DefaultsProvider &defaultsProvider;
@@ -55,94 +57,78 @@ struct ConsoleUI
 
 #define ON_STUB                                                                                    \
     {                                                                                              \
-        SCLOG_WFUNC("Message");                                                                    \
+        if (logMessages)                                                                           \
+            SCLOG_WFUNC("Message");                                                                \
     }
 
     // Serialization to Client Messages
-    void onErrorFromEngine(const scxt::messaging::client::s2cError_t &) ON_STUB
-        void onEngineStatus(const engine::Engine::EngineStatusMessage &e) ON_STUB
-        void onMappingUpdated(const scxt::messaging::client::mappingSelectedZoneViewResposne_t &)
-            ON_STUB void onSamplesUpdated(
-                const scxt::messaging::client::sampleSelectedZoneViewResposne_t &) ON_STUB
-        void onStructureUpdated(const engine::Engine::pgzStructure_t &) ON_STUB
-        void onGroupOrZoneEnvelopeUpdated(
-            const scxt::messaging::client::adsrViewResponsePayload_t &payload) ON_STUB
-        void onGroupOrZoneProcessorDataAndMetadata(
-            const scxt::messaging::client::processorDataResponsePayload_t &d) ON_STUB
-        void onZoneProcessorDataMismatch(
-            const scxt::messaging::client::processorMismatchPayload_t &) ON_STUB
+    void onErrorFromEngine(const scxt::messaging::client::s2cError_t &) ON_STUB;
+    void onEngineStatus(const engine::Engine::EngineStatusMessage &e) ON_STUB;
+    void
+    onMappingUpdated(const scxt::messaging::client::mappingSelectedZoneViewResposne_t &) ON_STUB;
+    void
+    onSamplesUpdated(const scxt::messaging::client::sampleSelectedZoneViewResposne_t &) ON_STUB;
+    void onStructureUpdated(const engine::Engine::pgzStructure_t &) ON_STUB;
+    void onGroupOrZoneEnvelopeUpdated(
+        const scxt::messaging::client::adsrViewResponsePayload_t &payload) ON_STUB;
+    void onGroupOrZoneProcessorDataAndMetadata(
+        const scxt::messaging::client::processorDataResponsePayload_t &d) ON_STUB;
+    void onZoneProcessorDataMismatch(
+        const scxt::messaging::client::processorMismatchPayload_t &) ON_STUB;
 
-        void onZoneVoiceMatrixMetadata(
-            const scxt::voice::modulation::voiceMatrixMetadata_t &) ON_STUB
-        void onZoneVoiceMatrix(const scxt::voice::modulation::Matrix::RoutingTable &) ON_STUB
+    void onZoneVoiceMatrixMetadata(const scxt::voice::modulation::voiceMatrixMetadata_t &) ON_STUB;
+    void onZoneVoiceMatrix(const scxt::voice::modulation::Matrix::RoutingTable &) ON_STUB;
 
-        void onGroupMatrixMetadata(const scxt::modulation::groupMatrixMetadata_t &) ON_STUB
-        void onGroupMatrix(const scxt::modulation::GroupMatrix::RoutingTable &) ON_STUB
+    void onGroupMatrixMetadata(const scxt::modulation::groupMatrixMetadata_t &) ON_STUB;
+    void onGroupMatrix(const scxt::modulation::GroupMatrix::RoutingTable &) ON_STUB;
 
-        void onGroupTriggerConditions(const scxt::engine::GroupTriggerConditions &) ON_STUB
+    void onGroupTriggerConditions(const scxt::engine::GroupTriggerConditions &) ON_STUB;
 
-        void onGroupOrZoneModulatorStorageUpdated(
-            const scxt::messaging::client::indexedModulatorStorageUpdate_t &) ON_STUB
-        void onGroupOrZoneMiscModStorageUpdated(
-            const scxt::messaging::client::gzMiscStorageUpdate_t &) ON_STUB
-        void onZoneOutputInfoUpdated(const scxt::messaging::client::zoneOutputInfoUpdate_t &p)
-            ON_STUB void onGroupOutputInfoUpdated(
-                const scxt::messaging::client::groupOutputInfoUpdate_t &p) ON_STUB
+    void onGroupOrZoneModulatorStorageUpdated(
+        const scxt::messaging::client::indexedModulatorStorageUpdate_t &) ON_STUB;
+    void onGroupOrZoneMiscModStorageUpdated(
+        const scxt::messaging::client::gzMiscStorageUpdate_t &) ON_STUB;
+    void onZoneOutputInfoUpdated(const scxt::messaging::client::zoneOutputInfoUpdate_t &p) ON_STUB;
+    void
+    onGroupOutputInfoUpdated(const scxt::messaging::client::groupOutputInfoUpdate_t &p) ON_STUB;
 
-        void onGroupZoneMappingSummary(const scxt::engine::Part::zoneMappingSummary_t &) ON_STUB
-        void onSelectionState(const scxt::messaging::client::selectedStateMessage_t &) ON_STUB
-        void onSelectedPart(const int16_t) ON_STUB
+    void onGroupZoneMappingSummary(const scxt::engine::Part::zoneMappingSummary_t &) ON_STUB;
+    void onSelectionState(const scxt::messaging::client::selectedStateMessage_t &) ON_STUB;
+    void onSelectedPart(const int16_t) ON_STUB;
 
-        void onPartConfiguration(
-            const scxt::messaging::client::partConfigurationPayload_t &) ON_STUB
+    void onPartConfiguration(const scxt::messaging::client::partConfigurationPayload_t &) ON_STUB;
 
-        void onOtherTabSelection(
-            const scxt::selection::SelectionManager::otherTabSelection_t &p) ON_STUB
+    void
+    onOtherTabSelection(const scxt::selection::SelectionManager::otherTabSelection_t &p) ON_STUB;
 
-        void onBusOrPartEffectFullData(const scxt::messaging::client::busEffectFullData_t &) ON_STUB
-        void onBusOrPartSendData(const scxt::messaging::client::busSendData_t &) ON_STUB
+    void onBusOrPartEffectFullData(const scxt::messaging::client::busEffectFullData_t &) ON_STUB;
+    void onBusOrPartSendData(const scxt::messaging::client::busSendData_t &) ON_STUB;
 
-        void onBrowserRefresh(const bool) ON_STUB
-        void onBrowserQueueLengthRefresh(const std::pair<int32_t, int32_t>) ON_STUB
+    void onBrowserRefresh(const bool) ON_STUB;
+    void onBrowserQueueLengthRefresh(const std::pair<int32_t, int32_t>) ON_STUB;
 
-        void onDebugInfoGenerated(const scxt::messaging::client::debugResponse_t &) ON_STUB
+    void onDebugInfoGenerated(const scxt::messaging::client::debugResponse_t &) ON_STUB;
 
-        void onAllProcessorDescriptions(
-            const std::vector<dsp::processor::ProcessorDescription> &v) ON_STUB
+    void
+    onAllProcessorDescriptions(const std::vector<dsp::processor::ProcessorDescription> &v) ON_STUB;
 
-        void onActivityNotification(
-            const scxt::messaging::client::activityNotificationPayload_t &) ON_STUB
+    void
+    onActivityNotification(const scxt::messaging::client::activityNotificationPayload_t &) ON_STUB;
 
-        void onMacroFullState(const scxt::messaging::client::macroFullState_t &) ON_STUB
-        void onMacroValue(const scxt::messaging::client::macroValue_t &) ON_STUB
+    void onMacroFullState(const scxt::messaging::client::macroFullState_t &) ON_STUB;
+    void onMacroValue(const scxt::messaging::client::macroValue_t &) ON_STUB;
 
-        void onMissingResolutionWorkItemList(
-            const std::vector<engine::MissingResolutionWorkItem> &) ON_STUB
+    void
+    onMissingResolutionWorkItemList(const std::vector<engine::MissingResolutionWorkItem> &) ON_STUB;
 
-        void stepUI();
+    void stepUI();
 
   private:
     std::mutex callbackMutex;
     std::queue<std::string> callbackQueue;
     void drainQueue();
-};
+}; // namespace scxt::tests
 
-struct TestHarness : scxt::MoveableOnly<TestHarness>
-{
-    std::unique_ptr<scxt::engine::Engine> engine;
-    std::unique_ptr<ConsoleUI> editor;
-
-    bool start(double sampleRate = 48000);
-
-    ~TestHarness();
-
-    // to do non copyable
-
-  private:
-    std::unique_ptr<std::thread> audioThread;
-    std::atomic<bool> keepProcessing;
-    void runAudioThread();
-};
 } // namespace scxt::tests
 
 #endif // CONSOLE_UI_H

--- a/tests/selection_manager.cpp
+++ b/tests/selection_manager.cpp
@@ -26,19 +26,22 @@
  */
 
 #include "catch2/catch2.hpp"
-#include <chrono>
+#include "engine/engine.h"
+
+#include "test_utilities.h"
 #include "console_ui.h"
 
-TEST_CASE("Basic Console UI Startup")
+TEST_CASE("Create a Single Blank Zone and it is Selected")
 {
     scxt::tests::TestHarness th;
-    REQUIRE(th.start(true));
-    REQUIRE(th.engine);
-    REQUIRE(th.editor);
+    th.start();
 
-    for (int i = 0; i < 36; ++i)
-    {
-        th.editor->stepUI();
-        std::this_thread::sleep_for(std::chrono::milliseconds(17));
-    }
+    th.stepUI();
+
+    th.sendToSerialization(scxt::messaging::client::AddBlankZone({0, 0, 60, 72, 0, 64}));
+
+    th.stepUI();
+
+    REQUIRE(th.engine->getSelectionManager()->leadZone[0] ==
+            scxt::selection::SelectionManager::ZoneAddress{0, 0, 0});
 }

--- a/tests/test_utilities.cpp
+++ b/tests/test_utilities.cpp
@@ -25,20 +25,31 @@
  * https://github.com/surge-synthesizer/shortcircuit-xt
  */
 
-#include "catch2/catch2.hpp"
-#include <chrono>
-#include "console_ui.h"
+#include "test_utilities.h"
 
-TEST_CASE("Basic Console UI Startup")
+namespace scxt::tests
 {
-    scxt::tests::TestHarness th;
-    REQUIRE(th.start(true));
-    REQUIRE(th.engine);
-    REQUIRE(th.editor);
 
-    for (int i = 0; i < 36; ++i)
-    {
-        th.editor->stepUI();
-        std::this_thread::sleep_for(std::chrono::milliseconds(17));
-    }
+bool TestHarness::start(bool logMessages, double sampleRate)
+{
+    engine = std::make_unique<scxt::engine::Engine>();
+    engine->runningEnvironment = "SCXT Test Harness";
+
+    engine->setSampleRate(sampleRate);
+
+    editor = std::make_unique<ConsoleUI>(*(engine->getMessageController()), *(engine->defaults),
+                                         *(engine->getSampleManager()), *(engine->getBrowser()),
+                                         engine->sharedUIMemoryState);
+    editor->logMessages = logMessages;
+
+    audioThreadProvider = std::make_unique<AudioThreadProvider>(*engine);
+    return true;
 }
+
+TestHarness::~TestHarness()
+{
+    audioThreadProvider.reset();
+    editor.reset();
+    engine.reset();
+}
+} // namespace scxt::tests

--- a/tests/test_utilities.h
+++ b/tests/test_utilities.h
@@ -1,0 +1,107 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2024, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef TEST_UTILITIES_H
+#define TEST_UTILITIES_H
+
+#include <thread>
+#include <atomic>
+#include "engine/engine.h"
+
+#include "messaging/messaging.h"
+#include "messaging/client/client_messages.h"
+
+#include "console_ui.h"
+
+namespace scxt::tests
+{
+struct AudioThreadProvider
+{
+    AudioThreadProvider(engine::Engine &e) : engine(e)
+    {
+        keepProcessing = true;
+        audioThread = std::make_unique<std::thread>([this]() { runAudioThread(); });
+    }
+    ~AudioThreadProvider()
+    {
+        if (keepProcessing)
+        {
+            keepProcessing.store(false);
+            audioThread->join();
+        }
+    }
+
+  private:
+    engine::Engine &engine;
+    std::unique_ptr<std::thread> audioThread;
+    std::atomic<bool> keepProcessing{false};
+    void runAudioThread()
+    {
+        auto sr = engine.getSampleRate();
+        if (sr < 44100)
+        {
+            SCLOG("Engine sample rate is wrong at " << sr);
+            throw std::logic_error("Set sapmle rate to something realistic");
+        }
+        auto sleepTime = (uint32_t)(scxt::blockSize / sr * 1000000 * 0.5);
+
+        while (keepProcessing)
+        {
+            engine.processAudio();
+            engine.transport.timeInBeats +=
+                (double)scxt::blockSize * 120 * engine.getSampleRateInv() / 60.f;
+            std::this_thread::sleep_for(std::chrono::microseconds(sleepTime));
+        }
+    }
+};
+
+struct TestHarness : scxt::MoveableOnly<TestHarness>
+{
+    std::unique_ptr<scxt::engine::Engine> engine;
+    std::unique_ptr<ConsoleUI> editor;
+    std::unique_ptr<AudioThreadProvider> audioThreadProvider;
+
+    ~TestHarness();
+
+    bool start(bool logMessages = false, double sampleRate = 48000);
+
+    void stepUI(size_t forSteps = 10)
+    {
+        for (int i = 0; i < forSteps; ++i)
+        {
+            editor->stepUI();
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    }
+
+    template <typename T> void sendToSerialization(const T &t)
+    {
+        scxt::messaging::client::clientSendToSerialization(t, *engine->getMessageController());
+    }
+};
+} // namespace scxt::tests
+#endif // TEST_UTILITIES_H


### PR DESCRIPTION
1. More of the shared classes we need to actually write and run tests of the logical-version of ui gestures

2. A test to make sure that if we add a single blank zone to a newly minted empty engine that it is selected

Addresses #413