### PR TITLE
Simplify selection manager by moving contiguous selection

### DIFF
--- a/src/json/selection_traits.h
+++ b/src/json/selection_traits.h
@@ -45,9 +45,9 @@ namespace scxt::json
 SC_STREAMDEF(scxt::selection::SelectionManager::SelectActionContents, SC_FROM({
                  auto &e = from;
                  assert(SC_STREAMING_FOR_IN_PROCESS);
-                 v = {{"p", e.part},      {"g", e.group},         {"z", e.zone},
-                      {"s", e.selecting}, {"d", e.distinct},      {"sl", e.selectingAsLead},
-                      {"fz", e.forZone},  {"ic", e.isContiguous}, {"cf", e.contiguousFrom}};
+                 v = {{"p", e.part},      {"g", e.group},    {"z", e.zone},
+                      {"s", e.selecting}, {"d", e.distinct}, {"sl", e.selectingAsLead},
+                      {"fz", e.forZone}};
              }),
              SC_TO({
                  auto &z = to;
@@ -58,8 +58,6 @@ SC_STREAMDEF(scxt::selection::SelectionManager::SelectActionContents, SC_FROM({
                  findIf(v, "d", z.distinct);
                  findIf(v, "sl", z.selectingAsLead);
                  findIf(v, "fz", z.forZone);
-                 findIf(v, "ic", z.isContiguous);
-                 findIf(v, "cf", z.contiguousFrom);
              }));
 
 SC_STREAMDEF(scxt::selection::SelectionManager::ZoneAddress, SC_FROM({

--- a/src/selection/selection_manager.cpp
+++ b/src/selection/selection_manager.cpp
@@ -120,46 +120,6 @@ void SelectionManager::multiSelectAction(const std::vector<SelectActionContents>
 void SelectionManager::selectAction(
     const scxt::selection::SelectionManager::SelectActionContents &z)
 {
-    /* A wildcard zone single select means select all in group */
-    if (z.forZone && z.isContiguous)
-    {
-        auto zf = (ZoneAddress)z;
-        auto zt = z.contiguousFrom;
-        if (zt < zf)
-        {
-            std::swap(zf, zt);
-        }
-        if (zf.part != zt.part)
-        {
-            SCLOG("ERROR: Can't do contiguous selection across parts");
-            return;
-        }
-        auto gs = zf.group;
-        auto ge = zt.group;
-        std::vector<SelectActionContents> res;
-
-        for (auto gi = gs; gi <= ge; ++gi)
-        {
-            const auto &grp = engine.getPatch()->getPart(zf.part)->getGroup(gi);
-            auto sz = ((gi == gs && zf.zone >= 0) ? zf.zone : 0);
-            auto ez = ((gi == ge && zt.zone >= 0) ? zt.zone : grp->getZones().size() - 1);
-            for (auto zi = sz; zi <= ez; ++zi)
-            {
-                SelectActionContents se;
-                se.part = zt.part;
-                se.group = gi;
-                se.zone = zi;
-                se.selecting = true;
-                se.distinct = false;
-                se.selectingAsLead = false;
-
-                res.push_back(se);
-            }
-
-            multiSelectAction(res);
-        }
-        return;
-    }
     if (z.forZone && z.zone == -1)
     {
         auto za = (ZoneAddress)z;

--- a/src/selection/selection_manager.h
+++ b/src/selection/selection_manager.h
@@ -68,6 +68,7 @@ struct SelectionManager
         int32_t group{-1};
         int32_t zone{-1};
 
+        bool operator!=(const ZoneAddress &other) const { return !(*this == other); }
         bool operator==(const ZoneAddress &other) const
         {
             return part == other.part && group == other.group && zone == other.zone;
@@ -133,9 +134,6 @@ struct SelectionManager
         bool selectingAsLead{true}; // Should I force this selection to be lead?
 
         bool forZone{true}; // does this target the zone selection set (T) or group (F)
-
-        bool isContiguous{false};     // Is this a gesture which implies a contiguous selection
-        ZoneAddress contiguousFrom{}; // and if so, starting from where?
 
         friend std::ostream &operator<<(std::ostream &os, const SelectActionContents &z)
         {


### PR DESCRIPTION
Contiguous selection was a server side feature of the selection manager, along with single and multi select. This just adds complexity in the code and to the test surface. instead hav ethe UI build up an appropriate multi select action when doing the contiguous select gesture

No feature change, just moving where logic lives