### PR TITLE
Selection: Group and Zone selection re-couple

### DIFF
--- a/src-ui/app/SCXTEditor.h
+++ b/src-ui/app/SCXTEditor.h
@@ -280,6 +280,7 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel,
     void doSelectionAction(const selection::SelectionManager::SelectActionContents &);
     void doSelectionAction(const std::vector<selection::SelectionManager::SelectActionContents> &);
     std::optional<selection::SelectionManager::ZoneAddress> currentLeadZoneSelection;
+    std::optional<selection::SelectionManager::ZoneAddress> currentLeadGroupSelection;
     selection::SelectionManager::selectedZones_t allZoneSelections;
     selection::SelectionManager::selectedZones_t allGroupSelections;
     int16_t selectedPart{0};

--- a/src-ui/app/edit-screen/components/GroupZoneTreeControl.h
+++ b/src-ui/app/edit-screen/components/GroupZoneTreeControl.h
@@ -148,6 +148,7 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
             const auto &sg = tgl[rowNumber];
 
             bool isLeadZone = isZone() && gsb->isLeadZone(sg.address);
+            bool isLeadGroup = isGroup() && gsb->isLeadGroup(sg.address);
 
             auto editor = gsb->partGroupSidebar->editor;
 
@@ -186,11 +187,17 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
             }
             else
             {
-                if (isSelected && isGroup())
+                if (isLeadGroup && isGroup())
                 {
                     fillColor = editor->themeColor(theme::ColorMap::accent_1b, 0.4);
                     textColor = editor->themeColor(theme::ColorMap::generic_content_highest);
                     lowTextColor = editor->themeColor(theme::ColorMap::accent_1a);
+                }
+                else if (isSelected && isGroup())
+                {
+                    fillColor = editor->themeColor(theme::ColorMap::accent_1b, 0.2);
+                    textColor = editor->themeColor(theme::ColorMap::generic_content_medium);
+                    lowTextColor = editor->themeColor(theme::ColorMap::accent_1b);
                 }
             }
 

--- a/src-ui/app/edit-screen/components/PartGroupSidebar.cpp
+++ b/src-ui/app/edit-screen/components/PartGroupSidebar.cpp
@@ -226,6 +226,12 @@ struct GroupZoneSidebarBase : juce::Component, HasEditor, juce::DragAndDropConta
         return editor->currentLeadZoneSelection.has_value() &&
                za == *(editor->currentLeadZoneSelection);
     }
+
+    bool isLeadGroup(const selection::SelectionManager::ZoneAddress &za)
+    {
+        return editor->currentLeadGroupSelection.has_value() &&
+               za == *(editor->currentLeadGroupSelection);
+    }
 };
 
 struct GroupSidebar : GroupZoneSidebarBase<GroupSidebar, false>

--- a/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -275,19 +275,12 @@ void SCXTEditor::onErrorFromEngine(const scxt::messaging::client::s2cError_t &e)
 void SCXTEditor::onSelectionState(const scxt::messaging::client::selectedStateMessage_t &a)
 {
     allZoneSelections = std::get<1>(a);
-    allGroupSelections = std::get<2>(a);
+    allGroupSelections = std::get<3>(a);
 
-    auto optLead = std::get<0>(a);
-    if (optLead.has_value())
-    {
-        currentLeadZoneSelection = *optLead;
-    }
-    else
-    {
-        currentLeadZoneSelection = std::nullopt;
-        assert(allZoneSelections.empty());
-    }
+    currentLeadZoneSelection = std::get<0>(a);
+    currentLeadGroupSelection = std::get<2>(a);
 
+    SCLOG_ONCE("TODO - this may not be needed in group multi world");
     groupsWithSelectedZones.clear();
     for (const auto &sel : allZoneSelections)
     {

--- a/src/messaging/client/selection_messages.h
+++ b/src/messaging/client/selection_messages.h
@@ -50,6 +50,7 @@ CLIENT_TO_SERIAL(SelectPart, c2s_select_part, int16_t,
 // Lead Zone, Zone Selection, Gropu Selection
 typedef std::tuple<std::optional<selection::SelectionManager::ZoneAddress>,
                    selection::SelectionManager::selectedZones_t,
+                   std::optional<selection::SelectionManager::ZoneAddress>,
                    selection::SelectionManager::selectedZones_t>
     selectedStateMessage_t;
 SERIAL_TO_CLIENT(SetSelectionState, s2c_send_selection_state, selectedStateMessage_t,


### PR DESCRIPTION
Selected group = {group(selected zone)}
Lead group = group(lead zone)
Click on a group in the group view and select its zones

Although this allows group multi-select (via the zone side at least so far) the edit is still just on the lead.

Addresses #1741