### PR TITLE
More Selection Changes and Fixes

### DIFF
--- a/src-ui/app/edit-screen/components/ProcessorPane.cpp
+++ b/src-ui/app/edit-screen/components/ProcessorPane.cpp
@@ -1213,8 +1213,7 @@ void ProcessorPane::mouseUp(const juce::MouseEvent &e)
     sst::jucegui::components::NamedPanel::mouseUp(e);
 }
 
-void ProcessorPane::setAsMultiZone(int32_t primaryType, const std::string &nm,
-                                   const std::set<int32_t> &otherTypes)
+void ProcessorPane::setAsMultiZone(int32_t primaryType, const std::string &nm)
 {
     multiZone = true;
     multiName = nm;

--- a/src-ui/app/edit-screen/components/ProcessorPane.h
+++ b/src-ui/app/edit-screen/components/ProcessorPane.h
@@ -74,8 +74,7 @@ struct ProcessorPane : sst::jucegui::components::NamedPanel, HasEditor, juce::Dr
         rebuildControlsFromDescription();
     }
 
-    void setAsMultiZone(int32_t primaryType, const std::string &nm,
-                        const std::set<int32_t> &otherTypes);
+    void setAsMultiZone(int32_t primaryType, const std::string &nm);
 
     void rebuildControlsFromDescription();
     void attachRebuildToIntAttachment(int idx);

--- a/src-ui/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
+++ b/src-ui/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
@@ -60,14 +60,16 @@ void ZoneLayoutDisplay::mouseDown(const juce::MouseEvent &e)
             auto cla = *display->editor->currentLeadZoneSelection;
             for (const auto &z : display->summary)
             {
+                if (!editor->isAnyZoneFromGroupSelected(z.address.group))
+                    continue;
+
                 auto r = rectangleForZone(z);
-                if (z.address == cla && rectangleForZone(z).contains(e.position))
+                if (z.address == cla && r.contains(e.position))
                 {
                     youClickedLead = true;
                     zaLead = z.address;
                 }
-                else if (display->editor->isSelected(z.address) &&
-                         rectangleForZone(z).contains(e.position))
+                else if (display->editor->isSelected(z.address) && r.contains(e.position))
                 {
                     youClickedAnySelected = true;
                     zaPrefSel = z.address;
@@ -89,6 +91,9 @@ void ZoneLayoutDisplay::mouseDown(const juce::MouseEvent &e)
             // You clicked some random blue area. Lead select it and rmb
             for (const auto &z : display->summary)
             {
+                if (!editor->isAnyZoneFromGroupSelected(z.address.group))
+                    continue;
+
                 auto r = rectangleForZone(z);
                 if (r.contains(e.position))
                 {
@@ -680,6 +685,9 @@ void ZoneLayoutDisplay::mouseUp(const juce::MouseEvent &e)
         bool first = true;
         for (const auto &z : display->summary)
         {
+            if (!editor->isAnyZoneFromGroupSelected(z.address.group))
+                continue;
+
             if (rz.intersects(rectangleForZone(z)))
             {
                 display->editor->doSelectionAction(z.address, true, first && firstAsLead,
@@ -1160,6 +1168,9 @@ void ZoneLayoutDisplay::paint(juce::Graphics &g)
 
             for (const auto &z : display->summary)
             {
+                if (!editor->isAnyZoneFromGroupSelected(z.address.group))
+                    continue;
+
                 auto rz = rectangleForZone(z);
                 if (rz.intersects(r))
                 {
@@ -1317,7 +1328,7 @@ void ZoneLayoutDisplay::updateTooltipContents(bool andShow, const juce::Point<in
 {
     if (!cacheLastZone.has_value())
         return;
-    SCLOG_UNIMPL_ONCE("Update Tooltip in ZoneDisplaye currently bypassed");
+
     if (andShow)
     {
         juce::Timer::callAfterDelay(100, [pos, w = juce::Component::SafePointer(this)]() {

--- a/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -154,8 +154,8 @@ void SCXTEditor::onGroupOrZoneProcessorDataAndMetadata(
 void SCXTEditor::onZoneProcessorDataMismatch(
     const scxt::messaging::client::processorMismatchPayload_t &pl)
 {
-    const auto &[idx, leadType, leadName, otherTypes] = pl;
-    editScreen->getZoneElements()->processors[idx]->setAsMultiZone(leadType, leadName, otherTypes);
+    const auto &[idx, leadType, leadName] = pl;
+    editScreen->getZoneElements()->processors[idx]->setAsMultiZone(leadType, leadName);
 }
 
 void SCXTEditor::onZoneVoiceMatrixMetadata(const scxt::voice::modulation::voiceMatrixMetadata_t &d)

--- a/src/messaging/client/processor_messages.h
+++ b/src/messaging/client/processor_messages.h
@@ -44,7 +44,7 @@ SERIAL_TO_CLIENT(ProcessorMetadataAndData, s2c_respond_single_processor_metadata
                  processorDataResponsePayload_t, onGroupOrZoneProcessorDataAndMetadata);
 
 // zone, lead type, leadName, all types
-typedef std::tuple<int, int, std::string, std::set<int32_t>> processorMismatchPayload_t;
+typedef std::tuple<int, int, std::string> processorMismatchPayload_t;
 SERIAL_TO_CLIENT(ProcessorsMismatched, s2c_notify_mismatched_processors_for_zone,
                  processorMismatchPayload_t, onZoneProcessorDataMismatch);
 

--- a/src/selection/selection_manager.h
+++ b/src/selection/selection_manager.h
@@ -158,6 +158,13 @@ struct SelectionManager
     void clearAllSelections();
 
   protected:
+    enum ConsistencyCheck
+    {
+        PROCESSOR_TYPE,
+        MATRIX_ROW
+    };
+    bool acrossSelectionConsistency(bool forZone, ConsistencyCheck whichCheck, int index);
+
     std::vector<SelectActionContents>
     transformSelectionActions(const std::vector<SelectActionContents> &);
     void adjustInternalStateForAction(const SelectActionContents &);
@@ -200,8 +207,6 @@ struct SelectionManager
 
     // To ponder. Does this belong on this object or the engine?
     void copyZoneProcessorLeadToAll(int which);
-
-    std::set<dsp::processor::ProcessorType> processorTypesForSelectedZones(int pidx);
 
   public:
     using otherTabSelection_t = std::unordered_map<std::string, std::string>;


### PR DESCRIPTION
1. Make the 'consistency' check have a central API and use it at least for processors for now (zone only still)

2. Change the message for inconsistent processors to not have lots of unused data

3. Fix the mapping zone detecting non-displayed zones when doing RMG or Marquee. Closes #1773