### PR TITLE
Interim fix for group multi-select

### DIFF
--- a/src/selection/selection_manager.cpp
+++ b/src/selection/selection_manager.cpp
@@ -86,6 +86,8 @@ void SelectionManager::sendClientDataForLeadSelectionState()
     if (allSelectedGroups[selectedPart].size() > 1)
     {
         SCLOG_UNIMPL_ONCE("Multi-group selection to do");
+        auto [gp, gg, gz] = leadGroup[selectedPart];
+        sendDisplayDataForSingleGroup(gp, gg);
     }
     else if (allSelectedGroups[selectedPart].size() == 1)
     {


### PR DESCRIPTION
As an interim fix for group multi-select, at least make sure the UI displays the lead group configuration when multiple groups are selected.