### PR TITLE
Selection Consistency with a better api

### DIFF
--- a/src-ui/app/SCXTEditor.h
+++ b/src-ui/app/SCXTEditor.h
@@ -223,7 +223,6 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel,
     onGroupOrZoneEnvelopeUpdated(const scxt::messaging::client::adsrViewResponsePayload_t &payload);
     void onGroupOrZoneProcessorDataAndMetadata(
         const scxt::messaging::client::processorDataResponsePayload_t &d);
-    void onZoneProcessorDataMismatch(const scxt::messaging::client::processorMismatchPayload_t &);
 
     void onZoneVoiceMatrixMetadata(const scxt::voice::modulation::voiceMatrixMetadata_t &);
     void onZoneVoiceMatrix(const scxt::voice::modulation::Matrix::RoutingTable &);

--- a/src-ui/app/edit-screen/components/LFOPane.cpp
+++ b/src-ui/app/edit-screen/components/LFOPane.cpp
@@ -1165,7 +1165,7 @@ struct ConsistencyLFOPane : juce::Component
     ConsistencyLFOPane(LfoPane *p) : parent(p)
     {
         conLabel = std::make_unique<jcmp::Label>();
-        conLabel->setText("LFO Type is Inconsistent across zone selection");
+        conLabel->setText("Multiple LFO Types Selected");
         addAndMakeVisible(*conLabel);
 
         conButton = std::make_unique<jcmp::TextPushButton>();

--- a/src-ui/app/edit-screen/components/OutputPane.cpp
+++ b/src-ui/app/edit-screen/components/OutputPane.cpp
@@ -74,7 +74,7 @@ template <typename OTTraits> struct ProcTab : juce::Component, HasEditor
         addAndMakeVisible(*procRouting);
 
         consistentLabel = std::make_unique<jcmp::Label>();
-        consistentLabel->setText("Routing inconsistent across selection");
+        consistentLabel->setText("Multiple Routings Selected");
         addChildComponent(*consistentLabel);
         consistentButton = std::make_unique<jcmp::TextPushButton>();
         consistentButton->setLabel("Make Consistent");

--- a/src-ui/app/edit-screen/components/ProcessorPane.cpp
+++ b/src-ui/app/edit-screen/components/ProcessorPane.cpp
@@ -1213,17 +1213,6 @@ void ProcessorPane::mouseUp(const juce::MouseEvent &e)
     sst::jucegui::components::NamedPanel::mouseUp(e);
 }
 
-void ProcessorPane::setAsMultiZone(int32_t primaryType, const std::string &nm)
-{
-    multiZone = true;
-    multiName = nm;
-    setEnabled(true);
-    setName("Multiple");
-    resetControls();
-    setToggleDataSource(nullptr);
-    resized();
-    repaint();
-}
 void ProcessorPane::itemDragEnter(const juce::DragAndDropTarget::SourceDetails &dragSourceDetails)
 {
     setIsAccented(true);

--- a/src-ui/app/edit-screen/components/ProcessorPane.h
+++ b/src-ui/app/edit-screen/components/ProcessorPane.h
@@ -68,13 +68,25 @@ struct ProcessorPane : sst::jucegui::components::NamedPanel, HasEditor, juce::Dr
     setProcessorControlDescriptionAndStorage(const dsp::processor::ProcessorControlDescription &pcd,
                                              const dsp::processor::ProcessorStorage &ps)
     {
-        multiZone = false;
-        processorControlDescription = pcd;
-        processorView = ps;
-        rebuildControlsFromDescription();
+        if (ps.procTypeConsistent)
+        {
+            multiZone = false;
+            processorControlDescription = pcd;
+            processorView = ps;
+            rebuildControlsFromDescription();
+        }
+        else
+        {
+            multiZone = true;
+            multiName = pcd.typeDisplayName;
+            setEnabled(true);
+            setName("Multiple");
+            resetControls();
+            setToggleDataSource(nullptr);
+        }
+        resized();
+        repaint();
     }
-
-    void setAsMultiZone(int32_t primaryType, const std::string &nm);
 
     void rebuildControlsFromDescription();
     void attachRebuildToIntAttachment(int idx);

--- a/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -151,13 +151,6 @@ void SCXTEditor::onGroupOrZoneProcessorDataAndMetadata(
     }
 }
 
-void SCXTEditor::onZoneProcessorDataMismatch(
-    const scxt::messaging::client::processorMismatchPayload_t &pl)
-{
-    const auto &[idx, leadType, leadName] = pl;
-    editScreen->getZoneElements()->processors[idx]->setAsMultiZone(leadType, leadName);
-}
-
 void SCXTEditor::onZoneVoiceMatrixMetadata(const scxt::voice::modulation::voiceMatrixMetadata_t &d)
 {
     const auto &[active, sinf, tinf, cinf] = d;

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -81,6 +81,9 @@ static constexpr uint16_t triggerConditionsPerGroup{4};
 
 static constexpr uint16_t maxGeneratorsPerVoice{64};
 
+static constexpr size_t modMatrixRowsPerZone{12};
+static constexpr size_t modMatrixRowsPerGroup{12};
+
 /*
  * This namespace guards some very useful debugging guards and logs in the code.
  */

--- a/src/dsp/processor/processor.h
+++ b/src/dsp/processor/processor.h
@@ -212,6 +212,8 @@ struct ProcessorStorage
     bool isTemposynced{false};
     int16_t streamingVersion{-1};
 
+    bool procTypeConsistent{true};
+
     bool operator==(const ProcessorStorage &other) const
     {
         return (type == other.type && mix == other.mix && floatParams == other.floatParams &&

--- a/src/json/dsp_traits.h
+++ b/src/json/dsp_traits.h
@@ -57,6 +57,7 @@ SC_STREAMDEF(
                  {"intParams", t.intParams},
                  {"deactivated", t.deactivated},
                  {"isActive", t.isActive},
+                 {"procTypeConsistent", t.procTypeConsistent},
                  {"streamingVersion", t.streamingVersion}};
         }
     }),
@@ -92,6 +93,7 @@ SC_STREAMDEF(
             findOrSet(v, "isKeytracked", false, result.isKeytracked);
             findOrSet(v, "isTemposynced", false, result.isTemposynced);
             findOrSet(v, "streamingVersion", -1, result.streamingVersion);
+            findOrSet(v, "procTypeConsistent", true, result.procTypeConsistent);
 
             /*
              * If engine stream correct here

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -209,7 +209,6 @@ enum SerializationToClientMessageIds
     s2c_send_group_trigger_conditions,
 
     s2c_respond_single_processor_metadata_and_data,
-    s2c_notify_mismatched_processors_for_zone,
 
     s2c_send_part_configuration,
     s2c_send_selected_part,

--- a/src/messaging/client/processor_messages.h
+++ b/src/messaging/client/processor_messages.h
@@ -43,11 +43,6 @@ typedef std::tuple<bool, int, bool, dsp::processor::ProcessorControlDescription,
 SERIAL_TO_CLIENT(ProcessorMetadataAndData, s2c_respond_single_processor_metadata_and_data,
                  processorDataResponsePayload_t, onGroupOrZoneProcessorDataAndMetadata);
 
-// zone, lead type, leadName, all types
-typedef std::tuple<int, int, std::string> processorMismatchPayload_t;
-SERIAL_TO_CLIENT(ProcessorsMismatched, s2c_notify_mismatched_processors_for_zone,
-                 processorMismatchPayload_t, onZoneProcessorDataMismatch);
-
 // C2S set processor type (sends back data and metadata)
 // tuple is forzone, whichprocessor, type
 typedef std::tuple<bool, int32_t, int32_t> setProcessorPayload_t;

--- a/src/modulation/group_matrix.h
+++ b/src/modulation/group_matrix.h
@@ -65,7 +65,7 @@ struct GroupMatrixConfig
     static bool supportsLag(const SourceIdentifier &s) { return true; }
 
     static constexpr bool IsFixedMatrix{true};
-    static constexpr size_t FixedMatrixSize{12};
+    static constexpr size_t FixedMatrixSize{scxt::modMatrixRowsPerGroup};
     static constexpr bool providesTargetRanges{true};
 
     using TI = TargetIdentifier;

--- a/src/modulation/voice_matrix.h
+++ b/src/modulation/voice_matrix.h
@@ -67,7 +67,7 @@ struct MatrixConfig
     static bool supportsLag(const SourceIdentifier &s) { return true; }
 
     static constexpr bool IsFixedMatrix{true};
-    static constexpr size_t FixedMatrixSize{12};
+    static constexpr size_t FixedMatrixSize{scxt::modMatrixRowsPerZone};
     static constexpr bool providesTargetRanges{true};
 
     using TI = TargetIdentifier;

--- a/src/selection/selection_manager.h
+++ b/src/selection/selection_manager.h
@@ -161,7 +161,9 @@ struct SelectionManager
     enum ConsistencyCheck
     {
         PROCESSOR_TYPE,
-        MATRIX_ROW
+        MATRIX_ROW,
+        PROC_ROUTING,
+        LFO_SHAPE
     };
     bool acrossSelectionConsistency(bool forZone, ConsistencyCheck whichCheck, int index);
 

--- a/tests/console_ui.h
+++ b/tests/console_ui.h
@@ -73,8 +73,6 @@ struct ConsoleUI
         const scxt::messaging::client::adsrViewResponsePayload_t &payload) ON_STUB;
     void onGroupOrZoneProcessorDataAndMetadata(
         const scxt::messaging::client::processorDataResponsePayload_t &d) ON_STUB;
-    void onZoneProcessorDataMismatch(
-        const scxt::messaging::client::processorMismatchPayload_t &) ON_STUB;
 
     void onZoneVoiceMatrixMetadata(const scxt::voice::modulation::voiceMatrixMetadata_t &) ON_STUB;
     void onZoneVoiceMatrix(const scxt::voice::modulation::Matrix::RoutingTable &) ON_STUB;


### PR DESCRIPTION
1. Everything has an on-object member rather than separate message
2. Consistenc check vectors through a single function
3. While at it move group and zone matrix count to a config variable