### PR TITLE
Fix a problem where delets would make inconsistent state

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -304,6 +304,14 @@ std::string logTimestamp();
         }                                                                                          \
     }
 
+#define SCLOG_WFUNC_IF(x, ...)                                                                     \
+    {                                                                                              \
+        if constexpr (scxt::log::x)                                                                \
+        {                                                                                          \
+            SCLOG_WFUNC("[" << #x << "] " << __VA_ARGS__);                                         \
+        }                                                                                          \
+    }
+
 #define SCLOG_ONCE_IF(x, ...)                                                                      \
     {                                                                                              \
         if constexpr (scxt::log::x)                                                                \


### PR DESCRIPTION
Deleting a zone could result in an inconsistency between leadZone and allSelectedZones. Also, deleting the last zone crashed post multi-grop-select. Fix both