### PR TITLE
Group MIDI Channel

### DIFF
--- a/src-ui/app/edit-screen/components/GroupSettingsCard.h
+++ b/src-ui/app/edit-screen/components/GroupSettingsCard.h
@@ -68,6 +68,7 @@ struct GroupSettingsCard : juce::Component, HasEditor
 
     void showPolyMenu();
     void showPolyModeMenu();
+    void showMidiChannelMenu();
 };
 } // namespace scxt::ui::app::edit_screen
 #endif // GROUPSETTINGSCARD_H

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -146,9 +146,13 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
             if (!part->configuration.mute && !part->configuration.muteDueToSolo &&
                 part->configuration.active && part->respondsToMIDIChannel(channel))
             {
+                auto prex = part->respondsToMIDIChannelExcludingGroupMask(channel);
                 auto kt = part->configuration.transpose;
                 for (const auto &[gidx, group] : sst::cpputils::enumerate(*part))
                 {
+                    if (!group->respondsToChannelOrUsesPartChannel(channel, prex))
+                        continue;
+
                     if (!group->triggerConditions.value(*this, *group))
                         continue;
 

--- a/src/engine/group.cpp
+++ b/src/engine/group.cpp
@@ -524,6 +524,7 @@ const engine::Engine *Group::getEngine() const
 void Group::setupOnUnstream(engine::Engine &e)
 {
     onRoutingChanged();
+    onGroupMidiChannelSubscriptionChanged();
     rePrepareAndBindGroupMatrix();
 
     for (auto i = 0U; i < engine::lfosPerZone; ++i)
@@ -549,6 +550,16 @@ void Group::setupOnUnstream(engine::Engine &e)
     triggerConditions.setupOnUnstream(parentPart->groupTriggerInstrumentState);
     resetPolyAndPlaymode(e);
 }
+
+void Group::onGroupMidiChannelSubscriptionChanged()
+{
+    assert(parentPart);
+    if (parentPart)
+    {
+        parentPart->rebuildGroupChannelMask();
+    }
+}
+
 void Group::onSampleRateChanged()
 {
     if (getEngine())

--- a/src/engine/group.h
+++ b/src/engine/group.h
@@ -46,7 +46,6 @@
 #include "modulation/group_matrix.h"
 #include "modulation/has_modulators.h"
 #include "group_triggers.h"
-#include "part.h"
 
 namespace scxt::engine
 {

--- a/src/engine/group.h
+++ b/src/engine/group.h
@@ -46,6 +46,7 @@
 #include "modulation/group_matrix.h"
 #include "modulation/has_modulators.h"
 #include "group_triggers.h"
+#include "part.h"
 
 namespace scxt::engine
 {
@@ -93,6 +94,8 @@ struct Group : MoveableOnly<Group>,
         // makes it not quite worth it
         uint32_t vmPlayModeInt{0};
         uint64_t vmPlayModeFeaturesInt{0};
+
+        int16_t midiChannel{-1}; // -1 means "Follow Part"
     } outputInfo;
 
     GroupTriggerConditions triggerConditions;
@@ -108,6 +111,7 @@ struct Group : MoveableOnly<Group>,
     bool lastOversample{true};
 
     void setupOnUnstream(engine::Engine &e);
+    void onGroupMidiChannelSubscriptionChanged();
 
     // ToDo editable name
     std::string getName() const { return name; }
@@ -185,6 +189,20 @@ struct Group : MoveableOnly<Group>,
     void onSampleRateChanged() override;
 
     void resetPolyAndPlaymode(engine::Engine &);
+
+    /*
+     * Only call this if you have *already* checked the part containing
+     * this group responds to the channel
+     */
+    bool respondsToChannelOrUsesPartChannel(int16_t channel, bool parentRespondsExcluding)
+    {
+        if (outputInfo.midiChannel < 0)
+            return parentRespondsExcluding;
+
+        if (outputInfo.midiChannel == channel)
+            return true;
+        return false;
+    }
 
     sst::filters::HalfRate::HalfRateFilter osDownFilter;
 

--- a/src/engine/part.cpp
+++ b/src/engine/part.cpp
@@ -219,6 +219,7 @@ void Part::initializeAfterUnstream(Engine &e)
             sendBusEffectInfoToClient(e, idx);
         }
     }
+    rebuildGroupChannelMask();
 }
 
 void Part::setBusEffectType(Engine &e, int idx, AvailableBusEffects t)

--- a/src/engine/part.cpp
+++ b/src/engine/part.cpp
@@ -253,4 +253,14 @@ void Part::sendBusEffectInfoToClient(const Engine &e, int slot)
         *(e.getMessageController()));
 }
 
+void Part::rebuildGroupChannelMask()
+{
+    std::fill(groupChannelMask.begin(), groupChannelMask.end(), false);
+    for (const auto &g : groups)
+    {
+        if (g->outputInfo.midiChannel >= 0)
+            groupChannelMask[g->outputInfo.midiChannel] = true;
+    }
+}
+
 } // namespace scxt::engine

--- a/src/engine/part.h
+++ b/src/engine/part.h
@@ -94,15 +94,7 @@ struct Part : MoveableOnly<Part>, SampleRateSupport
         return configuration.channel == PartConfiguration::mpeChannel &&
                channel != configuration.mpeGlobalChannel;
     }
-    void rebuildGroupChannelMask()
-    {
-        std::fill(groupChannelMask.begin(), groupChannelMask.end(), false);
-        for (const auto &g : groups)
-        {
-            if (g->outputInfo.midiChannel >= 0)
-                groupChannelMask[g->outputInfo.midiChannel] = true;
-        }
-    }
+    void rebuildGroupChannelMask();
 
     struct PartConfiguration
     {

--- a/src/json/engine_traits.h
+++ b/src/json/engine_traits.h
@@ -373,6 +373,7 @@ SC_STREAMDEF(scxt::engine::Group::GroupOutputInfo, SC_FROM({
                       {"routeTo", (int)t.routeTo},
                       {"hip", t.hasIndependentPolyLimit},
                       {"pl", t.polyLimit},
+                      {"mc", t.midiChannel},
                       {"vpm", groupInfoPlayModeTo(t.vmPlayModeInt)},
                       {"vpf", groupInfoPlayModeFeatureTo(t.vmPlayModeFeaturesInt)}};
              }),
@@ -388,6 +389,7 @@ SC_STREAMDEF(scxt::engine::Group::GroupOutputInfo, SC_FROM({
                  findIf(v, "hip", result.hasIndependentPolyLimit);
                  findIf(v, "pl", result.polyLimit);
                  findOrSet(v, "prCon", true, result.procRoutingConsistent);
+                 findOrSet(v, "mc", -1, result.midiChannel);
                  result.routeTo = (engine::BusAddress)(rt);
 
                  std::string tmp;

--- a/src/messaging/client/client_serial.h
+++ b/src/messaging/client/client_serial.h
@@ -108,6 +108,7 @@ enum ClientToSerializationMessagesIds
     c2s_update_group_output_int16_t_value,
     c2s_update_group_output_bool_value,
     c2s_update_group_output_info_polyphony,
+    c2s_update_group_output_info_midichannel,
 
     c2s_update_group_trigger_conditions,
 

--- a/src/messaging/client/group_messages.h
+++ b/src/messaging/client/group_messages.h
@@ -95,5 +95,23 @@ CLIENT_TO_SERIAL(UpdateGroupOutputInfoPolyphony, c2s_update_group_output_info_po
                  scxt::engine::Group::GroupOutputInfo,
                  doUpdateGroupOutputInfoPolyphony(payload, engine, cont));
 
+inline void doUpdateGroupOutputInfoMidiChannel(const scxt::engine::Group::GroupOutputInfo payload,
+                                               const engine::Engine &engine,
+                                               messaging::MessageController &cont)
+{
+    auto ga = engine.getSelectionManager()->currentLeadGroup(engine);
+    if (ga.has_value())
+    {
+        cont.scheduleAudioThreadCallback([p = payload, g = *ga](auto &eng) {
+            auto &grp = eng.getPatch()->getPart(g.part)->getGroup(g.group);
+            grp->outputInfo = p;
+            grp->onGroupMidiChannelSubscriptionChanged();
+        });
+    }
+}
+CLIENT_TO_SERIAL(UpdateGroupOutputInfoMidiChannel, c2s_update_group_output_info_midichannel,
+                 scxt::engine::Group::GroupOutputInfo,
+                 doUpdateGroupOutputInfoMidiChannel(payload, engine, cont));
+
 } // namespace scxt::messaging::client
 #endif // SHORTCIRCUIT_GROUP_MESSAGES_H


### PR DESCRIPTION
Implements group having midi channel independent from part, defaulting to part.

Start by adding data member making it editable and adding framework for updating on subscription changed.

Set up group channel mask
So now group MIDI message works as expected
Channel menu consistent

Closes #1401