### PR TITLE
More VA blep fixes, and a part fx tail workaround

### DIFF
--- a/src/engine/part.cpp
+++ b/src/engine/part.cpp
@@ -54,6 +54,7 @@ void Part::process(Engine &e)
     lev = lev * lev * lev;
 
     bool defaultAssigned{false};
+    bool noGroups{true};
 
     namespace pl = sst::basic_blocks::dsp::pan_laws;
     auto pan = configuration.pan;
@@ -65,6 +66,7 @@ void Part::process(Engine &e)
     {
         if (g->isActive())
         {
+            noGroups = false;
             g->process(e);
 
             auto bi = g->outputInfo.routeTo;
@@ -106,7 +108,10 @@ void Part::process(Engine &e)
         }
     }
 
-    if (defaultAssigned)
+    if (noGroups)
+        memset(defOut, 0, sizeof(defOut));
+
+    if (defaultAssigned || noGroups)
     {
         // this should be the route to point
         auto bi = configuration.routeTo;

--- a/src/engine/part.h
+++ b/src/engine/part.h
@@ -210,7 +210,16 @@ struct Part : MoveableOnly<Part>, SampleRateSupport
     }
 
     uint32_t activeGroups{0};
-    bool isActive() { return activeGroups != 0 && configuration.active; }
+    bool isActive()
+    {
+        auto res = activeGroups != 0 && configuration.active;
+        // Temporary fix until we implement 1804
+        for (auto &pe : partEffectStorage)
+        {
+            res = res || (pe.type != AvailableBusEffects::none);
+        }
+        return res;
+    }
     void addActiveGroup() { activeGroups++; }
     void removeActiveGroup()
     {


### PR DESCRIPTION
1. Fix the VA blep for very high frequency crash scenarios
2. Address #1804 partly by making a part with a part fx run the fx even absent active groups. This isn't a tail implementation but is a starting point.