### PR TITLE
Add a 'hasFeatures' feature and  turn off unimplemented features

### DIFF
--- a/src-ui/app/browser-ui/BrowserPane.h
+++ b/src-ui/app/browser-ui/BrowserPane.h
@@ -64,7 +64,7 @@ struct BrowserPane : public app::HasEditor, sst::jucegui::components::NamedPanel
     std::unique_ptr<SearchPane> searchPane;
     std::unique_ptr<BrowserPaneFooter> footerArea;
 
-    void selectPane(int);
+    void selectPane(int, bool updatePrefs = false);
     int selectedPane{0};
 
     bool autoPreviewEnabled{true};

--- a/src-ui/app/edit-screen/components/AdsrPane.cpp
+++ b/src-ui/app/edit-screen/components/AdsrPane.cpp
@@ -40,7 +40,7 @@ AdsrPane::AdsrPane(SCXTEditor *e, int idx, bool fz)
 {
     setContentAreaComponent(std::make_unique<juce::Component>());
 
-    hasHamburger = true;
+    hasHamburger = hasFeature::alternateEGModes;
 
     rebuildPanelComponents(idx);
 

--- a/src-ui/app/edit-screen/components/ModPane.cpp
+++ b/src-ui/app/edit-screen/components/ModPane.cpp
@@ -863,7 +863,7 @@ ModPane<GZTrait>::ModPane(SCXTEditor *e, bool fz) : jcmp::NamedPanel(""), HasEdi
     // getContentAreaComponent()->addAndMakeVisible(*viewPort);
     addAndMakeVisible(*viewPort);
 
-    hasHamburger = true;
+    hasHamburger = false;
     if (GZTrait::forZone)
     {
         setName("MOD MATRIX");

--- a/src-ui/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
+++ b/src-ui/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
@@ -49,8 +49,11 @@ MappingDisplay::MappingDisplay(MacroMappingVariantPane *p)
     zoneLayoutViewport->setVZoomFloor(32.f / 128.f);
     addAndMakeVisible(*zoneLayoutViewport);
 
-    zoneHeader = std::make_unique<MappingZoneHeader>(editor);
-    addAndMakeVisible(*zoneHeader);
+    if (hasFeature::zoneAutoMapControls)
+    {
+        zoneHeader = std::make_unique<MappingZoneHeader>(editor);
+        addAndMakeVisible(*zoneHeader);
+    }
 
     // Start here tomorrow
     using ffac =
@@ -216,10 +219,14 @@ void MappingDisplay::resized()
 
     // Header
     auto b = getLocalBounds();
-    zoneHeader->setBounds(b.withHeight(headerSize));
+    auto z = b;
+    if (hasFeature::zoneAutoMapControls)
+    {
+        zoneHeader->setBounds(b.withHeight(headerSize));
 
-    // Mapping Display
-    auto z = b.withTrimmedTop(headerSize);
+        // Mapping Display
+        z = b.withTrimmedTop(headerSize);
+    }
     auto viewArea = z.withWidth(getWidth() - controlSize - 5);
     zoneLayoutViewport->setBounds(viewArea);
     /*

--- a/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src-ui/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -433,6 +433,13 @@ void SCXTEditor::onOtherTabSelection(
     {
         editScreen->onOtherTabSelection();
     }
+
+    auto bs = queryTabSelection("browser.source");
+    if (!bs.empty() && editScreen && editScreen->browser)
+    {
+        auto v = std::atoi(bs.c_str());
+        editScreen->browser->selectPane(v);
+    }
 }
 
 void SCXTEditor::onPartConfiguration(

--- a/src-ui/app/shared/HeaderRegion.cpp
+++ b/src-ui/app/shared/HeaderRegion.cpp
@@ -127,15 +127,18 @@ HeaderRegion::HeaderRegion(SCXTEditor *e) : HasEditor(e)
     });
     addAndMakeVisible(*scMenu);
 
-    undoButton = std::make_unique<jcmp::TextPushButton>();
-    undoButton->setLabel("Undo");
-    undoButton->setOnCallback(editor->makeComingSoon());
-    addAndMakeVisible(*undoButton);
+    if (hasFeature::undoRedo)
+    {
+        undoButton = std::make_unique<jcmp::TextPushButton>();
+        undoButton->setLabel("Undo");
+        undoButton->setOnCallback(editor->makeComingSoon());
+        addAndMakeVisible(*undoButton);
 
-    redoButton = std::make_unique<jcmp::TextPushButton>();
-    redoButton->setLabel("Redo");
-    redoButton->setOnCallback(editor->makeComingSoon());
-    addAndMakeVisible(*redoButton);
+        redoButton = std::make_unique<jcmp::TextPushButton>();
+        redoButton->setLabel("Redo");
+        redoButton->setOnCallback(editor->makeComingSoon());
+        addAndMakeVisible(*redoButton);
+    }
 
     tuningButton = std::make_unique<jcmp::TextPushButton>();
     tuningButton->setLabel("Tune");
@@ -159,9 +162,12 @@ HeaderRegion::HeaderRegion(SCXTEditor *e) : HasEditor(e)
     });
     addAndMakeVisible(*zoomButton);
 
-    chipButton = std::make_unique<jcmp::GlyphButton>(jcmp::GlyphPainter::MEMORY);
-    chipButton->setOnCallback(editor->makeComingSoon());
-    addAndMakeVisible(*chipButton);
+    if (hasFeature::memoryUsageExplanation)
+    {
+        chipButton = std::make_unique<jcmp::GlyphButton>(jcmp::GlyphPainter::MEMORY);
+        chipButton->setOnCallback(editor->makeComingSoon());
+        addAndMakeVisible(*chipButton);
+    }
 
     saveAsButton = std::make_unique<jcmp::GlyphButton>(jcmp::GlyphPainter::SAVE);
     saveAsButton->setOnCallback([w = juce::Component::SafePointer(this)]() {
@@ -221,13 +227,19 @@ void HeaderRegion::resized()
     auto b = getBounds().reduced(6);
     selectedPage->setBounds(b.withWidth(196));
 
-    undoButton->setBounds(b.withTrimmedLeft(246).withWidth(48));
-    redoButton->setBounds(b.withTrimmedLeft(246 + 50).withWidth(48));
+    if (hasFeature::undoRedo)
+    {
+        undoButton->setBounds(b.withTrimmedLeft(246).withWidth(48));
+        redoButton->setBounds(b.withTrimmedLeft(246 + 50).withWidth(48));
+    }
 
     tuningButton->setBounds(b.withTrimmedLeft(823).withWidth(48));
     zoomButton->setBounds(b.withTrimmedLeft(823 + 50).withWidth(48));
 
-    chipButton->setBounds(b.withTrimmedLeft(393).withWidth(24));
+    if (hasFeature::memoryUsageExplanation)
+    {
+        chipButton->setBounds(b.withTrimmedLeft(393).withWidth(24));
+    }
     saveAsButton->setBounds(b.withTrimmedLeft(755).withWidth(24));
 
     multiMenuButton->setBounds(b.withTrimmedLeft(421).withWidth(330));

--- a/src/browser/browser_db.cpp
+++ b/src/browser/browser_db.cpp
@@ -83,7 +83,7 @@ std::vector<std::pair<fs::path, bool>> BrowserDB::getBrowserLocations()
         auto q = SQL::Statement(conn, query);
         while (q.step())
         {
-            res.emplace_back(fs::path{q.col_str(0)}, false);
+            res.emplace_back(fs::path{q.col_str(0)}, true);
         }
         q.finalize();
     }

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -101,5 +101,16 @@ static constexpr bool missingResolution{false};
 static constexpr bool patchIO{false};
 } // namespace log
 
+// The wireframe implies features beyond what we have. I started coding up the UI elements
+// but this turns them off or providers simpler versions.
+namespace hasFeature
+{
+static constexpr bool undoRedo{false};               // undo-redo
+static constexpr bool memoryUsageExplanation{false}; // that chip in the header
+static constexpr bool zoneAutoMapControls{false};    // do we show the midi and automap
+static constexpr bool alternateEGModes{false};       // do we have DA only etc...
+static constexpr bool hasBrowserSearch{false};
+} // namespace hasFeature
+
 } // namespace scxt
 #endif // __SCXT__CONFIGURATION_H


### PR DESCRIPTION
add configuration hasFeatures sub namespace with constexpr bools for things we haven't coded

Add ifs to deal with those with alternate implementations and/or layotus

Basically allows us to look at a more complete appearing synth without having the unimplemented extras on screen for now