### PR TITLE
Fix a problem in group tail implementation

### DIFF
--- a/src/scxt-core/engine/group.cpp
+++ b/src/scxt-core/engine/group.cpp
@@ -413,7 +413,8 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
         {
             silenceTime += blockSize;
         }
-        else
+
+        if (silenceTime > silenceMax)
         {
             if (blocksToTerminate < 0)
             {

--- a/src/scxt-core/engine/part.cpp
+++ b/src/scxt-core/engine/part.cpp
@@ -133,6 +133,26 @@ void Part::process(Engine &e)
     }
 }
 
+bool Part::isActive()
+{
+    if (!configuration.active)
+        return false;
+    auto res = activeGroups != 0;
+    // Temporary fix until we implement 1804
+
+    bool hasAny{false};
+    for (auto &pe : partEffectStorage)
+    {
+        hasAny = hasAny || (pe.type != AvailableBusEffects::none);
+    }
+
+    if (!res && hasAny)
+    {
+        // This is the part ringout clause
+    }
+    return res || hasAny;
+}
+
 Part::zoneMappingSummary_t Part::getZoneMappingSummary()
 {
     zoneMappingSummary_t res;

--- a/src/scxt-core/engine/part.h
+++ b/src/scxt-core/engine/part.h
@@ -210,16 +210,7 @@ struct Part : MoveableOnly<Part>, SampleRateSupport
     }
 
     uint32_t activeGroups{0};
-    bool isActive()
-    {
-        auto res = activeGroups != 0 && configuration.active;
-        // Temporary fix until we implement 1804
-        for (auto &pe : partEffectStorage)
-        {
-            res = res || (pe.type != AvailableBusEffects::none);
-        }
-        return res;
-    }
+    bool isActive();
     void addActiveGroup() { activeGroups++; }
     void removeActiveGroup()
     {


### PR DESCRIPTION
The group tail implementation stopped the group correctly but didn't notify the parent that the group was stopped. Fix that through the implementation of an if rather than else in the group chain.

I figured this out by starting to work on part ringout so did a bit of the pre-work for that but nothing material.