### PR TITLE
Step 1 of Bus Ringout

### DIFF
--- a/src/scxt-core/engine/bus.cpp
+++ b/src/scxt-core/engine/bus.cpp
@@ -101,6 +101,13 @@ void Bus::initializeAfterUnstream(Engine &e)
 }
 void Bus::process()
 {
+    if (inRingout != wasInRingout)
+    {
+        SCLOG_IF(ringout, "BUS " << getBusAddressLabel(address) << " " << SCD(inRingout));
+    }
+
+    wasInRingout = inRingout;
+
     if (hasOSSignal)
     {
         if (!previousHadOSSignal)

--- a/src/scxt-core/engine/bus.h
+++ b/src/scxt-core/engine/bus.h
@@ -99,6 +99,8 @@ struct Bus : MoveableOnly<Bus>, SampleRateSupport
     float auxoutputPreVCA alignas(16)[2][blockSize];
     float auxoutputPostVCA alignas(16)[2][blockSize];
     float vuLevel[2]{0.f, 0.f}, vuFalloff{0.f};
+    bool inRingout{false}, wasInRingout{false};
+    void setInRingout(bool b) { inRingout = b; }
 
     sst::filters::HalfRate::HalfRateFilter downsampleFilter;
 
@@ -107,6 +109,7 @@ struct Bus : MoveableOnly<Bus>, SampleRateSupport
         memset(output, 0, sizeof(output));
         memset(outputOS, 0, sizeof(outputOS));
         hasOSSignal = false;
+        inRingout = true;
     }
 
     void process();

--- a/src/scxt-core/engine/patch.cpp
+++ b/src/scxt-core/engine/patch.cpp
@@ -64,6 +64,7 @@ void Patch::process(Engine &e)
                 if (b.busSendStorage.sendLevels[i] != 0.f)
                 {
                     busses.busUsed[i + AUX_0] = true;
+                    busses.auxBusses[i].inRingout = busses.auxBusses[i].inRingout && b.inRingout;
                     switch (b.busSendStorage.auxLocation[i])
                     {
                     case Bus::BusSendStorage::PRE_FX:
@@ -102,6 +103,7 @@ void Patch::process(Engine &e)
     {
         if (br == 0)
         {
+            busses.mainBus.inRingout = busses.mainBus.inRingout && busses.partBusses[bi].inRingout;
             // accumulate onto main
             mech::accumulate_from_to<blockSize>(busses.partBusses[bi].output[0],
                                                 busses.mainBus.output[0]);

--- a/src/scxt-core/engine/patch.h
+++ b/src/scxt-core/engine/patch.h
@@ -169,6 +169,7 @@ struct Patch : MoveableOnly<Patch>, SampleRateSupport
     Bus &getBusForOutput(BusAddress &ba)
     {
         busses.busUsed[(int)ba] = true;
+        busses.busByAddress(ba).setInRingout(false);
         return busses.busByAddress(ba);
     }
 


### PR DESCRIPTION
This is step 1 of bus ringout. The bus now knows if it is in a potential ringout state (namely nothing has been pushed to it) so it can self-shortcircuit. It doesn't do that though and just keeps processing, here with a turned-off log for when it is in ringout state

Addresses #1223