### PR TITLE
Phasor Panel Upgrade: Engine Side

### DIFF
--- a/src/scxt-core/engine/group.cpp
+++ b/src/scxt-core/engine/group.cpp
@@ -725,7 +725,7 @@ void Group::resetLFOs(int whichLFO)
     }
 
     randomEvaluator.evaluate(getEngine()->rng, miscSourceStorage);
-    phasorEvaluator.attack(getEngine()->transport, miscSourceStorage);
+    phasorEvaluator.attack(getEngine()->transport, miscSourceStorage, getEngine()->rng);
 }
 
 bool Group::isActive() const

--- a/src/scxt-core/json/modulation_traits.h
+++ b/src/scxt-core/json/modulation_traits.h
@@ -147,6 +147,7 @@ SC_STREAMDEF(modulation::modulators::PhasorStorage, SC_FROM({
                  addUnlessDefault<val_t>(v, "sy", ps::SyncMode::VOICEPOS, from.syncMode);
                  addUnlessDefault<val_t>(v, "nu", 1, from.numerator);
                  addUnlessDefault<val_t>(v, "de", 4, from.denominator);
+                 addUnlessDefault<val_t>(v, "ph", 0.f, from.phase);
              }),
              SC_TO({
                  using ps = modulation::modulators::PhasorStorage;
@@ -154,6 +155,7 @@ SC_STREAMDEF(modulation::modulators::PhasorStorage, SC_FROM({
                  findOrSet(v, "sy", ps::SyncMode::VOICEPOS, to.syncMode);
                  findOrSet(v, "nu", 1, to.numerator);
                  findOrSet(v, "de", 4, to.denominator);
+                 findOrSet(v, "ph", 0, to.phase);
              }));
 
 STREAM_ENUM(modulation::modulators::RandomStorage::Style,

--- a/src/scxt-core/modulation/modulator_storage.cpp
+++ b/src/scxt-core/modulation/modulator_storage.cpp
@@ -42,6 +42,8 @@ std::string PhasorStorage::toStringDivision(const Division &s)
         return "t";
     case Division::DOTTED:
         return "d";
+    case Division::OF_BEAT:
+        return "ob";
     }
     return "ERR";
 }
@@ -49,7 +51,7 @@ std::string PhasorStorage::toStringDivision(const Division &s)
 PhasorStorage::Division PhasorStorage::fromStringDivision(const std::string &s)
 {
     static auto inverse = makeEnumInverse<PhasorStorage::Division, PhasorStorage::toStringDivision>(
-        PhasorStorage::Division::NOTE, PhasorStorage::Division::DOTTED);
+        PhasorStorage::Division::NOTE, PhasorStorage::Division::OF_BEAT);
     auto p = inverse.find(s);
     if (p == inverse.end())
         return PhasorStorage::Division::NOTE;

--- a/src/scxt-core/modulation/modulator_storage.h
+++ b/src/scxt-core/modulation/modulator_storage.h
@@ -93,9 +93,12 @@ struct PhasorStorage
     {
         NOTE,
         TRIPLET,
-        DOTTED
+        DOTTED,
+        OF_BEAT,
     } division{NOTE};
     DECLARE_ENUM_STRING(Division);
+
+    float phase{0.f};
 
     int32_t numerator{1}, denominator{4};
 };

--- a/src/scxt-core/voice/voice.cpp
+++ b/src/scxt-core/voice/voice.cpp
@@ -163,7 +163,7 @@ void Voice::voiceStarted()
     }
 
     randomEvaluator.evaluate(engine->rng, zone->miscSourceStorage);
-    phasorEvaluator.attack(engine->transport, zone->miscSourceStorage);
+    phasorEvaluator.attack(engine->transport, zone->miscSourceStorage, engine->rng);
 
     auto &aegp = endpoints->egTarget[0];
     if (*aegp.dlyP < 1e-5)


### PR DESCRIPTION
This is the engine side of #1643

1. Adds phasor phase and displays it in selections.
2. Adds a new "OF_BEAT" mode to N/T/D which is basically a fraction of the time signature beat. So in 4/4 a fraction of a quarter and in 6/8 a fraction of an 8th.

It does not address any of the UI changes with the N/D control

Addresses #1643