### PR TITLE
VU meter fix due to bus tails

### DIFF
--- a/src/scxt-core/engine/bus.cpp
+++ b/src/scxt-core/engine/bus.cpp
@@ -112,7 +112,8 @@ void Bus::process()
             }
             idx++;
         }
-        if (silenceTime > silenceMaxUpstreamBusses + silenceMaxSelf)
+        if (silenceTime > silenceMaxUpstreamBusses + silenceMaxSelf && vuLevel[0] < silenceThresh &&
+            vuLevel[1] < silenceThresh)
         {
             if (!wasSilent)
             {


### PR DESCRIPTION
Bus tails were for audio but the VU has ballistics which are slower than audio so the vu meter wouldn't update once the bus was silent in no effect. Just use the vu level as another done criteria.