### PR TITLE
Stress Test: Zone Layout paint improves

### DIFF
--- a/src/clients/stress-tests/make-stress.cpp
+++ b/src/clients/stress-tests/make-stress.cpp
@@ -37,12 +37,13 @@ int main(int argc, char **argv)
     namespace cmsg = scxt::messaging::client;
 
     using abz = cmsg::AddBlankZone;
-    for (int k = 0; k < 10; ++k)
+    auto dc{5};
+    for (int k = 0; k < 127; k += dc)
     {
         SCLOG("Starting key " << k)
-        for (int v = 0; v < 127; ++v)
+        for (int v = 0; v < 127; v += dc)
         {
-            ch->sendToSerialization(abz({0, 0, k, k + 1, v, v + 1}));
+            ch->sendToSerialization(abz({0, 0, k, k + dc - 1, v, v + dc - 1}));
         }
         ch->stepUI();
     }

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
@@ -316,7 +316,9 @@ void MappingDisplay::setGroupZoneMappingSummary(const engine::Part::zoneMappingS
     if (editor->currentLeadZoneSelection.has_value())
         setLeadSelection(*(editor->currentLeadZoneSelection));
     if (mappingZones)
-        mappingZones->repaint();
+    {
+        mappingZones->mappingWasReset();
+    }
     repaint();
 }
 

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.h
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.h
@@ -48,6 +48,8 @@ struct ZoneLayoutDisplay : juce::Component, HasEditor
     juce::Rectangle<float> rectangleForRange(int kL, int kH, int vL, int vH);
     juce::Rectangle<float> rectangleForRangeSkipEnd(int kL, int kH, int vL, int vH);
 
+    std::unordered_map<std::string, juce::GlyphArrangement> glyphArrangementCache;
+    std::unordered_map<std::string, juce::Rectangle<float>> glyphBBCache;
     void labelZoneRectangle(juce::Graphics &g, const juce::Rectangle<float> &, const std::string &,
                             const juce::Colour &);
 
@@ -152,6 +154,8 @@ struct ZoneLayoutDisplay : juce::Component, HasEditor
 
     void showZoneMenu(const selection::SelectionManager::ZoneAddress &za);
     void showMappingNonZoneMenu(const juce::Point<int> &);
+
+    void mappingWasReset() { repaint(); }
 
     float hPct{0.0}, hZoom{1.0}, vPct{0.0}, vZoom{1.0};
     void setHorizontalZoom(float pctStart, float zoomFactor)


### PR DESCRIPTION
The zone layout was spending massive amounts of time doing text math on labels with Glyph Arrangements. A few well placed caches and one prediction incrases performance from unusable to totally smoothin with the 5x5 test case