### PR TITLE
Fix an SF2 bug

### DIFF
--- a/src/scxt-core/sample/multisample_support/multisample_compound_file_impl.cpp
+++ b/src/scxt-core/sample/multisample_support/multisample_compound_file_impl.cpp
@@ -1,6 +1,29 @@
-//
-// Created by Paul Walker on 11/12/25.
-//
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2025, Various authors, as described in the github
+ * transaction log.
+ *
+ * ShortcircuitXT is released under the Gnu General Public Licence
+ * V3 or later (GPL-3.0-or-later). The license is found in the file
+ * "LICENSE" in the root of this repository or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Individual sections of code which comprises ShortcircuitXT in this
+ * repository may also be used under an MIT license. Please see the
+ * section  "Licensing" in "README.md" for details.
+ *
+ * ShortcircuitXT is inspired by, and shares code with, the
+ * commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
 
 #include <miniz.h>
 #include "sample/compound_file.h"

--- a/src/scxt-core/sample/sf2_support/sf2_import.cpp
+++ b/src/scxt-core/sample/sf2_support/sf2_import.cpp
@@ -126,10 +126,8 @@ bool importSF2(const fs::path &p, engine::Engine &e, int preset)
                         return c;
                     };
 
-                    auto lk =
-                        noneOr(region->loKey, presetRegion->loKey, (int)sfsamp->OriginalPitch);
-                    auto hk =
-                        noneOr(region->hiKey, presetRegion->hiKey, (int)sfsamp->OriginalPitch);
+                    auto lk = noneOr(region->loKey, presetRegion->loKey, (int)0);
+                    auto hk = noneOr(region->hiKey, presetRegion->hiKey, (int)127);
                     zn->mapping.keyboardRange = {lk, hk};
 
                     auto lv = noneOr(region->minVel, presetRegion->minVel, 0);


### PR DESCRIPTION
If the keyrange is non for both region and parent, the sf2 spec implies 0...127 not rootkey...rootkey.