### PR TITLE
Implement group audio mute

### DIFF
--- a/src/scxt-core/engine/engine.cpp
+++ b/src/scxt-core/engine/engine.cpp
@@ -501,14 +501,19 @@ Engine::pgzStructure_t Engine::getPartGroupZoneStructure() const
         int32_t groupidx{0};
         for (const auto &group : *part)
         {
-            res.push_back({{partidx, groupidx, -1}, group->getName()});
+            int32_t groupFeatures{0};
+            if (group->outputInfo.muted)
+            {
+                groupFeatures += GroupZoneFeatures::MUTED;
+            }
+            res.push_back({{partidx, groupidx, -1}, group->getName(), groupFeatures});
             int32_t zoneidx{0};
             for (const auto &zone : *group)
             {
                 int32_t zoneFeatures{0};
                 if (zone->missingSampleCount() > 0)
                 {
-                    zoneFeatures |= ZoneFeatures::MISSING_SAMPLE;
+                    zoneFeatures |= GroupZoneFeatures::MISSING_SAMPLE;
                 }
 
                 res.push_back({{partidx, groupidx, zoneidx}, zone->getName(), zoneFeatures});

--- a/src/scxt-core/engine/feature_enums.h
+++ b/src/scxt-core/engine/feature_enums.h
@@ -30,9 +30,10 @@
 
 namespace scxt::engine
 {
-enum ZoneFeatures
+enum GroupZoneFeatures
 {
     MISSING_SAMPLE = 1 << 0,
+    MUTED = 1 << 1,
 };
 }
 

--- a/src/scxt-core/engine/group.cpp
+++ b/src/scxt-core/engine/group.cpp
@@ -378,6 +378,7 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
     }
 
     mlev = std::max(mlev, 0.f);
+
     if constexpr (OS)
     {
         outputAmpOS.set_target(mlev * mlev * mlev);

--- a/src/scxt-core/engine/part.cpp
+++ b/src/scxt-core/engine/part.cpp
@@ -187,7 +187,7 @@ Part::zoneMappingSummary_t Part::getZoneMappingSummary()
             int32_t features{0};
             if (z->missingSampleCount() > 0)
             {
-                features |= ZoneFeatures::MISSING_SAMPLE;
+                features |= GroupZoneFeatures::MISSING_SAMPLE;
             }
             auto data = zoneMappingItem_t{addr, z->mapping.keyboardRange, z->mapping.velocityRange,
                                           z->getName(), features};

--- a/src/scxt-core/messaging/client/client_serial.h
+++ b/src/scxt-core/messaging/client/client_serial.h
@@ -148,6 +148,8 @@ enum ClientToSerializationMessagesIds
     c2s_rename_zone,
     c2s_rename_group,
 
+    c2s_mute_solo_group,
+
     c2s_set_tuning_mode,
 
     c2s_noteonoff,

--- a/src/scxt-core/voice/voice.cpp
+++ b/src/scxt-core/voice/voice.cpp
@@ -770,6 +770,11 @@ template <bool OS> bool Voice::processWithOS()
     }
     pao = std::max(pao, 0.f);
 
+    if (zone->parentGroup->outputInfo.muted)
+    {
+        pao = 0.f;
+    }
+
     if constexpr (OS)
     {
         outputAmpOS.set_target(pao * pao * pao * noteExpressions[(int)ExpressionIDs::VOLUME]);

--- a/src/scxt-plugin/app/edit-screen/components/PartGroupSidebar.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/PartGroupSidebar.cpp
@@ -217,7 +217,6 @@ struct GroupZoneSidebarBase : juce::Component, HasEditor, juce::DragAndDropConta
     {
         gzTreeControl->selectedZones =
             std::set<selection::SelectionManager::ZoneAddress>(sel.begin(), sel.end());
-        ;
         gzTreeControl->reassignAllComponents();
     }
 

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
@@ -882,7 +882,7 @@ void ZoneLayoutDisplay::paint(juce::Graphics &g)
             auto fillColor = editor->themeColor(theme::ColorMap::accent_2b).withAlpha(0.32f);
             auto textColor = editor->themeColor(theme::ColorMap::accent_2a);
 
-            if (z.features & engine::ZoneFeatures::MISSING_SAMPLE)
+            if (z.features & engine::GroupZoneFeatures::MISSING_SAMPLE)
             {
                 borderColor = editor->themeColor(theme::ColorMap::warning_1b);
                 fillColor = editor->themeColor(theme::ColorMap::warning_1b).withAlpha(0.32f);
@@ -894,7 +894,7 @@ void ZoneLayoutDisplay::paint(juce::Graphics &g)
                 fillColor = borderColor.withAlpha(0.32f);
                 textColor = editor->themeColor(theme::ColorMap::accent_1a);
 
-                if (z.features & engine::ZoneFeatures::MISSING_SAMPLE)
+                if (z.features & engine::GroupZoneFeatures::MISSING_SAMPLE)
                 {
                     borderColor = editor->themeColor(theme::ColorMap::warning_1a);
                     fillColor = editor->themeColor(theme::ColorMap::warning_1a).withAlpha(0.32f);
@@ -929,7 +929,7 @@ void ZoneLayoutDisplay::paint(juce::Graphics &g)
 
             auto selZoneColor = editor->themeColor(theme::ColorMap::accent_1a);
             auto borderColor = selZoneColor;
-            if (z.features & engine::ZoneFeatures::MISSING_SAMPLE)
+            if (z.features & engine::GroupZoneFeatures::MISSING_SAMPLE)
             {
                 selZoneColor = editor->themeColor(theme::ColorMap::warning_1a);
                 borderColor = editor->themeColor(theme::ColorMap::accent_1a);


### PR DESCRIPTION
Addresses #1923

Groups have a mute which is an audio mute (set output to zero and continue to run voices) togglable in the side bar. No solo still and still testing to do, but this gets us in a bit better shape for beta