### PR TITLE
Fix a focus problem which caused typein-click-away to appear broken

### DIFF
--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
@@ -174,6 +174,11 @@ MappingDisplay::MappingDisplay(MacroMappingVariantPane *p)
     fAdd(mappingView.tracking, floatAttachments.Tracking, textEds.Tracking);
     makeLabel(labels.Tracking, "KT");
     labels.Tracking->setJustification(juce::Justification::centredLeft);
+
+    setAccessible(true);
+    setTitle("Mapping");
+    setDescription("Mapping");
+    setWantsKeyboardFocus(true);
 }
 
 MappingDisplay::~MappingDisplay() = default;

--- a/src/scxt-plugin/app/editor-impl/SCXTEditorMenus.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditorMenus.cpp
@@ -140,6 +140,12 @@ void SCXTEditor::showMainMenu()
             []() { SCLOG("Cancel Pressed"); });
     });
     dp.addSeparator();
+    dp.addItem("Toggle Focus Debugger", [w = juce::Component::SafePointer(this)]() {
+        if (!w)
+            return;
+        w->focusDebugger->setDoFocusDebug(!w->focusDebugger->doFocusDebug);
+    });
+    dp.addSeparator();
 
 #if HAS_MELATONIN_INSPECTOR
     if (melatoninInspector)


### PR DESCRIPTION
If you click on something non-focusable, then focuslost will never be raised!

closes #1952