### PR TITLE
Routing/Output Consistency with New UI

### DIFF
--- a/src/scxt-core/engine/group.h
+++ b/src/scxt-core/engine/group.h
@@ -84,6 +84,7 @@ struct Group : MoveableOnly<Group>,
         ProcRoutingPath procRouting{procRoute_linear};
         bool procRoutingConsistent{true};
         BusAddress routeTo{DEFAULT_BUS};
+        bool busRoutingConsistent{true};
 
         bool hasIndependentPolyLimit{false};
         int32_t polyLimit{0};

--- a/src/scxt-core/engine/zone.h
+++ b/src/scxt-core/engine/zone.h
@@ -168,6 +168,7 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
         ProcRoutingPath procRouting{procRoute_linear};
         bool procRoutingConsistent{true};
         BusAddress routeTo{DEFAULT_BUS};
+        bool busRoutingConsistent{true};
     } outputInfo;
     static_assert(std::is_standard_layout<ZoneOutputInfo>::value);
 

--- a/src/scxt-core/json/engine_traits.h
+++ b/src/scxt-core/json/engine_traits.h
@@ -382,6 +382,7 @@ SC_STREAMDEF(scxt::engine::Group::GroupOutputInfo, SC_FROM({
                       {"muted", t.muted},
                       {"procRouting", t.procRouting},
                       {"prCon", t.procRoutingConsistent},
+                      {"buCon", t.busRoutingConsistent},
                       {"routeTo", (int)t.routeTo},
                       {"hip", t.hasIndependentPolyLimit},
                       {"pl", t.polyLimit},
@@ -404,6 +405,7 @@ SC_STREAMDEF(scxt::engine::Group::GroupOutputInfo, SC_FROM({
                  findIf(v, "hip", result.hasIndependentPolyLimit);
                  findIf(v, "pl", result.polyLimit);
                  findOrSet(v, "prCon", true, result.procRoutingConsistent);
+                 findOrSet(v, "buCon", true, result.busRoutingConsistent);
                  findOrSet(v, "mc", -1, result.midiChannel);
                  findOrSet(v, "pbu", 2, result.pbUp);
                  findOrSet(v, "pbd", 2, result.pbDown);
@@ -471,6 +473,7 @@ SC_STREAMDEF(scxt::engine::Group, SC_FROM({
 SC_STREAMDEF(scxt::engine::Zone::ZoneOutputInfo, SC_FROM({
                  v = {{"amp", t.amplitude}, {"pan", t.pan}, {"to", (int)t.routeTo}};
                  addUnlessDefault<val_t>(v, "prc", true, t.procRoutingConsistent);
+                 addUnlessDefault<val_t>(v, "brc", true, t.busRoutingConsistent);
                  addUnlessDefault<val_t>(v, "prt", engine::Zone::ProcRoutingPath::procRoute_linear,
                                          t.procRouting);
                  addUnlessDefault<val_t>(v, "muted", false, t.muted);
@@ -485,6 +488,7 @@ SC_STREAMDEF(scxt::engine::Zone::ZoneOutputInfo, SC_FROM({
                            engine::Zone::ProcRoutingPath::procRoute_linear, zo.procRouting);
                  int rt{engine::BusAddress::DEFAULT_BUS};
                  findIf(v, {"to", "routeTo"}, rt);
+                 findOrSet(v, "brc", true, zo.busRoutingConsistent);
 
                  // There was an error which streamed garbage for a while.
                  // Might as well be defensive hereon out even though I

--- a/src/scxt-core/selection/selection_manager.cpp
+++ b/src/scxt-core/selection/selection_manager.cpp
@@ -586,6 +586,7 @@ void SelectionManager::sendDisplayDataForZonesBasedOnLead(int p, int g, int z)
     // Update across selections here to see if the routing is consistent
     auto rt = zp->outputInfo.procRouting;
     zp->outputInfo.procRoutingConsistent = acrossSelectionConsistency(true, PROC_ROUTING, 0);
+    zp->outputInfo.busRoutingConsistent = acrossSelectionConsistency(true, OUTPUT_ROUTING, 0);
 
     serializationSendToClient(cms::s2c_update_zone_output_info,
                               cms::zoneOutputInfoUpdate_t{true, zp->outputInfo},
@@ -883,7 +884,7 @@ void SelectionManager::clearAllSelections()
 bool SelectionManager::acrossSelectionConsistency(bool forZone, ConsistencyCheck whichCheck,
                                                   int index)
 {
-    auto doCheck = [forZone, whichCheck, index](const auto &lz, const auto &it) {
+    auto doCheck = [whichCheck, index](const auto &lz, const auto &it) {
         switch (whichCheck)
         {
         case PROCESSOR_TYPE:
@@ -910,6 +911,12 @@ bool SelectionManager::acrossSelectionConsistency(bool forZone, ConsistencyCheck
             if (lz->outputInfo.procRouting != it->outputInfo.procRouting)
                 return false;
             break;
+        case OUTPUT_ROUTING:
+        {
+            if (lz->outputInfo.routeTo != it->outputInfo.routeTo)
+                return false;
+            break;
+        }
         }
         return true;
     };

--- a/src/scxt-core/selection/selection_manager.h
+++ b/src/scxt-core/selection/selection_manager.h
@@ -163,6 +163,7 @@ struct SelectionManager
         PROCESSOR_TYPE,
         MATRIX_ROW,
         PROC_ROUTING,
+        OUTPUT_ROUTING,
         LFO_SHAPE
     };
     bool acrossSelectionConsistency(bool forZone, ConsistencyCheck whichCheck, int index);

--- a/src/scxt-plugin/app/edit-screen/components/RoutingPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/RoutingPane.cpp
@@ -297,6 +297,7 @@ struct RoutingPaneContents : juce::Component, HasEditor, sst::jucegui::layouts::
         auto c = info.procRoutingConsistent;
         multiW->setVisible(c);
         routingLayoutComp->setVisible(c);
+        svgPaths->setVisible(c);
         consistentButton->setVisible(!c);
         consistentLabel->setVisible(!c);
 
@@ -307,6 +308,15 @@ struct RoutingPaneContents : juce::Component, HasEditor, sst::jucegui::layouts::
         else
         {
             updateFromProcessorPanes();
+        }
+
+        if (info.busRoutingConsistent)
+        {
+            outputRouting->setLabel(getRoutingLabel(info.routeTo));
+        }
+        else
+        {
+            outputRouting->setLabel("Varied Outputs");
         }
     }
 


### PR DESCRIPTION
Make sure the proc routing inconsistent-across-selection and bus routing inconsistent-across-selection UIs work properly with the new expanded UI organization.

Closes #1968