### PR TITLE
Fix an ASAN error in expanding drive area

### DIFF
--- a/src/scxt-plugin/app/browser-ui/BrowserPane.cpp
+++ b/src/scxt-plugin/app/browser-ui/BrowserPane.cpp
@@ -378,6 +378,7 @@ struct DriveFSArea : juce::Component, HasEditor
     {
         auto &ent = contents[row];
         assert(!ent.isExpanded);
+        ent.isExpanded = true;
         auto ct = browser::Browser::expandForBrowser(ent.dirent.path());
         if (!ct.empty())
         {
@@ -388,7 +389,6 @@ struct DriveFSArea : juce::Component, HasEditor
                 after++;
             }
         }
-        ent.isExpanded = true;
         listView->refresh();
         if (!ct.empty())
         {


### PR DESCRIPTION
The refernce to entry may not survive the insertino of elements, so reorder the setting of isExpanded to before expanding