### PR TITLE
Stop menu typines from sometimes skipping

### DIFF
--- a/src/scxt-plugin/connectors/PayloadDataAttachment.h
+++ b/src/scxt-plugin/connectors/PayloadDataAttachment.h
@@ -180,7 +180,7 @@ struct PayloadDataAttachment : sst::jucegui::data::Continuous
         {
             f = description.snapToTemposync(f);
         }
-        if (f != prevValue)
+        if ((ValueType)f != value)
         {
             prevValue = value;
             value = (ValueType)f;


### PR DESCRIPTION
A bad compare for 'if changed' on value vs prev value meant that we wouldn't go back to 2 ago with the menu typein in a way which was wrong but also confusing. and a little annoying to find. and easy to fix one I did

Closes #1956