### PR TITLE
Add a 'select no zones' gesture

### DIFF
--- a/src/scxt-core/json/selection_traits.h
+++ b/src/scxt-core/json/selection_traits.h
@@ -78,11 +78,9 @@ SC_STREAMDEF(scxt::selection::SelectionManager::ZoneAddress, SC_FROM({
 
 SC_STREAMDEF(selection::SelectionManager, SC_FROM({
                  auto &e = from;
-                 v = {{"zones", e.allSelectedZones},
-                      {"leadZone", e.leadZone},
-                      {"groups", e.allSelectedGroups},
-                      {"tabs", e.otherTabSelection},
-                      {"selectedPart", e.selectedPart}};
+                 v = {{"zones", e.allSelectedZones},   {"leadZone", e.leadZone},
+                      {"groups", e.allSelectedGroups}, {"dgroups", e.allDisplayGroups},
+                      {"tabs", e.otherTabSelection},   {"selectedPart", e.selectedPart}};
              }),
              SC_TO({
                  auto &z = to;
@@ -99,6 +97,7 @@ SC_STREAMDEF(selection::SelectionManager, SC_FROM({
                      findIf(v, "tabs", z.otherTabSelection);
                      findIf(v, "zones", z.allSelectedZones);
                      findIf(v, "groups", z.allSelectedGroups);
+                     findIf(v, "dgroups", z.allDisplayGroups);
                      findIf(v, "leadZone", z.leadZone);
                      findIf(v, "selectedPart", z.selectedPart);
                  }

--- a/src/scxt-core/messaging/client/selection_messages.h
+++ b/src/scxt-core/messaging/client/selection_messages.h
@@ -51,6 +51,7 @@ CLIENT_TO_SERIAL(SelectPart, c2s_select_part, int16_t,
 typedef std::tuple<std::optional<selection::SelectionManager::ZoneAddress>,
                    selection::SelectionManager::selectedZones_t,
                    std::optional<selection::SelectionManager::ZoneAddress>,
+                   selection::SelectionManager::selectedZones_t,
                    selection::SelectionManager::selectedZones_t>
     selectedStateMessage_t;
 SERIAL_TO_CLIENT(SetSelectionState, s2c_send_selection_state, selectedStateMessage_t,

--- a/src/scxt-core/selection/selection_manager.h
+++ b/src/scxt-core/selection/selection_manager.h
@@ -132,8 +132,15 @@ struct SelectionManager
         bool selecting{true};       // am i selecting (T) or deselecting (F) this zone
         bool distinct{true};        // Is this a single selection or a multi-selection gesture
         bool selectingAsLead{true}; // Should I force this selection to be lead?
+        bool forZone{true};         // does this target the zone selection set (T) or group (F)
 
-        bool forZone{true}; // does this target the zone selection set (T) or group (F)
+        static SelectActionContents deselectSentinel() { return {-1, -1, -1, true, true, false}; }
+
+        bool isDeselectSentinel() const
+        {
+            return part == -1 && group == -1 && zone == -1 && selecting && distinct &&
+                   !selectingAsLead;
+        }
 
         friend std::ostream &operator<<(std::ostream &os, const SelectActionContents &z)
         {
@@ -215,7 +222,8 @@ struct SelectionManager
   public:
     using otherTabSelection_t = std::unordered_map<std::string, std::string>;
     otherTabSelection_t otherTabSelection;
-    std::array<selectedZones_t, scxt::numParts> allSelectedZones, allSelectedGroups;
+    std::array<selectedZones_t, scxt::numParts> allSelectedZones, allSelectedGroups,
+        allDisplayGroups;
     std::array<ZoneAddress, scxt::numParts> leadZone, leadGroup;
 };
 } // namespace scxt::selection

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
@@ -677,6 +677,7 @@ void ZoneLayoutDisplay::mouseUp(const juce::MouseEvent &e)
     {
         auto rz = juce::Rectangle<float>(firstMousePos, e.position);
         bool selectedLead{false};
+        bool selectedAny{false};
         if (display->editor->currentLeadZoneSelection.has_value())
         {
             const auto &sel = *(display->editor->currentLeadZoneSelection);
@@ -685,7 +686,9 @@ void ZoneLayoutDisplay::mouseUp(const juce::MouseEvent &e)
                 if (!(z.address == sel))
                     continue;
                 if (rz.intersects(rectangleForZone(z)))
+                {
                     selectedLead = true;
+                }
             }
         }
         bool firstAsLead = !selectedLead && !e.mods.isShiftDown();
@@ -700,7 +703,13 @@ void ZoneLayoutDisplay::mouseUp(const juce::MouseEvent &e)
                 display->editor->doSelectionAction(z.address, true, first && firstAsLead,
                                                    first && firstAsLead);
                 first = false;
+                selectedAny = true;
             }
+        }
+        if (!selectedAny)
+        {
+            display->editor->doSelectionAction(
+                selection::SelectionManager::SelectActionContents::deselectSentinel());
         }
     }
     if (mouseState == CREATE_EMPTY_ZONE)

--- a/src/scxt-plugin/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -269,6 +269,7 @@ void SCXTEditor::onSelectionState(const scxt::messaging::client::selectedStateMe
 {
     allZoneSelections = std::get<1>(a);
     allGroupSelections = std::get<3>(a);
+    auto allDisplays = std::get<4>(a);
 
     currentLeadZoneSelection = std::get<0>(a);
     currentLeadGroupSelection = std::get<2>(a);
@@ -279,6 +280,11 @@ void SCXTEditor::onSelectionState(const scxt::messaging::client::selectedStateMe
     {
         if (sel.group >= 0)
             groupsWithSelectedZones.insert(sel.group);
+    }
+    for (const auto &gz : allDisplays)
+    {
+        if (gz.group >= 0)
+            groupsWithSelectedZones.insert(gz.group);
     }
 
     editScreen->partSidebar->editorSelectionChanged();


### PR DESCRIPTION
Select no zones gesture is click on empty space when in zone mode.

But it requires addition of a display group distinct from selected group structure and threading that through hence the larger change than expected

Closes #1988