### PR TITLE
Set up CMAKE install rules on unix not apple systems

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -4,8 +4,8 @@ add_library(simde INTERFACE)
 target_include_directories(simde INTERFACE simde)
 add_library(shortcircuit::simde ALIAS simde)
 
-add_subdirectory(clap/clap)
-add_subdirectory(clap/clap-helpers)
+add_subdirectory(clap/clap EXCLUDE_FROM_ALL)
+add_subdirectory(clap/clap-helpers EXCLUDE_FROM_ALL)
 
 set(CLAP_WRAPPER_DOWNLOAD_DEPENDENCIES TRUE CACHE BOOL "Get em")
 set(CLAP_WRAPPER_DONT_ADD_TARGETS TRUE CACHE BOOL "I'll targetize")
@@ -17,17 +17,17 @@ endif()
 if (WIN32)
     set(RTAUDIO_API_ASIO ON CACHE BOOL "Enable ASIO for Windows standalone" FORCE)
 endif()
-add_subdirectory(clap/clap-wrapper)
+add_subdirectory(clap/clap-wrapper EXCLUDE_FROM_ALL)
 
 add_subdirectory(sst/sst-clap-helpers)
 message("Including JUCE from ${SCXT_JUCE_PATH}")
 add_clap_juce_shim(JUCE_PATH ${SCXT_JUCE_PATH})
 
 
-add_subdirectory(fmt)
+add_subdirectory(fmt EXCLUDE_FROM_ALL)
 # Modify this basedon the outcome of https://github.com/taocpp/PEGTL/issues/347
 set(PEGTL_NO_STD_FILESYSTEM ON CACHE BOOL "Skip PEGTL FileSystem")
-add_subdirectory(taocpp_json)
+add_subdirectory(taocpp_json EXCLUDE_FROM_ALL)
 if ("${CMAKE_GENERATOR_PLATFORM}" STREQUAL "arm64ec")
     target_compile_definitions(taocpp-json INTERFACE -DRYU_ONLY_64_BIT_OPS)
 endif()

--- a/libs/xiph/CMakeLists.txt
+++ b/libs/xiph/CMakeLists.txt
@@ -11,7 +11,7 @@ if (${SCXT_USE_FLAC})
     set(WITH_OGG OFF CACHE BOOL "ogg support (default: test for libogg)" FORCE)
     set(WITH_AVX OFF CACHE BOOL "scxt is sse4.2 not ACXX" FORCE)
 
-    add_subdirectory(flac)
+    add_subdirectory(flac EXCLUDE_FROM_ALL)
     target_compile_definitions(FLAC++ PUBLIC SCXT_USE_FLAC=1)
 
 

--- a/src/clients/clap-first/CMakeLists.txt
+++ b/src/clients/clap-first/CMakeLists.txt
@@ -38,3 +38,44 @@ make_clapfirst_plugins(
 set_target_properties(${PROJECT_NAME}_all PROPERTIES ARTEFACT_DIRECTORY ${CMAKE_BINARY_DIR}/${PROJECT_NAME}_assets)
 
 target_compile_definitions(clap-wrapper-compile-options-public INTERFACE CLAP_WRAPPER_LOGLEVEL=0)
+
+if (UNIX AND NOT APPLE)
+    # For now I'm adding a set of cmake install rules only for linux
+    # The directories on windows and macos aren't run by the INSTALL dir
+    # and special casing them here vs using existing COPY_FROM_PLUGIN
+    # and installer/sign workflow seems silly.
+    #
+    # If you disagree fix it up and send in a PR!
+    include(GNUInstallDirs)
+
+    # Typical Linux/Unix locations under the installation prefix
+    set(SCXT_CLAP_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/clap")
+    set(SCXT_VST3_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/vst3")
+    set(SCXT_STANDALONE_INSTALL_DIR "${CMAKE_INSTALL_BINDIR}")
+
+    # CLAP plugin (.clap bundle or module)
+    if(TARGET scxt_clapfirst_clap)
+        install(TARGETS scxt_clapfirst_clap
+            BUNDLE  DESTINATION "${SCXT_CLAP_INSTALL_DIR}"
+            LIBRARY DESTINATION "${SCXT_CLAP_INSTALL_DIR}"
+            RUNTIME DESTINATION "${SCXT_CLAP_INSTALL_DIR}"
+        )
+    endif()
+
+    # VST3 plugin (.vst3 bundle)
+    if(TARGET scxt_clapfirst_vst3)
+        install(TARGETS scxt_clapfirst_vst3
+            BUNDLE  DESTINATION "${SCXT_VST3_INSTALL_DIR}"
+            LIBRARY DESTINATION "${SCXT_VST3_INSTALL_DIR}"
+            RUNTIME DESTINATION "${SCXT_VST3_INSTALL_DIR}"
+        )
+    endif()
+
+    # Standalone app/executable
+    if(TARGET scxt_clapfirst_standalone)
+        install(TARGETS scxt_clapfirst_standalone
+            BUNDLE  DESTINATION "${SCXT_STANDALONE_INSTALL_DIR}"
+            RUNTIME DESTINATION "${SCXT_STANDALONE_INSTALL_DIR}"
+        )
+    endif()
+endif()


### PR DESCRIPTION
1. Use EXCLUDE_FROM_ALL to skip a lot of install rules from sub-programs
2. Add an INSTALL rule set for the clap vst3 and exe butonly on unix
3. Add a comment for why I skipped macos and windows

Addresses #1974