### PR TITLE
Deleting a variant with playing voice no longer crashes

### DIFF
--- a/src/scxt-core/engine/zone.cpp
+++ b/src/scxt-core/engine/zone.cpp
@@ -55,6 +55,12 @@ void Zone::process(Engine &e)
 
 template <bool OS> void Zone::processWithOS(scxt::engine::Engine &onto)
 {
+    if (terminateOnNextProcess)
+    {
+        terminateOnNextProcess = false;
+        terminateAllVoices();
+        return;
+    }
     constexpr size_t osBlock{blockSize << (OS ? 1 : 0)};
     namespace blk = sst::basic_blocks::mechanics;
     // TODO these memsets are probably gratuitous
@@ -479,6 +485,8 @@ int16_t Zone::missingSampleCount() const
 void Zone::deleteVariant(int idx)
 {
     assert(idx >= 0 && idx < maxVariantsPerZone);
+    terminateOnNextProcess = true;
+
     for (int nv = idx + 1; nv < maxVariantsPerZone; ++nv)
     {
         variantData.variants[nv - 1] = variantData.variants[nv];

--- a/src/scxt-core/engine/zone.h
+++ b/src/scxt-core/engine/zone.h
@@ -239,6 +239,7 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
     std::array<voice::Voice *, maxVoices> voiceWeakPointers;
     int gatedVoiceCount{0};
     void terminateAllVoices();
+    bool terminateOnNextProcess{false};
 
     void initialize();
     // Just a weak ref - don't take ownership. engine manages lifetime

--- a/src/scxt-core/messaging/client/zone_messages.h
+++ b/src/scxt-core/messaging/client/zone_messages.h
@@ -220,9 +220,9 @@ inline void doDeleteVariant(const deleteVariantPayload_t &payload, engine::Engin
             [p = ps, g = gs, z = zs, var = payload](auto &eng) {
                 const auto &zone = eng.getPatch()->getPart(p)->getGroup(g)->getZone(z);
                 zone->deleteVariant(var);
-                eng.getSampleManager()->purgeUnreferencedSamples();
             },
             [p = ps, g = gs, z = zs](auto &e) {
+                e.getSampleManager()->purgeUnreferencedSamples();
                 SCLOG_ONCE("Delete variant could be optimized to not sending so much back");
                 e.sendFullRefreshToClient();
             });


### PR DESCRIPTION
It does silence that zones voice. That's OK for now. Maybe do something cleverer in the future.

Closes #2015