### PR TITLE
Fewer MD5 calls

### DIFF
--- a/cmake/compiler-options.cmake
+++ b/cmake/compiler-options.cmake
@@ -67,6 +67,7 @@ if (APPLE)
 
     set(OS_LINK_LIBRARIES
             "-framework CoreServices"
+            "-framework Security" # for MD5
             )
 elseif (UNIX AND NOT APPLE)
     set(OS_COMPILE_OPTIONS

--- a/src/scxt-core/configuration.h
+++ b/src/scxt-core/configuration.h
@@ -103,6 +103,7 @@ static constexpr bool voiceLifecycle{false};
 static constexpr bool generatorInitialization{false};
 static constexpr bool sampleLoadAndPurge{false};
 static constexpr bool sampleCompoundParsers{false};
+static constexpr bool monoliths{sampleLoadAndPurge || false};
 static constexpr bool missingResolution{false};
 static constexpr bool ringout{false};
 static constexpr bool streaming{false};

--- a/src/scxt-core/engine/missing_resolution.cpp
+++ b/src/scxt-core/engine/missing_resolution.cpp
@@ -135,8 +135,8 @@ void resolveMultiFileMissingWorkItem(engine::Engine &e, const MissingResolutionW
                         if (isSF2)
                         {
                             nid = e.getSampleManager()->loadSampleFromSF2(
-                                p, nullptr, v.sampleID.multiAddress[0], v.sampleID.multiAddress[1],
-                                v.sampleID.multiAddress[2]);
+                                p, v.sampleID.md5, nullptr, v.sampleID.multiAddress[0],
+                                v.sampleID.multiAddress[1], v.sampleID.multiAddress[2]);
                         }
                         if (isMultiSample)
                         {

--- a/src/scxt-core/sample/gig_support/gig_import.cpp
+++ b/src/scxt-core/sample/gig_support/gig_import.cpp
@@ -126,7 +126,7 @@ bool importGIG(const fs::path &p, engine::Engine &e, int preset)
                 // messageController->updateClientActivityNotification("Loading " +
                 // p.filename().u8string()+ " sample " +
                 //                                                                     std::to_string(j));
-                auto sid = e.getSampleManager()->loadSampleFromGIG(p, gig.get(), -1, -1, sidx);
+                auto sid = e.getSampleManager()->loadSampleFromGIG(p, md5, gig.get(), -1, -1, sidx);
                 if (!sid.has_value())
                     continue;
                 e.getSampleManager()->getSample(*sid)->md5Sum = md5;

--- a/src/scxt-core/sample/sample_manager.h
+++ b/src/scxt-core/sample/sample_manager.h
@@ -83,17 +83,17 @@ struct SampleManager : MoveableOnly<SampleManager>
 
     std::optional<SampleID> loadSampleByPath(const fs::path &);
 
-    std::optional<SampleID> loadSampleFromSF2(const fs::path &,
+    std::optional<SampleID> loadSampleFromSF2(const fs::path &, const std::string &omd5,
                                               sf2::File *f, // if this is null I will re-open it
                                               int preset, int instrument, int region);
     int findSF2SampleIndexFor(sf2::File *, int preset, int instrument, int region);
 
-    std::optional<SampleID> loadSampleFromGIG(const fs::path &,
+    std::optional<SampleID> loadSampleFromGIG(const fs::path &, const std::string &omd5,
                                               gig::File *f, // if this is null I will re-open it
                                               int preset, int instrument, int region);
 
     std::optional<SampleID>
-    loadSampleFromSCXTMonolith(const fs::path &,
+    loadSampleFromSCXTMonolith(const fs::path &, const std::string &md5,
                                RIFF::File *f, // if this is null I will re-open it
                                int preset, int instrument, int region);
 
@@ -223,18 +223,22 @@ struct SampleManager : MoveableOnly<SampleManager>
 
     sampleMap_t samples;
 
+    using md5cache_t = std::unordered_map<std::string, std::string>;
     std::unordered_map<std::string, std::tuple<std::unique_ptr<RIFF::File>,
                                                std::unique_ptr<sf2::File>>>
         sf2FilesByPath; // last is the md5sum
-    std::unordered_map<std::string, std::string> sf2MD5ByPath;
+    md5cache_t sf2MD5ByPath;
     std::unordered_map<std::string, std::tuple<std::unique_ptr<RIFF::File>,
                                                std::unique_ptr<gig::File>>>
         gigFilesByPath; // last is the md5sum
-    std::unordered_map<std::string, std::string> gigMD5ByPath;
+    md5cache_t gigMD5ByPath;
 
     std::unordered_map<std::string, std::unique_ptr<RIFF::File>>
         scxtMonolithFilesByPath; // last is the md5sum
-    std::unordered_map<std::string, std::string> scxtMonolithMD5ByPath;
+    md5cache_t scxtMonolithMD5ByPath;
+
+    void setOrCalcMD5Cache(md5cache_t &, const fs::path &, const std::string &m,
+                           const std::string &flavor) const;
 
     std::unordered_map<std::string, std::unique_ptr<ZipArchiveHolder>> zipArchives;
 };

--- a/src/scxt-core/sample/sf2_support/sf2_import.cpp
+++ b/src/scxt-core/sample/sf2_support/sf2_import.cpp
@@ -99,7 +99,7 @@ bool importSF2(const fs::path &p, engine::Engine &e, int preset)
                     if (sfsamp == nullptr)
                         continue;
 
-                    auto sid = e.getSampleManager()->loadSampleFromSF2(p, sf.get(), pc, i, j);
+                    auto sid = e.getSampleManager()->loadSampleFromSF2(p, md5, sf.get(), pc, i, j);
                     if (!sid.has_value())
                         continue;
                     e.getSampleManager()->getSample(*sid)->md5Sum = md5;

--- a/src/scxt-plugin/clap/scxt-plugin.cpp
+++ b/src/scxt-plugin/clap/scxt-plugin.cpp
@@ -141,6 +141,7 @@ bool SCXTPlugin::stateSave(const clap_ostream *ostream) noexcept
 
 bool SCXTPlugin::stateLoad(const clap_istream *istream) noexcept
 {
+    SCLOG_IF(plugin, "Loading state");
     static constexpr uint32_t initSize = 1 << 16, chunkSize = 1 << 8;
     std::vector<char> buffer;
     buffer.resize(initSize);
@@ -169,7 +170,10 @@ bool SCXTPlugin::stateLoad(const clap_istream *istream) noexcept
     auto data = std::string(buffer.data());
 
     engine->getMessageController()->threadingChecker.bypassThreadChecks = true;
+    SCLOG_IF(plugin, "State has size " << buffer.size());
+
     synchronousEngineUnstream(engine, data);
+    SCLOG_IF(plugin, "Back from unstream");
 
     scxt::messaging::client::clientSendToSerialization(
         scxt::messaging::client::RequestHostCallback{(uint64_t)RESCAN_PARAM_IVT},


### PR DESCRIPTION
If a streamed session has the MD5 in the ID and the file is found re-use that sum rather than over-summing.
Also avoid a double sum on gig, sf2 and monolith files in some cases And move to macOS built in MD5 implementation