### PR TITLE
Partial fix for Part/Multi withy Collected sapmles

### DIFF
--- a/src/scxt-core/sample/sample_manager.cpp
+++ b/src/scxt-core/sample/sample_manager.cpp
@@ -543,7 +543,15 @@ SampleManager::getSampleAddressesFor(const std::vector<SampleID> &sids) const
         }
         else
         {
-            res.emplace_back(sid, smp->getSampleFileAddress());
+            auto sfa = smp->getSampleFileAddress();
+            if (!reparentPath.empty())
+            {
+                auto prior = sfa.path;
+                sfa.path = reparentPath / sfa.path.filename();
+                SCLOG_IF(sampleLoadAndPurge, "SampleManager::getSampleAddressesFor: reparenting "
+                                                 << prior << " to " << sfa.path);
+            }
+            res.emplace_back(sid, sfa);
         }
     }
     return res;


### PR DESCRIPTION
This is a partial fix for #2051

1. Part with collected samples now works as well as multis
2. Sample dir is no longer a sub dir. Rather if you save Foo.scp you get a side-by-side Foo Samples

Still not working: Save collected when one of your samples is a sub-sample from a separate monoilth or multi. Fix that separately