### PR TITLE
Fix multi-resolution quadratic blowout

### DIFF
--- a/src/scxt-core/engine/missing_resolution.cpp
+++ b/src/scxt-core/engine/missing_resolution.cpp
@@ -74,9 +74,11 @@ void resolveSingleFileMissingWorkItem(engine::Engine &e, const MissingResolution
 {
 
     auto smp = e.getSampleManager()->loadSampleByPath(p);
-    SCLOG("Resolving : " << p.u8string());
-    SCLOG("      Was : " << mwi.missingID.to_string());
-    SCLOG("       To : " << smp->to_string());
+    e.getMessageController()->updateClientActivityNotification("Resolving " +
+                                                               p.filename().u8string());
+    SCLOG_IF(missingResolution, "Resolving : " << p.u8string());
+    SCLOG_IF(missingResolution, "      Was : " << mwi.missingID.to_string());
+    SCLOG_IF(missingResolution, "       To : " << smp->to_string());
     if (smp.has_value())
     {
         for (auto &p : *(e.getPatch()))
@@ -90,7 +92,7 @@ void resolveSingleFileMissingWorkItem(engine::Engine &e, const MissingResolution
                     {
                         if (v.active && v.sampleID == mwi.missingID)
                         {
-                            SCLOG("     Zone : " << z->getName());
+                            SCLOG_IF(missingResolution, "     Zone : " << z->getName());
                             v.sampleID = *smp;
                             z->attachToSampleAtVariation(
                                 *(e.getSampleManager()), *smp, vidx,

--- a/src/scxt-core/messaging/client/client_serial.h
+++ b/src/scxt-core/messaging/client/client_serial.h
@@ -183,6 +183,7 @@ enum ClientToSerializationMessagesIds
     c2s_send_full_part_config,
 
     c2s_resolve_sample,
+    c2s_resolve_multiple_samples,
 
     c2s_initiate_midizone_action, // the buttons at the top
 

--- a/src/scxt-plugin/app/missing-resolution/MissingResolutionScreen.cpp
+++ b/src/scxt-plugin/app/missing-resolution/MissingResolutionScreen.cpp
@@ -249,15 +249,18 @@ void MissingResolutionScreen::applyResolution(int idx, const fs::path &toThis)
 void MissingResolutionScreen::applyDirectoryResolution(
     std::vector<engine::MissingResolutionWorkItem> indexes, const fs::path &newParent)
 {
-    SCLOG("Resolving into " << newParent.u8string() << " with " << indexes.size() << " items");
+    SCLOG_IF(missingResolution,
+             "Resolving into " << newParent.u8string() << " with " << indexes.size() << " items");
 
+    std::vector<messaging::client::resolveSamplePayload_t> resolve;
     for (auto &wi : indexes)
     {
         auto toThis = newParent / wi.path.filename();
 
-        SCLOG("Resolving " << wi.path << " to " << toThis.u8string());
-        sendToSerialization(scxt::messaging::client::ResolveSample({wi, toThis.u8string()}));
+        SCLOG_IF(missingResolution, "Multi-Resolving " << wi.path << " to " << toThis.u8string());
+        resolve.emplace_back(wi, toThis.u8string());
     }
+    sendToSerialization(scxt::messaging::client::ResolveMultiSample(resolve));
 }
 
 } // namespace scxt::ui::app::missing_resolution


### PR DESCRIPTION
When resolving lots of files from a directory the system would send a full ui refresh after each one, leading to a "99-bottles-of-beer" style quadratic blowout.

Fix that by having a single message for all the collected items which applies server side then notifies

While at it, update the client notification while resolving.

Closes #2052