### PR TITLE
Fix an error when de-registering client with message outstanding

### DIFF
--- a/src/scxt-core/messaging/client/detail/client_serial_impl.h
+++ b/src/scxt-core/messaging/client/detail/client_serial_impl.h
@@ -178,6 +178,7 @@ inline void serializationSendToClient(SerializationToClientMessageIds id, const 
 
     try
     {
+        auto lk = mc.acquireClientCallbackMutex();
         // TODO - consider waht to do here. Dropping the message is probably best
         if (!mc.clientCallback)
         {

--- a/src/scxt-core/messaging/messaging.h
+++ b/src/scxt-core/messaging/messaging.h
@@ -198,6 +198,11 @@ struct MessageController : MoveableOnly<MessageController>
 
     typedef std::function<void(const serialToClientMessage_t &)> clientCallback_t;
     clientCallback_t clientCallback{nullptr};
+    mutable std::mutex clientCallbackMutex;
+    std::unique_lock<std::mutex> acquireClientCallbackMutex() const
+    {
+        return std::unique_lock<std::mutex>(clientCallbackMutex);
+    }
     std::vector<std::string> preClientConnectionCache;
 
     /**

--- a/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
@@ -131,12 +131,16 @@ SCXTEditor::SCXTEditor(messaging::MessageController &e, infrastructure::Defaults
             std::lock_guard<std::mutex> g(callbackMutex);
             callbackQueue.push(s);
         }
-        juce::MessageManager::callAsync([this]() { drainCallbackQueue(); });
+        juce::MessageManager::callAsync([w = juce::Component::SafePointer(this)]() {
+            if (w)
+                w->drainCallbackQueue();
+        });
     });
 }
 
 SCXTEditor::~SCXTEditor() noexcept
 {
+    juce::PopupMenu::dismissAllActiveMenus();
     idleTimer->stopTimer();
     msgCont.unregisterClient();
     setLookAndFeel(nullptr);


### PR DESCRIPTION
Which reaper does

1. Make sure to lock the client callback pointer everywhere, not just on set and unset
2. That callback should keep a weak reference to the editor, not a long lived one

These two defeat the timing problems which show in Reaper, which transiently creates and destroys and editor at outset.

CLoses #2034