### PR TITLE
Add a develoepr/send full refresh menu item

### DIFF
--- a/src/scxt-core/messaging/client/client_serial.h
+++ b/src/scxt-core/messaging/client/client_serial.h
@@ -63,6 +63,7 @@ enum ClientToSerializationMessagesIds
     // Registration and Reset Messages
     c2s_register_client,
     c2s_reset_engine,
+    c2s_resend_full_state,
 
     // Stream and IO Messages
     c2s_unstream_engine_state,

--- a/src/scxt-core/messaging/client/interaction_messages.h
+++ b/src/scxt-core/messaging/client/interaction_messages.h
@@ -98,5 +98,19 @@ inline void doResetEngine(const std::string &fl, engine::Engine &e, MessageContr
 }
 CLIENT_TO_SERIAL(ResetEngine, c2s_reset_engine, std::string, doResetEngine(payload, engine, cont));
 
+inline void doResendFullState(const bool &b, engine::Engine &e, MessageController &cont)
+{
+    if (b)
+    {
+        e.sendFullRefreshToClient();
+    }
+    else
+    {
+        SCLOG_IF(debug, "Why did you bother sending the resend false message?");
+    }
+}
+CLIENT_TO_SERIAL(ResendFullState, c2s_resend_full_state, bool,
+                 doResendFullState(payload, engine, cont));
+
 } // namespace scxt::messaging::client
 #endif // SHORTCIRCUIT_INTERACTION_MESSAGES_H

--- a/src/scxt-plugin/app/editor-impl/SCXTEditorMenus.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditorMenus.cpp
@@ -103,6 +103,12 @@ void SCXTEditor::showMainMenu()
     auto dp = juce::PopupMenu();
     dp.addSectionHeader("Developer");
     dp.addSeparator();
+    dp.addItem("Resend full engine state to UI", [w = juce::Component::SafePointer(this)]() {
+        if (!w)
+            return;
+        w->sendToSerialization(cmsg::ResendFullState{true});
+    });
+    dp.addSeparator();
     dp.addItem("Pretty JSON (DAW)", [w = juce::Component::SafePointer(this)]() {
         if (!w)
             return;


### PR DESCRIPTION
basically a 'get out of jail if we end up with a mis-sync to debug in beta' option.

I think this closes #2035 but if it doesn't I need a better example of that behavior