### PR TITLE
Add optional initVoiceEfffectPitch path

### DIFF
--- a/src/scxt-core/dsp/processor/processor.h
+++ b/src/scxt-core/dsp/processor/processor.h
@@ -241,6 +241,7 @@ struct Processor : MoveableOnly<Processor>, SampleRateSupport
 
     virtual void init_params() {}
     virtual void init() {}
+    virtual void init_pitch(float p) {}
 
     virtual bool isKeytracked() const { return false; }
     virtual bool setKeytrack(bool b) { return false; }

--- a/src/scxt-core/dsp/processor/processor_impl.h
+++ b/src/scxt-core/dsp/processor/processor_impl.h
@@ -152,6 +152,7 @@ template <int OSFactor> struct SCXTVFXConfig
     };
 HAS_MEMFN(initVoiceEffect);
 HAS_MEMFN(initVoiceEffectParams);
+HAS_MEMFN(initVoiceEffectPitch);
 HAS_MEMFN(processStereo);
 HAS_MEMFN(processMonoToMono);
 HAS_MEMFN(processMonoToStereo);
@@ -210,6 +211,14 @@ template <typename T> struct SSTVoiceEffectShim : T
         if constexpr (HasMemFn_initVoiceEffectParams<T>::value)
         {
             this->initVoiceEffectParams();
+        }
+    }
+
+    void init_pitch(float p) override
+    {
+        if constexpr (HasMemFn_initVoiceEffectPitch<T>::value)
+        {
+            this->initVoiceEffectPitch(p);
         }
     }
 

--- a/src/scxt-core/engine/group.cpp
+++ b/src/scxt-core/engine/group.cpp
@@ -588,6 +588,7 @@ void Group::onProcessorTypeChanged(int w, dsp::processor::ProcessorType t)
             endpoints.processorTarget[w].snapValues();
 
             processors[w]->init();
+            processors[w]->init_pitch(0);
         }
     }
     else

--- a/src/scxt-core/voice/voice.cpp
+++ b/src/scxt-core/voice/voice.cpp
@@ -1085,6 +1085,7 @@ void Voice::initializeProcessors()
         memcpy(&processorIntParams[i][0], zone->processorStorage[i].intParams.data(),
                sizeof(processorIntParams[i]));
 
+        auto fpitch = calculateVoicePitch();
         if ((processorIsActive[i] && processorType[i] != dsp::processor::proct_none) ||
             (processorType[i] == dsp::processor::proct_none && !processorIsActive[i]))
         {
@@ -1094,6 +1095,7 @@ void Voice::initializeProcessors()
                 processorPlacementStorage[i], dsp::processor::processorMemoryBufferSize,
                 zone->processorStorage[i], endpoints->processorTarget[i].fp, processorIntParams[i],
                 forceOversample, false);
+            processors[i]->init_pitch(fpitch - 69);
         }
         else
         {


### PR DESCRIPTION
If a processor implements `void initiVoiceEffectPitch(float)` then it will get called with the appropriate startup pitch in the initialization path (key-69 for voices, and 0 for groups) allowing things like pitch smoothers to start at the right spot.

Currently no fx do this, but I tried it by bodging one in and it got called

Closes #2086