### PR TITLE
Add a MIDI/Key Changed mod source (trigger)

### DIFF
--- a/src/scxt-core/engine/engine_voice_responder.cpp
+++ b/src/scxt-core/engine/engine_voice_responder.cpp
@@ -293,6 +293,7 @@ void Engine::VoiceManagerResponder::moveVoice(VMConfig::voice_t *v, uint16_t por
     auto dkey = v->key - v->originalMidiKey;
     v->key = key;
     v->originalMidiKey = key - dkey;
+    v->keyChangedInLegatoModeTrigger = 1.f;
     v->calculateVoicePitch();
 }
 

--- a/src/scxt-core/modulation/voice_matrix.cpp
+++ b/src/scxt-core/modulation/voice_matrix.cpp
@@ -150,6 +150,7 @@ void MatrixEndpoints::Sources::bind(scxt::voice::modulation::Matrix &m, engine::
     m.bindSourceValue(midiSources.releaseVelocitySource, v.releaseVelocity);
     m.bindSourceValue(midiSources.keytrackSource, v.keytrackPerOct);
     m.bindSourceValue(midiSources.polyATSource, v.polyAT);
+    m.bindSourceValue(midiSources.keyChangedLeg, v.keyChangedInLegatoModeTrigger);
 
     m.bindSourceValue(mpeSources.mpePressure, v.mpePressure);
     m.bindSourceValue(mpeSources.mpeTimbre, v.mpeTimbre);

--- a/src/scxt-core/modulation/voice_matrix.h
+++ b/src/scxt-core/modulation/voice_matrix.h
@@ -273,7 +273,8 @@ struct MatrixEndpoints
             MIDISources(engine::Engine *e)
                 : modWheelSource{'zmid', 'modw'}, velocitySource{'zmid', 'velo'},
                   releaseVelocitySource{'zmid', 'rvel'}, keytrackSource{'zmid', 'ktrk'},
-                  chanATSource{'zmid', 'chat'}, pbpm1Source{'zmid', 'pb11'}
+                  chanATSource{'zmid', 'chat'}, pbpm1Source{'zmid', 'pb11'},
+                  keyChangedLeg{'zmid', 'kclg'}
             {
                 registerVoiceModSource(e, modWheelSource, "MIDI", "Mod Wheel");
                 MatrixConfig::setDefaultLagFor(modWheelSource, 25);
@@ -285,9 +286,10 @@ struct MatrixEndpoints
                 MatrixConfig::setDefaultLagFor(polyATSource, 100);
                 registerVoiceModSource(e, pbpm1Source, "MIDI", "Pitch Bend");
                 MatrixConfig::setDefaultLagFor(pbpm1Source, 10);
+                registerVoiceModSource(e, keyChangedLeg, "MIDI", "Key Changed");
             }
             SR modWheelSource, velocitySource, releaseVelocitySource, keytrackSource, polyATSource,
-                chanATSource, pbpm1Source;
+                chanATSource, pbpm1Source, keyChangedLeg;
         } midiSources;
 
         struct MPESources

--- a/src/scxt-core/voice/voice.cpp
+++ b/src/scxt-core/voice/voice.cpp
@@ -846,6 +846,11 @@ template <bool OS> bool Voice::processWithOS()
 
         isVoicePlaying = false;
     }
+
+    if (keyChangedInLegatoModeTrigger > 0)
+    {
+        keyChangedInLegatoModeTrigger = 0;
+    }
     return true;
 }
 

--- a/src/scxt-core/voice/voice.h
+++ b/src/scxt-core/voice/voice.h
@@ -87,6 +87,8 @@ struct alignas(16) Voice : MoveableOnly<Voice>,
     float mpeTimbre{0.f};    // 0..1 normalized
     float mpePressure{0.f};  // 0..1 normalized
 
+    float keyChangedInLegatoModeTrigger{0.f};
+
     float retunedKeyAtAttack{0.f};
     bool retuneContinuous{true};
 


### PR DESCRIPTION
Add a mod source for the voice key changed which in legato mode allows you to use the mod matrix to differentially retrigger envelopes and lfos in an otherwise non-triggering voice.

Addresses #2041.
And might be all we need.