### PR TITLE
proct_none participates in selection consistency

### DIFF
--- a/src/scxt-core/json/dsp_traits.h
+++ b/src/scxt-core/json/dsp_traits.h
@@ -45,7 +45,15 @@ SC_STREAMDEF(
         auto &t = from;
         if (t.type == dsp::processor::proct_none)
         {
-            v = tao::json::empty_object;
+            if (t.procTypeConsistent)
+            {
+                v = tao::json::empty_object;
+            }
+            else
+            {
+                v = {{"type", scxt::dsp::processor::getProcessorStreamingName(t.type)},
+                     {"procTypeConsistent", t.procTypeConsistent}};
+            }
         }
         else
         {
@@ -82,6 +90,7 @@ SC_STREAMDEF(
         {
             result = scxt::dsp::processor::ProcessorStorage();
             result.type = dsp::processor::proct_none;
+            findOrSet(v, "procTypeConsistent", true, result.procTypeConsistent);
         }
         else
         {

--- a/src/scxt-plugin/app/edit-screen/components/ProcessorPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/ProcessorPane.cpp
@@ -489,9 +489,8 @@ void ProcessorPane::setupJsonTypeMap()
 void ProcessorPane::rebuildControlsFromDescription()
 {
     resetControls();
-    // TODO: Am I actually an off type? Then bail.
 
-    if (!isEnabled())
+    if (!isEnabled() && !multiZone)
     {
         setToggleDataSource(nullptr);
         setName(processorControlDescription.typeDisplayName);


### PR DESCRIPTION
proct_none streaming optimization meant that the is-consistent-selection state was not streamed to the client; and moreover the client would supress it. This allows multi select with none-and-not-none to allow reset across the selection to none like any other type

Closes #2107