### PR TITLE
Dropping multiple samples creates non-overlapping zones

### DIFF
--- a/src/scxt-plugin/app/browser-ui/BrowserPane.cpp
+++ b/src/scxt-plugin/app/browser-ui/BrowserPane.cpp
@@ -494,15 +494,20 @@ struct DriveFSRowComponent : public juce::Component, WithSampleInfo
         return entry.expandableAddress;
     }
     bool encompassesMultipleSampleInfos() const override { return isDraggingMulti; }
-    std::set<WithSampleInfo *> getMultipleSampleInfos() const override
+    std::vector<WithSampleInfo *> getMultipleSampleInfos() const override
     {
-        std::set<WithSampleInfo *> r;
+        std::vector<DriveFSRowComponent *> r;
+        std::vector<WithSampleInfo *> res;
 
         for (auto q : browserPane->devicesPane->driveFSArea->selectedRows)
         {
-            r.insert(q);
+            r.push_back(q);
         }
-        return r;
+        std::sort(r.begin(), r.end(), [](auto &a, auto &b) { return a->rowNumber < b->rowNumber; });
+
+        for (auto q : r)
+            res.push_back(q);
+        return res;
     }
 
     void mouseDown(const juce::MouseEvent &event) override

--- a/src/scxt-plugin/app/browser-ui/BrowserPaneInterfaces.h
+++ b/src/scxt-plugin/app/browser-ui/BrowserPaneInterfaces.h
@@ -41,7 +41,7 @@ struct WithSampleInfo
     virtual std::optional<fs::directory_entry> getDirEnt() const = 0;
     virtual std::optional<sample::compound::CompoundElement> getCompoundElement() const = 0;
     virtual bool encompassesMultipleSampleInfos() const = 0;
-    virtual std::set<WithSampleInfo *> getMultipleSampleInfos() const = 0;
+    virtual std::vector<WithSampleInfo *> getMultipleSampleInfos() const = 0;
 };
 
 template <typename T> static bool hasSampleInfo(const T &t)

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.h
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.h
@@ -173,6 +173,7 @@ struct MappingDisplay : juce::Component,
     bool isInterestedInDragSource(const SourceDetails &dragSourceDetails) override;
     void itemDropped(const SourceDetails &dragSourceDetails) override;
     bool isUndertakingDrop{false};
+    size_t dropElementCount{7};
     juce::Point<int> currentDragPoint;
     void itemDragEnter(const SourceDetails &dragSourceDetails) override;
 

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.h
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.h
@@ -43,6 +43,8 @@ struct ZoneLayoutDisplay : juce::Component, HasEditor
     void resized() override;
 
     std::array<int16_t, 3> rootAndRangeForPosition(const juce::Point<int> &);
+    std::vector<std::pair<int16_t, int16_t>> subdivideRangeForMultiDrop(int16_t start, int16_t end,
+                                                                        size_t nEls);
 
     juce::Rectangle<float> rectangleForZone(const engine::Part::zoneMappingItem_t &sum);
     juce::Rectangle<float> rectangleForRange(int kL, int kH, int vL, int vH);


### PR DESCRIPTION
From the browser and OS both, dropping multiple samples adds them aligned as opposed to overlapped, with what seems like a pretty reasonable heuristic