### PR TITLE
Fix some spacing problems with multi-element drop

### DIFF
--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.h
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.h
@@ -42,9 +42,14 @@ struct ZoneLayoutDisplay : juce::Component, HasEditor
     void paint(juce::Graphics &g) override;
     void resized() override;
 
-    std::array<int16_t, 3> rootAndRangeForPosition(const juce::Point<int> &);
-    std::vector<std::pair<int16_t, int16_t>> subdivideRangeForMultiDrop(int16_t start, int16_t end,
-                                                                        size_t nEls);
+    struct RootAndRange
+    {
+        RootAndRange(int16_t r, int16_t l, int16_t h) : root(r), lo(l), hi(h) {}
+        int16_t root, lo, hi;
+    };
+    std::vector<RootAndRange>
+    rootAndRangeForPosition(const juce::Point<int> &, size_t nFiles,
+                            bool isMappedInstrument /* like an SFZ or such */);
 
     juce::Rectangle<float> rectangleForZone(const engine::Part::zoneMappingItem_t &sum);
     juce::Rectangle<float> rectangleForRange(int kL, int kH, int vL, int vH);


### PR DESCRIPTION
1. Make sure all elements are the same size, so 6 samples are all width 1, 2, 3, etc.....
2. Restructure the code a bit to share better and adjust paint and so on with option for future different treatment of multisample drops
3. Fix some problems where samples would get cramped together

Closes #2175
Closes #2151