### PR TITLE
DSP: Fix toggle-active-voice in some routing modes

### DIFF
--- a/src/scxt-core/dsp/processor/routing.h
+++ b/src/scxt-core/dsp/processor/routing.h
@@ -143,8 +143,6 @@ inline bool allActive(Processor *processors[engine::processorCount], Indices... 
     return (isActive(processors, idxs) && ...);
 }
 
-
-
 // -> 1 -> 2 -> 3 -> 4 ->
 template <bool OS, bool forceStereo, int N, typename Mix, typename Endpoints>
 inline void processSequential(float fpitch, Processor *processors[engine::processorCount],


### PR DESCRIPTION
I had not been consistent in applying processor && processor->bypass and so some routing modes when with an active voice you turned off a processor kept the last block output from the processor being streamed, leading to dsp mess.

Fix that by adding a proper isActive/anyActive/allActive api in routing.h

Closes #2181