### PR TITLE
Fix a win-to-maclin relative streaming issue

### DIFF
--- a/src/scxt-core/configuration.h
+++ b/src/scxt-core/configuration.h
@@ -87,6 +87,8 @@ static constexpr size_t modMatrixRowsPerGroup{12};
 // For tail detection use a full block below this level as silence
 static constexpr float silenceThresh{1e-10f};
 
+static constexpr const char *relativeSentinel = "SCXT_RELATIVE_PATH_MARKER";
+
 /*
  * This namespace guards some very useful debugging guards and logs in the code.
  * Some of them log in the realtime thread so please leave them all

--- a/src/scxt-core/json/scxt_traits.h
+++ b/src/scxt-core/json/scxt_traits.h
@@ -31,6 +31,7 @@
 #include <initializer_list>
 #include "tao/json/traits.hpp"
 #include "filesystem/import.h"
+#include "configuration.h"
 
 namespace scxt::json
 {
@@ -251,6 +252,15 @@ inline fs::path unstreamPathFromString(const std::string &s)
         std::replace(r.begin(), r.end(), '\\', '/');
         auto res = fs::path(fs::u8path(mnt + r));
         return res;
+    }
+    else if (s.starts_with(std::string(scxt::relativeSentinel) + "\\"))
+    {
+        // Streamed on windows with a buggy version.
+        auto q = strlen(scxt::relativeSentinel);
+        auto newS = s;
+        newS[q] = '/';
+
+        return fs::path(fs::u8path(newS));
     }
     else
     {

--- a/src/scxt-core/sample/sample_manager.h
+++ b/src/scxt-core/sample/sample_manager.h
@@ -119,7 +119,6 @@ struct SampleManager : MoveableOnly<SampleManager>
     }
 
     fs::path reparentPath;
-    static constexpr const char *relativeSentinel = "SCXT_RELATIVE_PATH_MARKER";
     void reparentSamplesOnStreamToRelative(const fs::path &newParent)
     {
         reparentPath = fs::path{relativeSentinel} / newParent;


### PR DESCRIPTION
Streaming win streams as STREAMING_SENTINEL\path not /path so handle it just like we do c:\ etc... for now and open a separate issue to stream right way perhaps.