### PR TITLE
Fix an SFZ parser crash

### DIFF
--- a/src/scxt-core/sample/sfz_support/sfz_parse.cpp
+++ b/src/scxt-core/sample/sfz_support/sfz_parse.cpp
@@ -366,6 +366,8 @@ SFZParser::document_t SFZParser::parse(const std::string &s)
                 OpCode oc;
                 oc.name = opcode;
                 oc.value = stripTrailingAndQuotes(key);
+                if (res.empty())
+                    res.push_back({{Header::master, "default"}, {}});
                 res.back().second.push_back(oc);
             }
             else


### PR DESCRIPTION
if there is an opcode in no region, push it into master avoiding a parser time crash

Closes #2191