### PR TITLE
UI: Don't show a lingering tooltip on proct_non

### DIFF
--- a/src/scxt-plugin/app/edit-screen/components/ProcessorPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/ProcessorPane.cpp
@@ -546,6 +546,12 @@ void ProcessorPane::rebuildControlsFromDescription()
     if (processorControlDescription.type == dsp::processor::proct_none)
     {
         setToggleDataSource(nullptr);
+        if (toggleButton)
+        {
+            // this is a long lived component; remove the tooltip
+            toggleButton->onIdleHover = []() {};
+            toggleButton->onIdleHoverEnd = []() {};
+        }
         repaint();
         return;
     }


### PR DESCRIPTION
The switch to none would have the attachment and subsequent tooltip linger linger. Fix

Closes #2197