### PR TITLE
SFZ Parser Tweak

### DIFF
--- a/src/scxt-core/sample/sfz_support/sfz_parse.cpp
+++ b/src/scxt-core/sample/sfz_support/sfz_parse.cpp
@@ -366,9 +366,11 @@ SFZParser::document_t SFZParser::parse(const std::string &s)
                 OpCode oc;
                 oc.name = opcode;
                 oc.value = stripTrailingAndQuotes(key);
-                if (res.empty())
-                    res.push_back({{Header::master, "default"}, {}});
-                res.back().second.push_back(oc);
+                // After discussions on SFZ discord, SFZ with opcodes
+                // before a header are invalid; and those opcodes can be
+                // dropped
+                if (!res.empty())
+                    res.back().second.push_back(oc);
             }
             else
             {


### PR DESCRIPTION
After a discussion of my fix in f91ea55ea60e893c00180886fe290fa3591237a9 with the SFZ maintainers, we decided it was better to drop rathern than impute master for opcodes absent a header. Still dont crash though!