### PR TITLE
UI Performance: Marquee Selection batches Selection Messages

### DIFF
--- a/src/scxt-plugin/app/SCXTEditor.h
+++ b/src/scxt-plugin/app/SCXTEditor.h
@@ -288,6 +288,9 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel,
     } clipboard;
 
     // Originate client to serialization messages
+    selection::SelectionManager::SelectActionContents
+    makeSelectActionContents(const selection::SelectionManager::ZoneAddress &a, bool selecting,
+                             bool distinct, bool asLead) const;
     void doSelectionAction(const selection::SelectionManager::ZoneAddress &, bool selecting,
                            bool distinct, bool asLead);
     void doSelectionAction(const selection::SelectionManager::SelectActionContents &);

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
@@ -608,9 +608,10 @@ void ZoneLayoutDisplay::mouseUp(const juce::MouseEvent &e)
 
     if (mouseState == MULTI_SELECT)
     {
+        std::vector<selection::SelectionManager::SelectActionContents> actions;
+
         auto rz = juce::Rectangle<float>(firstMousePos, e.position);
         bool selectedLead{false};
-        bool selectedAny{false};
         if (display->editor->currentLeadZoneSelection.has_value())
         {
             const auto &sel = *(display->editor->currentLeadZoneSelection);
@@ -633,16 +634,19 @@ void ZoneLayoutDisplay::mouseUp(const juce::MouseEvent &e)
 
             if (rz.intersects(rectangleForZone(z)))
             {
-                display->editor->doSelectionAction(z.address, true, first && firstAsLead,
-                                                   first && firstAsLead);
+                actions.push_back(display->editor->makeSelectActionContents(
+                    z.address, true, first && firstAsLead, first && firstAsLead));
                 first = false;
-                selectedAny = true;
             }
         }
-        if (!selectedAny)
+        if (actions.empty())
         {
             display->editor->doSelectionAction(
                 selection::SelectionManager::SelectActionContents::deselectSentinel());
+        }
+        else
+        {
+            display->editor->doSelectionAction(actions);
         }
     }
     if (mouseState == CREATE_EMPTY_ZONE)

--- a/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
@@ -336,11 +336,18 @@ void SCXTEditor::drainCallbackQueue()
     }
 }
 
+selection::SelectionManager::SelectActionContents
+SCXTEditor::makeSelectActionContents(const selection::SelectionManager::ZoneAddress &a,
+                                     bool selecting, bool distinct, bool asLead) const
+{
+    return selection::SelectionManager::SelectActionContents{a.part,    a.group,  a.zone,
+                                                             selecting, distinct, asLead};
+}
+
 void SCXTEditor::doSelectionAction(const selection::SelectionManager::ZoneAddress &a,
                                    bool selecting, bool distinct, bool asLead)
 {
-    doSelectionAction(selection::SelectionManager::SelectActionContents{
-        a.part, a.group, a.zone, selecting, distinct, asLead});
+    doSelectionAction(makeSelectActionContents(a, selecting, distinct, asLead));
 }
 
 void SCXTEditor::doSelectionAction(const selection::SelectionManager::SelectActionContents &p)


### PR DESCRIPTION
Marquee Selection would send individual multi-select messages which was silly and caused message graffic which was super big and noticable (and probably quadratic). Fix it by batching and using the multi transaction api in the zone layout display

Closes #2216