### PR TITLE
Edit: Shift-drop of multiple samples velocity stacks

### DIFF
--- a/src/scxt-plugin/app/SCXTEditor.h
+++ b/src/scxt-plugin/app/SCXTEditor.h
@@ -359,7 +359,7 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel,
     // Keyboard shortcuts
     std::unique_ptr<KeyBindings> keyBindings;
     bool keyPressed(const juce::KeyPress &key) override;
-
+    void modifierKeysChanged(const juce::ModifierKeys &modifiers) override;
     void switchGroupOrZoneFocus();
 
   protected:

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
@@ -450,15 +450,16 @@ void MappingDisplay::itemDropped(const juce::DragAndDropTarget::SourceDetails &d
                 if (e->getCompoundElement().has_value())
                 {
                     sendToSerialization(cmsg::AddCompoundElementWithRange(
-                        {*e->getCompoundElement(), loc.root, loc.lo, loc.hi, 0, 127}));
+                        {*e->getCompoundElement(), loc.root, loc.lo, loc.hi, loc.vlo, loc.vhi}));
                 }
                 else if (
                     e->getDirEnt()
                         .has_value()) //  &&
                                       //  !browser::Browser::isLoadableSingleSample(wsi->getDirEnt()->path()))
                 {
-                    sendToSerialization(cmsg::AddSampleWithRange(
-                        {e->getDirEnt()->path().u8string(), loc.root, loc.lo, loc.hi, 0, 127}));
+                    sendToSerialization(
+                        cmsg::AddSampleWithRange({e->getDirEnt()->path().u8string(), loc.root,
+                                                  loc.lo, loc.hi, loc.vlo, loc.vhi}));
                 }
             }
         }
@@ -467,7 +468,7 @@ void MappingDisplay::itemDropped(const juce::DragAndDropTarget::SourceDetails &d
             auto loc = r[0];
             assert(r.size() == 1);
             sendToSerialization(cmsg::AddCompoundElementWithRange(
-                {*wsi->getCompoundElement(), loc.root, loc.lo, loc.hi, 0, 127}));
+                {*wsi->getCompoundElement(), loc.root, loc.lo, loc.hi, loc.vlo, loc.vhi}));
         }
         else if (wsi->getDirEnt().has_value())
         {
@@ -475,8 +476,9 @@ void MappingDisplay::itemDropped(const juce::DragAndDropTarget::SourceDetails &d
             assert(r.size() == 1);
             auto inst = browser::Browser::getMultiInstrumentElements(wsi->getDirEnt()->path());
             if (inst.empty())
-                sendToSerialization(cmsg::AddSampleWithRange(
-                    {wsi->getDirEnt()->path().u8string(), loc.root, loc.lo, loc.hi, 0, 127}));
+                sendToSerialization(
+                    cmsg::AddSampleWithRange({wsi->getDirEnt()->path().u8string(), loc.root, loc.lo,
+                                              loc.hi, loc.vlo, loc.vhi}));
             else
             {
                 promptForMultiInstrument(inst);
@@ -554,8 +556,8 @@ void MappingDisplay::filesDropped(const juce::StringArray &files, int x, int y)
         auto inst = browser::Browser::getMultiInstrumentElements(p);
         if (inst.empty())
         {
-            sendToSerialization(
-                cmsg::AddSampleWithRange({f.toStdString(), loc.root, loc.lo, loc.hi, 0, 127}));
+            sendToSerialization(cmsg::AddSampleWithRange(
+                {f.toStdString(), loc.root, loc.lo, loc.hi, loc.vlo, loc.vhi}));
         }
         else
         {

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.h
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.h
@@ -44,8 +44,12 @@ struct ZoneLayoutDisplay : juce::Component, HasEditor
 
     struct RootAndRange
     {
-        RootAndRange(int16_t r, int16_t l, int16_t h) : root(r), lo(l), hi(h) {}
-        int16_t root, lo, hi;
+        RootAndRange(int16_t r, int16_t l, int16_t h) : root(r), lo(l), hi(h), vlo(0), vhi(127) {}
+        RootAndRange(int16_t r, int16_t l, int16_t h, int16_t vl, int16_t vh)
+            : root(r), lo(l), hi(h), vlo(vl), vhi(vh)
+        {
+        }
+        int16_t root, lo, hi, vlo, vhi;
     };
     std::vector<RootAndRange>
     rootAndRangeForPosition(const juce::Point<int> &, size_t nFiles,

--- a/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
@@ -612,4 +612,13 @@ void SCXTEditor::processorBypassToggled(int which)
     }
 }
 
+void SCXTEditor::modifierKeysChanged(const juce::ModifierKeys &modifiers)
+{
+    if (editScreen && editScreen->mappingPane)
+    {
+        // Bit of a hammer for now
+        editScreen->mappingPane->repaint();
+    }
+}
+
 } // namespace scxt::ui::app


### PR DESCRIPTION
When dropping multiple samples shift dropping it in the editor will stack it in the vertical direction.

partly addresses #2213