### PR TITLE
Add a few test items to the developer menu

### DIFF
--- a/src/scxt-plugin/app/SCXTEditor.h
+++ b/src/scxt-plugin/app/SCXTEditor.h
@@ -381,6 +381,11 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel,
     std::unique_ptr<melatonin::Inspector> melatoninInspector;
 #endif
 
+    // Developer testing functions
+
+    // Sweep the entire keybad from 0-127 using the gui note.
+    void devSweepKeys(int msBetween, int key = 0);
+
   public:
     std::unique_ptr<juce::FileChooser> fileChooser;
 

--- a/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
@@ -621,4 +621,25 @@ void SCXTEditor::modifierKeysChanged(const juce::ModifierKeys &modifiers)
     }
 }
 
+void SCXTEditor::devSweepKeys(int msBetween, int key)
+{
+    namespace cmsg = scxt::messaging::client;
+    if (key != 0)
+    {
+        SCLOG_IF(debug, "Note OFF << key=" << key - 1);
+        sendToSerialization(cmsg::NoteFromGUI({key - 1, 0.9, false}));
+    }
+
+    if (key == 127)
+    {
+        SCLOG_IF(debug, "Key sweep done");
+        return;
+    }
+
+    SCLOG_IF(debug, "Note ON  >> key=" << key);
+    sendToSerialization(cmsg::NoteFromGUI({key, 0.9, true}));
+    juce::Timer::callAfterDelay(msBetween,
+                                [this, nk = key + 1, ms = msBetween]() { devSweepKeys(ms, nk); });
+}
+
 } // namespace scxt::ui::app

--- a/src/scxt-plugin/app/editor-impl/SCXTEditorMenus.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditorMenus.cpp
@@ -75,6 +75,19 @@ void SCXTEditor::showMainMenu()
     addUIThemesMenu(skin);
     m.addSubMenu("UI Behavior", skin);
 
+    m.addSeparator();
+    m.addItem("Release all Voices", [w = juce::Component::SafePointer(this)]() {
+        if (!w)
+            return;
+        w->sendToSerialization(cmsg::StopSounds{false});
+    });
+    m.addItem("Stop all Sounds", [w = juce::Component::SafePointer(this)]() {
+        if (!w)
+            return;
+        w->sendToSerialization(cmsg::StopSounds{true});
+    });
+    m.addSeparator();
+
     m.addItem("Show Log", [w = juce::Component::SafePointer(this)] {
         if (w)
             w->showLogOverlay();
@@ -128,18 +141,7 @@ void SCXTEditor::showMainMenu()
     dp.addSeparator();
     dp.addItem("Dump Colormap JSON", [this]() { SCLOG_IF(always, themeApplier.colors->toJson()); });
     dp.addSeparator();
-    dp.addItem("Raise Dummy Error", [w = juce::Component::SafePointer(this)]() {
-        if (!w)
-            return;
-        w->sendToSerialization(cmsg::RaiseDebugError{true});
-    });
-    dp.addItem("Raise Dummy OK Cancel", [w = juce::Component::SafePointer(this)]() {
-        if (!w)
-            return;
-        w->promptOKCancel(
-            "Dummy OK Cancel", "This is the dummy OK Cancel Message",
-            []() { SCLOG_IF(always, "OK Pressed"); }, []() { SCLOG_IF(always, "Cancel Pressed"); });
-    });
+
     dp.addSeparator();
     dp.addItem("Toggle Focus Debugger", [w = juce::Component::SafePointer(this)]() {
         if (!w)
@@ -173,16 +175,37 @@ void SCXTEditor::showMainMenu()
     }
 #endif
 
-    dp.addItem("Release all Voices", [w = juce::Component::SafePointer(this)]() {
+    auto devpm = juce::PopupMenu();
+
+    devpm.addItem("Raise Dummy OK Cancel", [w = juce::Component::SafePointer(this)]() {
         if (!w)
             return;
-        w->sendToSerialization(cmsg::StopSounds{false});
+        w->promptOKCancel(
+            "Dummy OK Cancel", "This is the dummy OK Cancel Message",
+            []() { SCLOG_IF(always, "OK Pressed"); }, []() { SCLOG_IF(always, "Cancel Pressed"); });
     });
-    dp.addItem("Stop all Sounds", [w = juce::Component::SafePointer(this)]() {
+    devpm.addItem("Raise Dummy Error", [w = juce::Component::SafePointer(this)]() {
         if (!w)
             return;
-        w->sendToSerialization(cmsg::StopSounds{true});
+        w->sendToSerialization(cmsg::RaiseDebugError{true});
     });
+    devpm.addSeparator();
+    devpm.addItem("Sweep keys (30ms)", [w = juce::Component::SafePointer(this)]() {
+        if (!w)
+            return;
+        w->devSweepKeys(30);
+    });
+    devpm.addItem("Sweep keys (3ms)", [w = juce::Component::SafePointer(this)]() {
+        if (!w)
+            return;
+        w->devSweepKeys(3);
+    });
+    devpm.addItem("Sweep keys (0ms)", [w = juce::Component::SafePointer(this)]() {
+        if (!w)
+            return;
+        w->devSweepKeys(0);
+    });
+    dp.addSubMenu("Test Tools", devpm);
 
     m.addSubMenu("Developer", dp);
 


### PR DESCRIPTION
In debugging #2229 I realized I wanted to automate that key sweep so I added a 'sweep keys' method. this exercises the heck out of the voice manager, and leads me to a potential fix for that issue, but I wanted the reorg of the dev menu and associated test function to be in a separate commit from voice manager changes, hence this