### PR TITLE
CrashFix: Flood of UI messages could mislead serailization thread

### DIFF
--- a/src/scxt-core/messaging/messaging.cpp
+++ b/src/scxt-core/messaging/messaging.cpp
@@ -213,7 +213,8 @@ void MessageController::runSerialization()
                    (audioToSerializationQueue.empty()) && !audioStateChanged)
             {
                 clientToSerializationConditionVar.wait_for(lock, 50ms);
-                audioStateChanged = updateAudioRunning();
+                audioStateChanged = updateAudioRunning(clientToSerializationQueue.empty() &&
+                                                       audioToSerializationQueue.empty());
             }
             if (!clientToSerializationQueue.empty())
             {
@@ -265,7 +266,7 @@ void MessageController::runSerialization()
     }
 }
 
-bool MessageController::updateAudioRunning()
+bool MessageController::updateAudioRunning(bool includeCountdown)
 {
     assert(threadingChecker.isSerialThread());
     bool retval = false;
@@ -274,7 +275,8 @@ bool MessageController::updateAudioRunning()
         isAudioRunning = true;
         retval = true;
     }
-    else if (isAudioRunning && localCopyOfEngineProcessRuns == engineProcessRuns)
+    else if (isAudioRunning && localCopyOfEngineProcessRuns == engineProcessRuns &&
+             includeCountdown)
     {
         engineOffCountdown--;
         if (engineOffCountdown <= 0)

--- a/src/scxt-core/messaging/messaging.h
+++ b/src/scxt-core/messaging/messaging.h
@@ -172,7 +172,7 @@ struct MessageController : MoveableOnly<MessageController>
     std::atomic<bool> isClientConnected{false}, isAudioRunning{false};
     std::atomic<int64_t> engineProcessRuns{0}; // each time process is called this updates
     std::atomic<bool> forceStatusUpdate{false};
-    bool updateAudioRunning(); // returns true if there is a state change
+    bool updateAudioRunning(bool includeCountdown); // returns true if there is a state change
 
     /**
      * start. Called from the startup thread after the engine is created.

--- a/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
@@ -626,8 +626,11 @@ void SCXTEditor::devSweepKeys(int msBetween, int key)
     namespace cmsg = scxt::messaging::client;
     if (key != 0)
     {
-        SCLOG_IF(debug, "Note OFF << key=" << key - 1);
         sendToSerialization(cmsg::NoteFromGUI({key - 1, 0.9, false}));
+    }
+    else
+    {
+        SCLOG_IF(debug, "Starting keysweep");
     }
 
     if (key == 127)
@@ -636,7 +639,6 @@ void SCXTEditor::devSweepKeys(int msBetween, int key)
         return;
     }
 
-    SCLOG_IF(debug, "Note ON  >> key=" << key);
     sendToSerialization(cmsg::NoteFromGUI({key, 0.9, true}));
     juce::Timer::callAfterDelay(msBetween,
                                 [this, nk = key + 1, ms = msBetween]() { devSweepKeys(ms, nk); });


### PR DESCRIPTION
The serialization thread wakes up whenever voices are avialble and each time did an udpate audio status, but that status requires the engine to advance, so if enough ui messages occured withint one audio side block, the serial thread could convince itself that the audio thread was not running and mis-schedule a message.

This came up with a thread of very fast messages, for instance a linux sweep across the virtual keyboard where the events are very rapidly delivered. But also with the test / sweep notes.

Fix this by not doing the 'no activity' countdown in the udpate if there is still a queue pending.

Closes #2229