### PR TITLE
Fix a voice init / param coordination problem

### DIFF
--- a/src/scxt-core/engine/group.cpp
+++ b/src/scxt-core/engine/group.cpp
@@ -577,6 +577,7 @@ void Group::onProcessorTypeChanged(int w, dsp::processor::ProcessorType t)
             dsp::processor::unspawnProcessor(processors[w]);
         }
         // FIXME - replace the float params with something modulatable
+        endpoints.processorTarget[w].snapValues();
         processors[w] = dsp::processor::spawnProcessorInPlace(
             t, asT()->getEngine(), asT()->getEngine()->getMemoryPool().get(),
             processorPlacementStorage[w], dsp::processor::processorMemoryBufferSize,

--- a/src/scxt-core/voice/voice.cpp
+++ b/src/scxt-core/voice/voice.cpp
@@ -699,6 +699,7 @@ template <bool OS> bool Voice::processWithOS()
         {
             processorType[i] = proct;
             // this is copied below in the init.
+            endpoints->processorTarget[i].snapValues();
             processors[i] = dsp::processor::spawnProcessorInPlace(
                 processorType[i], zone->getEngine(), zone->getEngine()->getMemoryPool().get(),
                 processorPlacementStorage[i], dsp::processor::processorMemoryBufferSize,
@@ -1115,6 +1116,7 @@ void Voice::initializeProcessors()
         if ((processorIsActive[i] && processorType[i] != dsp::processor::proct_none) ||
             (processorType[i] == dsp::processor::proct_none && !processorIsActive[i]))
         {
+            endpoints->processorTarget[i].snapValues();
             // this init code is partly copied above in the voice state toggle
             processors[i] = dsp::processor::spawnProcessorInPlace(
                 processorType[i], zone->getEngine(), zone->getEngine()->getMemoryPool().get(),


### PR DESCRIPTION
Voice init sometimes consumes params, but the voice didn't set up params reliably, so sometimes a voice would start a proc with old versions of params, which if consumed in init (which happens rarely) would cause an issue. Floating point issues only that is.

This would show up in, say, a high voice count VA with other sounds sometimes starting with a sync ratio of like 26 for one frame

Fix by doing the endpoint snap (which is special for procs to project the matrix onto a contiguous array) before init

Closes #2025