### PR TITLE
Partial fix for variants failing to load on unstream

### DIFF
--- a/src/scxt-core/engine/engine.cpp
+++ b/src/scxt-core/engine/engine.cpp
@@ -179,6 +179,7 @@ Engine::~Engine()
         }
     }
     messageController->stop();
+    messageController->threadingChecker.bypassThreadChecks = true;
     sampleManager->purgeUnreferencedSamples();
 
     /*

--- a/src/scxt-core/engine/zone.cpp
+++ b/src/scxt-core/engine/zone.cpp
@@ -204,7 +204,12 @@ void Zone::setupOnUnstream(const engine::Engine &e)
             variantData.variants[i].sampleID = nid;
         }
 
-        attachToSample(*(e.getSampleManager()), i, Zone::NONE);
+        if (!attachToSample(*(e.getSampleManager()), i, Zone::NONE))
+        {
+            e.getMessageController()->reportErrorToClient(
+                "Sample Unstream Error", std::string() + "Unable to attach zone to sample " +
+                                             oid.to_string() + " at index " + std::to_string(i));
+        }
     }
     for (int p = 0; p < processorCount; ++p)
     {
@@ -221,6 +226,7 @@ bool Zone::attachToSample(const sample::SampleManager &manager, int index, int s
     }
     else
     {
+        SCLOG_IF(sampleLoadAndPurge, getName() << " : No sample ID for variant " << index);
         samplePointers[index].reset();
     }
 

--- a/src/scxt-core/engine/zone.h
+++ b/src/scxt-core/engine/zone.h
@@ -184,6 +184,8 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
             return givenName;
         if (samplePointers[0])
             return samplePointers[0]->getDisplayName();
+        if (!samplePointers[0] && variantData.variants[0].active)
+            return fmt::format("{}/BadVariant", id.to_string());
         return id.to_string();
     }
 

--- a/src/scxt-core/sample/sample_manager.cpp
+++ b/src/scxt-core/sample/sample_manager.cpp
@@ -491,6 +491,9 @@ std::optional<SampleID> SampleManager::loadSampleFromMultiSample(const fs::path 
 
 void SampleManager::purgeUnreferencedSamples()
 {
+    assert(threadingChecker.isSerialThread());
+    SCLOG_IF(sampleLoadAndPurge,
+             "Attempting to Purge Unreferenced Samples " << std::this_thread::get_id());
     auto lk = acquireMapLock();
     auto preSize{samples.size()};
     auto b = samples.begin();

--- a/src/scxt-plugin/clap/scxt-plugin.cpp
+++ b/src/scxt-plugin/clap/scxt-plugin.cpp
@@ -113,7 +113,13 @@ std::unique_ptr<juce::Component> SCXTPlugin::createEditor()
 
 bool SCXTPlugin::stateSave(const clap_ostream *ostream) noexcept
 {
-    engine->getSampleManager()->purgeUnreferencedSamples();
+    // Thie entire function needs to send and wait on serialization
+    // thread, but that's a big change. For now its entire read-only
+    // except for this purge, which I beleive causes #2205 so comment
+    // out to get beta not flaky with the mild cost that a daw could
+    // reference a sample a zone does not if a delete absent a purge
+    // happens in the code path.
+    // engine->getSampleManager()->purgeUnreferencedSamples();
     engine->prepareToStream();
     try
     {


### PR DESCRIPTION
We had several reports (like #2205) that large numers of samples in some daws when unstreaming would miss some zones.

The reason for this is because saveState is currently on the main thread and doesn't delegate to the serial thread; but also it does a purge; and that purge can coincide with a still running unstream. So the zone doesn't find the sample

The correct long term solution is to have save wait on a serial thread return of the stream blob. But for now we do

1. remove the purge from save state. This has the small price that in some edge cases the daw could refer to more than we need, but it will get cleaned up on next load
2. Add error messages, debug asserts, and renames if the problem does occur and I'm wrong

If this addresses 2205 I'll close that and open a separate issue for more thread secure save state. Still a couple of edges here but the big one - where save does a write bia the purge - is gone