### PR TITLE
Workflow: Variant file opens in directory of current variant

### DIFF
--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
@@ -729,7 +729,13 @@ void VariantDisplay::showFileBrowser()
     }
     filePattern.erase(filePattern.size() - 1);
 
-    fileChooser.reset(new juce::FileChooser("Select an audio file...", {}, filePattern));
+    juce::File initDirectory{};
+    auto cSamp = editor->sampleManager.getSample(variantView.variants[selectedVariation].sampleID);
+    if (cSamp && !cSamp->getPath().empty() && !cSamp->getPath().parent_path().empty())
+    {
+        initDirectory = shared::fsPathToJuceFile(cSamp->getPath().parent_path());
+    }
+    fileChooser.reset(new juce::FileChooser("Select an audio file...", initDirectory, filePattern));
 
     fileChooser->launchAsync(
         juce::FileBrowserComponent::openMode | juce::FileBrowserComponent::canSelectFiles,

--- a/src/scxt-plugin/app/shared/UIHelpers.h
+++ b/src/scxt-plugin/app/shared/UIHelpers.h
@@ -59,6 +59,15 @@ inline fs::path juceFileToFSPath(const juce::File &f)
     return juceStringToFSPath(fullPathName);
 }
 
+inline juce::File fsPathToJuceFile(const fs::path &p)
+{
+#if JUCE_WINDOWS
+    return juce::File(juce::String((wchar_t *)p.u16string().c_str()));
+#else
+    return juce::File(p.u8string());
+#endif
+}
+
 } // namespace scxt::ui::app::shared
 
 #endif // SHORTCIRCUITXT_UIHELPERS_H


### PR DESCRIPTION
Basically if you click there, we know whats on display, and if it has a valid parent path etc... try to open the file chooser there.

Also introduces fsPathToJuceFile to the UIHelpers header

Closes #2284