### PR TITLE
Create a clean error on non-utf8-encoded SFZ

### DIFF
--- a/src/scxt-core/engine/engine.cpp
+++ b/src/scxt-core/engine/engine.cpp
@@ -685,7 +685,8 @@ void Engine::loadCompoundElementIntoSelectedPartAndGroup(const sample::compound:
             messageController->stopAudioThreadThenRunOnSerial([this, p](const auto &) {
                 auto res = sfz_support::importSFZ(p.sampleAddress.path, *this);
                 if (!res)
-                    messageController->reportErrorToClient("SFZ Import Failed", "Dunno why");
+                    messageController->reportErrorToClient("SFZ Import Failed",
+                                                           "Check log for errors");
                 messageController->restartAudioThreadFromSerial();
                 serializationSendToClient(messaging::client::s2c_send_pgz_structure,
                                           getPartGroupZoneStructure(), *messageController);
@@ -790,7 +791,8 @@ void Engine::loadSampleIntoSelectedPartAndGroup(const fs::path &p, int16_t rootK
         messageController->stopAudioThreadThenRunOnSerial([this, p](const auto &) {
             auto res = sfz_support::importSFZ(p, *this);
             if (!res)
-                messageController->reportErrorToClient("SFZ Import Failed", "Dunno why");
+                messageController->reportErrorToClient("SFZ Import Failed",
+                                                       "Check log for further errors");
             messageController->restartAudioThreadFromSerial();
             serializationSendToClient(messaging::client::s2c_send_pgz_structure,
                                       getPartGroupZoneStructure(), *messageController);
@@ -803,7 +805,8 @@ void Engine::loadSampleIntoSelectedPartAndGroup(const fs::path &p, int16_t rootK
         messageController->stopAudioThreadThenRunOnSerial([this, p](const auto &) {
             auto res = exs_support::importEXS(p, *this);
             if (!res)
-                messageController->reportErrorToClient("EXS Import Failed", "Dunno why");
+                messageController->reportErrorToClient("EXS Import Failed",
+                                                       "Check log for subsequent errors");
             messageController->restartAudioThreadFromSerial();
             serializationSendToClient(messaging::client::s2c_send_pgz_structure,
                                       getPartGroupZoneStructure(), *messageController);
@@ -815,7 +818,8 @@ void Engine::loadSampleIntoSelectedPartAndGroup(const fs::path &p, int16_t rootK
         messageController->stopAudioThreadThenRunOnSerial([this, p](const auto &) {
             auto res = multisample_support::importMultisample(p, *this);
             if (!res)
-                messageController->reportErrorToClient("SFZ Import Failed", "Dunno why");
+                messageController->reportErrorToClient("Multisample Import Failed",
+                                                       "Check log for subsequent errors");
             messageController->restartAudioThreadFromSerial();
             serializationSendToClient(messaging::client::s2c_send_pgz_structure,
                                       getPartGroupZoneStructure(), *messageController);
@@ -827,7 +831,8 @@ void Engine::loadSampleIntoSelectedPartAndGroup(const fs::path &p, int16_t rootK
         messageController->stopAudioThreadThenRunOnSerial([this, p](const auto &) {
             auto res = akai_support::importAKP(p, *this);
             if (!res)
-                messageController->reportErrorToClient("AKP Import Failed", "Dunno why");
+                messageController->reportErrorToClient("AKP Import Failed",
+                                                       "Check log for subsequent errors");
             messageController->restartAudioThreadFromSerial();
             serializationSendToClient(messaging::client::s2c_send_pgz_structure,
                                       getPartGroupZoneStructure(), *messageController);

--- a/src/scxt-core/utils.cpp
+++ b/src/scxt-core/utils.cpp
@@ -120,4 +120,37 @@ std::string logTimestamp()
            << current_milliseconds;
     return stream.str();
 }
+
+bool isValidUtf(const std::string &s)
+{
+    auto it = s.begin();
+    while (it != s.end())
+    {
+        unsigned char c = static_cast<unsigned char>(*it);
+        int n = 0;
+        if ((c & 0x80) == 0)
+            n = 0;
+        else if ((c & 0xE0) == 0xC0)
+            n = 1;
+        else if ((c & 0xF0) == 0xE0)
+            n = 2;
+        else if ((c & 0xF8) == 0xF0)
+            n = 3;
+        else
+            return false;
+
+        for (int i = 0; i < n; ++i)
+        {
+            it++;
+            if (it == s.end())
+                return false;
+            unsigned char nextC = static_cast<unsigned char>(*it);
+            if ((nextC & 0xC0) != 0x80)
+                return false;
+        }
+        it++;
+    }
+    return true;
+}
+
 } // namespace scxt

--- a/src/scxt-core/utils.h
+++ b/src/scxt-core/utils.h
@@ -398,6 +398,8 @@ inline std::string humanReadableVersion(uint64_t v)
     return fmt::format("{:04x}-{:02x}-{:02x}", (v >> 16) & 0xFFFF, (v >> 8) & 0xFF, v & 0xFF);
 }
 
+bool isValidUtf(const std::string &s);
+
 } // namespace scxt
 
 // Make the ID hashable so we can use it as a map key


### PR DESCRIPTION
SFZ and encoding is, well, a mess. Just use ASCII if you are using SFZ.

But folks who don't do that would, with short circuit, generate a crash when we checked for a utf8 message buffer.

So now, if we have a sapmle which is not a text encoded as a valid UTF8 name throw an error and stop import.

Closes #2299