### PR TITLE
Frew small cleanup tweaks

### DIFF
--- a/src/scxt-core/configuration.h
+++ b/src/scxt-core/configuration.h
@@ -113,8 +113,8 @@ static constexpr bool ringout{false};
 static constexpr bool streaming{false};
 static constexpr bool sqlDb{false};
 static constexpr bool groupTrigggers{false};
-static constexpr bool zoneLayout{true};
-static constexpr bool undoRedo{true};
+static constexpr bool zoneLayout{false};
+static constexpr bool undoRedo{false};
 
 static constexpr bool patchIO{false};
 static constexpr bool jsonUI{false};
@@ -143,7 +143,6 @@ namespace hasFeature
  */
 static constexpr bool geometryChangesAdjustFade{false};
 
-static constexpr bool undoRedo{false};               // undo-redo
 static constexpr bool memoryUsageExplanation{false}; // that chip in the header
 static constexpr bool mappingPane11Controls{false};  // zone mapping header skipped for 1.0
 static constexpr bool hasBrowserSearch{false};

--- a/src/scxt-plugin/app/edit-screen/components/ModPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/ModPane.cpp
@@ -383,9 +383,7 @@ template <typename GZTrait> struct ModRow : juce::Component, HasEditor
         }
         sl += vl;
 
-        std::vector<jcmp::ToolTip::Row> rows;
         auto lineOne = sl + " " + u8"\U00002192" + " " + tl;
-        rows.push_back(jcmp::ToolTip::Row(lineOne));
 
         auto &epo = parent->routingTable.routes[index].extraPayload;
         if (!epo.has_value())

--- a/src/scxt-plugin/app/edit-screen/components/ProcessorPaneEQsFilters.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/ProcessorPaneEQsFilters.cpp
@@ -306,11 +306,11 @@ void ProcessorPane::layoutControlsEQNBandParm()
         ms->setBounds(cols[0].withHeight(50).withWidth(cols[0].getWidth() / 2));
         otherEditors.push_back(std::move(ms));
     }
-    std::vector<std::string> lab = {"Gain", "Freq", "BW"};
+    auto lab = std::array{"Gain", "Freq", "BW"};
     for (int i = 0; i < 3 * eqdisp->nBands; ++i)
     {
-        floatEditors[i] = createWidgetAttachedTo(floatAttachments[i],
-                                                 lab[i % 3] + " " + std::to_string(i / 3 + 1));
+        floatEditors[i] = createWidgetAttachedTo(
+            floatAttachments[i], std::string(lab[i % 3]) + " " + std::to_string(i / 3 + 1));
         auto orig = floatAttachments[i]->onGuiValueChanged;
         floatAttachments[i]->onGuiValueChanged =
             [orig, w = juce::Component::SafePointer(eqdisp.get())](const auto &a) {
@@ -391,10 +391,11 @@ void ProcessorPane::layoutControlsEQMorph()
 
     floatEditors[0] = createWidgetAttachedTo(floatAttachments[0], "Morph");
 
-    std::vector<std::string> lab{"Morph", "Freq1", "Freq2", "Gain", "BW"};
+    auto lab = std::array{"Morph", "Freq1", "Freq2", "Gain", "BW"};
     auto cols = lo::columns(presets.translated(0, 18).withHeight(38), 5);
 
-    for (int i = 0; i < 5; ++i)
+    static_assert(lab.size() < maxProcessorFloatParams);
+    for (int i = 0; i < lab.size(); ++i)
     {
         floatEditors[i] = createWidgetAttachedTo(floatAttachments[i], lab[i]);
         floatAttachments[i]->andThenOnGui(thenRecalc);

--- a/src/scxt-plugin/app/shared/HeaderRegion.cpp
+++ b/src/scxt-plugin/app/shared/HeaderRegion.cpp
@@ -261,11 +261,8 @@ void HeaderRegion::resized()
     auto b = getBounds().reduced(6);
     selectedPage->setBounds(b.withWidth(196));
 
-    if (hasFeature::undoRedo)
-    {
-        undoButton->setBounds(b.withTrimmedLeft(246).withWidth(48));
-        redoButton->setBounds(b.withTrimmedLeft(246 + 50).withWidth(48));
-    }
+    undoButton->setBounds(b.withTrimmedLeft(246).withWidth(48));
+    redoButton->setBounds(b.withTrimmedLeft(246 + 50).withWidth(48));
 
     tuningButton->setBounds(b.withTrimmedLeft(823).withWidth(48));
     omniButton->setBounds(b.withTrimmedLeft(823 + 50).withWidth(48));


### PR DESCRIPTION
- array vs vector. Closes #2310
- Remove an unsued vector fro depth tooltip. Closes #2309
- turn off undo logging.