### PR TITLE
Fix bus description for Studio One

### DIFF
--- a/src/scxt-plugin/clap/scxt-plugin.cpp
+++ b/src/scxt-plugin/clap/scxt-plugin.cpp
@@ -217,6 +217,11 @@ bool SCXTPlugin::audioPortsInfo(uint32_t index, bool isInput,
         info->id = 1000 + index - 1;
         info->in_place_pair = CLAP_INVALID_ID;
         snprintf(info->name, sizeof(info->name) - 1, "Out %d", index);
+        /*
+         * StudioOne incorrectly (I think) makes output busses which arent main
+         * non-activatable both in clap and vst3. Other DAWW ignore this.
+         * So let them know but for now...
+         */
         info->flags = CLAP_AUDIO_PORT_IS_MAIN;
         info->channel_count = 2;
         info->port_type = CLAP_PORT_STEREO;


### PR DESCRIPTION
Studio One requires all output busses be MAIN. This is annoying, and I think a misread of both the VST3 and the CLAP spec, but only so many hills to die on, since other hosts ignore the fact that it is not main on output

Closes #2337