### PR TITLE
Dont use sample mapping data in drag-drop gesture

### DIFF
--- a/src/scxt-core/engine/engine.h
+++ b/src/scxt-core/engine/engine.h
@@ -568,9 +568,13 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     /*
      * Serialization thread originated mutation apis
      */
-    void loadSampleIntoSelectedPartAndGroup(const fs::path &, int16_t rootKey = 60,
-                                            KeyboardRange krange = {48, 72},
-                                            VelocityRange vrange = {0, 127});
+    void loadSampleIntoSelectedPartAndGroup(const fs::path &, int16_t rootKey, KeyboardRange krange,
+                                            VelocityRange vrange,
+                                            bool sampleRangeInfoOverridesArguments = false);
+    void loadSampleIntoSelectedPartAndGroup(const fs::path &p)
+    {
+        loadSampleIntoSelectedPartAndGroup(p, 60, {48, 72}, {0, 127}, true);
+    }
 
     void loadCompoundElementIntoSelectedPartAndGroup(
         const scxt::sample::compound::CompoundElement &, int16_t rootKey = 60,

--- a/src/scxt-core/sample/sample.cpp
+++ b/src/scxt-core/sample/sample.cpp
@@ -52,7 +52,7 @@ bool Sample::load(const fs::path &path)
     resetErrorString();
     if (!fs::exists(path))
     {
-        addError("File " + path.u8string() + " does not exist.");
+        addError("File '" + path.u8string() + "' does not exist.");
         return false;
     }
 

--- a/src/scxt-core/sample/sample_manager.cpp
+++ b/src/scxt-core/sample/sample_manager.cpp
@@ -147,6 +147,7 @@ SampleManager::loadSampleByFileAddress(const Sample::SampleFileAddress &addr, co
 
 std::optional<SampleID> SampleManager::loadSampleByPath(const fs::path &p)
 {
+    SCLOG_IF(sampleLoadAndPurge, "Loading sample by path '" << p.u8string() << "'");
     assert(threadingChecker.isSerialThread());
 
     for (const auto &[alreadyId, sm] : samples)
@@ -492,8 +493,6 @@ std::optional<SampleID> SampleManager::loadSampleFromMultiSample(const fs::path 
 void SampleManager::purgeUnreferencedSamples()
 {
     assert(threadingChecker.isSerialThread());
-    SCLOG_IF(sampleLoadAndPurge,
-             "Attempting to Purge Unreferenced Samples " << std::this_thread::get_id());
     auto lk = acquireMapLock();
     auto preSize{samples.size()};
     auto b = samples.begin();


### PR DESCRIPTION
If undertaking a drag and drop gesture, ignore sample mapping data (root key, ranges, etc...) only apply loop and endpoint.

If loading via double click etc... still use the data

Closes #2301