### PR TITLE
Expand voice and group matrix to 18 rows

### DIFF
--- a/src/scxt-core/configuration.h
+++ b/src/scxt-core/configuration.h
@@ -81,8 +81,8 @@ static constexpr uint16_t triggerConditionsPerGroup{4};
 
 static constexpr uint16_t maxGeneratorsPerVoice{64};
 
-static constexpr size_t modMatrixRowsPerZone{12};
-static constexpr size_t modMatrixRowsPerGroup{12};
+static constexpr size_t modMatrixRowsPerZone{18};
+static constexpr size_t modMatrixRowsPerGroup{18};
 
 // For tail detection use a full block below this level as silence
 static constexpr float silenceThresh{1e-10f};


### PR DESCRIPTION
Turns out it was just as easy as changing the constant, because I wrote the code defensively in unstream already, but had to check that.

Closes #2319