### PR TITLE
Rework error path so we get original source and line

### DIFF
--- a/src/scxt-core/browser/browser_db.cpp
+++ b/src/scxt-core/browser/browser_db.cpp
@@ -90,7 +90,7 @@ std::vector<std::pair<fs::path, bool>> BrowserDB::getBrowserLocations()
     catch (SQL::Exception &e)
     {
         SCLOG_IF(sqlDb, e.what());
-        mc.reportErrorToClient("Database Error", e.what());
+        RAISE_ERROR_CONT(mc, "Database Error", e.what());
     }
     return res;
 }

--- a/src/scxt-core/engine/missing_resolution.cpp
+++ b/src/scxt-core/engine/missing_resolution.cpp
@@ -118,9 +118,8 @@ void resolveMultiFileMissingWorkItem(engine::Engine &e, const MissingResolutionW
     if (!isSF2 && !isMultiSample)
     {
         SCLOG_IF(missingResolution, "Cant deteremine multi style for " << p.u8string());
-        e.getMessageController()->reportErrorToClient(
-            "Unable to resolve missing with multifile",
-            "Can't determine the multifile type for path '" + p.u8string() + "''");
+        RAISE_ERROR_ENGINE(e, "Unable to resolve missing with multifile",
+                           "Can't determine the multifile type for path '" + p.u8string() + "''");
         return;
     }
 

--- a/src/scxt-core/engine/zone.cpp
+++ b/src/scxt-core/engine/zone.cpp
@@ -221,9 +221,9 @@ void Zone::setupOnUnstream(const engine::Engine &e)
 
         if (!attachToSample(*(e.getSampleManager()), i, Zone::NONE))
         {
-            e.getMessageController()->reportErrorToClient(
-                "Sample Unstream Error", std::string() + "Unable to attach zone to sample " +
-                                             oid.to_string() + " at index " + std::to_string(i));
+            RAISE_ERROR_ENGINE(e, "Sample Unstream Error",
+                               std::string() + "Unable to attach zone to sample " +
+                                   oid.to_string() + " at index " + std::to_string(i));
         }
     }
     for (int p = 0; p < processorCount; ++p)

--- a/src/scxt-core/messaging/client/browser_messages.h
+++ b/src/scxt-core/messaging/client/browser_messages.h
@@ -112,9 +112,9 @@ inline void doPreviewBrowserSample(const previewBrowserSamplePayload_t &p,
         }
         else
         {
-            cont.reportErrorToClient("Unable to launch preview",
-                                     "Sample file preview load failed for " +
-                                         sampleAddress.path.u8string());
+            RAISE_ERROR_CONT(cont, "Unable to launch preview",
+                             "Sample file preview load failed for " +
+                                 sampleAddress.path.u8string());
         }
     }
     else if (action == 0)

--- a/src/scxt-core/messaging/client/detail/client_serial_impl.h
+++ b/src/scxt-core/messaging/client/detail/client_serial_impl.h
@@ -201,7 +201,7 @@ inline void serializationSendToClient(SerializationToClientMessageIds id, const 
     {
         if (id != s2c_report_error)
         {
-            mc.reportErrorToClient("JSON Streaming Error", e.what());
+            RAISE_ERROR_CONT(mc, "JSON Streaming Error", e.what());
         }
     }
 }

--- a/src/scxt-core/messaging/client/enginestatus_messages.h
+++ b/src/scxt-core/messaging/client/enginestatus_messages.h
@@ -65,9 +65,8 @@ inline void doUnstreamEngineState(const unstreamEngineStatePayload_t &payload,
             }
             catch (std::exception &err)
             {
-                nonconste.getMessageController()->reportErrorToClient(
-                    "Unstreaming Error",
-                    std::string("Unable to unstream engine state ") + err.what());
+                RAISE_ERROR_ENGINE(nonconste, "Unstreaming Error",
+                                   std::string("Unable to unstream engine state ") + err.what());
             }
         });
     }
@@ -83,8 +82,8 @@ inline void doUnstreamEngineState(const unstreamEngineStatePayload_t &payload,
         }
         catch (std::exception &err)
         {
-            engine.getMessageController()->reportErrorToClient(
-                "Unstreaming Error", std::string("Unable to unstream engine state ") + err.what());
+            RAISE_ERROR_ENGINE(engine, "Unstreaming Error",
+                               std::string("Unable to unstream engine state ") + err.what());
         }
     }
 }

--- a/src/scxt-core/messaging/client/interaction_messages.h
+++ b/src/scxt-core/messaging/client/interaction_messages.h
@@ -34,23 +34,25 @@
 #include "engine/engine.h"
 #include "client_macros.h"
 #include "patch_io/patch_io.h"
+#include "utils.h"
 
 namespace scxt::messaging::client
 {
-typedef std::pair<std::string, std::string> s2cError_t;
+// title, message, source file, source line
+typedef std::tuple<std::string, std::string, std::string, int> s2cError_t;
 SERIAL_TO_CLIENT(ReportError, s2c_report_error, s2cError_t, onErrorFromEngine);
 
 inline void raiseDebugError(MessageController &c, int count)
 {
     for (int i = 0; i < count; ++i)
     {
-        c.reportErrorToClient("A Dummy Error " + std::to_string(i),
-                              "This is a dummy error " + std::to_string(i) +
-                                  ". I chose to have it have "
-                                  "a very long message like this one so I can test multiline "
-                                  "string rendering in the error box. So this one has details "
-                                  "like "
-                                  "this and that");
+        RAISE_ERROR_CONT(c, "A Dummy Error " + std::to_string(i),
+                         "This is a dummy error " + std::to_string(i) +
+                             ". I chose to have it have "
+                             "a very long message like this one so I can test multiline "
+                             "string rendering in the error box. So this one has details "
+                             "like "
+                             "this and that");
     }
 }
 CLIENT_TO_SERIAL(RaiseDebugError, c2s_raise_debug_error, int, raiseDebugError(cont, payload))

--- a/src/scxt-core/messaging/client/mixer_messages.h
+++ b/src/scxt-core/messaging/client/mixer_messages.h
@@ -124,8 +124,8 @@ inline void doBusSwapFX(const busFxSwap_t &payload, const engine::Engine &engine
     auto [bs1, sl1, bs2, sl2, smc] = payload;
     if (bs1 == bs2 && sl1 == sl2)
     {
-        cont.reportErrorToClient("Cant move fx onto itself",
-                                 "Bus Swap FX had same bus/slot location");
+        RAISE_ERROR_CONT(cont, "Cant move fx onto itself",
+                         "Bus Swap FX had same bus/slot location");
         return;
     }
 

--- a/src/scxt-core/messaging/client/part_messages.h
+++ b/src/scxt-core/messaging/client/part_messages.h
@@ -62,14 +62,13 @@ inline void doPartSwapFX(const partFxSwap_t &payload, const engine::Engine &engi
     auto [p1, b1, p2, b2, smc] = payload;
     if (p1 != p2)
     {
-        cont.reportErrorToClient("Cross Part Moves not supported yet",
-                                 "Part Swap FX must be within the same part");
+        RAISE_ERROR_CONT(cont, "Cross Part Moves not supported yet",
+                         "Part Swap FX must be within the same part");
         return;
     }
     if (b1 == b2)
     {
-        cont.reportErrorToClient("Cant move part onto itself",
-                                 "Part Swap FX had same bus location");
+        RAISE_ERROR_CONT(cont, "Cant move part onto itself", "Part Swap FX had same bus location");
         return;
     }
 

--- a/src/scxt-core/messaging/client/patch_io_messages.h
+++ b/src/scxt-core/messaging/client/patch_io_messages.h
@@ -41,7 +41,7 @@ inline void doSaveMulti(const saveMultiPayload_t &pl, engine::Engine &engine,
     auto style = (patch_io::SaveStyles)styleInt;
     if (style == patch_io::SaveStyles::AS_SFZ)
     {
-        cont.reportErrorToClient("SFZ Export for multi", "Report this software error to devs");
+        RAISE_ERROR_CONT(cont, "SFZ Export for multi", "Report this software error to devs");
         return;
     }
     patch_io::saveMulti(fs::path(fs::u8path(s)), engine, style);

--- a/src/scxt-core/messaging/messaging.cpp
+++ b/src/scxt-core/messaging/messaging.cpp
@@ -360,9 +360,10 @@ void MessageController::sendRawFromClient(const clientToSerializationMessage_t &
     clientToSerializationConditionVar.notify_one();
 }
 
-void MessageController::reportErrorToClient(const std::string &title, const std::string &body)
+void MessageController::reportErrorToClient(const std::string &title, const std::string &body,
+                                            const std::string &source, int line)
 {
-    SCLOG_IF(warnings, "Error: [" << title << "]");
+    SCLOG_IF(warnings, "[[" << title << "]] (loc: " << source << ":" << line << ")");
     auto blog = body;
     auto pos{0};
     while ((pos = blog.find("\n", pos)) != std::string::npos)
@@ -370,8 +371,8 @@ void MessageController::reportErrorToClient(const std::string &title, const std:
         blog[pos] = ' ';
     }
     SCLOG_IF(warnings, blog);
-    client::serializationSendToClient(client::s2c_report_error, client::s2cError_t{title, body},
-                                      *(this));
+    client::serializationSendToClient(client::s2c_report_error,
+                                      client::s2cError_t{title, body, source, line}, *(this));
 }
 
 void MessageController::prepareSerializationThreadForAudioQueueDrain()

--- a/src/scxt-core/messaging/messaging.h
+++ b/src/scxt-core/messaging/messaging.h
@@ -312,7 +312,8 @@ struct MessageController : MoveableOnly<MessageController>
     /*
      * A convenience function to report an error to the UI
      */
-    void reportErrorToClient(const std::string &title, const std::string &body);
+    void reportErrorToClient(const std::string &title, const std::string &body,
+                             const std::string &source, int line);
 
     /*
      * Some stats on messages back

--- a/src/scxt-core/patch_io/patch_io.cpp
+++ b/src/scxt-core/patch_io/patch_io.cpp
@@ -127,8 +127,8 @@ bool addMonolithBinaries(const std::unique_ptr<RIFF::File> &f, const engine::Eng
     {
         if (!browser::Browser::isLoadableSingleSample(sample->getPath()))
         {
-            e.getMessageController()->reportErrorToClient(
-                "Unable to add multifile to monolith",
+            RAISE_ERROR_ENGINE(
+                e, "Unable to add multifile to monolith",
                 "Monoliths currently only support single file (wav, flac, aiff, etc...)");
             return false;
         }
@@ -458,11 +458,11 @@ std::unordered_map<SampleID, fs::path> collectSamplesInto(const fs::path &collec
         if (collectedFilenames.find(c.filename()) != collectedFilenames.end())
         {
             SCLOG_IF(patchIO, "Duplicate Sample Name " << c.filename());
-            e.getMessageController()->reportErrorToClient(
-                "Unable to copy sample", "Your patch has two samples with the same filename ('" +
-                                             c.filename().u8string() + "' with " +
-                                             "different paths. This is currently unsupported for "
-                                             "collect mode and needs fixing soonish!");
+            RAISE_ERROR_ENGINE(e, "Unable to copy sample",
+                               "Your patch has two samples with the same filename ('" +
+                                   c.filename().u8string() + "' with " +
+                                   "different paths. This is currently unsupported for "
+                                   "collect mode and needs fixing soonish!");
             return {};
         }
         collectedFilenames.insert(c.filename());
@@ -476,7 +476,7 @@ std::unordered_map<SampleID, fs::path> collectSamplesInto(const fs::path &collec
         catch (fs::filesystem_error &fse)
         {
             SCLOG_IF(patchIO, "Unable to copy " << c.u8string() << " " << fse.what());
-            e.getMessageController()->reportErrorToClient("Unable to copy sample", fse.what());
+            RAISE_ERROR_ENGINE(e, "Unable to copy sample", fse.what());
             return {};
         }
     }
@@ -503,15 +503,13 @@ bool onlyCollect(const fs::path &p, scxt::engine::Engine &e, int part)
     }
     catch (const fs::filesystem_error &fse)
     {
-        e.getMessageController()->reportErrorToClient("Unable to create directory",
-                                                      p.u8string() + "\n" + fse.what());
+        RAISE_ERROR_ENGINE(e, "Unable to create directory", p.u8string() + "\n" + fse.what());
         return false;
     }
     auto collectMap = patch_io::collectSamplesInto(p, e, part);
     if (collectMap.empty())
     {
-        e.getMessageController()->reportErrorToClient("No Samples Collected",
-                                                      "No samples were saved to " + p.u8string());
+        RAISE_ERROR_ENGINE(e, "No Samples Collected", "No samples were saved to " + p.u8string());
         return false;
     }
     return true;
@@ -541,7 +539,7 @@ bool saveMulti(const fs::path &p, scxt::engine::Engine &e, SaveStyles style)
         }
         else
         {
-            e.getMessageController()->reportErrorToClient("Unable to create collect dir", emsg);
+            RAISE_ERROR_ENGINE(e, "Unable to create collect dir", emsg);
         }
     }
 
@@ -625,7 +623,7 @@ bool savePart(const fs::path &p, scxt::engine::Engine &e, int part, patch_io::Sa
         }
         else
         {
-            e.getMessageController()->reportErrorToClient("Unable to create collect dir", emsg);
+            RAISE_ERROR_ENGINE(e, "Unable to create collect dir", emsg);
         }
     }
 

--- a/src/scxt-core/sample/gig_support/gig_import.cpp
+++ b/src/scxt-core/sample/gig_support/gig_import.cpp
@@ -136,8 +136,8 @@ bool importGIG(const fs::path &p, engine::Engine &e, int preset)
 
                 if (!zn->attachToSample(*(e.getSampleManager())))
                 {
-                    messageController->reportErrorToClient("GIG Load Error",
-                                                           "Zone Unable to Attach to Sample");
+                    RAISE_ERROR_CONT(*messageController, "GIG Load Error",
+                                     "Zone Unable to Attach to Sample");
                     return false;
                 }
 
@@ -157,12 +157,12 @@ bool importGIG(const fs::path &p, engine::Engine &e, int preset)
     }
     catch (RIFF::Exception e)
     {
-        messageController->reportErrorToClient("GIG Load Error", e.Message);
+        RAISE_ERROR_CONT(*messageController, "GIG Load Error", e.Message);
         return false;
     }
     catch (const SCXTError &e)
     {
-        messageController->reportErrorToClient("GIG Load Error", e.what());
+        RAISE_ERROR_CONT(*messageController, "GIG Load Error", e.what());
         return false;
     }
     catch (...)

--- a/src/scxt-core/sample/multisample_support/multisample_import.cpp
+++ b/src/scxt-core/sample/multisample_support/multisample_import.cpp
@@ -75,8 +75,7 @@ bool importMultisample(const fs::path &p, engine::Engine &engine)
     if (fileToIndex.find("multisample.xml") == fileToIndex.end())
     {
         SCLOG_IF(sampleCompoundParsers, "No Multisapmle.xml");
-        engine.getMessageController()->reportErrorToClient("Multisample Error",
-                                                           "Mo XML file in Multisample");
+        RAISE_ERROR_ENGINE(engine, "Multisample Error", "Mo XML file in Multisample");
         return false;
     }
 
@@ -93,8 +92,7 @@ bool importMultisample(const fs::path &p, engine::Engine &engine)
         SCLOG_IF(sampleCompoundParsers, "XML Parse Fail");
         mz_zip_reader_end(&zip_archive);
 
-        engine.getMessageController()->reportErrorToClient("Multisample Error",
-                                                           "XML Failed to parse");
+        RAISE_ERROR_ENGINE(engine, "Multisample Error", "XML Failed to parse");
         return false;
     }
 
@@ -108,7 +106,7 @@ bool importMultisample(const fs::path &p, engine::Engine &engine)
     {
         SCLOG_IF(sampleCompoundParsers, "XML is not a multisample document");
         mz_zip_reader_end(&zip_archive);
-        engine.getMessageController()->reportErrorToClient("Multisample Error", "XML invalid");
+        RAISE_ERROR_ENGINE(engine, "Multisample Error", "XML invalid");
         return false;
     }
 
@@ -125,8 +123,7 @@ bool importMultisample(const fs::path &p, engine::Engine &engine)
         if (!fc->Attribute("file"))
         {
             SCLOG_IF(sampleCompoundParsers, "Sample is not a file");
-            engine.getMessageController()->reportErrorToClient("Multisample Error",
-                                                               "Sample is not a file");
+            RAISE_ERROR_ENGINE(engine, "Multisample Error", "Sample is not a file");
             return false;
         }
 

--- a/src/scxt-core/sample/sf2_support/sf2_import.cpp
+++ b/src/scxt-core/sample/sf2_support/sf2_import.cpp
@@ -325,12 +325,12 @@ bool importSF2(const fs::path &p, engine::Engine &e, int preset)
     }
     catch (RIFF::Exception e)
     {
-        messageController->reportErrorToClient("SF2 Load Error", e.Message);
+        RAISE_ERROR_CONT(*messageController, "SF2 Load Error", e.Message);
         return false;
     }
     catch (const SCXTError &e)
     {
-        messageController->reportErrorToClient("SF2 Load Error", e.what());
+        RAISE_ERROR_CONT(*messageController, "SF2 Load Error", e.what());
         return false;
     }
     catch (...)

--- a/src/scxt-core/sample/sfz_support/sfz_export.cpp
+++ b/src/scxt-core/sample/sfz_support/sfz_export.cpp
@@ -45,8 +45,7 @@ bool exportSFZ(const fs::path &toFile, engine::Engine &e, int partNumber)
     }
     catch (const fs::filesystem_error &fse)
     {
-        e.getMessageController()->reportErrorToClient("Unable to create directory",
-                                                      dir.u8string() + "\n" + fse.what());
+        RAISE_ERROR_ENGINE(e, "Unable to create directory", dir.u8string() + "\n" + fse.what());
         return false;
     }
     auto collectMap = patch_io::collectSamplesInto(dir, e, partNumber);
@@ -67,15 +66,13 @@ bool exportSFZ(const fs::path &toFile, engine::Engine &e, int partNumber)
             }
             if (va == 0)
             {
-                e.getMessageController()->reportErrorToClient(
-                    "SFZ Export Error",
-                    "Zones with no samples are not yet supported in SFZ export");
+                RAISE_ERROR_ENGINE(e, "SFZ Export Error",
+                                   "Zones with no samples are not yet supported in SFZ export");
             }
             if (va > 1)
             {
-                e.getMessageController()->reportErrorToClient(
-                    "SFZ Export Error",
-                    "Zones multiple variants are not yet supported in SFZ export");
+                RAISE_ERROR_ENGINE(e, "SFZ Export Error",
+                                   "Zones multiple variants are not yet supported in SFZ export");
             }
             oss << "\n<region>\n";
             oss << "// zone name: " << z->getName() << "\n";
@@ -102,9 +99,9 @@ bool exportSFZ(const fs::path &toFile, engine::Engine &e, int partNumber)
             auto cmf = collectMap.find(z->variantData.variants[0].sampleID);
             if (cmf == collectMap.end())
             {
-                e.getMessageController()->reportErrorToClient(
-                    "SFZ Export Error",
-                    "Can't remap " + z->variantData.variants[0].sampleID.to_string());
+                RAISE_ERROR_ENGINE(e, "SFZ Export Error",
+                                   "Can't remap " +
+                                       z->variantData.variants[0].sampleID.to_string());
             }
             auto pt = cmf->second;
             auto rp = pt.lexically_relative(dir.parent_path());
@@ -132,8 +129,7 @@ bool exportSFZ(const fs::path &toFile, engine::Engine &e, int partNumber)
     auto ofs = std::ofstream(toFile);
     if (!ofs.is_open())
     {
-        e.getMessageController()->reportErrorToClient("Unable to open file for writing",
-                                                      toFile.u8string());
+        RAISE_ERROR_ENGINE(e, "Unable to open file for writing", toFile.u8string());
         return false;
     }
     ofs << oss.str();

--- a/src/scxt-core/sample/sfz_support/sfz_import.cpp
+++ b/src/scxt-core/sample/sfz_support/sfz_import.cpp
@@ -277,9 +277,7 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
         "Loading SFZ '" + f.filename().u8string() + "'", *(messageController));
 
     SFZParser parser;
-    parser.onError = [&e](const auto &s) {
-        e.getMessageController()->reportErrorToClient("SFZ Import Error", s);
-    };
+    parser.onError = [&e](const auto &s) { RAISE_ERROR_ENGINE(e, "SFZ Import Error", s); };
 
     auto doc = parser.parse(f);
     auto rootDir = f.parent_path();
@@ -352,10 +350,10 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
             if (!scxt::isValidUtf(sampleFileString))
             {
                 SCLOG_IF(warnings, "Original file name is `" << sampleFileString << "`");
-                e.getMessageController()->reportErrorToClient(
-                    "SFZ Import Error", "Sample filename in region " + std::to_string(regionCount) +
-                                            " contains invalid UTF-8 sequence. "
-                                            "Stopping SFZ import");
+                RAISE_ERROR_ENGINE(e, "SFZ Import Error",
+                                   "Sample filename in region " + std::to_string(regionCount) +
+                                       " contains invalid UTF-8 sequence. "
+                                       "Stopping SFZ import");
                 return false;
             }
 
@@ -377,8 +375,8 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
                 {
                     SCLOG_IF(sampleCompoundParsers,
                              "Cannot load Sample : " << samplePath.u8string());
-                    e.getMessageController()->reportErrorToClient(
-                        "SFZ Import Error", "Cannot load sample '" + samplePath.u8string() + "'");
+                    RAISE_ERROR_ENGINE(e, "SFZ Import Error",
+                                       "Cannot load sample '" + samplePath.u8string() + "'");
                     break;
                 }
             }
@@ -392,8 +390,8 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
                 else
                 {
                     SCLOG_IF(sampleCompoundParsers, "Cannot load Sample : " << sampleFile);
-                    e.getMessageController()->reportErrorToClient(
-                        "SFZ Import Error", "Cannot load sample '" + sampleFile.u8string() + "'");
+                    RAISE_ERROR_ENGINE(e, "SFZ Import Error",
+                                       "Cannot load sample '" + sampleFile.u8string() + "'");
                     return false;
                 }
             }
@@ -402,9 +400,9 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
                 SCLOG_IF(sampleCompoundParsers, "Unable to load either '"
                                                     << samplePath.u8string() << "' or '"
                                                     << sampleFile.u8string() << "'");
-                e.getMessageController()->reportErrorToClient(
-                    "SFZ Import Error", "Unable to load either '" + samplePath.u8string() +
-                                            "' or '" + sampleFile.u8string() + "'");
+                RAISE_ERROR_ENGINE(e, "SFZ Import Error",
+                                   "Unable to load either '" + samplePath.u8string() + "' or '" +
+                                       sampleFile.u8string() + "'");
                 return false;
             }
 
@@ -444,7 +442,7 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
             consumeOpcode(mergedOpcodes, "seq_position");
 
             auto onError = [&e](const std::string &title, const std::string &msg) {
-                e.getMessageController()->reportErrorToClient(title, msg);
+                RAISE_ERROR_ENGINE(e, title, msg);
             };
             zoneGeometry(zn, mergedOpcodes, loadInfo, onError, octaveOffset);
             zonePlayback(zn, mergedOpcodes);
@@ -478,9 +476,9 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
                 }
                 if (!attached)
                 {
-                    e.getMessageController()->reportErrorToClient(
-                        "Mis-mapped SFZ Round Robin",
-                        std::string("Unable to locate zone for sample ") + sampleFile.u8string());
+                    RAISE_ERROR_ENGINE(e, "Mis-mapped SFZ Round Robin",
+                                       std::string("Unable to locate zone for sample ") +
+                                           sampleFile.u8string());
                 }
             }
             else

--- a/src/scxt-core/utils.h
+++ b/src/scxt-core/utils.h
@@ -304,6 +304,11 @@ std::string logTimestamp();
 
 #define SCD(x) #x << "=" << (x) << " "
 
+#define RAISE_ERROR_CONT(C, title, msg) (C).reportErrorToClient((title), (msg), __FILE__, __LINE__)
+
+#define RAISE_ERROR_ENGINE(E, title, msg)                                                          \
+    RAISE_ERROR_CONT(*((E).getMessageController()), title, msg)
+
 struct DebugTimeGuard
 {
     std::string msg, file;

--- a/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
@@ -592,7 +592,6 @@ void SCXTEditor::promptOKCancel(const std::string &title, const std::string &mes
 
 void SCXTEditor::displayError(const std::string &title, const std::string &message)
 {
-    SCLOG_IF(warnings, "Displaying error: [" << title << "] " << message);
     if (auto ao = searchForOverlay<sst::jucegui::screens::AlertOrPrompt>())
     {
         ao->appendTitleAndMessage(title, message);

--- a/src/scxt-plugin/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -261,7 +261,7 @@ void SCXTEditor::onGroupZoneMappingSummary(const scxt::engine::Part::zoneMapping
 
 void SCXTEditor::onErrorFromEngine(const scxt::messaging::client::s2cError_t &e)
 {
-    auto &[title, msg] = e;
+    auto &[title, msg, source, line] = e;
     displayError(title, msg);
 }
 


### PR DESCRIPTION
in log but not in user facing

Also provide macros to make it less grunky if we change the API

Closes #2366