### PR TITLE
FIx a quadratic message on swap / ketrack changes

### DIFF
--- a/src/scxt-core/engine/group_and_zone.h
+++ b/src/scxt-core/engine/group_and_zone.h
@@ -81,9 +81,10 @@ template <typename T> struct HasGroupZoneProcessors
                                                   float *pfp, int *ifp, bool initFromDefaults);
 
     // Returns true if I changed anything
-    bool checkOrAdjustIntConsistency(int whichProcessor);
-    bool checkOrAdjustBoolConsistency(int whichProcessor);
+    bool checkOrAdjustIntConsistency(int whichProcessor, bool notifySerial);
+    bool checkOrAdjustBoolConsistency(int whichProcessor, bool notifySerial);
     void updateRoutingTableAfterProcessorSwap(size_t f, size_t t);
+    static void notifySerialOfProcessorRefresh(const engine::Engine &, int whichProcessor);
 
     std::array<dsp::processor::ProcessorStorage, processorCount> processorStorage;
     std::array<dsp::processor::ProcessorControlDescription, processorCount> processorDescription;

--- a/src/scxt-core/engine/group_and_zone_impl.h
+++ b/src/scxt-core/engine/group_and_zone_impl.h
@@ -180,7 +180,7 @@ HasGroupZoneProcessors<T>::spawnTempProcessor(int whichProcessor,
 }
 
 template <typename T>
-bool HasGroupZoneProcessors<T>::checkOrAdjustIntConsistency(int whichProcessor)
+bool HasGroupZoneProcessors<T>::checkOrAdjustIntConsistency(int whichProcessor, bool notifySerial)
 {
     auto &pd = asT()->processorDescription[whichProcessor];
 
@@ -206,13 +206,10 @@ bool HasGroupZoneProcessors<T>::checkOrAdjustIntConsistency(int whichProcessor)
             memcpy(ps.intParams.data(), ifp, sizeof(ps.intParams));
         }
 
-        // TODO: This could be more parsimonious
-        messaging::audio::AudioToSerialization updateProc;
-        updateProc.id = messaging::audio::a2s_processor_refresh;
-        updateProc.payloadType = messaging::audio::AudioToSerialization::INT;
-        updateProc.payload.i[0] = forZone;
-        updateProc.payload.i[1] = whichProcessor;
-        asT()->getEngine()->getMessageController()->sendAudioToSerialization(updateProc);
+        if (notifySerial)
+        {
+            notifySerialOfProcessorRefresh(*(asT()->getEngine()), whichProcessor);
+        }
 
         dsp::processor::unspawnProcessor(tmpProcessor);
 
@@ -223,7 +220,7 @@ bool HasGroupZoneProcessors<T>::checkOrAdjustIntConsistency(int whichProcessor)
 }
 
 template <typename T>
-bool HasGroupZoneProcessors<T>::checkOrAdjustBoolConsistency(int whichProcessor)
+bool HasGroupZoneProcessors<T>::checkOrAdjustBoolConsistency(int whichProcessor, bool notifySerial)
 {
     auto &pd = asT()->processorDescription[whichProcessor];
 
@@ -235,17 +232,27 @@ bool HasGroupZoneProcessors<T>::checkOrAdjustBoolConsistency(int whichProcessor)
             ps.previousIsKeytracked = ps.isKeytracked ? 1 : 0;
             asT()->setupProcessorControlDescriptions(whichProcessor, ps.type, nullptr, true);
 
-            messaging::audio::AudioToSerialization updateProc;
-            updateProc.id = messaging::audio::a2s_processor_refresh;
-            updateProc.payloadType = messaging::audio::AudioToSerialization::INT;
-            updateProc.payload.i[0] = forZone;
-            updateProc.payload.i[1] = whichProcessor;
-            asT()->getEngine()->getMessageController()->sendAudioToSerialization(updateProc);
+            if (notifySerial)
+            {
+                notifySerialOfProcessorRefresh(*(asT()->getEngine()), whichProcessor);
+            }
             return true;
         }
     }
 
     return false;
+}
+
+template <typename T>
+void HasGroupZoneProcessors<T>::notifySerialOfProcessorRefresh(const engine::Engine &e,
+                                                               int whichProcessor)
+{
+    messaging::audio::AudioToSerialization updateProc;
+    updateProc.id = messaging::audio::a2s_processor_refresh;
+    updateProc.payloadType = messaging::audio::AudioToSerialization::INT;
+    updateProc.payload.i[0] = forZone;
+    updateProc.payload.i[1] = whichProcessor;
+    e.getMessageController()->sendAudioToSerialization(updateProc);
 }
 
 template <typename T>

--- a/src/scxt-core/messaging/client/processor_messages.h
+++ b/src/scxt-core/messaging/client/processor_messages.h
@@ -146,8 +146,9 @@ inline void setFullProcessorStorage(sendFullProcessorStorage_t payload, engine::
                         if (g->processorStorage[which].type != st.type)
                             g->setProcessorType(which, st.type);
                         g->processorStorage[which] = st;
-                        g->checkOrAdjustIntConsistency(which);
+                        g->checkOrAdjustIntConsistency(which, false);
                     }
+                    engine::Group::notifySerialOfProcessorRefresh(e, which);
                 },
                 [a = *lg, which = w](const auto &engine) {
                     const auto &g = engine.getPatch()->getPart(a.part)->getGroup(a.group);
@@ -182,8 +183,10 @@ inline void setFullProcessorStorage(sendFullProcessorStorage_t payload, engine::
                         if (z->processorStorage[which].type != st.type)
                             z->setProcessorType(which, st.type);
                         z->processorStorage[which] = st;
-                        z->checkOrAdjustIntConsistency(which);
+                        z->checkOrAdjustIntConsistency(which, false);
                     }
+
+                    engine::Zone::notifySerialOfProcessorRefresh(e, which);
                 },
                 [a = *lz, which = w](const auto &engine) {
                     const auto &z =
@@ -233,16 +236,19 @@ CLIENT_TO_SERIAL_CONSTRAINED(
             for (const auto &a : sz)
             {
                 const auto &z = e.getPatch()->getPart(a.part)->getGroup(a.group)->getZone(a.zone);
-                z->checkOrAdjustIntConsistency(wp);
+                z->checkOrAdjustIntConsistency(wp, false);
             }
+
+            engine::Zone::notifySerialOfProcessorRefresh(e, wp);
         },
         [payload](auto &e, auto &sg) {
             auto wp = std::get<1>(payload);
             for (const auto &a : sg)
             {
                 const auto &g = e.getPatch()->getPart(a.part)->getGroup(a.group);
-                g->checkOrAdjustIntConsistency(wp);
+                g->checkOrAdjustIntConsistency(wp, false);
             }
+            engine::Group::notifySerialOfProcessorRefresh(e, wp);
         }));
 
 CLIENT_TO_SERIAL_CONSTRAINED(
@@ -256,16 +262,18 @@ CLIENT_TO_SERIAL_CONSTRAINED(
             for (const auto &a : sz)
             {
                 const auto &z = e.getPatch()->getPart(a.part)->getGroup(a.group)->getZone(a.zone);
-                z->checkOrAdjustBoolConsistency(wp);
+                z->checkOrAdjustBoolConsistency(wp, false);
             }
+            engine::Zone::notifySerialOfProcessorRefresh(e, wp);
         },
         [payload](auto &e, auto &sg) {
             auto wp = std::get<1>(payload);
             for (const auto &a : sg)
             {
                 const auto &g = e.getPatch()->getPart(a.part)->getGroup(a.group);
-                g->checkOrAdjustBoolConsistency(wp);
+                g->checkOrAdjustBoolConsistency(wp, false);
             }
+            engine::Group::notifySerialOfProcessorRefresh(e, wp);
         }));
 
 // C2S set processor type (sends back data and metadata)
@@ -296,11 +304,13 @@ inline void swapZoneProcessors(const processorPair_t &whichToType, const engine:
 
                     z->updateRoutingTableAfterProcessorSwap(f, t);
 
-                    z->checkOrAdjustBoolConsistency(f);
-                    z->checkOrAdjustIntConsistency(f);
-                    z->checkOrAdjustBoolConsistency(t);
-                    z->checkOrAdjustIntConsistency(t);
+                    z->checkOrAdjustBoolConsistency(f, false);
+                    z->checkOrAdjustIntConsistency(f, false);
+                    z->checkOrAdjustBoolConsistency(t, false);
+                    z->checkOrAdjustIntConsistency(t, false);
                 }
+                engine::Zone::notifySerialOfProcessorRefresh(engine, f);
+                engine::Zone::notifySerialOfProcessorRefresh(engine, t);
             },
             [a = *lz](const auto &engine) {
                 engine.getSelectionManager()->sendDisplayDataForZonesBasedOnLead(a.part, a.group,
@@ -341,13 +351,15 @@ inline void swapGroupProcessors(const processorPair_t &whichToType, const engine
 
                     g->updateRoutingTableAfterProcessorSwap(f, t);
 
-                    g->checkOrAdjustBoolConsistency(f);
-                    g->checkOrAdjustIntConsistency(f);
-                    g->checkOrAdjustBoolConsistency(t);
-                    g->checkOrAdjustIntConsistency(t);
+                    g->checkOrAdjustBoolConsistency(f, false);
+                    g->checkOrAdjustIntConsistency(f, false);
+                    g->checkOrAdjustBoolConsistency(t, false);
+                    g->checkOrAdjustIntConsistency(t, false);
 
                     g->rePrepareAndBindGroupMatrix();
                 }
+                engine::Group::notifySerialOfProcessorRefresh(engine, f);
+                engine::Group::notifySerialOfProcessorRefresh(engine, t);
             },
             [a = *lg](const auto &engine) {
                 engine.getSelectionManager()->sendDisplayDataForGroupsBasedOnLead(a.part, a.group);


### PR DESCRIPTION
In some cases changing a keytrack or swapping processors with keytrack or other int / bool checks would generate quadratic refreshes to the UI with large selections. Fix this by notifying of change outside selection application loop.

Closes #2315