### PR TITLE
Group Playmode Enums

### DIFF
--- a/src/scxt-core/configuration.h
+++ b/src/scxt-core/configuration.h
@@ -33,7 +33,7 @@
 
 namespace scxt
 {
-static constexpr uint64_t currentStreamingVersion{0x2025'11'12};
+static constexpr uint64_t currentStreamingVersion{0x2026'03'08};
 
 static constexpr uint16_t blockSize{16};
 static constexpr uint16_t blockSizeQuad{16 >> 2};

--- a/src/scxt-core/engine/engine_voice_responder.cpp
+++ b/src/scxt-core/engine/engine_voice_responder.cpp
@@ -50,8 +50,7 @@ int32_t Engine::VoiceManagerResponder::beginVoiceCreationTransaction(
 
         voiceCreationWorkingBuffer[voicesCreated] = {path, -1};
         if (z->parentGroup->outputInfo.hasIndependentPolyLimit ||
-            z->parentGroup->outputInfo.vmPlayModeInt !=
-                (uint32_t)Engine::voiceManager_t::PlayMode::POLY_VOICES)
+            z->parentGroup->outputInfo.playMode != Group::PlayMode::POLY)
         {
             SCLOG_IF(voiceResponder,
                      "-- Setting polyphony group to group basd " << (uint64_t)z->parentGroup);

--- a/src/scxt-core/engine/group.cpp
+++ b/src/scxt-core/engine/group.cpp
@@ -789,36 +789,55 @@ void Group::onRoutingChanged() { rePrepareAndBindGroupMatrix(); }
 
 void Group::resetPolyAndPlaymode(engine::Engine &e)
 {
-    if (outputInfo.vmPlayModeInt == (uint32_t)Engine::voiceManager_t::PlayMode::MONO_NOTES)
+    auto pgrp = (uint64_t)this;
+    e.voiceManager.guaranteeGroup(pgrp);
+
+    if (outputInfo.playMode == Group::PlayMode::POLY)
     {
-        if (outputInfo.vmPlayModeFeaturesInt == 0)
-        {
-            outputInfo.vmPlayModeFeaturesInt =
-                (uint64_t)Engine::voiceManager_t::MonoPlayModeFeatures::NATURAL_MONO;
-        }
-        auto pgrp = (uint64_t)this;
-        SCLOG_IF(voiceResponder, "Setting up mono group " << pgrp);
-        e.voiceManager.guaranteeGroup(pgrp);
-        e.voiceManager.setPlaymode(pgrp, Engine::voiceManager_t::PlayMode::MONO_NOTES,
-                                   outputInfo.vmPlayModeFeaturesInt);
-    }
-    else
-    {
-        auto pgrp = (uint64_t)this;
         SCLOG_IF(voiceResponder, "Setting up poly group " << pgrp);
 
-        e.voiceManager.setPlaymode(pgrp, Engine::voiceManager_t::PlayMode::POLY_VOICES,
-                                   outputInfo.vmPlayModeFeaturesInt);
-        assert(outputInfo.vmPlayModeInt == (uint32_t)Engine::voiceManager_t::PlayMode::POLY_VOICES);
+        e.voiceManager.setPlaymode(pgrp, Engine::voiceManager_t::PlayMode::POLY_VOICES);
+
         if (!outputInfo.hasIndependentPolyLimit)
         {
-            // TODO we really want a 'clear'
-            e.voiceManager.setPolyphonyGroupVoiceLimit((uint64_t)this, maxVoices);
+            e.voiceManager.setPolyphonyGroupVoiceLimit(pgrp, maxVoices);
         }
         else
         {
-            e.voiceManager.setPolyphonyGroupVoiceLimit((uint64_t)this, outputInfo.polyLimit);
+            e.voiceManager.setPolyphonyGroupVoiceLimit(pgrp, outputInfo.polyLimit);
         }
+    }
+    else
+    {
+        SCLOG_IF(voiceResponder, "Setting up mono/legato group " << pgrp);
+
+        uint64_t features = 0;
+        if (outputInfo.playMode == Group::PlayMode::MONO)
+        {
+            features |= (uint64_t)Engine::voiceManager_t::MonoPlayModeFeatures::MONO_RETRIGGER;
+        }
+        else
+        {
+            features |= (uint64_t)Engine::voiceManager_t::MonoPlayModeFeatures::MONO_LEGATO;
+        }
+
+        switch (outputInfo.notePriority)
+        {
+        case Group::NotePriority::LATEST:
+            features |=
+                (uint64_t)Engine::voiceManager_t::MonoPlayModeFeatures::ON_RELEASE_TO_LATEST;
+            break;
+        case Group::NotePriority::HIGHEST:
+            features |=
+                (uint64_t)Engine::voiceManager_t::MonoPlayModeFeatures::ON_RELEASE_TO_HIGHEST;
+            break;
+        case Group::NotePriority::LOWEST:
+            features |=
+                (uint64_t)Engine::voiceManager_t::MonoPlayModeFeatures::ON_RELEASE_TO_LOWEST;
+            break;
+        }
+
+        e.voiceManager.setPlaymode(pgrp, Engine::voiceManager_t::PlayMode::MONO_NOTES, features);
     }
 }
 
@@ -841,6 +860,54 @@ Group::GlideRateMode Group::fromStringGlideRateMode(const std::string &s)
     auto p = inverse.find(s);
     if (p == inverse.end())
         return CONSTANT_TIME;
+    return p->second;
+}
+
+std::string Group::toStringPlayMode(const PlayMode &m)
+{
+    switch (m)
+    {
+    case POLY:
+        return "p";
+    case MONO:
+        return "m";
+    case LEGATO:
+        return "l";
+    }
+    return "p";
+}
+
+Group::PlayMode Group::fromStringPlayMode(const std::string &s)
+{
+    static auto inverse = makeEnumInverse<Group::PlayMode, Group::toStringPlayMode>(
+        Group::PlayMode::POLY, Group::PlayMode::LEGATO);
+    auto p = inverse.find(s);
+    if (p == inverse.end())
+        return POLY;
+    return p->second;
+}
+
+std::string Group::toStringNotePriority(const NotePriority &m)
+{
+    switch (m)
+    {
+    case LATEST:
+        return "lat";
+    case HIGHEST:
+        return "hi";
+    case LOWEST:
+        return "lo";
+    }
+    return "lat";
+}
+
+Group::NotePriority Group::fromStringNotePriority(const std::string &s)
+{
+    static auto inverse = makeEnumInverse<Group::NotePriority, Group::toStringNotePriority>(
+        Group::NotePriority::LATEST, Group::NotePriority::LOWEST);
+    auto p = inverse.find(s);
+    if (p == inverse.end())
+        return LATEST;
     return p->second;
 }
 

--- a/src/scxt-core/engine/group.h
+++ b/src/scxt-core/engine/group.h
@@ -82,6 +82,22 @@ struct Group : MoveableOnly<Group>,
     };
     DECLARE_ENUM_STRING(GlideRateMode);
 
+    enum PlayMode : int32_t
+    {
+        POLY = 0,
+        MONO,
+        LEGATO
+    };
+    DECLARE_ENUM_STRING(PlayMode);
+
+    enum NotePriority : int32_t
+    {
+        LATEST = 0,
+        HIGHEST,
+        LOWEST
+    };
+    DECLARE_ENUM_STRING(NotePriority);
+
     struct GroupOutputInfo
     {
         float amplitude{1.f}, pan{0.f}, velocitySensitivity{0.6f}, tuning{0.f};
@@ -97,18 +113,15 @@ struct Group : MoveableOnly<Group>,
         bool hasIndependentPolyLimit{false};
         int32_t polyLimit{0};
 
-        // I wish I could define these as the enum
-        // but this includes before engine and template blah
-        // makes it not quite worth it
-        uint32_t vmPlayModeInt{0};
-        uint64_t vmPlayModeFeaturesInt{0};
-
         int16_t pbUp{2}, pbDown{2};
 
         int16_t midiChannel{-1}; // -1 means "Follow Part"
 
         float glideTime{0.f}; // portamento glide time as 0..1 param for 25-second exp scale
         GlideRateMode glideRateMode{CONSTANT_TIME};
+
+        PlayMode playMode{POLY};
+        NotePriority notePriority{LATEST};
     } outputInfo;
 
     GroupTriggerConditions triggerConditions;

--- a/src/scxt-core/json/engine_traits.h
+++ b/src/scxt-core/json/engine_traits.h
@@ -351,62 +351,12 @@ SC_STREAMDEF(scxt::engine::GroupTriggerConditions, SC_FROM({
                  findIf(v, "conj", to.conjunctions);
              }));
 
-/*
- * PlayMode uses engine vm typedefs so is a bit of a special case
- */
-inline std::string groupInfoPlayModeTo(uint32_t p)
-{
-    if (p == (uint32_t)engine::Engine::voiceManager_t::PlayMode::POLY_VOICES)
-        return "p";
-    if (p == (uint32_t)engine::Engine::voiceManager_t::PlayMode::MONO_NOTES)
-        return "m";
-    return "p";
-}
-inline uint32_t groupInfoPlayModeFrom(const std::string &s)
-{
-    if (s == "m")
-        return (uint32_t)engine::Engine::voiceManager_t::PlayMode::MONO_NOTES;
-    return (uint32_t)engine::Engine::voiceManager_t::PlayMode::POLY_VOICES;
-}
-
-// this is kinda gross, but its nov 6 2024 and i just want something we can make stable
-#define PMTS(pm, s)                                                                                \
-    if (x & (uint64_t)engine::Engine::voiceManager_t::MonoPlayModeFeatures::pm)                    \
-        oss << "|" << s "|";
-inline std::string groupInfoPlayModeFeatureTo(uint64_t x)
-{
-    std::ostringstream oss;
-    PMTS(MONO_RETRIGGER, "mr");
-    PMTS(MONO_LEGATO, "ml");
-    PMTS(ON_RELEASE_TO_LATEST, "rl");
-    PMTS(ON_RELEASE_TO_HIGHEST, "rh");
-    PMTS(ON_RELEASE_TO_LOWEST, "rh");
-    return oss.str();
-}
-#undef PMTS
-#define PMTS(pm, s)                                                                                \
-    {                                                                                              \
-        std::string q = std::string("|") + s + "|";                                                \
-        if (x.find(q) != std::string::npos)                                                        \
-        {                                                                                          \
-            res |= (uint64_t)engine::Engine::voiceManager_t::MonoPlayModeFeatures::pm;             \
-        }                                                                                          \
-    }
-
-inline uint64_t groupInfoPlayModeFeatureFrom(const std::string &x)
-{
-    uint64_t res{0};
-    PMTS(MONO_RETRIGGER, "mr");
-    PMTS(MONO_LEGATO, "ml");
-    PMTS(ON_RELEASE_TO_LATEST, "rl");
-    PMTS(ON_RELEASE_TO_HIGHEST, "rh");
-    PMTS(ON_RELEASE_TO_LOWEST, "rh");
-    return res;
-}
-#undef PMTS
-
 STREAM_ENUM(engine::Group::GlideRateMode, engine::Group::toStringGlideRateMode,
             engine::Group::fromStringGlideRateMode);
+STREAM_ENUM(engine::Group::PlayMode, engine::Group::toStringPlayMode,
+            engine::Group::fromStringPlayMode);
+STREAM_ENUM(engine::Group::NotePriority, engine::Group::toStringNotePriority,
+            engine::Group::fromStringNotePriority);
 
 SC_STREAMDEF(scxt::engine::Group::GroupOutputInfo, SC_FROM({
                  v = {{"amplitude", t.amplitude},
@@ -425,10 +375,10 @@ SC_STREAMDEF(scxt::engine::Group::GroupOutputInfo, SC_FROM({
                       {"mc", t.midiChannel},
                       {"pbu", t.pbUp},
                       {"pbd", t.pbDown},
-                      {"vpm", groupInfoPlayModeTo(t.vmPlayModeInt)},
-                      {"vpf", groupInfoPlayModeFeatureTo(t.vmPlayModeFeaturesInt)},
                       {"glt", t.glideTime},
-                      {"grm", t.glideRateMode}};
+                      {"grm", t.glideRateMode},
+                      {"pm", t.playMode},
+                      {"np", t.notePriority}};
              }),
              SC_TO({
                  findIf(v, "amplitude", result.amplitude);
@@ -450,13 +400,42 @@ SC_STREAMDEF(scxt::engine::Group::GroupOutputInfo, SC_FROM({
                  findOrSet(v, "pbd", 2, result.pbDown);
                  result.routeTo = (engine::BusAddress)(rt);
 
-                 std::string tmp;
-                 findIf(v, "vpm", tmp);
-                 result.vmPlayModeInt = groupInfoPlayModeFrom(tmp);
-                 findIf(v, "vpf", tmp);
-                 result.vmPlayModeFeaturesInt = groupInfoPlayModeFeatureFrom(tmp);
                  findOrSet(v, "glt", 0.f, result.glideTime);
                  findIf(v, "grm", result.glideRateMode);
+                 findOrSet(v, "pm", engine::Group::PlayMode::POLY, result.playMode);
+                 findOrSet(v, "np", engine::Group::NotePriority::LATEST, result.notePriority);
+
+                 if (SC_UNSTREAMING_FROM_PRIOR_TO(0x2026'03'08))
+                 {
+                     std::string vpm, vpf;
+                     findIf(v, "vpm", vpm);
+                     findIf(v, "vpf", vpf);
+                     result.notePriority = engine::Group::NotePriority::LATEST;
+                     if (vpm == "m")
+                     {
+                         if (vpf.find("|ml|") != std::string::npos)
+                         {
+                             result.playMode = engine::Group::PlayMode::LEGATO;
+                         }
+                         else
+                         {
+                             result.playMode = engine::Group::PlayMode::MONO;
+                         }
+
+                         if (vpf.find("|rh|") != std::string::npos)
+                         {
+                             result.notePriority = engine::Group::NotePriority::HIGHEST;
+                         }
+                         else if (vpf.find("|rl|") != std::string::npos)
+                         {
+                             result.notePriority = engine::Group::NotePriority::LOWEST;
+                         }
+                     }
+                     else
+                     {
+                         result.playMode = engine::Group::PlayMode::POLY;
+                     }
+                 }
              }));
 
 SC_STREAMDEF(scxt::engine::Group, SC_FROM({

--- a/src/scxt-plugin/app/edit-screen/components/GroupSettingsCard.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/GroupSettingsCard.cpp
@@ -194,13 +194,12 @@ void GroupSettingsCard::resized()
 
 void GroupSettingsCard::rebuildFromInfo()
 {
-    if (info.vmPlayModeInt == (int32_t)engine::Engine::voiceManager_t::PlayMode::MONO_NOTES)
+    if (info.playMode != engine::Group::PlayMode::POLY)
     {
         polyMenu->setEnabled(false);
         prioMenu->setEnabled(true);
 
-        if (info.vmPlayModeFeaturesInt &
-            (int32_t)engine::Engine::voiceManager_t::MonoPlayModeFeatures::MONO_LEGATO)
+        if (info.playMode == engine::Group::PlayMode::LEGATO)
         {
             polyModeMenu->setLabel("LEG");
         }
@@ -238,8 +237,7 @@ void GroupSettingsCard::rebuildFromInfo()
         }
     }
 
-    bool isMono =
-        (info.vmPlayModeInt == (int32_t)engine::Engine::voiceManager_t::PlayMode::MONO_NOTES);
+    bool isMono = (info.playMode != engine::Group::PlayMode::POLY);
     glideDrag->setEnabled(isMono);
     glideMenu->setEnabled(isMono);
     glideMenu->setLabel(info.glideRateMode == engine::Group::CONSTANT_RATE ? "RATE" : "TIME");
@@ -309,43 +307,36 @@ void GroupSettingsCard::showPolyModeMenu()
     p.addSectionHeader("Play Mode");
     p.addSeparator();
 
-    bool isAnyMono =
-        info.vmPlayModeInt == (uint32_t)engine::Engine::voiceManager_t::PlayMode::MONO_NOTES;
-    bool isMonoRetrig =
-        info.vmPlayModeFeaturesInt &
-        (uint64_t)engine::Engine::voiceManager_t::MonoPlayModeFeatures::MONO_RETRIGGER;
-    bool isMonoLegato = info.vmPlayModeFeaturesInt &
-                        (uint64_t)engine::Engine::voiceManager_t::MonoPlayModeFeatures::MONO_LEGATO;
+    p.addItem("Poly", true, info.playMode == engine::Group::PlayMode::POLY,
+              [w = juce::Component::SafePointer(this)]() {
+                  if (!w)
+                      return;
+                  w->info.playMode = engine::Group::PlayMode::POLY;
 
-    p.addItem("Poly", true, !isAnyMono, [w = juce::Component::SafePointer(this)]() {
-        if (!w)
-            return;
-        w->info.vmPlayModeInt = (uint32_t)engine::Engine::voiceManager_t::PlayMode::POLY_VOICES;
+                  w->rebuildFromInfo();
+                  w->sendToSerialization(
+                      messaging::client::UpdateGroupOutputInfoPolyphony{w->info});
+              });
+    p.addItem("Mono", true, info.playMode == engine::Group::PlayMode::MONO,
+              [w = juce::Component::SafePointer(this)]() {
+                  if (!w)
+                      return;
+                  w->info.playMode = engine::Group::PlayMode::MONO;
 
-        w->rebuildFromInfo();
-        w->sendToSerialization(messaging::client::UpdateGroupOutputInfoPolyphony{w->info});
-    });
-    p.addItem("Mono", true, isAnyMono && isMonoRetrig, [w = juce::Component::SafePointer(this)]() {
-        if (!w)
-            return;
-        w->info.vmPlayModeInt = (uint32_t)engine::Engine::voiceManager_t::PlayMode::MONO_NOTES;
-        w->info.vmPlayModeFeaturesInt =
-            (uint64_t)engine::Engine::voiceManager_t::MonoPlayModeFeatures::NATURAL_MONO;
+                  w->rebuildFromInfo();
+                  w->sendToSerialization(
+                      messaging::client::UpdateGroupOutputInfoPolyphony{w->info});
+              });
+    p.addItem("Legato", true, info.playMode == engine::Group::PlayMode::LEGATO,
+              [w = juce::Component::SafePointer(this)]() {
+                  if (!w)
+                      return;
+                  w->info.playMode = engine::Group::PlayMode::LEGATO;
 
-        w->rebuildFromInfo();
-        w->sendToSerialization(messaging::client::UpdateGroupOutputInfoPolyphony{w->info});
-    });
-    p.addItem(
-        "Legato", true, isAnyMono && isMonoLegato, [w = juce::Component::SafePointer(this)]() {
-            if (!w)
-                return;
-            w->info.vmPlayModeInt = (uint32_t)engine::Engine::voiceManager_t::PlayMode::MONO_NOTES;
-            w->info.vmPlayModeFeaturesInt =
-                (uint64_t)engine::Engine::voiceManager_t::MonoPlayModeFeatures::NATURAL_LEGATO;
-
-            w->rebuildFromInfo();
-            w->sendToSerialization(messaging::client::UpdateGroupOutputInfoPolyphony{w->info});
-        });
+                  w->rebuildFromInfo();
+                  w->sendToSerialization(
+                      messaging::client::UpdateGroupOutputInfoPolyphony{w->info});
+              });
 
     p.showMenuAsync(editor->defaultPopupMenuOptions());
 }
@@ -356,62 +347,36 @@ void GroupSettingsCard::showNotePrioMenu()
 
     p.addSectionHeader("Note Priority");
 
-    p.addItem(
-        "Latest", true,
-        info.vmPlayModeFeaturesInt &
-            (uint32_t)engine::Engine::voiceManager_t::MonoPlayModeFeatures::ON_RELEASE_TO_LATEST,
-        [w = juce::Component::SafePointer(this)]() {
-            if (!w)
-                return;
-            w->info.vmPlayModeInt = (uint32_t)engine::Engine::voiceManager_t::PlayMode::MONO_NOTES;
-            w->info.vmPlayModeFeaturesInt &=
-                ~(uint64_t)
-                    engine::Engine::voiceManager_t::MonoPlayModeFeatures::ON_RELEASE_TO_HIGHEST;
-            w->info.vmPlayModeFeaturesInt &= ~(
-                uint64_t)engine::Engine::voiceManager_t::MonoPlayModeFeatures::ON_RELEASE_TO_LOWEST;
-            w->info.vmPlayModeFeaturesInt |= (uint64_t)
-                engine::Engine::voiceManager_t::MonoPlayModeFeatures::ON_RELEASE_TO_LATEST;
+    p.addItem("Latest", true, info.notePriority == engine::Group::NotePriority::LATEST,
+              [w = juce::Component::SafePointer(this)]() {
+                  if (!w)
+                      return;
+                  w->info.notePriority = engine::Group::NotePriority::LATEST;
 
-            w->rebuildFromInfo();
-            w->sendToSerialization(messaging::client::UpdateGroupOutputInfoPolyphony{w->info});
-        });
-    p.addItem(
-        "Highest", true,
-        info.vmPlayModeFeaturesInt &
-            (uint32_t)engine::Engine::voiceManager_t::MonoPlayModeFeatures::ON_RELEASE_TO_HIGHEST,
-        [w = juce::Component::SafePointer(this)]() {
-            if (!w)
-                return;
-            w->info.vmPlayModeInt = (uint32_t)engine::Engine::voiceManager_t::PlayMode::MONO_NOTES;
-            w->info.vmPlayModeFeaturesInt |= (uint64_t)
-                engine::Engine::voiceManager_t::MonoPlayModeFeatures::ON_RELEASE_TO_HIGHEST;
-            w->info.vmPlayModeFeaturesInt &= ~(
-                uint64_t)engine::Engine::voiceManager_t::MonoPlayModeFeatures::ON_RELEASE_TO_LOWEST;
-            w->info.vmPlayModeFeaturesInt &= ~(
-                uint64_t)engine::Engine::voiceManager_t::MonoPlayModeFeatures::ON_RELEASE_TO_LATEST;
+                  w->rebuildFromInfo();
+                  w->sendToSerialization(
+                      messaging::client::UpdateGroupOutputInfoPolyphony{w->info});
+              });
+    p.addItem("Highest", true, info.notePriority == engine::Group::NotePriority::HIGHEST,
+              [w = juce::Component::SafePointer(this)]() {
+                  if (!w)
+                      return;
+                  w->info.notePriority = engine::Group::NotePriority::HIGHEST;
 
-            w->rebuildFromInfo();
-            w->sendToSerialization(messaging::client::UpdateGroupOutputInfoPolyphony{w->info});
-        });
-    p.addItem(
-        "Lowest", true,
-        info.vmPlayModeFeaturesInt &
-            (uint32_t)engine::Engine::voiceManager_t::MonoPlayModeFeatures::ON_RELEASE_TO_LOWEST,
-        [w = juce::Component::SafePointer(this)]() {
-            if (!w)
-                return;
-            w->info.vmPlayModeInt = (uint32_t)engine::Engine::voiceManager_t::PlayMode::MONO_NOTES;
-            w->info.vmPlayModeFeaturesInt |= (uint64_t)
-                engine::Engine::voiceManager_t::MonoPlayModeFeatures::ON_RELEASE_TO_LOWEST;
-            w->info.vmPlayModeFeaturesInt &= ~(
-                uint64_t)engine::Engine::voiceManager_t::MonoPlayModeFeatures::ON_RELEASE_TO_LOWEST;
-            w->info.vmPlayModeFeaturesInt &=
-                ~(uint64_t)
-                    engine::Engine::voiceManager_t::MonoPlayModeFeatures::ON_RELEASE_TO_HIGHEST;
+                  w->rebuildFromInfo();
+                  w->sendToSerialization(
+                      messaging::client::UpdateGroupOutputInfoPolyphony{w->info});
+              });
+    p.addItem("Lowest", true, info.notePriority == engine::Group::NotePriority::LOWEST,
+              [w = juce::Component::SafePointer(this)]() {
+                  if (!w)
+                      return;
+                  w->info.notePriority = engine::Group::NotePriority::LOWEST;
 
-            w->rebuildFromInfo();
-            w->sendToSerialization(messaging::client::UpdateGroupOutputInfoPolyphony{w->info});
-        });
+                  w->rebuildFromInfo();
+                  w->sendToSerialization(
+                      messaging::client::UpdateGroupOutputInfoPolyphony{w->info});
+              });
 
     p.showMenuAsync(editor->defaultPopupMenuOptions());
 }


### PR DESCRIPTION
It was a mistake to stream exact voice manager features into short circuit, making the code confusing in a variety of ways. So add group enums for PlayMode and NOtePriority and set up the voice manager propery from them in a more private part of the code

Handle streaming from the old types, though, wiht a streaming version update.