### PR TITLE
Control of Group Processor pitch

### DIFF
--- a/src/scxt-core/dsp/processor/processor.cpp
+++ b/src/scxt-core/dsp/processor/processor.cpp
@@ -396,6 +396,41 @@ void unspawnProcessor(Processor *f)
     f->~Processor();
 }
 
+std::string ProcessorStorage::toStringGroupProcessorPitch(const GroupProcessorPitch &m)
+{
+    switch (m)
+    {
+    case GP_CONSTANT:
+        return "const";
+    case GP_NOTE_PRIO:
+        return "prio";
+    case GP_LATEST:
+        return "lat";
+    case GP_HIGHEST:
+        return "hi";
+    case GP_LOWEST:
+        return "lo";
+    }
+    return "prio";
+}
+
+ProcessorStorage::GroupProcessorPitch
+ProcessorStorage::fromStringGroupProcessorPitch(const std::string &s)
+{
+    static const std::unordered_map<std::string, ProcessorStorage::GroupProcessorPitch> inverse = {
+        {"const", ProcessorStorage::GP_CONSTANT},
+        {"prio", ProcessorStorage::GP_NOTE_PRIO},
+        {"lat", ProcessorStorage::GP_LATEST},
+        {"hi", ProcessorStorage::GP_HIGHEST},
+        {"lo", ProcessorStorage::GP_LOWEST}};
+
+    auto p = inverse.find(s);
+    if (p == inverse.end())
+        return ProcessorStorage::GP_NOTE_PRIO;
+    else
+        return p->second;
+}
+
 ProcessorControlDescription Processor::getControlDescription() const
 {
     ProcessorControlDescription res;

--- a/src/scxt-core/dsp/processor/processor.h
+++ b/src/scxt-core/dsp/processor/processor.h
@@ -52,6 +52,7 @@ struct Engine;
 
 namespace scxt::dsp::processor
 {
+struct ProcessorStorage;
 
 static constexpr size_t maxProcessorFloatParams{scxt::maxProcessorFloatParams};
 static constexpr size_t maxProcessorIntParams{scxt::maxProcessorIntParams};
@@ -164,6 +165,21 @@ struct ProcessorStorage
         std::fill(intParams.begin(), intParams.end(), 0);
     }
 
+    enum GroupProcessorPitch : int32_t
+    {
+        GP_CONSTANT = 0,
+        GP_NOTE_PRIO,
+        GP_LATEST,
+        GP_HIGHEST,
+        GP_LOWEST
+    };
+    static std::string toStringGroupProcessorPitch(const GroupProcessorPitch &m);
+    static GroupProcessorPitch fromStringGroupProcessorPitch(const std::string &s);
+
+    /**
+     * Note that the pitchControl field is unused in zone mode
+     */
+    GroupProcessorPitch pitchControl{GP_NOTE_PRIO};
     ProcessorType type{proct_none};
     static constexpr float maxOutputDB{18.f};
     static constexpr float maxOutputAmp{7.943282347242815}; //  std::pow(10.f, maxOutputDB / 20.0);
@@ -182,8 +198,9 @@ struct ProcessorStorage
 
     bool operator==(const ProcessorStorage &other) const
     {
-        return (type == other.type && mix == other.mix && floatParams == other.floatParams &&
-                intParams == other.intParams && isActive == other.isActive);
+        return (type == other.type && pitchControl == other.pitchControl && mix == other.mix &&
+                floatParams == other.floatParams && intParams == other.intParams &&
+                isActive == other.isActive);
     }
     bool operator!=(const ProcessorStorage &other) const { return !(*this == other); }
 };

--- a/src/scxt-core/dsp/processor/routing.h
+++ b/src/scxt-core/dsp/processor/routing.h
@@ -35,11 +35,11 @@
 namespace scxt::dsp::processor
 {
 
-template <bool OS, bool forceStereo, int N, typename Mix, typename Endpoints>
-inline void runSingleProcessor(int i, float fpitch, Processor *processors[engine::processorCount],
-                               bool processorConsumesMono[engine::processorCount], Mix &mix,
-                               Mix &outLev, Endpoints *endpoints, bool &chainIsMono,
-                               float input[2][N], float output[2][N])
+template <bool OS, bool forceStereo, int N, typename Mix, typename Endpoints, typename PitchPtr>
+inline void
+runSingleProcessor(int i, PitchPtr fpitch, Processor *processors[engine::processorCount],
+                   bool processorConsumesMono[engine::processorCount], Mix &mix, Mix &outLev,
+                   Endpoints *endpoints, bool &chainIsMono, float input[2][N], float output[2][N])
 {
     if (processors[i]->bypassAnyway)
     {
@@ -57,9 +57,19 @@ inline void runSingleProcessor(int i, float fpitch, Processor *processors[engine
         mixl = 1.0;
     mix[i].set_target(mixl);
 
+    float p;
+    if constexpr (std::is_same_v<PitchPtr, float>)
+    {
+        p = fpitch;
+    }
+    else
+    {
+        p = fpitch[i];
+    }
+
     if constexpr (forceStereo)
     {
-        processors[i]->process_stereo(input[0], input[1], tempbuf[0], tempbuf[1], fpitch);
+        processors[i]->process_stereo(input[0], input[1], tempbuf[0], tempbuf[1], p);
         mix[i].fade_blocks(input[0], tempbuf[0], output[0]);
         mix[i].fade_blocks(input[1], tempbuf[1], output[1]);
 
@@ -71,14 +81,14 @@ inline void runSingleProcessor(int i, float fpitch, Processor *processors[engine
             !processors[i]->monoInputCreatesStereoOutput())
         {
             // mono to mono
-            processors[i]->process_monoToMono(input[0], tempbuf[0], fpitch);
+            processors[i]->process_monoToMono(input[0], tempbuf[0], p);
             mix[i].fade_blocks(input[0], tempbuf[0], output[0]);
         }
         else if (chainIsMono && processorConsumesMono[i])
         {
             assert(processors[i]->monoInputCreatesStereoOutput());
             // mono to stereo. process then toggle
-            processors[i]->process_monoToStereo(input[0], tempbuf[0], tempbuf[1], fpitch);
+            processors[i]->process_monoToStereo(input[0], tempbuf[0], tempbuf[1], p);
 
             // this input[0] is NOT a typo. Input is mono
             // And this order matters. Have to splat [1] first to keep [0] around
@@ -93,14 +103,14 @@ inline void runSingleProcessor(int i, float fpitch, Processor *processors[engine
             // stereo to stereo. copy L to R then process
             mech::copy_from_to<blockSize << (OS ? 1 : 0)>(input[0], input[1]);
             chainIsMono = false;
-            processors[i]->process_stereo(input[0], input[1], tempbuf[0], tempbuf[1], fpitch);
+            processors[i]->process_stereo(input[0], input[1], tempbuf[0], tempbuf[1], p);
             mix[i].fade_blocks(input[0], tempbuf[0], output[0]);
             mix[i].fade_blocks(input[1], tempbuf[1], output[1]);
         }
         else
         {
             // stereo to stereo. process
-            processors[i]->process_stereo(input[0], input[1], tempbuf[0], tempbuf[1], fpitch);
+            processors[i]->process_stereo(input[0], input[1], tempbuf[0], tempbuf[1], p);
             mix[i].fade_blocks(input[0], tempbuf[0], output[0]);
             mix[i].fade_blocks(input[1], tempbuf[1], output[1]);
             chainIsMono = false;
@@ -144,8 +154,8 @@ inline bool allActive(Processor *processors[engine::processorCount], Indices... 
 }
 
 // -> 1 -> 2 -> 3 -> 4 ->
-template <bool OS, bool forceStereo, int N, typename Mix, typename Endpoints>
-inline void processSequential(float fpitch, Processor *processors[engine::processorCount],
+template <bool OS, bool forceStereo, int N, typename Mix, typename Endpoints, typename PitchPtr>
+inline void processSequential(PitchPtr fpitch, Processor *processors[engine::processorCount],
                               bool processorConsumesMono[engine::processorCount], Mix &mix,
                               Mix &outLev, Endpoints *endpoints, bool &chainIsMono,
                               float output[2][N])
@@ -163,8 +173,9 @@ inline void processSequential(float fpitch, Processor *processors[engine::proces
 }
 
 // -> { A | B } ->
-template <bool OS, bool forceStereo, int N, typename Mix, typename Endpoints>
-void processParallelPair(int A, int B, float fpitch, Processor *processors[engine::processorCount],
+template <bool OS, bool forceStereo, int N, typename Mix, typename Endpoints, typename PitchPtr>
+void processParallelPair(int A, int B, PitchPtr fpitch,
+                         Processor *processors[engine::processorCount],
                          bool processorConsumesMono[engine::processorCount], Mix &mix, Mix &outLev,
                          Endpoints *endpoints, bool &chainIsMono, float output[2][N])
 {
@@ -239,8 +250,8 @@ void processParallelPair(int A, int B, float fpitch, Processor *processors[engin
 }
 
 // -> { 1 | 2 } -> { 3 | 4 } ->
-template <bool OS, bool forceStereo, int N, typename Mix, typename Endpoints>
-void processSer2Pattern(float fpitch, Processor *processors[engine::processorCount],
+template <bool OS, bool forceStereo, int N, typename Mix, typename Endpoints, typename PitchPtr>
+void processSer2Pattern(PitchPtr fpitch, Processor *processors[engine::processorCount],
                         bool processorConsumesMono[engine::processorCount], Mix &mix, Mix &outLev,
                         Endpoints *endpoints, bool &chainIsMono, float output[2][N])
 {
@@ -258,8 +269,8 @@ void processSer2Pattern(float fpitch, Processor *processors[engine::processorCou
 }
 
 // -> 1 -> { 2 | 3 } -> 4 ->
-template <bool OS, bool forceStereo, int N, typename Mix, typename Endpoints>
-void processSer3Pattern(float fpitch, Processor *processors[engine::processorCount],
+template <bool OS, bool forceStereo, int N, typename Mix, typename Endpoints, typename PitchPtr>
+void processSer3Pattern(PitchPtr fpitch, Processor *processors[engine::processorCount],
                         bool processorConsumesMono[engine::processorCount], Mix &mix, Mix &outLev,
                         Endpoints *endpoints, bool &chainIsMono, float output[2][N])
 {
@@ -283,8 +294,8 @@ void processSer3Pattern(float fpitch, Processor *processors[engine::processorCou
 }
 
 // All in parallel
-template <bool OS, bool forceStereo, int N, typename Mix, typename Endpoints>
-void processPar1Pattern(float fpitch, Processor *processors[engine::processorCount],
+template <bool OS, bool forceStereo, int N, typename Mix, typename Endpoints, typename PitchPtr>
+void processPar1Pattern(PitchPtr fpitch, Processor *processors[engine::processorCount],
                         bool processorConsumesMono[engine::processorCount], Mix &mix, Mix &outLev,
                         Endpoints *endpoints, bool &chainIsMono, float output[2][N])
 {
@@ -353,8 +364,8 @@ void processPar1Pattern(float fpitch, Processor *processors[engine::processorCou
 }
 
 // -> { { 1->2} | { 3->4 } ->
-template <bool OS, bool forceStereo, int N, typename Mix, typename Endpoints>
-void processPar2Pattern(float fpitch, Processor *processors[engine::processorCount],
+template <bool OS, bool forceStereo, int N, typename Mix, typename Endpoints, typename PitchPtr>
+void processPar2Pattern(PitchPtr fpitch, Processor *processors[engine::processorCount],
                         bool processorConsumesMono[engine::processorCount], Mix &mix, Mix &outLev,
                         Endpoints *endpoints, bool &chainIsMono, float output[2][N])
 {
@@ -479,8 +490,8 @@ void processPar2Pattern(float fpitch, Processor *processors[engine::processorCou
 }
 
 // -> { 1 | 2 | 3 } -> 4
-template <bool OS, bool forceStereo, int N, typename Mix, typename Endpoints>
-void processPar3Pattern(float fpitch, Processor *processors[engine::processorCount],
+template <bool OS, bool forceStereo, int N, typename Mix, typename Endpoints, typename PitchPtr>
+void processPar3Pattern(PitchPtr fpitch, Processor *processors[engine::processorCount],
                         bool processorConsumesMono[engine::processorCount], Mix &mix, Mix &outLev,
                         Endpoints *endpoints, bool &chainIsMono, float output[2][N])
 {

--- a/src/scxt-core/engine/group.cpp
+++ b/src/scxt-core/engine/group.cpp
@@ -166,7 +166,16 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
     fAnySounding = (fVoiceCount > 0) * 1.f;
 
     // Compute group-level voice tracking: last/high/low for pitch, key, midiKey
-    if (matrixContainsKeyAndPitchSources)
+    bool anyPitchModeIsNonConstant = false;
+    for (int i = 0; i < processorsPerZoneAndGroup; ++i)
+    {
+        if (processorStorage[i].pitchControl != dsp::processor::ProcessorStorage::GP_CONSTANT)
+        {
+            anyPitchModeIsNonConstant = true;
+            break;
+        }
+    }
+    if (matrixContainsKeyAndPitchSources || anyPitchModeIsNonConstant)
     {
         uint64_t newestCreationId = 0;
         pitchTrack.clear();
@@ -315,7 +324,42 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
     }
 
     // Groups are always unpitched and stereo
-    auto fpitch = 0;
+    float fpitch[processorsPerZoneAndGroup]{0, 0, 0, 0};
+    for (int i = 0; i < processorsPerZoneAndGroup; ++i)
+    {
+        switch (processorStorage[i].pitchControl)
+        {
+        case dsp::processor::ProcessorStorage::GP_CONSTANT:
+            fpitch[i] = 0;
+            break;
+        case dsp::processor::ProcessorStorage::GP_NOTE_PRIO:
+        {
+            switch (outputInfo.notePriority)
+            {
+            case NotePriority::LATEST:
+                fpitch[i] = pitchTrack.last * 12.f - 9.0;
+                break;
+            case NotePriority::HIGHEST:
+                fpitch[i] = pitchTrack.high * 12.f - 9.0;
+                break;
+            case NotePriority::LOWEST:
+                fpitch[i] = pitchTrack.low * 12.f - 9.0;
+                break;
+            }
+        }
+        break;
+        case dsp::processor::ProcessorStorage::GP_LATEST:
+            fpitch[i] = pitchTrack.last * 12.f - 9.0;
+            break;
+        case dsp::processor::ProcessorStorage::GP_HIGHEST:
+            fpitch[i] = pitchTrack.high * 12.f - 9.0;
+            break;
+        case dsp::processor::ProcessorStorage::GP_LOWEST:
+            fpitch[i] = pitchTrack.low * 12.f - 9.0;
+            break;
+        }
+    }
+
     bool processorConsumesMono[4]{false, false, false, false};
     bool chainIsMono{false};
 

--- a/src/scxt-core/json/dsp_traits.h
+++ b/src/scxt-core/json/dsp_traits.h
@@ -65,6 +65,7 @@ SC_STREAMDEF(
                  {"floatParams", t.floatParams},
                  {"intParams", t.intParams},
                  {"deactivated", t.deactivated},
+                 {"pitchControl", t.pitchControl},
                  {"isActive", t.isActive},
                  {"procTypeConsistent", t.procTypeConsistent},
                  {"streamingVersion", t.streamingVersion}};
@@ -99,6 +100,10 @@ SC_STREAMDEF(
             fromArrayWithSizeDifference(v.at("floatParams"), result.floatParams);
             fromArrayWithSizeDifference(v.at("intParams"), result.intParams);
             findIf(v, "deactivated", result.deactivated);
+            // This defaults tp GP_CONSTANT which was the value before we could stream it,
+            // even though new sessions will use GP_NOTEPRIO as default
+            findOrSet(v, "pitchControl", scxt::dsp::processor::ProcessorStorage::GP_CONSTANT,
+                      result.pitchControl);
             findOrSet(v, "isActive", false, result.isActive);
             findOrSet(v, "isKeytracked", false, result.isKeytracked);
             findOrSet(v, "isTemposynced", false, result.isTemposynced);

--- a/src/scxt-core/json/engine_traits.h
+++ b/src/scxt-core/json/engine_traits.h
@@ -357,6 +357,9 @@ STREAM_ENUM(engine::Group::PlayMode, engine::Group::toStringPlayMode,
             engine::Group::fromStringPlayMode);
 STREAM_ENUM(engine::Group::NotePriority, engine::Group::toStringNotePriority,
             engine::Group::fromStringNotePriority);
+STREAM_ENUM(scxt::dsp::processor::ProcessorStorage::GroupProcessorPitch,
+            scxt::dsp::processor::ProcessorStorage::toStringGroupProcessorPitch,
+            scxt::dsp::processor::ProcessorStorage::fromStringGroupProcessorPitch);
 
 SC_STREAMDEF(scxt::engine::Group::GroupOutputInfo, SC_FROM({
                  v = {{"amplitude", t.amplitude},

--- a/src/scxt-plugin/app/edit-screen/components/ProcessorPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/ProcessorPane.cpp
@@ -136,6 +136,7 @@ void ProcessorPane::showPresetsMenu()
         return;
 
     juce::PopupMenu p;
+
     p.addSectionHeader("Edit");
     p.addItem("Copy", [w = juce::Component::SafePointer(this)]() {
         if (!w)
@@ -148,6 +149,68 @@ void ProcessorPane::showPresetsMenu()
                       return;
                   w->pasteFromEditorClipboard();
               });
+    if (!forZone)
+    {
+        juce::PopupMenu pm;
+        pm.addItem("Constant", true,
+                   processorView.pitchControl == dsp::processor::ProcessorStorage::GP_CONSTANT,
+                   [w = juce::Component::SafePointer(this)]() {
+                       if (w)
+                       {
+                           w->processorView.pitchControl =
+                               dsp::processor::ProcessorStorage::GP_CONSTANT;
+                           w->sendToSerialization(cmsg::SendFullProcessorStorage(
+                               {w->forZone, w->index, w->processorView}));
+                       }
+                   });
+        pm.addItem("Note Priority", true,
+                   processorView.pitchControl == dsp::processor::ProcessorStorage::GP_NOTE_PRIO,
+                   [w = juce::Component::SafePointer(this)]() {
+                       if (w)
+                       {
+                           w->processorView.pitchControl =
+                               dsp::processor::ProcessorStorage::GP_NOTE_PRIO;
+                           w->sendToSerialization(cmsg::SendFullProcessorStorage(
+                               {w->forZone, w->index, w->processorView}));
+                       }
+                   });
+        pm.addItem("Latest Note", true,
+                   processorView.pitchControl == dsp::processor::ProcessorStorage::GP_LATEST,
+                   [w = juce::Component::SafePointer(this)]() {
+                       if (w)
+                       {
+                           w->processorView.pitchControl =
+                               dsp::processor::ProcessorStorage::GP_LATEST;
+                           w->sendToSerialization(cmsg::SendFullProcessorStorage(
+                               {w->forZone, w->index, w->processorView}));
+                       }
+                   });
+        pm.addItem("Highest Note", true,
+                   processorView.pitchControl == dsp::processor::ProcessorStorage::GP_HIGHEST,
+                   [w = juce::Component::SafePointer(this)]() {
+                       if (w)
+                       {
+                           w->processorView.pitchControl =
+                               dsp::processor::ProcessorStorage::GP_HIGHEST;
+                           w->sendToSerialization(cmsg::SendFullProcessorStorage(
+                               {w->forZone, w->index, w->processorView}));
+                       }
+                   });
+        pm.addItem("Lowest Note", true,
+                   processorView.pitchControl == dsp::processor::ProcessorStorage::GP_LOWEST,
+                   [w = juce::Component::SafePointer(this)]() {
+                       if (w)
+                       {
+                           w->processorView.pitchControl =
+                               dsp::processor::ProcessorStorage::GP_LOWEST;
+                           w->sendToSerialization(cmsg::SendFullProcessorStorage(
+                               {w->forZone, w->index, w->processorView}));
+                       }
+                   });
+        p.addSubMenu("Pitch Mode", pm);
+        p.addSeparator();
+    }
+
     p.addSeparator();
     p.addSectionHeader("Presets");
 


### PR DESCRIPTION
Group Processor used to have a constant pitch (0). This commit provides 5 modes to each group processor on a per-processor basis, Constant (so still 0), follow note priority, force low hi or latest

Editable via the processor hamburger menu.

Allows to start exploring some paraphonic workflows without having to get crazy with the mod matrix.

Default for new sessions is NOTE_PRIO, default for old sessions is CONSTANT to not break streaming.