### PR TITLE
Add SAMPLE_GATED envelope gate mode for zones/voices

### DIFF
--- a/src/scxt-core/engine/group.cpp
+++ b/src/scxt-core/engine/group.cpp
@@ -254,7 +254,7 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
         if (gegStorage[i].gateGroupEGOnAnyPlaying)
             envGate = (fVoiceCount > 0);
 
-        auto egiGate = getEnvSpecificGate(envGate, gegStorage[i], eg[i].stage);
+        auto egiGate = getEnvSpecificGate(envGate, gegStorage[i], eg[i].stage, false);
 
         if (egsActive[i])
         {
@@ -263,7 +263,7 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
             {
                 doEGRetrigger[i] = false;
                 eg[i].attackFromWithDelay(eg[i].outBlock0, *aegp.dlyP, *aegp.aP);
-                egiGate = getEnvSpecificGate(envGate, gegStorage[i], eg[i].stage);
+                egiGate = getEnvSpecificGate(envGate, gegStorage[i], eg[i].stage, false);
             }
             eg[i].processBlockWithDelay(*aegp.dlyP, *aegp.aP, *aegp.hP, *aegp.dP, *aegp.sP,
                                         *aegp.rP, *aegp.asP, *aegp.dsP, *aegp.rsP, egiGate, false);

--- a/src/scxt-core/modulation/has_modulators.h
+++ b/src/scxt-core/modulation/has_modulators.h
@@ -128,10 +128,10 @@ template <typename T, size_t egsPerObject> struct HasModulators
         }
     }
 
-    bool getEnvSpecificGate(bool keyGate, const modulation::modulators::AdsrStorage &adsr,
-                            ahdsrenv_t::Stage stage)
+    static bool evaluateGate(bool keyGate, modulation::modulators::AdsrStorage::GateMode mode,
+                             ahdsrenv_t::Stage stage, bool samplePlaying = false)
     {
-        switch (adsr.gateMode)
+        switch (mode)
         {
         case modulation::modulators::AdsrStorage::GateMode::GATED:
             return keyGate;
@@ -139,8 +139,16 @@ template <typename T, size_t egsPerObject> struct HasModulators
             return keyGate && stage < ahdsrenv_t::s_sustain;
         case modulation::modulators::AdsrStorage::GateMode::ONESHOT:
             return stage < ahdsrenv_t::s_sustain;
+        case modulation::modulators::AdsrStorage::GateMode::SAMPLE_GATED:
+            return samplePlaying;
         }
         return keyGate;
+    }
+
+    bool getEnvSpecificGate(bool keyGate, const modulation::modulators::AdsrStorage &adsr,
+                            ahdsrenv_t::Stage stage, bool samplePlaying = false)
+    {
+        return evaluateGate(keyGate, adsr.gateMode, stage, samplePlaying);
     }
 };
 } // namespace scxt::modulation::shared

--- a/src/scxt-core/modulation/modulator_storage.cpp
+++ b/src/scxt-core/modulation/modulator_storage.cpp
@@ -42,6 +42,8 @@ std::string AdsrStorage::toStringGateMode(const GateMode &s)
         return "s";
     case GateMode::ONESHOT:
         return "o";
+    case GateMode::SAMPLE_GATED:
+        return "q";
     }
     return "g";
 }
@@ -49,7 +51,7 @@ std::string AdsrStorage::toStringGateMode(const GateMode &s)
 AdsrStorage::GateMode AdsrStorage::fromStringGateMode(const std::string &s)
 {
     static auto inverse = makeEnumInverse<AdsrStorage::GateMode, AdsrStorage::toStringGateMode>(
-        AdsrStorage::GateMode::GATED, AdsrStorage::GateMode::ONESHOT);
+        AdsrStorage::GateMode::GATED, AdsrStorage::GateMode::SAMPLE_GATED);
     auto p = inverse.find(s);
     if (p == inverse.end())
         return GateMode::GATED;

--- a/src/scxt-core/modulation/modulator_storage.h
+++ b/src/scxt-core/modulation/modulator_storage.h
@@ -60,9 +60,10 @@ struct AdsrStorage
      */
     enum struct GateMode
     {
-        GATED,      // DAHDR, ungate to release
-        SEMI_GATED, // DAHDR, ungate or end of decay jumps to release (no sustain)
-        ONESHOT,    // DAHDR, gate ignored, full cycle always
+        GATED,        // DAHDSR, gated by keyboard / midi
+        SEMI_GATED,   // DAHDbR, gated until key release in DAHD, or end of decay
+        ONESHOT,      // DAHDbR, gate ignored, full cycle always
+        SAMPLE_GATED, // DAHDSR, gated by sample playback (zone/voice only)
     } gateMode{GateMode::GATED};
     DECLARE_ENUM_STRING(GateMode);
 

--- a/src/scxt-core/voice/voice.cpp
+++ b/src/scxt-core/voice/voice.cpp
@@ -316,14 +316,16 @@ template <bool OS> bool Voice::processWithOS()
     auto &aegp = endpoints->egTarget[0];
     auto rtaeg = doEGRetrigger[0];
     doEGRetrigger[0] = false;
-    auto aegGate = getEnvSpecificGate(envGate, zone->egStorage[0], aeg.stage);
+    auto aegGate =
+        getEnvSpecificGate(envGate, zone->egStorage[0], aeg.stage, isAnyGeneratorRunning);
     if constexpr (OS)
     {
         if (rtaeg)
         {
             aegOS.attackFromWithDelay(aegOS.outBlock0, *aegp.dlyP, *aegp.aP);
-            aegGate = getEnvSpecificGate(envGate, zone->egStorage[0],
-                                         (ahdsrenv_t::Stage)((int)aegOS.stage));
+            aegGate =
+                getEnvSpecificGate(envGate, zone->egStorage[0],
+                                   (ahdsrenv_t::Stage)((int)aegOS.stage), isAnyGeneratorRunning);
         }
         // we need the aegOS for the curve in oversample space
         aegOS.processBlockWithDelay(*aegp.dlyP, *aegp.aP, *aegp.hP, *aegp.dP, *aegp.sP, *aegp.rP,
@@ -334,7 +336,7 @@ template <bool OS> bool Voice::processWithOS()
     if (rtaeg)
     {
         aeg.attackFromWithDelay(aeg.outBlock0, *aegp.dlyP, *aegp.aP);
-        aegGate = getEnvSpecificGate(envGate, zone->egStorage[0], aeg.stage);
+        aegGate = getEnvSpecificGate(envGate, zone->egStorage[0], aeg.stage, isAnyGeneratorRunning);
     }
     aeg.processBlockWithDelay(*aegp.dlyP, *aegp.aP, *aegp.hP, *aegp.dP, *aegp.sP, *aegp.rP,
                               *aegp.asP, *aegp.dsP, *aegp.rsP, aegGate, true);
@@ -347,13 +349,15 @@ template <bool OS> bool Voice::processWithOS()
         {
             auto &eg2p = endpoints->egTarget[i];
 
-            auto egiGate = getEnvSpecificGate(envGate, zone->egStorage[i], eg[i].stage);
+            auto egiGate =
+                getEnvSpecificGate(envGate, zone->egStorage[i], eg[i].stage, isAnyGeneratorRunning);
 
             if (doEGRetrigger[i])
             {
                 doEGRetrigger[i] = false;
                 eg[i].attackFromWithDelay(eg[i].outBlock0, *eg2p.dlyP, *eg2p.aP);
-                egiGate = getEnvSpecificGate(envGate, zone->egStorage[0], eg[i].stage);
+                egiGate = getEnvSpecificGate(envGate, zone->egStorage[0], eg[i].stage,
+                                             isAnyGeneratorRunning);
             }
 
             eg[i].processBlockWithDelay(*eg2p.dlyP, *eg2p.aP, *eg2p.hP, *eg2p.dP, *eg2p.sP,

--- a/src/scxt-plugin/app/edit-screen/components/AdsrPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/AdsrPane.cpp
@@ -312,6 +312,22 @@ void AdsrPane::showHamburgerMenu()
                       cmsg::UpdateFullAdsrStorageForGroupsOrZones({w->forZone, aidx, w->adsrView}));
               });
 
+    if (forZone)
+    {
+        p.addItem("Sample Gated", true,
+                  adsrView.gateMode == modulation::modulators::AdsrStorage::GateMode::SAMPLE_GATED,
+                  [aidx, w = juce::Component::SafePointer(this)]() {
+                      if (!w)
+                          return;
+                      w->adsrView.gateMode =
+                          modulation::modulators::AdsrStorage::GateMode::SAMPLE_GATED;
+                      w->updateSustainBreakpoint();
+                      w->repaint();
+                      w->sendToSerialization(cmsg::UpdateFullAdsrStorageForGroupsOrZones(
+                          {w->forZone, aidx, w->adsrView}));
+                  });
+    }
+
     if (!forZone)
     {
         p.addSeparator();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(scxt-test
 
 		selection_tests.cpp
 		modify_structure.cpp
+		modulator_tests.cpp
 )
 
 target_link_libraries(scxt-test

--- a/tests/modulator_tests.cpp
+++ b/tests/modulator_tests.cpp
@@ -1,0 +1,119 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "catch2/catch2.hpp"
+#include "engine/zone.h"
+#include "modulation/modulator_storage.h"
+#include "modulation/has_modulators.h"
+
+// Use the Zone instantiation of HasModulators to access evaluateGate and the Stage type.
+// evaluateGate is static so no Zone object is needed.
+using ZoneMods = scxt::modulation::shared::HasModulators<scxt::engine::Zone, scxt::egsPerZone>;
+using AS = scxt::modulation::modulators::AdsrStorage;
+using GM = AS::GateMode;
+using Stage = ZoneMods::ahdsrenv_t::Stage;
+
+static constexpr Stage stg_attack{Stage::s_attack};
+static constexpr Stage stg_hold{Stage::s_hold};
+static constexpr Stage stg_decay{Stage::s_decay};
+static constexpr Stage stg_sustain{Stage::s_sustain};
+static constexpr Stage stg_release{Stage::s_release};
+
+TEST_CASE("GateMode::GATED follows key gate regardless of sample or stage")
+{
+    // Key held: always true
+    REQUIRE(ZoneMods::evaluateGate(true, GM::GATED, stg_attack));
+    REQUIRE(ZoneMods::evaluateGate(true, GM::GATED, stg_sustain));
+    REQUIRE(ZoneMods::evaluateGate(true, GM::GATED, stg_release));
+
+    // Key released: always false
+    REQUIRE_FALSE(ZoneMods::evaluateGate(false, GM::GATED, stg_attack));
+    REQUIRE_FALSE(ZoneMods::evaluateGate(false, GM::GATED, stg_sustain));
+
+    // samplePlaying has no effect on GATED
+    REQUIRE(ZoneMods::evaluateGate(true, GM::GATED, stg_sustain, false));
+    REQUIRE_FALSE(ZoneMods::evaluateGate(false, GM::GATED, stg_sustain, true));
+}
+
+TEST_CASE("GateMode::SEMI_GATED gates on key before sustain, open after")
+{
+    // Key held: true before sustain, false at/after sustain
+    REQUIRE(ZoneMods::evaluateGate(true, GM::SEMI_GATED, stg_attack));
+    REQUIRE(ZoneMods::evaluateGate(true, GM::SEMI_GATED, stg_hold));
+    REQUIRE(ZoneMods::evaluateGate(true, GM::SEMI_GATED, stg_decay));
+    REQUIRE_FALSE(ZoneMods::evaluateGate(true, GM::SEMI_GATED, stg_sustain));
+    REQUIRE_FALSE(ZoneMods::evaluateGate(true, GM::SEMI_GATED, stg_release));
+
+    // Key released: always false (regardless of stage)
+    REQUIRE_FALSE(ZoneMods::evaluateGate(false, GM::SEMI_GATED, stg_attack));
+    REQUIRE_FALSE(ZoneMods::evaluateGate(false, GM::SEMI_GATED, stg_decay));
+}
+
+TEST_CASE("GateMode::ONESHOT ignores key gate, open before sustain")
+{
+    // Key state irrelevant: true before sustain
+    REQUIRE(ZoneMods::evaluateGate(true, GM::ONESHOT, stg_attack));
+    REQUIRE(ZoneMods::evaluateGate(false, GM::ONESHOT, stg_attack));
+    REQUIRE(ZoneMods::evaluateGate(false, GM::ONESHOT, stg_decay));
+
+    // False at/after sustain regardless of key
+    REQUIRE_FALSE(ZoneMods::evaluateGate(true, GM::ONESHOT, stg_sustain));
+    REQUIRE_FALSE(ZoneMods::evaluateGate(false, GM::ONESHOT, stg_sustain));
+    REQUIRE_FALSE(ZoneMods::evaluateGate(true, GM::ONESHOT, stg_release));
+}
+
+TEST_CASE("GateMode::SAMPLE_GATED follows sample playback, ignores key gate and stage")
+{
+    // Sample playing: gate open regardless of key state or stage
+    REQUIRE(ZoneMods::evaluateGate(true, GM::SAMPLE_GATED, stg_attack, true));
+    REQUIRE(ZoneMods::evaluateGate(false, GM::SAMPLE_GATED, stg_attack, true));
+    REQUIRE(ZoneMods::evaluateGate(true, GM::SAMPLE_GATED, stg_sustain, true));
+    REQUIRE(ZoneMods::evaluateGate(false, GM::SAMPLE_GATED, stg_sustain, true));
+    REQUIRE(ZoneMods::evaluateGate(true, GM::SAMPLE_GATED, stg_release, true));
+
+    // Sample stopped: gate closed regardless of key state or stage
+    REQUIRE_FALSE(ZoneMods::evaluateGate(true, GM::SAMPLE_GATED, stg_attack, false));
+    REQUIRE_FALSE(ZoneMods::evaluateGate(false, GM::SAMPLE_GATED, stg_attack, false));
+    REQUIRE_FALSE(ZoneMods::evaluateGate(true, GM::SAMPLE_GATED, stg_sustain, false));
+    REQUIRE_FALSE(ZoneMods::evaluateGate(false, GM::SAMPLE_GATED, stg_release, false));
+}
+
+TEST_CASE("GateMode serialization round-trips including SAMPLE_GATED")
+{
+    REQUIRE(AS::toStringGateMode(GM::GATED) == "g");
+    REQUIRE(AS::toStringGateMode(GM::SEMI_GATED) == "s");
+    REQUIRE(AS::toStringGateMode(GM::ONESHOT) == "o");
+    REQUIRE(AS::toStringGateMode(GM::SAMPLE_GATED) == "q");
+
+    REQUIRE(AS::fromStringGateMode("g") == GM::GATED);
+    REQUIRE(AS::fromStringGateMode("s") == GM::SEMI_GATED);
+    REQUIRE(AS::fromStringGateMode("o") == GM::ONESHOT);
+    REQUIRE(AS::fromStringGateMode("q") == GM::SAMPLE_GATED);
+
+    // Unknown string falls back to GATED
+    REQUIRE(AS::fromStringGateMode("?") == GM::GATED);
+}


### PR DESCRIPTION
As first part of removing ONESHOT samples and moving them to an AEG feature, add the 'sample gated' mode to all the envelopes on voice/zone, which makes the envelope be gated as long as a sample is playing.