### PR TITLE
Improve drag-and-drop: group drops, batch drops, part sidebar drops

### DIFF
--- a/src/scxt-core/engine/engine.cpp
+++ b/src/scxt-core/engine/engine.cpp
@@ -912,6 +912,49 @@ void Engine::loadSampleIntoSelectedPartAndGroup(const fs::path &p, int16_t rootK
         });
 }
 
+void Engine::loadSampleIntoGroup(const fs::path &p, int part, int group)
+{
+    assert(messageController->threadingChecker.isSerialThread());
+
+    auto sid = sampleManager->loadSampleByPath(p);
+    if (!sid.has_value())
+    {
+        RAISE_ERROR_CONT(*messageController, "Unable to load Sample",
+                         "Sample load failed:\n\n" + p.u8string() + "\n\n" +
+                             "It is either an unsupported format or invalid file. "
+                             "More information may be available in the log file (menu/log)");
+        return;
+    }
+
+    auto zptr = std::make_unique<Zone>(*sid);
+    zptr->mapping.keyboardRange = {0, 127};
+    zptr->mapping.velocityRange = {0, 127};
+    zptr->mapping.rootKey = 60;
+    zptr->attachToSample(*sampleManager, 0, (int)Zone::SampleInformationRead::ALL);
+
+    auto sp = part, sg = group;
+
+    {
+        auto undoItem = std::make_unique<undo::GroupChangeItem>();
+        undoItem->store(*this, sp, sg);
+        undoManager.storeUndoStep(std::move(undoItem));
+    }
+
+    messageController->scheduleAudioThreadCallbackUnderStructureLock(
+        [sp = sp, sg = sg, zone = zptr.release()](auto &e) {
+            std::unique_ptr<Zone> zptr;
+            zptr.reset(zone);
+            e.getPatch()->getPart(sp)->guaranteeGroupCount(sg + 1);
+            e.getPatch()->getPart(sp)->getGroup(sg)->addZone(zptr);
+            messaging::audio::sendStructureRefresh(*(e.getMessageController()));
+        },
+        [sp = sp, sg = sg](auto &e) {
+            auto &g = e.getPatch()->getPart(sp)->getGroup(sg);
+            int32_t zi = g->getZones().size() - 1;
+            e.getSelectionManager()->applySelectActions({sp, sg, zi, true, true, true});
+        });
+}
+
 void Engine::createEmptyZone(int partN, int groupN, scxt::engine::KeyboardRange krange,
                              scxt::engine::VelocityRange vrange)
 {

--- a/src/scxt-core/engine/engine.h
+++ b/src/scxt-core/engine/engine.h
@@ -575,6 +575,8 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     {
         loadSampleIntoSelectedPartAndGroup(p, 60, {48, 72}, {0, 127}, true);
     }
+    // Drop a single audio file into an explicit group, bypassing selection
+    void loadSampleIntoGroup(const fs::path &p, int part, int group);
 
     void loadCompoundElementIntoSelectedPartAndGroup(
         const scxt::sample::compound::CompoundElement &, int16_t rootKey = 60,

--- a/src/scxt-core/messaging/client/client_serial.h
+++ b/src/scxt-core/messaging/client/client_serial.h
@@ -139,6 +139,7 @@ enum ClientToSerializationMessagesIds
 
     c2s_add_sample,
     c2s_add_sample_with_range,
+    c2s_add_sample_to_group,
     c2s_add_sample_in_zone,
     c2s_add_compound_element_with_range,
     c2s_add_compound_element_in_zone,

--- a/src/scxt-core/messaging/client/structure_messages.h
+++ b/src/scxt-core/messaging/client/structure_messages.h
@@ -90,6 +90,18 @@ inline void addSampleWithRange(const addSampleWithRange_t &payload, engine::Engi
 CLIENT_TO_SERIAL(AddSampleWithRange, c2s_add_sample_with_range, addSampleWithRange_t,
                  addSampleWithRange(payload, engine, cont);)
 
+// path, part, group — drops the sample into an explicit group bypassing selection
+using addSampleToGroupPayload_t = std::tuple<std::string, int, int>;
+inline void addSampleToGroupFn(const addSampleToGroupPayload_t &payload, engine::Engine &engine,
+                               MessageController &cont)
+{
+    assert(cont.threadingChecker.isSerialThread());
+    auto p = fs::path(fs::u8path(std::get<0>(payload)));
+    engine.loadSampleIntoGroup(p, std::get<1>(payload), std::get<2>(payload));
+}
+CLIENT_TO_SERIAL(AddSampleToGroup, c2s_add_sample_to_group, addSampleToGroupPayload_t,
+                 addSampleToGroupFn(payload, engine, cont);)
+
 using addCompoundElementWithRange_t =
     std::tuple<sample::compound::CompoundElement, int, int, int, int, int>;
 inline void addCompoundElementWithRange(const addCompoundElementWithRange_t &payload,

--- a/src/scxt-plugin/app/SCXTEditor.h
+++ b/src/scxt-plugin/app/SCXTEditor.h
@@ -134,6 +134,14 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel,
      */
     theme::ThemeApplier themeApplier;
     juce::Colour themeColor(scxt::ui::theme::ColorMap::Colors, float alpha = 1.f) const;
+
+    // Paint a soft occluding overlay: opaque bgColor base, frontColor@0.35 tint, 2px border,
+    // then textLines centered vertically split across the rectangle.
+    void occludeRegionWithText(juce::Graphics &g, juce::Rectangle<float> rect,
+                               theme::ColorMap::Colors frontColor, theme::ColorMap::Colors bgColor,
+                               theme::ColorMap::Colors textColor,
+                               const std::vector<std::string> &textLines) const;
+
     void resetColorsFromUserPreferences();
 
     /*

--- a/src/scxt-plugin/app/edit-screen/components/GroupZoneTreeControl.h
+++ b/src/scxt-plugin/app/edit-screen/components/GroupZoneTreeControl.h
@@ -39,6 +39,8 @@
 #include "engine/feature_enums.h"
 
 #include "app/shared/ZoneRightMouseMenu.h"
+#include "app/browser-ui/BrowserPaneInterfaces.h"
+#include "app/shared/SampleDropHandler.h"
 
 namespace scxt::ui::app::edit_screen
 {
@@ -107,10 +109,34 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
     selection::SelectionManager::ZoneAddress getZoneAddress(int rowNumber)
     {
         auto &tgl = gzData;
-        if (rowNumber < 0 || rowNumber >= tgl.size())
+        if (rowNumber < 0 || rowNumber >= (int)tgl.size())
             return {};
         auto &sad = tgl[rowNumber].address;
         return sad;
+    }
+
+    // Returns the group ZoneAddress (zone==-1) for the row at position (x,y) in this widget's
+    // local coordinate space, accounting for scrolling. If the position falls on a zone row the
+    // parent group address is returned. Returns an empty optional if out of bounds.
+    std::optional<selection::SelectionManager::ZoneAddress> groupAddressForDropPosition(int x,
+                                                                                        int y)
+    {
+        if (!viewPort || !getRowHeight)
+            return std::nullopt;
+        int rh = (int)getRowHeight();
+        if (rh <= 0)
+            return std::nullopt;
+        int contentY = y - viewPort->getY() + viewPort->getViewPositionY();
+        if (contentY < 0)
+            return std::nullopt;
+        int rowIdx = contentY / rh;
+        if (rowIdx < 0 || rowIdx >= (int)gzData.size())
+            return std::nullopt;
+        auto addr = gzData[rowIdx].address;
+        // If this is a zone row, return the parent group address
+        if (addr.zone >= 0)
+            addr.zone = -1;
+        return addr;
     }
 
     struct rowComponent : juce::Component, juce::DragAndDropTarget, juce::TextEditor::Listener
@@ -472,7 +498,20 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
 
         bool isInterestedInDragSource(const SourceDetails &dragSourceDetails) override
         {
-            return true; // !isZone();
+            // Always accept drags from other tree rows (zone/group reordering)
+            if (dynamic_cast<rowComponent *>(dragSourceDetails.sourceComponent.get()) != nullptr)
+                return true;
+            // Also accept browser sample drops (single or batch) onto group or zone rows
+            {
+                auto wsi = browser_ui::asSampleInfo(dragSourceDetails.sourceComponent);
+                if (wsi)
+                {
+                    if (wsi->encompassesMultipleSampleInfos())
+                        return !isZone(); // batch only onto group rows
+                    return shared::SampleDropSource::fromBrowserItem(wsi).isSingleSample();
+                }
+            }
+            return false;
         }
 
         void itemDragEnter(const SourceDetails &dragSourceDetails) override
@@ -494,6 +533,33 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
             auto sc = dragSourceDetails.sourceComponent;
             if (!sc) // weak component
                 return;
+
+            // Handle browser sample drop onto a group or zone row
+            {
+                auto wsi = browser_ui::asSampleInfo(dragSourceDetails.sourceComponent);
+                if (wsi)
+                {
+                    auto za = getZoneAddress();
+                    // For zone rows, resolve to the parent group
+                    int targetGroup = za.group;
+                    int targetPart = za.part;
+                    if (isZone())
+                    {
+                        // already have the right part/group — zone index doesn't matter
+                    }
+                    if (!isZone() && wsi->encompassesMultipleSampleInfos())
+                    {
+                        shared::executeBatchDropOnGroup(wsi, targetPart, targetGroup, gsb);
+                        return;
+                    }
+                    auto src = shared::SampleDropSource::fromBrowserItem(wsi);
+                    if (src.isSingleSample())
+                    {
+                        src.dropAsZoneInGroup(targetPart, targetGroup, gsb);
+                        return;
+                    }
+                }
+            }
 
             auto rd = dynamic_cast<rowComponent *>(sc.get());
             if (rd && rd->isZone())
@@ -614,7 +680,10 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
 
         bool isInterestedInDragSource(const SourceDetails &dragSourceDetails) override
         {
-            return fz; // !irsZone();
+            if (!fz)
+                return false;
+            // Only accept drags from other tree rows (zone reordering), not browser drops
+            return dynamic_cast<rowComponent *>(dragSourceDetails.sourceComponent.get()) != nullptr;
         }
 
         void itemDragEnter(const SourceDetails &dragSourceDetails) override
@@ -647,13 +716,23 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
 
                     if (rd->isDragMulti)
                     {
-                        gsb->sendToSerialization(cmsg::MoveZonesFromTo({lbm->selectedZones, tgt}));
+                        auto sz = lbm->selectedZones;
+                        // Filter out any selected zones with zone == -1
+                        std::erase_if(sz, [](const auto &za) { return za.zone == -1; });
+                        // if theres still zones available (so !sz.empty) go for it
+                        if (!sz.empty())
+                        {
+                            gsb->sendToSerialization(
+                                cmsg::MoveZonesFromTo({lbm->selectedZones, tgt}));
+                        }
                     }
                     else
                     {
                         auto src = rd->getZoneAddress();
-
-                        gsb->sendToSerialization(cmsg::MoveZonesFromTo({{src}, tgt}));
+                        if (src.zone > 0)
+                        {
+                            gsb->sendToSerialization(cmsg::MoveZonesFromTo({{src}, tgt}));
+                        }
                     }
                 }
                 else

--- a/src/scxt-plugin/app/edit-screen/components/PartGroupSidebar.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/PartGroupSidebar.cpp
@@ -41,13 +41,17 @@
 #include "GroupSettingsCard.h"
 #include "GroupTriggersCard.h"
 #include "app/shared/PartSidebarCard.h"
+#include "app/shared/SampleDropHandler.h"
 
 namespace scxt::ui::app::edit_screen
 {
 namespace jcmp = sst::jucegui::components;
 namespace cmsg = scxt::messaging::client;
 
-struct PartSidebar : juce::Component, HasEditor
+struct PartSidebar : juce::Component,
+                     HasEditor,
+                     juce::FileDragAndDropTarget,
+                     juce::DragAndDropTarget
 {
     PartGroupSidebar *partGroupSidebar{nullptr};
     std::unique_ptr<jcmp::Viewport> viewport;
@@ -151,10 +155,312 @@ struct PartSidebar : juce::Component, HasEditor
         addPartButton->setVisible(nDispParts < scxt::numParts);
         resized();
     }
+
+    // Drag state — kept during a drag for visual updates.
+    // All drop execution is recomputed from scratch at drop time to avoid the macOS
+    // fileDragExit-before-filesDropped ordering issue.
+    bool scmDragActive{false};
+    juce::String scmDragFileName;
+    bool sampleWarnActive{false}; // true when drag is plain audio — redirect to group/zone view
+
+    bool isInterestedInFileDrag(const juce::StringArray &files) override
+    {
+        if (files.isEmpty())
+            return false;
+        // Accept any recognizable audio or instrument file — WAVs show a redirect warning;
+        // instruments/SCPs/SCMs get the card overlay and actually load.
+        for (const auto &f : files)
+        {
+            if (f.endsWithIgnoreCase(".scp") || f.endsWithIgnoreCase(".scm"))
+                return true;
+            try
+            {
+                auto pt = fs::path{(const char *)(f.toUTF8())};
+                if (browser::Browser::isLoadableMultiSample(pt) ||
+                    browser::Browser::isLoadableSingleSample(pt))
+                    return true;
+            }
+            catch (fs::filesystem_error &)
+            {
+            }
+        }
+        return false;
+    }
+
+    // Returns the part index whose card is under (x, y) in PartSidebar local coordinates.
+    // Returns -1 if none.
+    int partAtPosition(int x, int y) const
+    {
+        // Convert to viewport-content coordinates
+        auto vpBounds = viewport->getBounds();
+        if (!vpBounds.contains(x, y))
+            return -1;
+        auto contentY = (y - vpBounds.getY()) + viewport->getViewPositionY();
+        for (int i = 0; i < scxt::numParts; ++i)
+        {
+            if (!parts[i]->isVisible())
+                continue;
+            auto b = parts[i]->getBounds();
+            if (b.getY() <= contentY && contentY < b.getBottom())
+                return i;
+        }
+        return -1;
+    }
+
+    // Show the "drop into group/zone view" redirect warning (plain audio files on part sidebar).
+    void showSampleWarn()
+    {
+        sampleWarnActive = true;
+        scmDragActive = false;
+        for (int i = 0; i < scxt::numParts; ++i)
+            parts[i]->clearDragOverlay();
+        repaint();
+    }
+
+    // Common drag-visual update used by both file-drag and browser-drag paths.
+    void updateDragFromSource(const shared::SampleDropSource &src, int x, int y)
+    {
+        // Plain audio sample — redirect to group/zone view instead of card overlay
+        if (src.isSingleSample())
+        {
+            showSampleWarn();
+            return;
+        }
+
+        if (src.showsFullSidebarHighlight())
+        {
+            sampleWarnActive = false;
+            scmDragActive = true;
+            scmDragFileName = src.displayName;
+            for (int i = 0; i < scxt::numParts; ++i)
+                parts[i]->clearDragOverlay();
+            repaint();
+            return;
+        }
+
+        sampleWarnActive = false;
+        scmDragActive = false;
+        int targetPart = partAtPosition(x, y);
+
+        bool isReplace = false;
+        if (targetPart >= 0 && src.showsReplaceSplit())
+        {
+            auto vpBounds = viewport->getBounds();
+            auto contentY = (y - vpBounds.getY()) + viewport->getViewPositionY();
+            auto cardBounds = parts[targetPart]->getBounds();
+            isReplace = contentY < (cardBounds.getY() + cardBounds.getHeight() / 2);
+        }
+
+        for (int i = 0; i < scxt::numParts; ++i)
+        {
+            if (!parts[i]->isVisible())
+                continue;
+            if (i == targetPart && !src.isNone())
+            {
+                using CDT = shared::PartSidebarCard::CardDragType;
+                auto cdt = src.isPartFile() ? CDT::SCP : CDT::Multi;
+                parts[i]->setDragOverlay(cdt, src.displayName, isReplace);
+            }
+            else
+            {
+                parts[i]->clearDragOverlay();
+            }
+        }
+        repaint();
+    }
+
+    void clearAllDragState()
+    {
+        scmDragActive = false;
+        sampleWarnActive = false;
+        for (int i = 0; i < scxt::numParts; ++i)
+            parts[i]->clearDragOverlay();
+        repaint();
+    }
+
+    void fileDragEnter(const juce::StringArray &files, int x, int y) override
+    {
+        if (files.size() == 1)
+        {
+            try
+            {
+                updateDragFromSource(
+                    shared::SampleDropSource::fromPath(fs::path{(const char *)files[0].toUTF8()}),
+                    x, y);
+            }
+            catch (fs::filesystem_error &)
+            {
+            }
+        }
+        else if (files.size() > 1)
+        {
+            showSampleWarn();
+        }
+    }
+
+    void fileDragMove(const juce::StringArray &files, int x, int y) override
+    {
+        if (files.size() == 1)
+        {
+            try
+            {
+                updateDragFromSource(
+                    shared::SampleDropSource::fromPath(fs::path{(const char *)files[0].toUTF8()}),
+                    x, y);
+            }
+            catch (fs::filesystem_error &)
+            {
+            }
+        }
+        else if (files.size() > 1)
+        {
+            showSampleWarn();
+        }
+    }
+
+    void fileDragExit(const juce::StringArray &) override { clearAllDragState(); }
+
+    void filesDropped(const juce::StringArray &files, int x, int y) override
+    {
+        // Clear visual state immediately. Do NOT use saved drag state — on macOS JUCE may call
+        // fileDragExit before filesDropped. Recompute everything from files/position instead.
+        clearAllDragState();
+
+        if (files.size() != 1)
+            return;
+
+        shared::SampleDropSource src;
+        try
+        {
+            src = shared::SampleDropSource::fromPath(fs::path{(const char *)files[0].toUTF8()});
+        }
+        catch (fs::filesystem_error &)
+        {
+            return;
+        }
+
+        if (src.isNone() || src.isSingleSample())
+            return; // plain audio: warn only, no action on part sidebar
+
+        if (src.isMultiFile())
+        {
+            src.dropOnPart(0, false, this);
+            return;
+        }
+
+        int dropTarget = partAtPosition(x, y);
+        if (dropTarget < 0)
+            return;
+
+        bool isReplace = false;
+        if (src.showsReplaceSplit())
+        {
+            auto vpBounds = viewport->getBounds();
+            auto contentY = (y - vpBounds.getY()) + viewport->getViewPositionY();
+            auto cardBounds = parts[dropTarget]->getBounds();
+            isReplace = contentY < (cardBounds.getY() + cardBounds.getHeight() / 2);
+        }
+
+        src.dropOnPart(dropTarget, isReplace, this);
+    }
+
+    // Internal (browser) drag-and-drop
+    bool isInterestedInDragSource(const SourceDetails &sd) override
+    {
+        return browser_ui::hasSampleInfo(sd.sourceComponent);
+    }
+
+    void itemDragEnter(const SourceDetails &sd) override
+    {
+        auto wsi = browser_ui::asSampleInfo(sd.sourceComponent);
+        if (!wsi)
+            return;
+        if (wsi->encompassesMultipleSampleInfos())
+            showSampleWarn(); // batch of audio files → redirect to group/zone view
+        else
+            updateDragFromSource(shared::SampleDropSource::fromBrowserItem(wsi), sd.localPosition.x,
+                                 sd.localPosition.y);
+    }
+
+    void itemDragMove(const SourceDetails &sd) override
+    {
+        auto wsi = browser_ui::asSampleInfo(sd.sourceComponent);
+        if (!wsi)
+            return;
+        if (wsi->encompassesMultipleSampleInfos())
+            showSampleWarn();
+        else
+            updateDragFromSource(shared::SampleDropSource::fromBrowserItem(wsi), sd.localPosition.x,
+                                 sd.localPosition.y);
+    }
+
+    void itemDragExit(const SourceDetails &) override { clearAllDragState(); }
+
+    void itemDropped(const SourceDetails &sd) override
+    {
+        clearAllDragState();
+
+        auto wsi = browser_ui::asSampleInfo(sd.sourceComponent);
+        if (!wsi)
+            return;
+
+        // Batch drops and plain audio files: redirect warning only, no action on part sidebar
+        if (wsi->encompassesMultipleSampleInfos())
+            return;
+
+        auto src = shared::SampleDropSource::fromBrowserItem(wsi);
+        if (src.isNone() || src.isSingleSample())
+            return;
+
+        // MultiFile (SCM) loads all parts — no specific card target required
+        if (src.isMultiFile())
+        {
+            src.dropOnPart(0, false, this);
+            return;
+        }
+
+        int dropTarget = partAtPosition(sd.localPosition.x, sd.localPosition.y);
+        if (dropTarget < 0)
+            return;
+
+        bool isReplace = false;
+        if (src.showsReplaceSplit())
+        {
+            auto vpBounds = viewport->getBounds();
+            auto contentY = (sd.localPosition.y - vpBounds.getY()) + viewport->getViewPositionY();
+            auto cardBounds = parts[dropTarget]->getBounds();
+            isReplace = contentY < (cardBounds.getY() + cardBounds.getHeight() / 2);
+        }
+
+        src.dropOnPart(dropTarget, isReplace, this);
+    }
+
+    void paintOverChildren(juce::Graphics &g) override
+    {
+        auto lb = viewport->getBounds().toFloat();
+
+        if (sampleWarnActive)
+        {
+            editor->occludeRegionWithText(g, lb, theme::ColorMap::warning_1b, theme::ColorMap::bg_1,
+                                          theme::ColorMap::generic_content_high,
+                                          {"Drop samples into the", "Group / Zone view"});
+            return;
+        }
+
+        if (!scmDragActive)
+            return;
+
+        editor->occludeRegionWithText(g, lb, theme::ColorMap::accent_1b, theme::ColorMap::bg_1,
+                                      theme::ColorMap::generic_content_high,
+                                      {"Replace all parts with", scmDragFileName.toStdString()});
+    }
 };
 
 template <typename T, bool forZone>
-struct GroupZoneSidebarBase : juce::Component, HasEditor, juce::DragAndDropContainer
+struct GroupZoneSidebarBase : juce::Component,
+                              HasEditor,
+                              juce::DragAndDropContainer,
+                              juce::FileDragAndDropTarget
 {
     PartGroupSidebar *partGroupSidebar{nullptr};
     std::unique_ptr<GroupZoneSidebarWidget<T, forZone>> gzTreeControl;
@@ -164,6 +470,64 @@ struct GroupZoneSidebarBase : juce::Component, HasEditor, juce::DragAndDropConta
 
     GroupZoneSidebarBase(PartGroupSidebar *p) : partGroupSidebar(p), HasEditor(p->editor) {}
     ~GroupZoneSidebarBase() {}
+
+    // FileDragAndDropTarget — accept single audio files from the OS; add as zones in current group
+    bool isInterestedInFileDrag(const juce::StringArray &files) override
+    {
+        if (files.isEmpty())
+            return false;
+        try
+        {
+            for (const auto &f : files)
+            {
+                auto p = fs::path{(const char *)(f.toUTF8())};
+                if (browser::Browser::isLoadableSingleSample(p))
+                    return true;
+            }
+        }
+        catch (fs::filesystem_error &)
+        {
+        }
+        return false;
+    }
+
+    void fileDragEnter(const juce::StringArray &, int, int) override {}
+    void fileDragMove(const juce::StringArray &, int, int) override {}
+    void fileDragExit(const juce::StringArray &) override {}
+
+    void filesDropped(const juce::StringArray &files, int x, int y) override
+    {
+        if (files.isEmpty())
+            return;
+
+        // Determine target group from drop position
+        std::optional<selection::SelectionManager::ZoneAddress> groupAddr;
+        if (gzTreeControl)
+        {
+            auto treePos = gzTreeControl->getBounds().getPosition();
+            groupAddr = gzTreeControl->groupAddressForDropPosition(x - treePos.x, y - treePos.y);
+        }
+
+        for (const auto &f : files)
+        {
+            shared::SampleDropSource src;
+            try
+            {
+                src = shared::SampleDropSource::fromPath(fs::path{(const char *)(f.toUTF8())});
+            }
+            catch (fs::filesystem_error &)
+            {
+                continue;
+            }
+            if (!src.isSingleSample())
+                continue;
+
+            if (groupAddr.has_value())
+                src.dropAsZoneInGroup(groupAddr->part, groupAddr->group, this);
+            else
+                src.dropAsZoneInCurrentGroup(this);
+        }
+    }
 
     void postInit()
     {
@@ -412,6 +776,138 @@ struct ZoneSidebar : GroupZoneSidebarBase<ZoneSidebar, true>
         lastZoneClicked = rowZone;
     }
 };
+
+// PartGroupSidebar FileDragAndDropTarget / DragAndDropTarget forwarding.
+//
+// JUCE's target-finding walk cannot cross Viewport content holders, so events that land on
+// PartGroupSidebar (the outermost named panel) need to be forwarded with coordinate translation
+// to whichever child sidebar tab is currently visible.
+
+static juce::DragAndDropTarget::SourceDetails
+adjustedDragDetails(const juce::DragAndDropTarget::SourceDetails &sd, juce::Component *target)
+{
+    auto d = sd;
+    d.localPosition -= target->getBounds().getPosition();
+    return d;
+}
+
+// Returns the translate offset for the currently visible sidebar child.
+template <typename Sidebar> static std::pair<int, int> offsetFor(const Sidebar *s, int x, int y)
+{
+    auto pos = s->getBounds().getPosition();
+    return {x - pos.x, y - pos.y};
+}
+
+bool PartGroupSidebar::isInterestedInFileDrag(const juce::StringArray &files)
+{
+    if (partSidebar && partSidebar->isVisible())
+        return partSidebar->isInterestedInFileDrag(files);
+    if (groupSidebar && groupSidebar->isVisible())
+        return groupSidebar->isInterestedInFileDrag(files);
+    if (zoneSidebar && zoneSidebar->isVisible())
+        return zoneSidebar->isInterestedInFileDrag(files);
+    return false;
+}
+
+void PartGroupSidebar::fileDragEnter(const juce::StringArray &files, int x, int y)
+{
+    if (partSidebar && partSidebar->isVisible())
+    {
+        auto [tx, ty] = offsetFor(partSidebar.get(), x, y);
+        partSidebar->fileDragEnter(files, tx, ty);
+    }
+    else if (groupSidebar && groupSidebar->isVisible())
+    {
+        auto [tx, ty] = offsetFor(groupSidebar.get(), x, y);
+        groupSidebar->fileDragEnter(files, tx, ty);
+    }
+    else if (zoneSidebar && zoneSidebar->isVisible())
+    {
+        auto [tx, ty] = offsetFor(zoneSidebar.get(), x, y);
+        zoneSidebar->fileDragEnter(files, tx, ty);
+    }
+}
+
+void PartGroupSidebar::fileDragMove(const juce::StringArray &files, int x, int y)
+{
+    if (partSidebar && partSidebar->isVisible())
+    {
+        auto [tx, ty] = offsetFor(partSidebar.get(), x, y);
+        partSidebar->fileDragMove(files, tx, ty);
+    }
+    else if (groupSidebar && groupSidebar->isVisible())
+    {
+        auto [tx, ty] = offsetFor(groupSidebar.get(), x, y);
+        groupSidebar->fileDragMove(files, tx, ty);
+    }
+    else if (zoneSidebar && zoneSidebar->isVisible())
+    {
+        auto [tx, ty] = offsetFor(zoneSidebar.get(), x, y);
+        zoneSidebar->fileDragMove(files, tx, ty);
+    }
+}
+
+void PartGroupSidebar::fileDragExit(const juce::StringArray &files)
+{
+    if (partSidebar)
+        partSidebar->fileDragExit(files);
+    if (groupSidebar)
+        groupSidebar->fileDragExit(files);
+    if (zoneSidebar)
+        zoneSidebar->fileDragExit(files);
+}
+
+void PartGroupSidebar::filesDropped(const juce::StringArray &files, int x, int y)
+{
+    if (partSidebar && partSidebar->isVisible())
+    {
+        auto [tx, ty] = offsetFor(partSidebar.get(), x, y);
+        partSidebar->filesDropped(files, tx, ty);
+    }
+    else if (groupSidebar && groupSidebar->isVisible())
+    {
+        auto [tx, ty] = offsetFor(groupSidebar.get(), x, y);
+        groupSidebar->filesDropped(files, tx, ty);
+    }
+    else if (zoneSidebar && zoneSidebar->isVisible())
+    {
+        auto [tx, ty] = offsetFor(zoneSidebar.get(), x, y);
+        zoneSidebar->filesDropped(files, tx, ty);
+    }
+}
+
+bool PartGroupSidebar::isInterestedInDragSource(const SourceDetails &sd)
+{
+    if (partSidebar && partSidebar->isVisible())
+        return partSidebar->isInterestedInDragSource(sd);
+    // Group/zone sidebars do not handle internal DnD at the container level;
+    // JUCE routes browser drags directly to rowComponent inside the tree.
+    return false;
+}
+
+void PartGroupSidebar::itemDragEnter(const SourceDetails &sd)
+{
+    if (partSidebar && partSidebar->isVisible())
+        partSidebar->itemDragEnter(adjustedDragDetails(sd, partSidebar.get()));
+}
+
+void PartGroupSidebar::itemDragMove(const SourceDetails &sd)
+{
+    if (partSidebar && partSidebar->isVisible())
+        partSidebar->itemDragMove(adjustedDragDetails(sd, partSidebar.get()));
+}
+
+void PartGroupSidebar::itemDragExit(const SourceDetails &sd)
+{
+    if (partSidebar)
+        partSidebar->itemDragExit(sd);
+}
+
+void PartGroupSidebar::itemDropped(const SourceDetails &sd)
+{
+    if (partSidebar && partSidebar->isVisible())
+        partSidebar->itemDropped(adjustedDragDetails(sd, partSidebar.get()));
+}
 
 PartGroupSidebar::PartGroupSidebar(SCXTEditor *e)
     : HasEditor(e), sst::jucegui::components::NamedPanel("Parts n Groups")

--- a/src/scxt-plugin/app/edit-screen/components/PartGroupSidebar.h
+++ b/src/scxt-plugin/app/edit-screen/components/PartGroupSidebar.h
@@ -39,7 +39,10 @@ struct GroupSidebar;
 struct PartSidebar;
 struct ZoneSidebar;
 
-struct PartGroupSidebar : sst::jucegui::components::NamedPanel, HasEditor
+struct PartGroupSidebar : sst::jucegui::components::NamedPanel,
+                          HasEditor,
+                          juce::FileDragAndDropTarget,
+                          juce::DragAndDropTarget
 {
     PartGroupSidebar(SCXTEditor *);
     ~PartGroupSidebar();
@@ -69,6 +72,20 @@ struct PartGroupSidebar : sst::jucegui::components::NamedPanel, HasEditor
     void showHamburgerMenu();
 
     void resized() override;
+
+    // FileDragAndDropTarget — forwards to partSidebar when the parts tab is visible
+    bool isInterestedInFileDrag(const juce::StringArray &files) override;
+    void fileDragEnter(const juce::StringArray &files, int x, int y) override;
+    void fileDragMove(const juce::StringArray &files, int x, int y) override;
+    void fileDragExit(const juce::StringArray &files) override;
+    void filesDropped(const juce::StringArray &files, int x, int y) override;
+
+    // DragAndDropTarget — forwards to partSidebar when the parts tab is visible
+    bool isInterestedInDragSource(const SourceDetails &sd) override;
+    void itemDragEnter(const SourceDetails &sd) override;
+    void itemDragMove(const SourceDetails &sd) override;
+    void itemDragExit(const SourceDetails &sd) override;
+    void itemDropped(const SourceDetails &sd) override;
 };
 } // namespace scxt::ui::app::edit_screen
 

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
@@ -32,6 +32,7 @@
 #include "ZoneLayoutDisplay.h"
 #include "ZoneLayoutKeyboard.h"
 #include "engine/zone.h"
+#include "app/shared/MultiInstrumentPrompt.h"
 
 #include <app/edit-screen/EditScreen.h>
 
@@ -443,10 +444,15 @@ bool MappingDisplay::isInterestedInDragSource(
 }
 void MappingDisplay::itemDropped(const juce::DragAndDropTarget::SourceDetails &dragSourceDetails)
 {
+    isUndertakingDrop = false;
+    currentDragSource = {};
+    // Recompute replace vs add from drop position — do not rely on saved drag state
+    bool savedReplace = dragSourceDetails.localPosition.x <
+                        (zoneLayoutViewport->getX() + zoneLayoutViewport->getWidth() / 2);
+
     auto wsi = browser_ui::asSampleInfo(dragSourceDetails.sourceComponent);
     if (wsi)
     {
-        namespace cmsg = scxt::messaging::client;
         auto r = mappingZones->rootAndRangeForPosition(dragSourceDetails.localPosition,
                                                        dropElementCount, false);
         assert(r.size() > 0);
@@ -466,10 +472,7 @@ void MappingDisplay::itemDropped(const juce::DragAndDropTarget::SourceDetails &d
                     sendToSerialization(cmsg::AddCompoundElementWithRange(
                         {*e->getCompoundElement(), loc.root, loc.lo, loc.hi, loc.vlo, loc.vhi}));
                 }
-                else if (
-                    e->getDirEnt()
-                        .has_value()) //  &&
-                                      //  !browser::Browser::isLoadableSingleSample(wsi->getDirEnt()->path()))
+                else if (e->getDirEnt().has_value())
                 {
                     sendToSerialization(
                         cmsg::AddSampleWithRange({e->getDirEnt()->path().u8string(), loc.root,
@@ -481,6 +484,9 @@ void MappingDisplay::itemDropped(const juce::DragAndDropTarget::SourceDetails &d
         {
             auto loc = r[0];
             assert(r.size() == 1);
+            auto src = shared::SampleDropSource::fromBrowserItem(wsi);
+            if (src.isInstrumentWhichCanReplace() && savedReplace)
+                sendToSerialization(cmsg::ClearPart(editor->selectedPart));
             sendToSerialization(cmsg::AddCompoundElementWithRange(
                 {*wsi->getCompoundElement(), loc.root, loc.lo, loc.hi, loc.vlo, loc.vhi}));
         }
@@ -488,14 +494,32 @@ void MappingDisplay::itemDropped(const juce::DragAndDropTarget::SourceDetails &d
         {
             auto loc = r[0];
             assert(r.size() == 1);
-            auto inst = browser::Browser::getMultiInstrumentElements(wsi->getDirEnt()->path());
-            if (inst.empty())
-                sendToSerialization(
-                    cmsg::AddSampleWithRange({wsi->getDirEnt()->path().u8string(), loc.root, loc.lo,
-                                              loc.hi, loc.vlo, loc.vhi}));
-            else
+            auto src = shared::SampleDropSource::fromBrowserItem(wsi);
+
+            if (src.isPartFile())
             {
-                promptForMultiInstrument(inst);
+                sendToSerialization(
+                    cmsg::LoadPartInto({src.pathStr, (int16_t)editor->selectedPart}));
+            }
+            else if (src.isMultiFile())
+            {
+                // SCM onto the mapping pane is not allowed
+            }
+            else if (src.isInstrumentWhichCanReplace())
+            {
+                if (savedReplace)
+                    sendToSerialization(cmsg::ClearPart(editor->selectedPart));
+                auto inst = browser::Browser::getMultiInstrumentElements(wsi->getDirEnt()->path());
+                if (inst.empty())
+                    sendToSerialization(cmsg::AddSampleWithRange(
+                        {src.pathStr, loc.root, loc.lo, loc.hi, loc.vlo, loc.vhi}));
+                else
+                    promptForMultiInstrument(inst);
+            }
+            else if (src.isSingleSample())
+            {
+                sendToSerialization(cmsg::AddSampleWithRange(
+                    {src.pathStr, loc.root, loc.lo, loc.hi, loc.vlo, loc.vhi}));
             }
         }
     }
@@ -503,31 +527,58 @@ void MappingDisplay::itemDropped(const juce::DragAndDropTarget::SourceDetails &d
     {
         editor->editScreen->partSidebar->setSelectedTab(2);
     }
-    isUndertakingDrop = false;
     repaint();
 }
 void MappingDisplay::itemDragEnter(const juce::DragAndDropTarget::SourceDetails &dragSourceDetails)
 {
-    // TODO Compound types are special here
     isUndertakingDrop = true;
     currentDragPoint = dragSourceDetails.localPosition;
+    currentDragSource = {};
+
+    auto wsi = browser_ui::asSampleInfo(dragSourceDetails.sourceComponent);
+    if (wsi && !wsi->encompassesMultipleSampleInfos())
+    {
+        currentDragSource = shared::SampleDropSource::fromBrowserItem(wsi);
+        if (currentDragSource.isInstrumentWhichCanReplace())
+        {
+            dragIsOnReplaceSide = dragSourceDetails.localPosition.x <
+                                  (zoneLayoutViewport->getX() + zoneLayoutViewport->getWidth() / 2);
+        }
+    }
     repaint();
 }
 
 void MappingDisplay::itemDragExit(const juce::DragAndDropTarget::SourceDetails &dragSourceDetails)
 {
     isUndertakingDrop = false;
+    currentDragSource = {};
     repaint();
 }
 
 void MappingDisplay::itemDragMove(const juce::DragAndDropTarget::SourceDetails &dragSourceDetails)
 {
     currentDragPoint = dragSourceDetails.localPosition;
+    if (currentDragSource.isInstrumentWhichCanReplace())
+    {
+        dragIsOnReplaceSide = dragSourceDetails.localPosition.x <
+                              (zoneLayoutViewport->getX() + zoneLayoutViewport->getWidth() / 2);
+    }
     repaint();
 }
 
 bool MappingDisplay::isInterestedInFileDrag(const juce::StringArray &files)
 {
+    // SCP: replace this part. SCM: show "can't drop" warning (accepted for visual, rejected on
+    // drop).
+    if (files.size() == 1)
+    {
+        if (files[0].endsWithIgnoreCase(".scp") || files[0].endsWithIgnoreCase(".scm"))
+        {
+            dropElementCount = 1;
+            return true;
+        }
+    }
+
     auto allLoadable = std::all_of(files.begin(), files.end(), [this](const auto &f) {
         try
         {
@@ -549,22 +600,100 @@ void MappingDisplay::fileDragEnter(const juce::StringArray &files, int x, int y)
 {
     isUndertakingDrop = true;
     currentDragPoint = {x, y};
+    currentDragSource = {};
+
+    if (files.size() == 1)
+    {
+        try
+        {
+            currentDragSource =
+                shared::SampleDropSource::fromPath(fs::path{(const char *)files[0].toUTF8()});
+            if (currentDragSource.isInstrumentWhichCanReplace())
+                dragIsOnReplaceSide =
+                    x < (zoneLayoutViewport->getX() + zoneLayoutViewport->getWidth() / 2);
+        }
+        catch (fs::filesystem_error &)
+        {
+        }
+    }
     repaint();
 }
+
 void MappingDisplay::fileDragMove(const juce::StringArray &files, int x, int y)
 {
     isUndertakingDrop = true;
     currentDragPoint = {x, y};
+    if (currentDragSource.isInstrumentWhichCanReplace())
+        dragIsOnReplaceSide = x < (zoneLayoutViewport->getX() + zoneLayoutViewport->getWidth() / 2);
     repaint();
 }
-void MappingDisplay::fileDragExit(const juce::StringArray &files)
+
+void MappingDisplay::fileDragExit(const juce::StringArray &)
 {
     isUndertakingDrop = false;
+    currentDragSource = {};
     repaint();
 }
+
 void MappingDisplay::filesDropped(const juce::StringArray &files, int x, int y)
 {
-    namespace cmsg = scxt::messaging::client;
+    // Do NOT rely on saved drag state — on macOS JUCE may call fileDragExit before filesDropped.
+    // Recompute everything from files and drop position.
+    isUndertakingDrop = false;
+    currentDragSource = {};
+
+    if (files.size() == 1)
+    {
+        shared::SampleDropSource src;
+        try
+        {
+            src = shared::SampleDropSource::fromPath(fs::path{(const char *)files[0].toUTF8()});
+        }
+        catch (fs::filesystem_error &)
+        {
+            repaint();
+            return;
+        }
+
+        if (src.isPartFile())
+        {
+            sendToSerialization(cmsg::LoadPartInto({src.pathStr, (int16_t)editor->selectedPart}));
+            repaint();
+            return;
+        }
+        if (src.isMultiFile())
+        {
+            // SCM onto the mapping pane is not allowed
+            repaint();
+            return;
+        }
+    }
+
+    // Recompute replace vs add from drop position (left half = replace, right half = add)
+    bool isReplace = x < (zoneLayoutViewport->getX() + zoneLayoutViewport->getWidth() / 2);
+
+    // Clear part first if all dropped files are instrument containers and we're replacing
+    bool allInstrument = !files.isEmpty();
+    for (auto &f : files)
+    {
+        try
+        {
+            if (!shared::SampleDropSource::fromPath(fs::path{(const char *)f.toUTF8()})
+                     .isInstrumentWhichCanReplace())
+            {
+                allInstrument = false;
+                break;
+            }
+        }
+        catch (fs::filesystem_error &)
+        {
+            allInstrument = false;
+            break;
+        }
+    }
+    if (allInstrument && isReplace)
+        sendToSerialization(cmsg::ClearPart(editor->selectedPart));
+
     auto regions = mappingZones->rootAndRangeForPosition({x, y}, files.size(), false);
     int lidx{0};
     for (auto f : files)
@@ -583,113 +712,68 @@ void MappingDisplay::filesDropped(const juce::StringArray &files, int x, int y)
         }
     }
     if (editor->editScreen->partSidebar)
-    {
         editor->editScreen->partSidebar->setSelectedTab(2);
-    }
-    isUndertakingDrop = false;
     repaint();
 }
-
-struct InstrumentPrompt : sst::jucegui::screens::ModalBase
-{
-    MappingDisplay *display{nullptr};
-    std::vector<sample::compound::CompoundElement> instruments;
-    std::unique_ptr<jcmp::TextPushButton> ok, cancel;
-    std::unique_ptr<jcmp::MenuButton> multiInst;
-    int selInstrument{0};
-    InstrumentPrompt(MappingDisplay *d, const std::vector<sample::compound::CompoundElement> &i)
-        : instruments(i), display(d)
-    {
-        ok = std::make_unique<jcmp::TextPushButton>();
-        ok->setLabel("OK");
-        ok->setOnCallback([this]() {
-            sendSelection();
-            setVisible(false);
-        });
-        cancel = std::make_unique<jcmp::TextPushButton>();
-        cancel->setLabel("Cancel");
-        cancel->setOnCallback([this]() { setVisible(false); });
-
-        selInstrument = 0;
-        multiInst = std::make_unique<jcmp::MenuButton>();
-        multiInst->setLabel(instruments[0].name);
-        multiInst->setOnCallback([this]() { showMenu(); });
-        addAndMakeVisible(*ok);
-        addAndMakeVisible(*cancel);
-        addAndMakeVisible(*multiInst);
-    }
-
-    void sendSelection()
-    {
-        display->sendToSerialization(
-            cmsg::AddCompoundElementWithRange({instruments[selInstrument], 60, 0, 127, 0, 127}));
-    }
-
-    void showMenu()
-    {
-        auto p = juce::PopupMenu();
-        p.addSectionHeader("Select Instrument");
-        p.addSeparator();
-        int idx{0};
-        for (auto &i : instruments)
-        {
-            p.addItem(instruments[idx].name, [this, ci = idx]() {
-                selInstrument = ci;
-                multiInst->setLabel(instruments[ci].name);
-            });
-            idx++;
-        }
-        p.showMenuAsync(juce::PopupMenu::Options().withTargetComponent(multiInst.get()));
-    }
-
-    static constexpr int titleSize{18}, margin{4}, buttonWidth{80};
-
-    void paintContents(juce::Graphics &g) override
-    {
-        auto p = getContentArea().reduced(4);
-
-        g.setColour(getColour(Styles::brightoutline));
-        g.drawHorizontalLine(p.getY() + titleSize + margin, p.getX(), p.getRight());
-        g.setFont(
-            style()->getFont(jcmp::Label::Styles::styleClass, jcmp::Label::Styles::labelfont));
-        g.setColour(
-            style()->getColour(jcmp::Label::Styles::styleClass, jcmp::Label::Styles::labelcolor));
-        g.drawText("Select Instrument", p.withHeight(titleSize), juce::Justification::centredLeft);
-    }
-    juce::Point<int> innerContentSize() override { return {300, 150}; }
-
-    void resized() override
-    {
-        ModalBase::resized();
-        auto p = getContentArea().reduced(4);
-
-        auto buttonBox = p.withTrimmedTop(p.getHeight() - titleSize)
-                             .withWidth(buttonWidth)
-                             .translated(p.getWidth() - buttonWidth, 0);
-
-        multiInst->setBounds(
-            p.withHeight(titleSize + margin).translated(0, titleSize * 2).reduced(10, 0));
-        if (cancel)
-        {
-            cancel->setBounds(buttonBox);
-            buttonBox = buttonBox.translated(-buttonWidth - margin, 0);
-        }
-        if (ok)
-        {
-            ok->setBounds(buttonBox);
-        }
-    }
-};
 
 void MappingDisplay::promptForMultiInstrument(
     const std::vector<sample::compound::CompoundElement> &inst)
 {
-    if (inst.size() == 1 && inst[0].type == sample::compound::CompoundElement::ERROR_SENTINEL)
-    {
-        editor->displayError(inst[0].name, inst[0].emsg);
+    shared::promptForMultiInstrument(editor, inst, [this](const auto &elem) {
+        sendToSerialization(cmsg::AddCompoundElementWithRange({elem, 60, 0, 127, 0, 127}));
+    });
+}
+
+void MappingDisplay::paintOverChildren(juce::Graphics &g)
+{
+    if (!isUndertakingDrop || currentDragSource.isNone())
         return;
+
+    auto lb = zoneLayoutViewport->getBounds().toFloat();
+
+    if (currentDragSource.isPartFile())
+    {
+        editor->occludeRegionWithText(
+            g, lb, theme::ColorMap::accent_1b, theme::ColorMap::bg_1,
+            theme::ColorMap::generic_content_high,
+            {"Replace this part with", currentDragSource.displayName.toStdString()});
     }
-    editor->displayModalOverlay(std::make_unique<InstrumentPrompt>(this, inst));
+    else if (currentDragSource.isMultiFile())
+    {
+        editor->occludeRegionWithText(g, lb, theme::ColorMap::warning_1a, theme::ColorMap::bg_1,
+                                      theme::ColorMap::generic_content_high,
+                                      {"Cannot drop multi onto mapping.", "Use the load function"});
+    }
+    else if (currentDragSource.isInstrumentWhichCanReplace())
+    {
+        auto halfX = lb.getX() + lb.getWidth() * 0.5f;
+        auto replaceHalf = lb.withRight(halfX);
+        auto addHalf = lb.withLeft(halfX);
+
+        // Shared bg_1 base
+        g.setColour(editor->themeColor(theme::ColorMap::bg_1));
+        g.fillRect(lb);
+
+        // Active half: frontColor@0.35; inactive half: frontColor@0.15
+        auto frontCol = editor->themeColor(theme::ColorMap::accent_1b);
+        g.setColour(frontCol.withAlpha(dragIsOnReplaceSide ? 0.35f : 0.15f));
+        g.fillRect(replaceHalf);
+        g.setColour(frontCol.withAlpha(dragIsOnReplaceSide ? 0.15f : 0.35f));
+        g.fillRect(addHalf);
+
+        // Text
+        g.setColour(editor->themeColor(theme::ColorMap::generic_content_high));
+        g.setFont(editor->themeApplier.interMediumFor(13));
+        g.drawText("Drop here to replace part", replaceHalf.toNearestInt(),
+                   juce::Justification::centred);
+        g.drawText("Drop here to add to part", addHalf.toNearestInt(),
+                   juce::Justification::centred);
+
+        // Outer 2px border + divider
+        g.setColour(frontCol);
+        g.drawRect(lb, 2.f);
+        g.drawVerticalLine((int)halfX, lb.getY(), lb.getBottom());
+    }
 }
 
 void MappingDisplay::doZoneRename(const selection::SelectionManager::ZoneAddress &z)

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.h
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.h
@@ -43,6 +43,7 @@
 #include "connectors/PayloadDataAttachment.h"
 #include "app/HasEditor.h"
 #include "app/edit-screen/components/MacroMappingVariantPane.h"
+#include "app/shared/SampleDropHandler.h"
 
 namespace scxt::ui::app::edit_screen
 {
@@ -188,6 +189,11 @@ struct MappingDisplay : juce::Component,
     void fileDragExit(const juce::StringArray &files) override;
     void filesDropped(const juce::StringArray &files, int x, int y) override;
 
+    // Drag overlay state — used by ZoneLayoutDisplay paint and MappingDisplay::paintOverChildren
+    shared::SampleDropSource currentDragSource;
+    bool dragIsOnReplaceSide{false}; // true = left (replace) half, for Instrument kind
+
+    void paintOverChildren(juce::Graphics &g) override;
     void promptForMultiInstrument(const std::vector<sample::compound::CompoundElement> &);
 
     void doZoneRename(const selection::SelectionManager::ZoneAddress &z);

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
@@ -900,9 +900,10 @@ void ZoneLayoutDisplay::paint(juce::Graphics &g)
         }
     }
 
-    if (display->isUndertakingDrop)
+    if (display->isUndertakingDrop && display->currentDragSource.isNone())
     {
-        // this can be expanded some....
+        // Zone-placement preview: only shown for regular single-sample drops.
+        // SCP/SCM/Multi overlays are painted by MappingDisplay::paintOverChildren instead.
         auto ranges =
             rootAndRangeForPosition(display->currentDragPoint, display->dropElementCount, false);
         auto mul = ranges.size() > 1;

--- a/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
@@ -578,6 +578,37 @@ juce::Colour SCXTEditor::themeColor(scxt::ui::theme::ColorMap::Colors c, float a
     return themeApplier.colors->get(c, alpha);
 }
 
+void SCXTEditor::occludeRegionWithText(juce::Graphics &g, juce::Rectangle<float> rect,
+                                       theme::ColorMap::Colors frontColor,
+                                       theme::ColorMap::Colors bgColor,
+                                       theme::ColorMap::Colors textColor,
+                                       const std::vector<std::string> &textLines) const
+{
+    g.setColour(themeColor(bgColor));
+    g.fillRect(rect);
+    g.setColour(themeColor(frontColor, 0.35f));
+    g.fillRect(rect);
+    g.setColour(themeColor(frontColor));
+    g.drawRect(rect, 2.f);
+
+    int n = (int)textLines.size();
+    if (n > 0)
+    {
+        g.setColour(themeColor(textColor));
+        g.setFont(themeApplier.interMediumFor(13));
+        float lineH = g.getCurrentFont().getHeight() + 4.f;
+        float totalH = n * lineH;
+        float startY = rect.getY() + (rect.getHeight() - totalH) * 0.5f;
+        for (int i = 0; i < n; ++i)
+        {
+            auto lineRect =
+                juce::Rectangle<float>(rect.getX(), startY + i * lineH, rect.getWidth(), lineH);
+            g.drawFittedText(juce::String::fromUTF8(textLines[i].c_str()), lineRect.toNearestInt(),
+                             juce::Justification::centred, 1, 1.f);
+        }
+    }
+}
+
 void SCXTEditor::resetColorsFromUserPreferences()
 {
     auto cmid = defaultsProvider.getUserDefaultValue(infrastructure::DefaultKeys::colormapId,

--- a/src/scxt-plugin/app/shared/MultiInstrumentPrompt.h
+++ b/src/scxt-plugin/app/shared/MultiInstrumentPrompt.h
@@ -1,0 +1,151 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_SCXT_PLUGIN_APP_SHARED_MULTIINSTRUMENTPROMPT_H
+#define SCXT_SRC_SCXT_PLUGIN_APP_SHARED_MULTIINSTRUMENTPROMPT_H
+
+#include <functional>
+#include <juce_gui_basics/juce_gui_basics.h>
+#include "sst/jucegui/screens/ModalBase.h"
+#include "sst/jucegui/components/TextPushButton.h"
+#include "sst/jucegui/components/MenuButton.h"
+#include "sst/jucegui/components/Label.h"
+#include "sample/compound_file.h"
+#include "app/SCXTEditor.h"
+
+namespace scxt::ui::app::shared
+{
+namespace jcmp = sst::jucegui::components;
+
+// Modal dialog for selecting a specific instrument from a multi-instrument file (e.g. SF2).
+// The onSelected callback is called with the chosen CompoundElement when the user clicks OK.
+struct InstrumentPrompt : sst::jucegui::screens::ModalBase
+{
+    std::vector<sample::compound::CompoundElement> instruments;
+    std::unique_ptr<jcmp::TextPushButton> ok, cancel;
+    std::unique_ptr<jcmp::MenuButton> multiInst;
+    int selInstrument{0};
+    std::function<void(const sample::compound::CompoundElement &)> onSelected;
+
+    InstrumentPrompt(const std::vector<sample::compound::CompoundElement> &i,
+                     std::function<void(const sample::compound::CompoundElement &)> cb)
+        : instruments(i), onSelected(std::move(cb))
+    {
+        ok = std::make_unique<jcmp::TextPushButton>();
+        ok->setLabel("OK");
+        ok->setOnCallback([this]() {
+            if (onSelected)
+                onSelected(instruments[selInstrument]);
+            setVisible(false);
+        });
+        cancel = std::make_unique<jcmp::TextPushButton>();
+        cancel->setLabel("Cancel");
+        cancel->setOnCallback([this]() { setVisible(false); });
+
+        selInstrument = 0;
+        multiInst = std::make_unique<jcmp::MenuButton>();
+        multiInst->setLabel(instruments[0].name);
+        multiInst->setOnCallback([this]() { showMenu(); });
+        addAndMakeVisible(*ok);
+        addAndMakeVisible(*cancel);
+        addAndMakeVisible(*multiInst);
+    }
+
+    void showMenu()
+    {
+        auto p = juce::PopupMenu();
+        p.addSectionHeader("Select Instrument");
+        p.addSeparator();
+        int idx{0};
+        for (auto &i : instruments)
+        {
+            p.addItem(instruments[idx].name, [this, ci = idx]() {
+                selInstrument = ci;
+                multiInst->setLabel(instruments[ci].name);
+            });
+            idx++;
+        }
+        p.showMenuAsync(juce::PopupMenu::Options().withTargetComponent(multiInst.get()));
+    }
+
+    static constexpr int titleSize{18}, margin{4}, buttonWidth{80};
+
+    void paintContents(juce::Graphics &g) override
+    {
+        auto p = getContentArea().reduced(4);
+
+        g.setColour(getColour(Styles::brightoutline));
+        g.drawHorizontalLine(p.getY() + titleSize + margin, p.getX(), p.getRight());
+        g.setFont(
+            style()->getFont(jcmp::Label::Styles::styleClass, jcmp::Label::Styles::labelfont));
+        g.setColour(
+            style()->getColour(jcmp::Label::Styles::styleClass, jcmp::Label::Styles::labelcolor));
+        g.drawText("Select Instrument", p.withHeight(titleSize), juce::Justification::centredLeft);
+    }
+
+    juce::Point<int> innerContentSize() override { return {300, 150}; }
+
+    void resized() override
+    {
+        ModalBase::resized();
+        auto p = getContentArea().reduced(4);
+
+        auto buttonBox = p.withTrimmedTop(p.getHeight() - titleSize)
+                             .withWidth(buttonWidth)
+                             .translated(p.getWidth() - buttonWidth, 0);
+
+        multiInst->setBounds(
+            p.withHeight(titleSize + margin).translated(0, titleSize * 2).reduced(10, 0));
+        if (cancel)
+        {
+            cancel->setBounds(buttonBox);
+            buttonBox = buttonBox.translated(-buttonWidth - margin, 0);
+        }
+        if (ok)
+        {
+            ok->setBounds(buttonBox);
+        }
+    }
+};
+
+// Show the multi-instrument selection prompt, or an error dialog for ERROR_SENTINEL results.
+// onSelected is called with the chosen element only if the user clicks OK.
+inline void
+promptForMultiInstrument(SCXTEditor *editor,
+                         const std::vector<sample::compound::CompoundElement> &inst,
+                         std::function<void(const sample::compound::CompoundElement &)> onSelected)
+{
+    if (inst.size() == 1 && inst[0].type == sample::compound::CompoundElement::ERROR_SENTINEL)
+    {
+        editor->displayError(inst[0].name, inst[0].emsg);
+        return;
+    }
+    editor->displayModalOverlay(std::make_unique<InstrumentPrompt>(inst, std::move(onSelected)));
+}
+
+} // namespace scxt::ui::app::shared
+#endif // SCXT_SRC_SCXT_PLUGIN_APP_SHARED_MULTIINSTRUMENTPROMPT_H

--- a/src/scxt-plugin/app/shared/PartSidebarCard.cpp
+++ b/src/scxt-plugin/app/shared/PartSidebarCard.cpp
@@ -515,29 +515,61 @@ void PartSidebarCard::showPartBlurbTooltip()
 
 void PartSidebarCard::hidePartBlurbTooltip() { editor->hideTooltip(); }
 
-bool PartSidebarCard::isInterestedInFileDrag(const juce::StringArray &files)
+void PartSidebarCard::setDragOverlay(CardDragType type, const juce::String &filename,
+                                     bool isReplace)
 {
-    return files.size() == 1 && files[0].endsWithIgnoreCase(".scp");
+    cardDragType = type;
+    cardDragFileName = filename;
+    cardDragIsOnReplaceSide = isReplace;
+    repaint();
 }
 
-void PartSidebarCard::filesDropped(const juce::StringArray &files, int x, int y)
+void PartSidebarCard::clearDragOverlay()
 {
-    if (files.size() == 1)
-    {
-        auto f = files[0];
-        if (f.endsWithIgnoreCase(".scp"))
-        {
-            editor->promptOKCancel(
-                "Load into Part " + std::to_string(part + 1),
-                "By loading the file you will clear the part and replace it with the contents of "
-                "the file. Continue?",
-                [w = juce::Component::SafePointer(this), f]() {
-                    if (!w)
-                        return;
+    cardDragType = CardDragType::None;
+    repaint();
+}
 
-                    w->sendToSerialization(cmsg::LoadPartInto({std::string(f.toUTF8()), w->part}));
-                });
-        }
+void PartSidebarCard::paintOverChildren(juce::Graphics &g)
+{
+    if (cardDragType == CardDragType::None)
+        return;
+
+    auto lb = getLocalBounds().toFloat();
+
+    if (cardDragType == CardDragType::SCP)
+    {
+        editor->occludeRegionWithText(g, lb, theme::ColorMap::accent_1b, theme::ColorMap::bg_1,
+                                      theme::ColorMap::generic_content_high,
+                                      {"Replace with", cardDragFileName.toStdString()});
+    }
+    else if (cardDragType == CardDragType::Multi)
+    {
+        auto halfY = lb.getY() + lb.getHeight() * 0.5f;
+        auto replaceHalf = lb.withBottom(halfY);
+        auto addHalf = lb.withTop(halfY);
+
+        // Shared bg_1 base for the whole card
+        g.setColour(editor->themeColor(theme::ColorMap::bg_1));
+        g.fillRect(lb);
+
+        // Active half: frontColor@0.35; inactive half: frontColor@0.15
+        auto frontCol = editor->themeColor(theme::ColorMap::accent_1b);
+        g.setColour(frontCol.withAlpha(cardDragIsOnReplaceSide ? 0.35f : 0.15f));
+        g.fillRect(replaceHalf);
+        g.setColour(frontCol.withAlpha(cardDragIsOnReplaceSide ? 0.15f : 0.35f));
+        g.fillRect(addHalf);
+
+        // Text
+        g.setColour(editor->themeColor(theme::ColorMap::generic_content_high));
+        g.setFont(editor->themeApplier.interMediumFor(11));
+        g.drawText("Replace part", replaceHalf.toNearestInt(), juce::Justification::centred);
+        g.drawText("Add to part", addHalf.toNearestInt(), juce::Justification::centred);
+
+        // Outer 2px border + divider line
+        g.setColour(frontCol);
+        g.drawRect(lb, 2.f);
+        g.drawHorizontalLine((int)halfY, lb.getX(), lb.getRight());
     }
 }
 } // namespace scxt::ui::app::shared

--- a/src/scxt-plugin/app/shared/PartSidebarCard.h
+++ b/src/scxt-plugin/app/shared/PartSidebarCard.h
@@ -44,8 +44,7 @@ namespace scxt::ui::app::shared
 struct PartSidebarCard : juce::Component,
                          HasEditor,
                          sst::jucegui::components::WithIdleTimer,
-                         juce::TextEditor::Listener,
-                         juce::FileDragAndDropTarget
+                         juce::TextEditor::Listener
 {
     int part;
 
@@ -103,8 +102,21 @@ struct PartSidebarCard : juce::Component,
 
     void resetFromEditorCache();
 
-    bool isInterestedInFileDrag(const juce::StringArray &files) override;
-    void filesDropped(const juce::StringArray &files, int x, int y) override;
+    // Drag overlay state — set by the PartSidebar container (which owns all file drag events)
+    enum class CardDragType
+    {
+        None,
+        SCP,
+        Multi
+    };
+    CardDragType cardDragType{CardDragType::None};
+    juce::String cardDragFileName;
+    bool cardDragIsOnReplaceSide{false}; // for Multi: true = top (replace) half
+
+    void setDragOverlay(CardDragType type, const juce::String &filename, bool isReplace);
+    void clearDragOverlay();
+
+    void paintOverChildren(juce::Graphics &g) override;
 };
 } // namespace scxt::ui::app::shared
 #endif // SHORTCIRCUITXT_PARTSIDEBARCARD_H

--- a/src/scxt-plugin/app/shared/SampleDropHandler.h
+++ b/src/scxt-plugin/app/shared/SampleDropHandler.h
@@ -1,0 +1,282 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_SCXT_PLUGIN_APP_SHARED_SAMPLEDROPHANDLER_H
+#define SCXT_SRC_SCXT_PLUGIN_APP_SHARED_SAMPLEDROPHANDLER_H
+
+#include <juce_gui_basics/juce_gui_basics.h>
+// MultiInstrumentPrompt pulls in SCXTEditor.h → messaging/messaging.h which must come before
+// structure_messages.h (structure_messages.h depends on the client_serial enums)
+#include "app/shared/MultiInstrumentPrompt.h"
+#include "browser/browser.h"
+#include "sample/compound_file.h"
+#include "app/browser-ui/BrowserPaneInterfaces.h"
+#include "messaging/client/structure_messages.h"
+
+namespace scxt::ui::app::shared
+{
+
+// Classifies a drag/drop source to drive visual affordances and message dispatch.
+// Covers both external file drops (fs::path) and internal browser drags (WithSampleInfo).
+struct SampleDropSource
+{
+    enum class Kind
+    {
+        None,       // Not a recognized sample source
+        MultiFile,  // .scm — replaces the whole multi
+        PartFile,   // .scp — loads into one part
+        Instrument, // SF2/SFZ/GIG/EXS/AKP or CompoundElement::INSTRUMENT — replace-or-append
+        Sample,     // Single audio file (WAV/FLAC/MP3/etc) or CompoundElement::SAMPLE
+    };
+
+    Kind kind{Kind::None};
+    juce::String displayName;
+    std::string pathStr;                                      // set if source is a file path
+    std::optional<sample::compound::CompoundElement> element; // set if source is a compound element
+
+    // ---- Predicates ----
+
+    bool isNone() const { return kind == Kind::None; }
+    bool isMultiFile() const { return kind == Kind::MultiFile; }
+    bool isPartFile() const { return kind == Kind::PartFile; }
+    // An instrument-container (SF2 preset / multi-sample file) that supports replace-or-append
+    bool isInstrumentWhichCanReplace() const { return kind == Kind::Instrument; }
+    // A plain audio sample — always appends as a new zone
+    bool isSingleSample() const { return kind == Kind::Sample; }
+
+    // True if the UI should show a top/bottom replace-vs-append split on a card
+    bool showsReplaceSplit() const { return isInstrumentWhichCanReplace(); }
+    // True if the UI should highlight the whole sidebar (replaces everything)
+    bool showsFullSidebarHighlight() const { return isMultiFile(); }
+    // True if this source can be dropped onto a group to add a zone
+    bool isDroppableOnGroup() const { return isSingleSample(); }
+
+    // ---- Factory methods ----
+
+    // Classify from a filesystem path
+    static SampleDropSource fromPath(const fs::path &p)
+    {
+        SampleDropSource s;
+        s.pathStr = p.u8string();
+        auto ps = juce::String::fromUTF8(p.u8string().c_str());
+        s.displayName = juce::File(ps).getFileName();
+
+        if (ps.endsWithIgnoreCase(".scm"))
+            s.kind = Kind::MultiFile;
+        else if (ps.endsWithIgnoreCase(".scp"))
+            s.kind = Kind::PartFile;
+        else if (browser::Browser::isLoadableMultiSample(p))
+            s.kind = Kind::Instrument;
+        else if (browser::Browser::isLoadableSingleSample(p))
+            s.kind = Kind::Sample;
+
+        return s;
+    }
+
+    // Classify from a single browser item — call only when !wsi->encompassesMultipleSampleInfos()
+    static SampleDropSource fromBrowserItem(browser_ui::WithSampleInfo *wsi)
+    {
+        if (!wsi || wsi->encompassesMultipleSampleInfos())
+            return {};
+
+        if (wsi->getDirEnt().has_value())
+        {
+            try
+            {
+                return fromPath(wsi->getDirEnt()->path());
+            }
+            catch (fs::filesystem_error &)
+            {
+                return {};
+            }
+        }
+
+        if (wsi->getCompoundElement().has_value())
+        {
+            auto el = wsi->getCompoundElement().value();
+            SampleDropSource s;
+            s.element = el;
+            s.displayName = juce::String::fromUTF8(el.name.c_str());
+            s.kind = (el.type == sample::compound::CompoundElement::Type::INSTRUMENT)
+                         ? Kind::Instrument
+                         : Kind::Sample;
+            return s;
+        }
+
+        return {};
+    }
+
+    // ---- Execute methods ----
+
+    // Drop onto targetPart. For Instrument/Sample: sends SelectPart first.
+    // replace=true sends ClearPart before loading (only meaningful for Instrument kind).
+    void dropOnPart(int targetPart, bool replace, HasEditor *editor) const
+    {
+        namespace cmsg = scxt::messaging::client;
+
+        switch (kind)
+        {
+        case Kind::MultiFile:
+            editor->sendToSerialization(cmsg::LoadMulti(pathStr));
+            return;
+
+        case Kind::PartFile:
+            editor->sendToSerialization(cmsg::LoadPartInto({pathStr, (int16_t)targetPart}));
+            return;
+
+        case Kind::Instrument:
+            editor->sendToSerialization(cmsg::SelectPart(targetPart));
+            if (replace)
+                editor->sendToSerialization(cmsg::ClearPart(targetPart));
+            if (element.has_value())
+            {
+                editor->sendToSerialization(
+                    cmsg::AddCompoundElementWithRange({*element, 60, 0, 127, 0, 127}));
+            }
+            else if (!pathStr.empty())
+            {
+                auto p = fs::path(fs::u8path(pathStr));
+                auto inst = browser::Browser::getMultiInstrumentElements(p);
+                if (inst.empty())
+                {
+                    editor->sendToSerialization(
+                        cmsg::AddSampleWithRange({pathStr, 60, 0, 127, 0, 127}));
+                }
+                else
+                {
+                    auto e = editor;
+                    promptForMultiInstrument(e->editor, inst, [e](const auto &elem) {
+                        e->sendToSerialization(
+                            cmsg::AddCompoundElementWithRange({elem, 60, 0, 127, 0, 127}));
+                    });
+                }
+            }
+            return;
+
+        case Kind::Sample:
+            editor->sendToSerialization(cmsg::SelectPart(targetPart));
+            if (element.has_value())
+            {
+                editor->sendToSerialization(
+                    cmsg::AddCompoundElementWithRange({*element, 60, 0, 127, 0, 127}));
+            }
+            else
+            {
+                editor->sendToSerialization(
+                    cmsg::AddSampleWithRange({pathStr, 60, 0, 127, 0, 127}));
+            }
+            return;
+
+        default:
+            return;
+        }
+    }
+
+    // Add as a new zone in the currently selected group.
+    // Only meaningful for Sample kind — other kinds are no-ops.
+    void dropAsZoneInCurrentGroup(HasEditor *editor) const
+    {
+        namespace cmsg = scxt::messaging::client;
+
+        if (kind != Kind::Sample)
+            return;
+        if (element.has_value())
+            editor->sendToSerialization(
+                cmsg::AddCompoundElementWithRange({*element, 60, 0, 127, 0, 127}));
+        else
+            editor->sendToSerialization(cmsg::AddSample(pathStr));
+    }
+
+    // Add as a new zone in an explicitly specified group, bypassing selection state.
+    // Only meaningful for Sample kind — other kinds are no-ops.
+    void dropAsZoneInGroup(int part, int group, HasEditor *editor) const
+    {
+        namespace cmsg = scxt::messaging::client;
+
+        if (kind != Kind::Sample)
+            return;
+        if (element.has_value())
+            editor->sendToSerialization(
+                cmsg::AddCompoundElementWithRange({*element, 60, 0, 127, 0, 127}));
+        else
+            editor->sendToSerialization(cmsg::AddSampleToGroup({pathStr, part, group}));
+    }
+};
+
+// Execute a batch drop (encompassesMultipleSampleInfos()) onto a specific part.
+inline void executeBatchDropOnPart(browser_ui::WithSampleInfo *wsi, int targetPart,
+                                   HasEditor *editor)
+{
+    namespace cmsg = scxt::messaging::client;
+    assert(wsi && wsi->encompassesMultipleSampleInfos());
+    editor->sendToSerialization(cmsg::SelectPart(targetPart));
+    for (auto *e : wsi->getMultipleSampleInfos())
+    {
+        if (e->getCompoundElement().has_value())
+            editor->sendToSerialization(
+                cmsg::AddCompoundElementWithRange({*e->getCompoundElement(), 60, 0, 127, 0, 127}));
+        else if (e->getDirEnt().has_value())
+            editor->sendToSerialization(
+                cmsg::AddSampleWithRange({e->getDirEnt()->path().u8string(), 60, 0, 127, 0, 127}));
+    }
+}
+
+// Execute a batch drop onto the currently selected group.
+inline void executeBatchDropOnGroup(browser_ui::WithSampleInfo *wsi, HasEditor *editor)
+{
+    namespace cmsg = scxt::messaging::client;
+    assert(wsi && wsi->encompassesMultipleSampleInfos());
+    for (auto *e : wsi->getMultipleSampleInfos())
+    {
+        if (e->getCompoundElement().has_value())
+            editor->sendToSerialization(
+                cmsg::AddCompoundElementWithRange({*e->getCompoundElement(), 60, 0, 127, 0, 127}));
+        else if (e->getDirEnt().has_value())
+            editor->sendToSerialization(cmsg::AddSample(e->getDirEnt()->path().u8string()));
+    }
+}
+
+// Execute a batch drop into an explicit group, bypassing selection state.
+inline void executeBatchDropOnGroup(browser_ui::WithSampleInfo *wsi, int part, int group,
+                                    HasEditor *editor)
+{
+    namespace cmsg = scxt::messaging::client;
+    assert(wsi && wsi->encompassesMultipleSampleInfos());
+    for (auto *e : wsi->getMultipleSampleInfos())
+    {
+        if (e->getCompoundElement().has_value())
+            editor->sendToSerialization(
+                cmsg::AddCompoundElementWithRange({*e->getCompoundElement(), 60, 0, 127, 0, 127}));
+        else if (e->getDirEnt().has_value())
+            editor->sendToSerialization(
+                cmsg::AddSampleToGroup({e->getDirEnt()->path().u8string(), part, group}));
+    }
+}
+
+} // namespace scxt::ui::app::shared
+
+#endif // SCXT_SRC_SCXT_PLUGIN_APP_SHARED_SAMPLEDROPHANDLER_H


### PR DESCRIPTION
Samples dropped from the browser onto a specific group row in the Group/Zone sidebar now land in that group, not in whichever group happens to contain the current zone selection. This required a new AddSampleToGroup engine message that bypasses the selection-based bestPartGroupForNewSample path entirely.

Batch browser drops (multiple items selected) onto a group row now work; previously they were silently ignored after the DragAndDropTarget removal from GroupZoneSidebarBase.

The Part sidebar (the Part 1–16 card column) no longer accepts plain audio file drops. Dragging a WAV/FLAC/MP3 or a batch of audio files over it now shows a soft redirect overlay — "Drop samples into the Group / Zone view" — and discards the drop. Instrument containers (SF2, SFZ, GIG, EXS) and patch files (SCP, SCM) are still accepted as before.

All drag-drop visual overlays have been unified behind a new SCXTEditor::occludeRegionWithText helper: a bg_1 opaque base, a 0.35-alpha colour tint, a 2 px solid border, and multi-line text stacked as a tight block in the centre — replacing the previous flat opaque fills. The replace/add split overlays on part cards and the mapping display follow the same pattern with 0.35/0.15 alpha for the active/inactive halves.

The multi-instrument selection prompt (SF2/SFZ files with multiple presets) has been extracted into a shared header so both the part card and the sidebar can use it without duplication.

Closes #2414
Closes #2415
Closes #2428