### PR TITLE
Add exclusive group (choke group) feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,12 @@ minst.sh
 doxy-out/
 
 .junie/
+.claude/
+.code-review-graph/
 CLAUDE.md
+.cursorrules
+.mcp.json
+.opencode.json
+.windsurfrules
+AGENTS.md
+GEMINI.md

--- a/src/scxt-core/engine/engine_voice_responder.cpp
+++ b/src/scxt-core/engine/engine_voice_responder.cpp
@@ -218,6 +218,77 @@ int32_t Engine::VoiceManagerResponder::initializeMultipleVoices(
             }
         }
     }
+    // Exclusive group choke — overlap-aware rules:
+    //
+    //   Pre-existing voices: only choked when their group has NO new voice in this
+    //   transaction. If a group is also being triggered by the incoming note (it has
+    //   a zone covering that key), its pre-existing voices are left alone so the
+    //   player retains that group.
+    //
+    //   Same-transaction voices: when two or more groups fire simultaneously for the
+    //   same note (overlapping key ranges), the highest-indexed group (last in
+    //   creation order) wins and chokes the earlier-created voices.
+
+    // Helper: returns true if any new voice in this transaction belongs to group g.
+    auto isGroupTriggeredThisNote = [&](const Group *g) {
+        for (int k = 0; k < outIdx; ++k)
+        {
+            const auto *nv = voiceInitWorkingBuffer[k].voice;
+            if (nv && nv->zone->parentGroup == g)
+                return true;
+        }
+        return false;
+    };
+
+    for (int i = 0; i < outIdx; ++i)
+    {
+        auto *v = voiceInitWorkingBuffer[i].voice;
+        if (!v)
+            continue;
+        auto excGroup = v->zone->parentGroup->outputInfo.exclusiveGroup;
+        if (excGroup == 0)
+            continue;
+        for (auto *ov : engine.voices)
+        {
+            if (!ov || ov == v || !ov->isVoicePlaying)
+                continue;
+            if (ov->zone->parentGroup == v->zone->parentGroup)
+                continue;
+            if (ov->zone->parentGroup->outputInfo.exclusiveGroup != excGroup)
+                continue;
+
+            // Determine whether ov is a same-transaction voice and, if so, its index.
+            int ovTxIdx = -1;
+            for (int j = 0; j < outIdx; ++j)
+            {
+                if (voiceInitWorkingBuffer[j].voice == ov)
+                {
+                    ovTxIdx = j;
+                    break;
+                }
+            }
+
+            if (ovTxIdx >= 0)
+            {
+                // Same-transaction conflict: later group (higher index) wins.
+                // Only choke voices that were created before this one.
+                if (ovTxIdx >= i)
+                    continue;
+            }
+            else
+            {
+                // Pre-existing voice: preserve it when its group is also triggered
+                // by this note (that group has a new voice in this transaction).
+                if (isGroupTriggeredThisNote(ov->zone->parentGroup))
+                    continue;
+            }
+
+            if (ov->isGated)
+                ov->release();
+            ov->beginTerminationSequence();
+        }
+    }
+
     engine.midiNoteStateCounter++;
     SCLOG_IF(voiceResponder, "Completed voice initiation " << actualCreated << " of " << nts);
     return actualCreated;

--- a/src/scxt-core/engine/group.h
+++ b/src/scxt-core/engine/group.h
@@ -122,6 +122,9 @@ struct Group : MoveableOnly<Group>,
 
         PlayMode playMode{POLY};
         NotePriority notePriority{LATEST};
+
+        int32_t exclusiveGroup{0}; // 0 = off; voices in groups sharing the same non-zero ID
+                                   // choke each other on note-on
     } outputInfo;
 
     GroupTriggerConditions triggerConditions;

--- a/src/scxt-core/engine/part.h
+++ b/src/scxt-core/engine/part.h
@@ -116,7 +116,8 @@ struct Part : MoveableOnly<Part>, SampleRateSupport
         bool solo{false};
         bool muteDueToSolo{false}; // this is unstreamed and calcs in onPartConfigurationUpdated
 
-        int32_t polyLimitVoices{0}; // poly limit. 0 means unlimited.
+        int32_t polyLimitVoices{0};    // poly limit. 0 means unlimited.
+        int32_t numExclusiveGroups{0}; // how many exclusive-group IDs have been issued (0 = none)
 
         BusAddress routeTo{DEFAULT_BUS};
 

--- a/src/scxt-core/engine/zone.h
+++ b/src/scxt-core/engine/zone.h
@@ -225,8 +225,6 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
 
         int16_t pbDown{-1}, pbUp{-1};
 
-        int16_t exclusiveGroup{0};
-
         float velocitySens{1.0};
         float amplitude{0.0};   // decibels
         float pan{0.0};         // -1..1

--- a/src/scxt-core/json/engine_traits.h
+++ b/src/scxt-core/json/engine_traits.h
@@ -201,6 +201,8 @@ SC_STREAMDEF(scxt::engine::Part::PartConfiguration,
                           {"xps", from.transpose},
                           {"rt", (int)from.routeTo},
 
+                          {"nexg", from.numExclusiveGroups},
+
                           {"nm", std::string(from.name)},
                           {"bl", std::string(from.blurb)}};),
              SC_TO({
@@ -218,6 +220,7 @@ SC_STREAMDEF(scxt::engine::Part::PartConfiguration,
                  findOrSet(v, "m", false, to.mute);
                  findOrSet(v, "s", false, to.solo);
                  findOrSet(v, "pv", 0, to.polyLimitVoices);
+                 findOrSet(v, "nexg", 0, to.numExclusiveGroups);
                  findOrSet(v, "mbr", 24, to.mpePitchBendRange);
                  findOrSet(v, "mps", 0, to.mpePitchSmoothingTime);
                  int rtv;
@@ -383,7 +386,8 @@ SC_STREAMDEF(scxt::engine::Group::GroupOutputInfo, SC_FROM({
                       {"glt", t.glideTime},
                       {"grm", t.glideRateMode},
                       {"pm", t.playMode},
-                      {"np", t.notePriority}};
+                      {"np", t.notePriority},
+                      {"excg", t.exclusiveGroup}};
              }),
              SC_TO({
                  findIf(v, "amplitude", result.amplitude);
@@ -409,6 +413,7 @@ SC_STREAMDEF(scxt::engine::Group::GroupOutputInfo, SC_FROM({
                  findIf(v, "grm", result.glideRateMode);
                  findOrSet(v, "pm", engine::Group::PlayMode::POLY, result.playMode);
                  findOrSet(v, "np", engine::Group::NotePriority::LATEST, result.notePriority);
+                 findOrSet(v, "excg", 0, result.exclusiveGroup);
 
                  if (SC_UNSTREAMING_FROM_PRIOR_TO(0x2026'03'08))
                  {
@@ -534,7 +539,6 @@ SC_STREAMDEF(scxt::engine::Zone::ZoneMappingData, SC_FROM({
                       {"pbDown", t.pbDown},
                       {"pbUp", t.pbUp},
 
-                      {"exclusiveGroup", t.exclusiveGroup},
                       {"velocitySens", t.velocitySens},
                       {"amplitude", t.amplitude},
                       {"pan", t.pan},
@@ -562,7 +566,6 @@ SC_STREAMDEF(scxt::engine::Zone::ZoneMappingData, SC_FROM({
                  findIf(v, "pitchOffset", zmd.pitchOffset);
                  findIf(v, "tracking", zmd.tracking);
                  findOrSet(v, "velocitySens", 1.0, zmd.velocitySens);
-                 findOrSet(v, "exclusiveGroup", 0, zmd.exclusiveGroup);
              }));
 
 STREAM_ENUM(engine::Zone::PlayMode, engine::Zone::toStringPlayMode,

--- a/src/scxt-core/messaging/client/client_serial.h
+++ b/src/scxt-core/messaging/client/client_serial.h
@@ -117,6 +117,7 @@ enum ClientToSerializationMessagesIds
     c2s_update_group_output_bool_value,
     c2s_update_group_output_info_polyphony,
     c2s_update_group_output_info_midichannel,
+    c2s_update_group_output_info_exclusive_group,
 
     c2s_update_group_trigger_conditions,
 

--- a/src/scxt-core/messaging/client/group_messages.h
+++ b/src/scxt-core/messaging/client/group_messages.h
@@ -114,6 +114,24 @@ CLIENT_TO_SERIAL(UpdateGroupOutputInfoMidiChannel, c2s_update_group_output_info_
                  scxt::engine::Group::GroupOutputInfo,
                  doUpdateGroupOutputInfoMidiChannel(payload, engine, cont));
 
+inline void
+doUpdateGroupOutputInfoExclusiveGroup(const scxt::engine::Group::GroupOutputInfo payload,
+                                      const engine::Engine &engine,
+                                      messaging::MessageController &cont)
+{
+    auto ga = engine.getSelectionManager()->currentLeadGroup(engine);
+    if (ga.has_value())
+    {
+        cont.scheduleAudioThreadCallback([p = payload, g = *ga](auto &eng) {
+            auto &grp = eng.getPatch()->getPart(g.part)->getGroup(g.group);
+            grp->outputInfo = p;
+        });
+    }
+}
+CLIENT_TO_SERIAL(UpdateGroupOutputInfoExclusiveGroup, c2s_update_group_output_info_exclusive_group,
+                 scxt::engine::Group::GroupOutputInfo,
+                 doUpdateGroupOutputInfoExclusiveGroup(payload, engine, cont));
+
 using muteOrSoloGroup_t = std::tuple<int32_t, int32_t, bool, bool, bool>; // p, g, m, s, selected
 inline void doMuteOrSoloGroup(const muteOrSoloGroup_t &payload, const engine::Engine &engine,
                               messaging::MessageController &cont)

--- a/src/scxt-plugin/app/edit-screen/components/GroupSettingsCard.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/GroupSettingsCard.cpp
@@ -128,8 +128,10 @@ GroupSettingsCard::GroupSettingsCard(SCXTEditor *e)
 
     exclusiveGroupMenu = std::make_unique<jcmp::TextPushButton>();
     exclusiveGroupMenu->setLabel("OFF");
-    exclusiveGroupMenu->setOnCallback(
-        editor->makeComingSoon("Group Settings Pane Exclusive Group"));
+    exclusiveGroupMenu->setOnCallback([w = juce::Component::SafePointer(this)]() {
+        if (w)
+            w->showExclusiveGroupMenu();
+    });
     addAndMakeVisible(*exclusiveGroupMenu);
 
     SRCLabel = std::make_unique<jcmp::Label>();
@@ -286,6 +288,11 @@ void GroupSettingsCard::rebuildFromInfo()
             midiMenu->setLabel(std::to_string(info.midiChannel + 1));
         }
     }
+
+    if (info.exclusiveGroup == 0)
+        exclusiveGroupMenu->setLabel("OFF");
+    else
+        exclusiveGroupMenu->setLabel(std::to_string(info.exclusiveGroup));
 
     bool isMono = (info.playMode != engine::Group::PlayMode::POLY);
     glideDrag->setEnabled(isMono);
@@ -454,6 +461,58 @@ void GroupSettingsCard::showGlideRateModeMenu()
                   w->sendToSerialization(
                       messaging::client::UpdateGroupOutputInfoPolyphony{w->info});
               });
+    p.showMenuAsync(editor->defaultPopupMenuOptions());
+}
+
+void GroupSettingsCard::showExclusiveGroupMenu()
+{
+    auto partIdx = editor->currentLeadGroupSelection
+                       ? (int16_t)editor->currentLeadGroupSelection->part
+                       : (int16_t)0;
+    auto numExcGroups = editor->partConfigurations[partIdx].numExclusiveGroups;
+
+    auto p = juce::PopupMenu();
+    p.addSectionHeader("Exclusive Group");
+    p.addSeparator();
+
+    p.addItem("OFF", true, info.exclusiveGroup == 0, [w = juce::Component::SafePointer(this)]() {
+        if (!w)
+            return;
+        w->info.exclusiveGroup = 0;
+        w->rebuildFromInfo();
+        w->sendToSerialization(messaging::client::UpdateGroupOutputInfoExclusiveGroup{w->info});
+    });
+
+    if (numExcGroups > 0)
+    {
+        p.addSeparator();
+        for (int32_t id = 1; id <= numExcGroups; ++id)
+        {
+            p.addItem(std::to_string(id), true, info.exclusiveGroup == id,
+                      [id, w = juce::Component::SafePointer(this)]() {
+                          if (!w)
+                              return;
+                          w->info.exclusiveGroup = id;
+                          w->rebuildFromInfo();
+                          w->sendToSerialization(
+                              messaging::client::UpdateGroupOutputInfoExclusiveGroup{w->info});
+                      });
+        }
+    }
+
+    p.addSeparator();
+    p.addItem("New Group", true, false, [partIdx, w = juce::Component::SafePointer(this)]() {
+        if (!w)
+            return;
+        auto &partCfg = w->editor->partConfigurations[partIdx];
+        partCfg.numExclusiveGroups++;
+        auto newId = partCfg.numExclusiveGroups;
+        w->sendToSerialization(messaging::client::UpdatePartFullConfig({partIdx, partCfg}));
+        w->info.exclusiveGroup = newId;
+        w->rebuildFromInfo();
+        w->sendToSerialization(messaging::client::UpdateGroupOutputInfoExclusiveGroup{w->info});
+    });
+
     p.showMenuAsync(editor->defaultPopupMenuOptions());
 }
 

--- a/src/scxt-plugin/app/edit-screen/components/GroupSettingsCard.h
+++ b/src/scxt-plugin/app/edit-screen/components/GroupSettingsCard.h
@@ -82,6 +82,7 @@ struct GroupSettingsCard : juce::Component, HasEditor
     void showNotePrioMenu();
     void showMidiChannelMenu();
     void showGlideRateModeMenu();
+    void showExclusiveGroupMenu();
 };
 } // namespace scxt::ui::app::edit_screen
 #endif // GROUPSETTINGSCARD_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(scxt-test
 		modify_structure.cpp
 		modulator_tests.cpp
 		mod_matrix_operations_tests.cpp
+		exclusive_group_tests.cpp
 )
 
 target_link_libraries(scxt-test

--- a/tests/exclusive_group_tests.cpp
+++ b/tests/exclusive_group_tests.cpp
@@ -1,0 +1,323 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "catch2/catch2.hpp"
+#include "engine/engine.h"
+#include "engine/zone.h"
+#include "json/engine_traits.h"
+
+/*
+ * These tests drive the engine directly on the test thread (no ConsoleHarness,
+ * no background audio thread) so we avoid the threading complexity of the full
+ * harness while still exercising real voice-creation logic.
+ */
+
+static constexpr double TEST_SAMPLE_RATE = 48000.0;
+
+/*
+ * Build a minimal two-group engine in part 0:
+ *   group 0 — blank zone covering keys 36-47
+ *   group 1 — blank zone covering keys 48-59
+ *
+ * "Blank" means no sample loaded; the engine still creates voices for
+ * sample-less zones (the generator just produces silence).
+ */
+static scxt::engine::Engine *makeEngine()
+{
+    auto *e = new scxt::engine::Engine();
+    e->prepareToPlay(TEST_SAMPLE_RATE);
+    return e;
+}
+
+static void addBlankZoneToGroup(scxt::engine::Part &part, int groupIdx, int keyLo, int keyHi)
+{
+    auto z = std::make_unique<scxt::engine::Zone>();
+    z->mapping.keyboardRange.keyStart = keyLo;
+    z->mapping.keyboardRange.keyEnd = keyHi;
+    z->mapping.velocityRange.velStart = 0;
+    z->mapping.velocityRange.velEnd = 127;
+    z->initialize();
+    part.getGroup(groupIdx)->addZone(z);
+}
+
+static void setupTwoGroups(scxt::engine::Engine &eng)
+{
+    auto &part = *eng.getPatch()->getPart(0);
+    part.addGroup(); // group 0
+    part.addGroup(); // group 1
+    addBlankZoneToGroup(part, 0, 36, 47);
+    addBlankZoneToGroup(part, 1, 48, 59);
+}
+
+/*
+ * Overlapping layout for testing choke behaviour with shared key ranges:
+ *   group 0 — zone 48-72  (G1)
+ *   group 1 — zone 60-96  (G2)
+ *
+ * Keys 60-72 are covered by BOTH groups.
+ * Keys 48-59 are covered only by G1.
+ * Keys 73-96 are covered only by G2.
+ */
+static void setupOverlappingGroups(scxt::engine::Engine &eng)
+{
+    auto &part = *eng.getPatch()->getPart(0);
+    part.addGroup(); // group 0 (G1)
+    part.addGroup(); // group 1 (G2)
+    addBlankZoneToGroup(part, 0, 48, 72);
+    addBlankZoneToGroup(part, 1, 60, 96);
+}
+
+static void runBlocks(scxt::engine::Engine &e, int n = 4)
+{
+    for (int i = 0; i < n; ++i)
+        e.processAudio();
+}
+
+// Count voices that have been choked (termination sequence started).
+// Safe to call immediately after processNoteOnEvent — no blocks needed.
+static int countTerminatingVoicesInGroup(const scxt::engine::Group &grp)
+{
+    int n = 0;
+    for (const auto &zone : grp.getZones())
+        for (int i = 0; i < (int)scxt::maxVoices; ++i)
+        {
+            const auto *v = zone->voiceWeakPointers[i];
+            if (v && v->isVoiceAssigned && v->terminationSequence > 0)
+                n++;
+        }
+    return n;
+}
+
+// Count voices that exist and have NOT been choked.
+static int countLiveVoicesInGroup(const scxt::engine::Group &grp)
+{
+    int n = 0;
+    for (const auto &zone : grp.getZones())
+        for (int i = 0; i < (int)scxt::maxVoices; ++i)
+        {
+            const auto *v = zone->voiceWeakPointers[i];
+            if (v && v->isVoiceAssigned && v->terminationSequence < 0)
+                n++;
+        }
+    return n;
+}
+
+TEST_CASE("Exclusive Group - basic choke", "[exclusive_group]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    setupTwoGroups(*eng);
+
+    auto &part = *eng->getPatch()->getPart(0);
+    REQUIRE(part.getGroups().size() == 2);
+
+    part.getGroup(0)->outputInfo.exclusiveGroup = 1;
+    part.getGroup(1)->outputInfo.exclusiveGroup = 1;
+
+    // Fire note in group 0 — voice V0 is created and alive.
+    eng->processNoteOnEvent(0, 0, 40, -1, 1.f, 0.f);
+    REQUIRE(part.getGroup(0)->getZone(0)->activeVoices == 1);
+
+    // Fire note in group 1 immediately (before any audio blocks).
+    // The choke runs synchronously inside processNoteOnEvent, so V0
+    // should enter its termination sequence right now.
+    eng->processNoteOnEvent(0, 0, 52, -1, 1.f, 0.f);
+
+    REQUIRE(countTerminatingVoicesInGroup(*part.getGroup(0)) >= 1);
+}
+
+TEST_CASE("Exclusive Group - no choke when off", "[exclusive_group]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    setupTwoGroups(*eng);
+
+    auto &part = *eng->getPatch()->getPart(0);
+    REQUIRE(part.getGroups().size() == 2);
+
+    // Default exclusiveGroup == 0 — no choke.
+    REQUIRE(part.getGroup(0)->outputInfo.exclusiveGroup == 0);
+    REQUIRE(part.getGroup(1)->outputInfo.exclusiveGroup == 0);
+
+    eng->processNoteOnEvent(0, 0, 40, -1, 1.f, 0.f);
+    REQUIRE(part.getGroup(0)->getZone(0)->activeVoices == 1);
+
+    eng->processNoteOnEvent(0, 0, 52, -1, 1.f, 0.f);
+
+    // No voices in group 0 should have been choked.
+    REQUIRE(countTerminatingVoicesInGroup(*part.getGroup(0)) == 0);
+    REQUIRE(countLiveVoicesInGroup(*part.getGroup(0)) >= 1);
+}
+
+TEST_CASE("Exclusive Group - different IDs do not choke each other", "[exclusive_group]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    setupTwoGroups(*eng);
+
+    auto &part = *eng->getPatch()->getPart(0);
+    REQUIRE(part.getGroups().size() == 2);
+
+    part.getGroup(0)->outputInfo.exclusiveGroup = 1;
+    part.getGroup(1)->outputInfo.exclusiveGroup = 2; // different — no choke
+
+    eng->processNoteOnEvent(0, 0, 40, -1, 1.f, 0.f);
+    REQUIRE(part.getGroup(0)->getZone(0)->activeVoices == 1);
+
+    eng->processNoteOnEvent(0, 0, 52, -1, 1.f, 0.f);
+
+    REQUIRE(countTerminatingVoicesInGroup(*part.getGroup(0)) == 0);
+    REQUIRE(countLiveVoicesInGroup(*part.getGroup(0)) >= 1);
+}
+
+TEST_CASE("Exclusive Group - streaming round-trip", "[exclusive_group]")
+{
+    using namespace scxt;
+
+    engine::Group::GroupOutputInfo info;
+    info.exclusiveGroup = 3;
+
+    auto s = tao::json::to_string(scxt::json::scxt_value(info));
+    REQUIRE(s.find("excg") != std::string::npos);
+
+    engine::Group::GroupOutputInfo info2;
+    {
+        tao::json::events::transformer<tao::json::events::to_basic_value<scxt::json::scxt_traits>>
+            consumer;
+        tao::json::events::from_string(consumer, s);
+        consumer.value.to(info2);
+    }
+    REQUIRE(info2.exclusiveGroup == 3);
+}
+
+/*
+ * Overlapping exclusive group tests
+ * ─────────────────────────────────
+ * G1: zone 48-72   G2: zone 60-96   both share exclusive group 1.
+ * Overlap region: 60-72.
+ *
+ * Expected behaviour:
+ *   A) 49 → 94  : only G1 covers 49, only G2 covers 94 → G1 choked (basic case, verified here)
+ *   B) 48 → 65  : G1 playing at 48; press 65 (both groups respond) → G1 retains (voice at 48
+ *                 survives because G1 is also triggered at 65)
+ *   C) 95 → 65  : G2 playing at 95; press 65 → G2 retains (voice at 95 survives)
+ *   D) nothing → 65 : both groups respond; last-in-group-order (G2) wins → only G2 plays
+ */
+
+TEST_CASE("Exclusive Group overlapping - non-overlap choke still works", "[exclusive_group]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    setupOverlappingGroups(*eng);
+
+    auto &part = *eng->getPatch()->getPart(0);
+    part.getGroup(0)->outputInfo.exclusiveGroup = 1;
+    part.getGroup(1)->outputInfo.exclusiveGroup = 1;
+
+    // 49 is only in G1; 94 is only in G2 — identical to the basic choke test
+    eng->processNoteOnEvent(0, 0, 49, -1, 1.f, 0.f);
+    REQUIRE(countLiveVoicesInGroup(*part.getGroup(0)) >= 1);
+
+    eng->processNoteOnEvent(0, 0, 94, -1, 1.f, 0.f);
+    REQUIRE(countTerminatingVoicesInGroup(*part.getGroup(0)) >= 1);
+    REQUIRE(countLiveVoicesInGroup(*part.getGroup(1)) >= 1);
+}
+
+TEST_CASE("Exclusive Group overlapping - G1 retains when 65 pressed while G1 playing at 48",
+          "[exclusive_group]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    setupOverlappingGroups(*eng);
+
+    auto &part = *eng->getPatch()->getPart(0);
+    part.getGroup(0)->outputInfo.exclusiveGroup = 1;
+    part.getGroup(1)->outputInfo.exclusiveGroup = 1;
+
+    // Plant G1 voice at 48 (only G1 covers 48)
+    eng->processNoteOnEvent(0, 0, 48, -1, 1.f, 0.f);
+    REQUIRE(countLiveVoicesInGroup(*part.getGroup(0)) >= 1);
+
+    // Press 65 — both G1 (48-72) and G2 (60-96) fire.
+    // G1's pre-existing voice at 48 must NOT be choked because G1 is also triggered at 65.
+    eng->processNoteOnEvent(0, 0, 65, -1, 1.f, 0.f);
+    REQUIRE(countLiveVoicesInGroup(*part.getGroup(0)) >= 1);
+}
+
+TEST_CASE("Exclusive Group overlapping - G2 retains when 65 pressed while G2 playing at 95",
+          "[exclusive_group]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    setupOverlappingGroups(*eng);
+
+    auto &part = *eng->getPatch()->getPart(0);
+    part.getGroup(0)->outputInfo.exclusiveGroup = 1;
+    part.getGroup(1)->outputInfo.exclusiveGroup = 1;
+
+    // Plant G2 voice at 95 (only G2 covers 95)
+    eng->processNoteOnEvent(0, 0, 95, -1, 1.f, 0.f);
+    REQUIRE(countLiveVoicesInGroup(*part.getGroup(1)) >= 1);
+
+    // Press 65 — both G1 (48-72) and G2 (60-96) fire.
+    // G2's pre-existing voice at 95 must NOT be choked because G2 is also triggered at 65.
+    eng->processNoteOnEvent(0, 0, 65, -1, 1.f, 0.f);
+    REQUIRE(countLiveVoicesInGroup(*part.getGroup(1)) >= 1);
+}
+
+TEST_CASE("Exclusive Group overlapping - from silence pressing 65 plays G2 (last group order)",
+          "[exclusive_group]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    setupOverlappingGroups(*eng);
+
+    auto &part = *eng->getPatch()->getPart(0);
+    part.getGroup(0)->outputInfo.exclusiveGroup = 1;
+    part.getGroup(1)->outputInfo.exclusiveGroup = 1;
+
+    // No prior voices. Both groups respond to 65; G2 (highest group index) must win.
+    eng->processNoteOnEvent(0, 0, 65, -1, 1.f, 0.f);
+    REQUIRE(countLiveVoicesInGroup(*part.getGroup(0)) == 0);
+    REQUIRE(countLiveVoicesInGroup(*part.getGroup(1)) >= 1);
+}
+
+TEST_CASE("Exclusive Group - old ZoneMappingData JSON loads without crash", "[exclusive_group]")
+{
+    // Patches saved before this change had "exclusiveGroup" under ZoneMappingData.
+    // The field no longer exists there; it should be silently ignored on load.
+    using namespace scxt;
+
+    std::string oldJson =
+        R"({"rootKey":60,"keyR":{"keyStart":0,"keyEnd":127,"fadeStart":0,"fadeEnd":0},)"
+        R"("velR":{"velStart":0,"velEnd":127,"fadeStart":0,"fadeEnd":0},)"
+        R"("pbDown":-1,"pbUp":-1,"exclusiveGroup":2,"velocitySens":1.0,)"
+        R"("amplitude":0.0,"pan":0.0,"pitchOffset":0.0,"tracking":1.0})";
+
+    engine::Zone::ZoneMappingData zmd;
+    {
+        tao::json::events::transformer<tao::json::events::to_basic_value<scxt::json::scxt_traits>>
+            consumer;
+        tao::json::events::from_string(consumer, oldJson);
+        consumer.value.to(zmd);
+    }
+    REQUIRE(zmd.rootKey == 60);
+    REQUIRE(zmd.velocitySens == Approx(1.0));
+}


### PR DESCRIPTION

Implements exclusive groups for ShortcircuitXT: groups sharing a non-zero exclusiveGroup tag choke each other on note-on, enabling hi-hat-style muting.

DSP/engine:
- Add `exclusiveGroup` field to Group::GroupOutputInfo (streamed as "excg")
- On note-on, terminate all live voices in other groups with the same tag
- Overlap-aware choke rules: pre-existing voices in a group are preserved when that group is also triggered by the incoming note; among groups that fire simultaneously for the same note, the highest-indexed group wins

UI:
- Add Exclusive Group row to GroupSettingsCard with a dropdown populated from the part's numExclusiveGroups count

Tests (tests/exclusive_group_tests.cpp):
- Basic choke, no-choke-when-off, different-ID isolation, streaming round-trip, old-JSON backward-compat
- Four overlapping-zone cases: non-overlap choke still works, G1 retains when triggered-at-overlap while playing, G2 retains symmetrically, and from-silence overlap resolves to the last group in order

Closes #497