### PR TITLE
Add DAW extra state scaffolding for per-instance settings

### DIFF
--- a/src/scxt-core/engine/engine.cpp
+++ b/src/scxt-core/engine/engine.cpp
@@ -1554,6 +1554,10 @@ void Engine::prepareToStream()
     }
 }
 
+void Engine::prepareDawExtraState() {}
+
+void Engine::onDawExtraStateLoaded() { SCLOG_IF(patchIO, "Unstreamed daw extra state"); }
+
 std::string Engine::toStringTuningMode(const TuningMode &m)
 {
     switch (m)

--- a/src/scxt-core/engine/engine.h
+++ b/src/scxt-core/engine/engine.h
@@ -273,6 +273,17 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
         bool applyOmniToAllPartsOnSelect{false};
     } runtimeConfig;
 
+    /*
+     * A structure to store extra state which is for a DAW session but not a patch.
+     * Must be updated on the serliazation thread.
+     * Currently only contains a dummy entry. Architectural only as of this commit.
+     * Only streamed when streamReason == FOR_DAW.
+     */
+    struct DawExtraState
+    {
+        bool dummy{true};
+    } dawExtraState;
+
     void resetTuningFromRuntimeConfig();
     void setMpeTuningAwareness(bool a);
     void setPBTuningAwareness(bool a);
@@ -725,6 +736,8 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     std::optional<fs::path> setupUserStorageDirectory();
 
     void prepareToStream();
+    void prepareDawExtraState();
+    void onDawExtraStateLoaded();
 
   private:
     std::unique_ptr<Patch> patch;

--- a/src/scxt-core/json/engine_traits.h
+++ b/src/scxt-core/json/engine_traits.h
@@ -86,6 +86,10 @@ SC_STREAMDEF(scxt::engine::Engine, SC_FROM({
                       {"runtimeConfig", from.runtimeConfig},
                       {"selectionManager", from.getSelectionManager()},
                       {"sampleManager", from.getSampleManager()}};
+                 if (SC_STREAMING_FOR_DAW)
+                 {
+                     addToObject<val_t>(v, "dawExtraState", from.dawExtraState);
+                 }
              }),
              SC_TO({
                  assert(to.getMessageController()->threadingChecker.isSerialThread());
@@ -113,7 +117,14 @@ SC_STREAMDEF(scxt::engine::Engine, SC_FROM({
 
                  // and finally set the sample rate
                  to.getPatch()->setSampleRate(to.getSampleRate());
+
+                 // DAW-only: restore per-instance extra state if present
+                 if (findIf(v, "dawExtraState", to.dawExtraState))
+                     to.onDawExtraStateLoaded();
              }))
+
+SC_STREAMDEF(scxt::engine::Engine::DawExtraState, SC_FROM({ v = {{"dummy", from.dummy}}; }),
+             SC_TO({ findIf(v, "dummy", to.dummy); }))
 
 SC_STREAMDEF(scxt::engine::Engine::RuntimeConfig, SC_FROM({
                  if (SC_STREAMING_FOR_DAW)

--- a/src/scxt-plugin/clap/scxt-plugin.cpp
+++ b/src/scxt-plugin/clap/scxt-plugin.cpp
@@ -121,6 +121,7 @@ bool SCXTPlugin::stateSave(const clap_ostream *ostream) noexcept
     // happens in the code path.
     // engine->getSampleManager()->purgeUnreferencedSamples();
     engine->prepareToStream();
+    engine->prepareDawExtraState();
     try
     {
         auto sg = scxt::engine::Engine::StreamGuard(engine::Engine::FOR_DAW);


### PR DESCRIPTION
Introduces Engine::DawExtraState (currently just a dummy) streamed only when SC_STREAMING_FOR_DAW, plus prepareDawExtraState/onDawExtraStateLoaded hooks so future per-instance settings can round-trip through DAW state.