### PR TITLE
Importer polish: ctx.loadSample, loadInfo masking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ CLAUDE.md
 .windsurfrules
 AGENTS.md
 GEMINI.md
+claude-plans/

--- a/src/scxt-core/messaging/client/detail/client_serial_impl.h
+++ b/src/scxt-core/messaging/client/detail/client_serial_impl.h
@@ -28,16 +28,12 @@
 #ifndef SCXT_SRC_SCXT_CORE_MESSAGING_CLIENT_DETAIL_CLIENT_SERIAL_IMPL_H
 #define SCXT_SRC_SCXT_CORE_MESSAGING_CLIENT_DETAIL_CLIENT_SERIAL_IMPL_H
 
+#include "messaging/client/client_serial.h"
+
 // Inter-process messages can pack as JSON (the streaming format we use)
 // or as msgpack messages which are a lot smaller and faster. PROCESS_AS_JSON
 // is really just useful for debugging where you actually want to see a message.
-// Defined here, before includes, so the JSON-only tao headers can be skipped.
-#ifndef PROCESS_AS_JSON
 #define PROCESS_AS_JSON 0
-#endif
-
-#include "messaging/client/client_serial.h"
-
 #if PROCESS_AS_JSON
 #include "tao/json/to_string.hpp"
 #include "tao/json/from_string.hpp"

--- a/src/scxt-core/sample/akai_support/akai_import.cpp
+++ b/src/scxt-core/sample/akai_support/akai_import.cpp
@@ -468,40 +468,14 @@ bool importAKP(const fs::path &path, engine::Engine &e)
             if (!z.mapped || z.sample.empty())
                 continue;
 
-            auto samplePath = rootDir / z.sample;
-            // Akai samples often don't have extensions in the AKP file, but are .WAV or .AIF on
-            // disk
-            if (!fs::exists(samplePath))
-            {
-                for (auto ext : {".WAV", ".wav", ".AIF", ".aif"})
-                {
-                    if (fs::exists(rootDir / (z.sample + ext)))
-                    {
-                        samplePath = rootDir / (z.sample + ext);
-                        break;
-                    }
-                }
-            }
-
-            SampleID sid;
-            if (fs::exists(samplePath))
-            {
-                auto lsid = e.getSampleManager()->loadSampleByPath(samplePath);
-                if (lsid.has_value())
-                {
-                    sid = *lsid;
-                }
-                else
-                {
-                    continue;
-                }
-            }
-            else
-            {
+            // AKP files reference samples by name without extension; the actual
+            // file on disk is .WAV or .AIF (and case may vary).
+            auto lsid =
+                ctx.loadSampleFromDisk({rootDir / z.sample}, {".WAV", ".wav", ".AIF", ".aif"});
+            if (!lsid)
                 continue;
-            }
 
-            auto zn = std::make_unique<engine::Zone>(sid);
+            auto zn = std::make_unique<engine::Zone>(*lsid);
             import_support::importZoneMapping(
                 *zn, ctx,
                 {
@@ -515,8 +489,10 @@ bool importAKP(const fs::path &path, engine::Engine &e)
                         z.semiTune + import_support::centsToSemitones((float)z.fineTune),
                 });
 
-            // If the sample itself has a root key, it will be loaded by attachToSample
-            zn->attachToSample(*e.getSampleManager());
+            // MAPPING is masked off because the AKP file already supplied root/key/vel
+            // and we don't want a smpl-chunk in the referenced WAV to clobber them.
+            zn->attachToSample(*e.getSampleManager(), 0,
+                               engine::Zone::ENDPOINTS | engine::Zone::LOOP);
 
             ctx.addZoneToGroup(groupId, std::move(zn));
         }

--- a/src/scxt-core/sample/exs_support/exs_import.cpp
+++ b/src/scxt-core/sample/exs_support/exs_import.cpp
@@ -681,12 +681,8 @@ bool importEXS(const fs::path &p, engine::Engine &e)
 
     for (auto &s : info.samples)
     {
-        auto sp = fs::path{s.filePath} / s.fileName;
-        auto lsid = e.getSampleManager()->loadSampleByPath(sp);
-        if (lsid.has_value())
-        {
+        if (auto lsid = ctx.loadSampleFromDisk({fs::path{s.filePath} / s.fileName}))
             sampleIDByOrder.push_back(*lsid);
-        }
     }
 
     for (auto &g : info.groups)
@@ -721,7 +717,10 @@ bool importEXS(const fs::path &p, engine::Engine &e)
                                               .velEnd = z.velocityHigh,
                                           });
 
-        zone->attachToSample(*(e.getSampleManager()));
+        // MAPPING masked off — EXS supplies root/key/vel itself; don't let a
+        // sample-meta smpl chunk clobber it.
+        zone->attachToSample(*(e.getSampleManager()), 0,
+                             engine::Zone::ENDPOINTS | engine::Zone::LOOP);
         ctx.addZoneToGroup(gi, std::move(zone));
     }
     return ctx.finish();

--- a/src/scxt-core/sample/import_support/import_harness.cpp
+++ b/src/scxt-core/sample/import_support/import_harness.cpp
@@ -84,6 +84,31 @@ void ImporterContext::addZoneToGroup(int groupIdx, std::unique_ptr<engine::Zone>
     addedZoneAddresses.emplace_back(groupIdx, zoneIdx);
 }
 
+std::optional<SampleID>
+ImporterContext::loadSampleFromDisk(std::initializer_list<fs::path> candidates,
+                                    std::initializer_list<const char *> extensionFallbacks)
+{
+    auto &sm = *engineRef.getSampleManager();
+    for (const auto &candidate : candidates)
+    {
+        if (fs::exists(candidate))
+        {
+            if (auto sid = sm.loadSampleByPath(candidate))
+                return sid;
+        }
+        for (auto ext : extensionFallbacks)
+        {
+            auto withExt = fs::path{candidate.u8string() + ext};
+            if (fs::exists(withExt))
+            {
+                if (auto sid = sm.loadSampleByPath(withExt))
+                    return sid;
+            }
+        }
+    }
+    return std::nullopt;
+}
+
 bool ImporterContext::finish()
 {
     if (!unsupportedItems.empty())

--- a/src/scxt-core/sample/import_support/import_harness.h
+++ b/src/scxt-core/sample/import_support/import_harness.h
@@ -28,7 +28,9 @@
 #ifndef SCXT_SRC_SCXT_CORE_SAMPLE_IMPORT_SUPPORT_IMPORT_HARNESS_H
 #define SCXT_SRC_SCXT_CORE_SAMPLE_IMPORT_SUPPORT_IMPORT_HARNESS_H
 
+#include <initializer_list>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -37,6 +39,7 @@
 #include "engine/part.h"
 #include "engine/zone.h"
 #include "messaging/messaging.h"
+#include "sample/sample_manager.h"
 
 namespace scxt::import_support
 {
@@ -74,6 +77,15 @@ class ImporterContext
     // Moves the zone into the named group and records its address for the
     // end-of-import selection push.
     void addZoneToGroup(int groupIdx, std::unique_ptr<engine::Zone> zone);
+
+    // Loads a sample from disk for file-based formats (SFZ/EXS/AKP/etc.). Tries
+    // each candidate path in order; for the first that exists, calls
+    // SampleManager::loadSampleByPath. extensionFallbacks (if non-empty) are
+    // appended to each candidate that doesn't exist as-given (e.g. AKP's
+    // `.WAV/.wav/.AIF/.aif` search). Returns nullopt if nothing resolved.
+    std::optional<SampleID>
+    loadSampleFromDisk(std::initializer_list<fs::path> candidates,
+                       std::initializer_list<const char *> extensionFallbacks = {});
 
     // Finalize: emits the unsupported-features summary, pushes a selection
     // action for everything added, and returns true iff ≥1 zone was added.

--- a/src/scxt-core/sample/multisample_support/multisample_import.cpp
+++ b/src/scxt-core/sample/multisample_support/multisample_import.cpp
@@ -204,8 +204,15 @@ bool importMultisample(const fs::path &p, engine::Engine &engine)
                                               .pitchOffsetSemitones = ktune,
                                           });
 
-        z->attachToSample(*engine.getSampleManager());
-        if (loopOn && loopStart + loopEnd > 0)
+        // MAPPING is supplied by the multisample.xml; mask it off so a smpl
+        // chunk in the embedded WAV can't clobber root/key/vel. LOOP is masked
+        // off only when the multisample explicitly sets loop bounds.
+        bool willWriteLoop = loopOn && loopStart + loopEnd > 0;
+        int32_t loadInfo = engine::Zone::ENDPOINTS;
+        if (!willWriteLoop)
+            loadInfo |= engine::Zone::LOOP;
+        z->attachToSample(*engine.getSampleManager(), 0, loadInfo);
+        if (willWriteLoop)
         {
             import_support::importZoneLoop(*z, ctx, 0,
                                            {

--- a/src/scxt-core/sample/sfz_support/sfz_import.cpp
+++ b/src/scxt-core/sample/sfz_support/sfz_import.cpp
@@ -359,40 +359,20 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
             auto sampleFile = fs::path{sampleFileString};
             auto samplePath = (sampleDir / sampleFile).lexically_normal();
 
-            SampleID sid;
-            if (fs::exists(samplePath))
+            auto lsid = ctx.loadSampleFromDisk({samplePath, sampleFile});
+            if (!lsid)
             {
-                auto lsid = e.getSampleManager()->loadSampleByPath(samplePath);
-                if (lsid.has_value())
-                {
-                    sid = *lsid;
-                }
-                else
-                {
-                    ctx.raise("SFZ Import Error",
-                              "Cannot load sample '" + samplePath.u8string() + "'");
-                    break;
-                }
+                // TODO: this should trigger a missing-sample resolution flow
+                // (prompt the user to locate the file) rather than raising +
+                // skipping the region. Same shape applies to a load failure on
+                // a path that DID exist (e.g. a corrupt WAV). For now: raise a
+                // user-visible error and skip this region; the rest of the SFZ
+                // continues to import.
+                ctx.raise("SFZ Import Error", "Unable to load sample '" + samplePath.u8string() +
+                                                  "' or '" + sampleFile.u8string() + "'");
+                break;
             }
-            else if (fs::exists(sampleFile))
-            {
-                auto lsid = e.getSampleManager()->loadSampleByPath(sampleFile);
-                if (lsid.has_value())
-                {
-                    sid = *lsid;
-                }
-                else
-                {
-                    return ctx.fail("SFZ Import Error",
-                                    "Cannot load sample '" + sampleFile.u8string() + "'");
-                }
-            }
-            else
-            {
-                return ctx.fail("SFZ Import Error", "Unable to load either '" +
-                                                        samplePath.u8string() + "' or '" +
-                                                        sampleFile.u8string() + "'");
-            }
+            SampleID sid = *lsid;
 
             // OK so do we have a sequence position > 1
             int roundRobinPosition{-1};


### PR DESCRIPTION
Add ImporterContext::loadSampleFromDisk(candidates, extensionFallbacks) covering the file-based importers' load-from-disk pattern. Migrates sfz/akp/exs to it — collapsing AKP's existence-check+extension-fallback from ~24 lines to 4, and SFZ's nested if/else load dance to one call.

Mask MAPPING off when calling attachToSample in akp/exs/multisample so a smpl chunk in the referenced WAV can't clobber the importer-supplied root/key/vel. Also mask LOOP off in multisample when the multisample.xml explicitly provides loop bounds. Container formats (sf2/gig) keep the default flags — they own their sample data and there is no rogue meta to fight.

SFZ keeps its "raise + continue on missing/unloadable sample" semantic (previously this only kicked in for "exists but load failed" — now it covers the combined missing-OR-unloadable case via the wrapper). TODO comment marks the spot where a future missing-sample resolution flow plugs in.

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>