### PR TITLE
Add defensive loop guard; flac smpl sanity check

### DIFF
--- a/src/scxt-core/dsp/generator.cpp
+++ b/src/scxt-core/dsp/generator.cpp
@@ -753,7 +753,7 @@ void GeneratorSample(GeneratorState *__restrict GD, GeneratorIO *__restrict IO)
                 {
                     auto q = k + SamplePos - FIRoffset;
                     if (q >= GD->loopUpperBound || q >= WaveSize)
-                        q -= LoopOffset;
+                        q -= std::min((unsigned)LoopOffset, q);
                     loopEndBufferLF32[k] = SampleDataFL[q];
                     if (stereo)
                         loopEndBufferRF32[k] = SampleDataFR[q];
@@ -786,7 +786,7 @@ void GeneratorSample(GeneratorState *__restrict GD, GeneratorIO *__restrict IO)
                 {
                     auto q = k + SamplePos - FIRoffset;
                     if (q >= GD->loopUpperBound || q >= WaveSize)
-                        q -= LoopOffset;
+                        q -= std::min((unsigned)LoopOffset, q);
 
                     loopEndBufferL[k] = SampleDataL[q];
                     if (stereo)
@@ -1093,7 +1093,7 @@ void GeneratorSample(GeneratorState *__restrict GD, GeneratorIO *__restrict IO)
                     {
                         auto q = k + SamplePos - FIRoffset;
                         if (q >= GD->loopUpperBound || q >= WaveSize)
-                            q -= LoopOffset;
+                            q -= std::min((unsigned)LoopOffset, q);
                         loopEndBufferLF32[k] = SampleDataFL[q];
                         if (stereo)
                             loopEndBufferRF32[k] = SampleDataFR[q];
@@ -1127,7 +1127,7 @@ void GeneratorSample(GeneratorState *__restrict GD, GeneratorIO *__restrict IO)
                     {
                         auto q = k + SamplePos - FIRoffset;
                         if (q >= GD->loopUpperBound || q >= WaveSize)
-                            q -= LoopOffset;
+                            q -= std::min((unsigned)LoopOffset, q);
                         loopEndBufferL[k] = SampleDataL[q];
                         if (stereo)
                             loopEndBufferR[k] = SampleDataR[q];

--- a/src/scxt-core/sample/loaders/load_flac.cpp
+++ b/src/scxt-core/sample/loaders/load_flac.cpp
@@ -314,7 +314,8 @@ bool Sample::parseFlac(const fs::path &p)
                         d += sizeof(loaders::SampleLoop);
 
                         meta.loop_start = smpl_loop.dwStart;
-                        meta.loop_end = smpl_loop.dwEnd + 1;
+                        meta.loop_end =
+                            std::min((uint32_t)smpl_loop.dwEnd + 1, sampleLengthPerChannel);
                         if (smpl_loop.dwType == 1)
                             meta.playmode = pm_forward_loop_bidirectional;
                         else


### PR DESCRIPTION
If you ended up with a misconfigured sample where the loop end was outside the sample you could end up winding back the clock way way too far and crashing. Defend by making max move of position pointer in loop back to zero.

This happened when some flac with bad sample data got read from an sfz i had. So also guard the flac reader to limit us to a sane value

Closes #2452