### PR TITLE
EXS expansion: groups, global parameters, filter, envelopes, tune+bend

### DIFF
--- a/src/scxt-core/sample/exs_support/exs_import.cpp
+++ b/src/scxt-core/sample/exs_support/exs_import.cpp
@@ -31,16 +31,43 @@
 #include <cstdint>
 #include "utils.h"
 #include "exs_import.h"
+#include "exs_parameters.h"
 #include "sample/import_support/import_harness.h"
 #include "sample/import_support/import_mapping.h"
 #include "sample/import_support/import_loop.h"
+#include "sample/import_support/import_envelope.h"
+#include "sample/import_support/import_filter.h"
+#include "sample/import_support/import_modulation.h"
 #include "sample/import_support/import_numeric.h"
+#include "dsp/processor/processor.h"
+#include <cmath>
 
 #include <messaging/messaging.h>
 
 namespace scxt::exs_support
 {
 using byteData_t = std::vector<uint8_t>;
+
+// EXS envelope time bytes (0..127) follow Logic's quartic time control, not
+// the linear value/127*10 the Java ConvertWithMoss reference uses (which we
+// initially mirrored — they have the same bug). Logic's max release is 10
+// seconds (confirmed against Sampler); a power-law fit to readings from
+// French Horns Legato.exs and Supergrain 5.exs gives k≈4 anchored at that
+// upper bound:
+//   v=0   -> 0 s       (hard-zeroed)
+//   v=37  -> 72 ms     ✓
+//   v=47  -> 188 ms    ✓
+//   v=87  -> 2.20 s    ✓
+//   v=115 -> 6.27 s    (formula gives 6.74 s; probably display rounding)
+//   v=127 -> 10 s      (max)
+// Fit: seconds = (v/127)^4 * 10.
+inline float exsEnvByteToSeconds(int v)
+{
+    if (v <= 0)
+        return 0.f;
+    float frac = v / 127.f;
+    return frac * frac * frac * frac * 10.f;
+}
 
 uint32_t readU32(std::ifstream &f, bool bigE)
 {
@@ -537,9 +564,21 @@ struct EXSSample : EXSObject
 
 struct EXSParameters : EXSObject
 {
-    // For vals see
-    // https://github.com/git-moss/ConvertWithMoss/blob/main/src/main/java/de/mossgrabers/convertwithmoss/format/exs/EXS24Parameters.java
+    // Sparse map of (param-id -> int16 value). Named ids live in
+    // exs_parameters.h; see that header (and ConvertWithMoss's
+    // EXS24Parameters.java which it was transcribed from) for what each id
+    // means.
     std::map<uint16_t, int16_t> params;
+
+    // Typed accessor: returns the stored value if present, otherwise
+    // `defaultVal`. Use the EXSParam enum so call sites read declaratively.
+    int16_t get(EXSParam id, int16_t defaultVal = 0) const
+    {
+        auto it = params.find(static_cast<uint16_t>(id));
+        return it != params.end() ? it->second : defaultVal;
+    }
+    bool has(EXSParam id) const { return params.find(static_cast<uint16_t>(id)) != params.end(); }
+
     EXSParameters(EXSBlock in) : EXSObject(in)
     {
         assert(in.type == EXSBlock::TYPE_PARAMS);
@@ -551,12 +590,20 @@ struct EXSParameters : EXSObject
         int paramCount = (int)readU32();
         int paramBlockLength = paramCount * 3;
 
+        // After the 4-byte count we just consumed, the chunk holds
+        // `paramCount` 1-byte IDs followed by `paramCount` 2-byte LE values.
+        // Offset both lookups by the current position so we read from
+        // *after* the count, not from byte 0 of the chunk (which is the
+        // count itself).
+        const auto idsBase = position;
+        const auto valuesBase = position + paramCount;
+
         for (int i = 0; i < paramCount; i++)
         {
-            int paramId = within.content[i] & 0xFF;
+            int paramId = within.content[idsBase + i] & 0xFF;
             if (paramId != 0)
             {
-                auto offset = paramCount + 2 * i;
+                auto offset = valuesBase + 2 * i;
                 int16_t value = within.content[offset] | (within.content[offset + 1] << 8);
                 params[paramId] = value;
             }
@@ -693,9 +740,145 @@ bool importEXS(const fs::path &p, engine::Engine &e)
             sampleIDByOrder.push_back(*lsid);
     }
 
+    // Group-level config (volume/pan to GroupOutputInfo, polyphony to playMode,
+    // exclusive to choke-group ID). Bumps Part::numExclusiveGroups for any
+    // non-zero exclusive IDs we've seen.
+    int maxExclusive = 0;
     for (auto &g : info.groups)
-        groupIndexByOrder.push_back(ctx.addGroup(g.within.name));
+    {
+        int scxtGid = ctx.addGroup(g.within.name);
+        groupIndexByOrder.push_back(scxtGid);
 
+        auto &grp = *ctx.getPart().getGroup(scxtGid);
+        if (g.volume != 0)
+            grp.outputInfo.amplitude = import_support::dBToCubicAttenuation((float)g.volume);
+        if (g.pan != 0)
+            grp.outputInfo.pan = g.pan / 50.f;
+
+        if (g.polyphony == 1)
+        {
+            grp.outputInfo.playMode = engine::Group::PlayMode::MONO;
+        }
+        else if (g.polyphony > 1)
+        {
+            grp.outputInfo.hasIndependentPolyLimit = true;
+            grp.outputInfo.polyLimit = g.polyphony;
+        }
+        // polyphony == 0: leave defaults (POLY, no limit).
+
+        if (g.exclusive > 0)
+        {
+            grp.outputInfo.exclusiveGroup = g.exclusive;
+            if (g.exclusive > maxExclusive)
+                maxExclusive = g.exclusive;
+        }
+    }
+    if (maxExclusive > 0)
+    {
+        auto &cfg = ctx.getPart().configuration;
+        if (maxExclusive > cfg.numExclusiveGroups)
+            cfg.numExclusiveGroups = maxExclusive;
+    }
+
+    // --- Global "parameters block" wiring ----------------------------------
+    //
+    // Logic stores program-wide settings (master tune, pitch-bend range,
+    // global filter, global ENV1=amp / ENV2=filter envelopes) in the
+    // parameters chunk. SCXT doesn't have a program-level filter or
+    // envelope, so we project these onto every zone — every zone gets the
+    // same ENV1/ENV2 + filter, and the global filter envelope (ENV2) is
+    // wired to filter cutoff via a mod route.
+    //
+    // Param IDs are in exs_parameters.h (named from ConvertWithMoss's
+    // EXS24Parameters.java); conversions follow the same reference unless
+    // noted.
+    const bool haveParams = info.parameters.has_value();
+    const auto &params = info.parameters;
+
+    float globalTuneSemis = 0;
+    if (haveParams)
+    {
+        int coarse = params->get(EXSParam::COARSE_TUNE);
+        int fine = params->get(EXSParam::FINE_TUNE);
+        globalTuneSemis = coarse + import_support::centsToSemitones((float)fine);
+    }
+
+    int16_t globalPbUp = 2, globalPbDown = 2;
+    bool haveGlobalPb = false;
+    if (haveParams && params->has(EXSParam::PITCH_BEND_UP))
+    {
+        haveGlobalPb = true;
+        int up = params->get(EXSParam::PITCH_BEND_UP, 2);
+        int down = params->get(EXSParam::PITCH_BEND_DOWN, -1);
+        globalPbUp = (int16_t)up;
+        // EXS convention: PITCH_BEND_DOWN == -1 means "match PITCH_BEND_UP"
+        globalPbDown = (int16_t)((down == -1) ? up : down);
+    }
+    if (haveGlobalPb)
+    {
+        for (int gid : groupIndexByOrder)
+        {
+            auto &grp = *ctx.getPart().getGroup(gid);
+            grp.outputInfo.pbUp = globalPbUp;
+            grp.outputInfo.pbDown = globalPbDown;
+        }
+    }
+
+    const bool filterEnabled = haveParams && params->get(EXSParam::FILTER1_TOGGLE) > 0;
+    import_support::FilterArgs filterArgs;
+    if (filterEnabled)
+    {
+        // TODO: map FILTER1_TYPE (0..5: LP4/LP3/LP2/LP1/HP2/BP2) to the best
+        // SCXT processor type rather than always CytomicSVF.
+        filterArgs.type = dsp::processor::ProcessorType::proct_CytomicSVF;
+        int rawCutoff = params->get(EXSParam::FILTER1_CUTOFF, 1000);
+        int rawReso = params->get(EXSParam::FILTER1_RESO, 0);
+        // Logic Sampler's filter cutoff is stored as 0..1000 (UI shows it as
+        // a 0..100% percentage with no Hz reading). The raw value maps
+        // logarithmically to Hz across the audio range: 0% → 20 Hz,
+        // 100% → 20 kHz. The Java ConvertWithMoss reference uses a linear
+        // 0..20kHz map which is wrong — they have the same bug.
+        // Formula: hz = 20 * 1000^(rawCutoff/1000).
+        float pct = std::clamp(rawCutoff / 1000.f, 0.f, 1.f);
+        float hz = 20.f * std::pow(1000.f, pct);
+        float cutoffSemis = 12.f * std::log2(hz / 440.f);
+        filterArgs.cutoff = std::clamp(cutoffSemis, -69.f, 70.f);
+        filterArgs.resonance = std::clamp(rawReso / 1000.f, 0.f, 1.f);
+    }
+
+    // Times go through exsEnvByteToSeconds (exponential curve, calibrated
+    // against Logic Sampler — not the linear /127*10 the Java reference
+    // uses). Sustain is a 0..127 byte → 0..1 level. Only write the field
+    // if the file actually specified it (matches Java's null-default
+    // behavior — important for sustain so an omitted param means "full
+    // sustain" 1.0 not "silent" 0).
+    auto envFromParams = [&](EXSParam delay, EXSParam attack, EXSParam hold, EXSParam decay,
+                             EXSParam sustain, EXSParam release) -> import_support::EnvelopeArgs {
+        import_support::EnvelopeArgs args;
+        if (!haveParams)
+            return args;
+        if (params->has(delay))
+            args.delaySeconds = exsEnvByteToSeconds(params->get(delay));
+        if (params->has(attack))
+            args.attackSeconds = exsEnvByteToSeconds(params->get(attack));
+        if (params->has(hold))
+            args.holdSeconds = exsEnvByteToSeconds(params->get(hold));
+        if (params->has(decay))
+            args.decaySeconds = exsEnvByteToSeconds(params->get(decay));
+        if (params->has(sustain))
+            args.sustainLevel = params->get(sustain) / 127.f;
+        if (params->has(release))
+            args.releaseSeconds = exsEnvByteToSeconds(params->get(release));
+        return args;
+    };
+    auto env1Args =
+        envFromParams(EXSParam::ENV1_DELAY_START, EXSParam::ENV1_ATK_HI_VEL, EXSParam::ENV1_HOLD,
+                      EXSParam::ENV1_DECAY, EXSParam::ENV1_SUSTAIN, EXSParam::ENV1_RELEASE);
+    auto env2Args =
+        envFromParams(EXSParam::ENV2_DELAY_START, EXSParam::ENV2_ATK_HI_VEL, EXSParam::ENV2_HOLD,
+                      EXSParam::ENV2_DECAY, EXSParam::ENV2_SUSTAIN, EXSParam::ENV2_RELEASE);
+
+    bool warnedAboutRoundRobin = false;
     int zoneOrdinal = 0;
     for (auto &z : info.zones)
     {
@@ -722,25 +905,67 @@ bool importEXS(const fs::path &p, engine::Engine &e)
         }
         auto gi = groupIndexByOrder[exsgi];
         auto si = sampleIDByOrder[exssi];
-        auto zone = std::make_unique<engine::Zone>(si);
+        const auto &exsGroup = info.groups[exsgi];
+
+        // EXS round-robin: groups flagged with enableByRoundRobin form a
+        // sequence keyed by roundRobinGroupPos (-1, 0, 1, …). Each "position"
+        // is a separate EXS group covering the same key/vel range; played
+        // back in order on repeated note-ons. SCXT does this via Zone
+        // variants — one zone with N variants — which would require gathering
+        // multiple EXS zones into a single SCXT zone instead of one-per-EXS.
+        // Not implemented yet; import the zone as a regular non-RR zone for
+        // now so it still plays.
+        if (exsGroup.enableByRoundRobin && !warnedAboutRoundRobin)
+        {
+            ctx.unsupported("EXS round-robin groups",
+                            "imported as parallel zones; per-variant RR not yet supported");
+            warnedAboutRoundRobin = true;
+        }
 
         // velocityRangeOn=false means "use full velocity range"; otherwise
         // honor the per-zone velocityLow/High the EXS specifies.
         int velStart = z.velocityRangeOn ? z.velocityLow : 0;
         int velEnd = z.velocityRangeOn ? z.velocityHigh : 127;
+        int keyStart = z.keyLow;
+        int keyEnd = z.keyHigh;
+
+        // Intersect with the group's vel/key range (per the ConvertWithMoss
+        // reference). Skip the zone entirely if it falls outside the group's
+        // range. The "!= 0" guards on the clamps preserve the reference
+        // behavior of treating zero as "no bound applied" — see EXS24Detector
+        // limitByGroupAttributes.
+        if (velEnd < exsGroup.minVelocity || velStart > exsGroup.maxVelocity)
+            continue;
+        if (keyEnd < exsGroup.startNote || keyStart > exsGroup.endNote)
+            continue;
+        if (exsGroup.minVelocity != 0 && velStart < exsGroup.minVelocity)
+            velStart = exsGroup.minVelocity;
+        if (exsGroup.maxVelocity != 0 && velEnd > exsGroup.maxVelocity)
+            velEnd = exsGroup.maxVelocity;
+        if (exsGroup.startNote != 0 && keyStart < exsGroup.startNote)
+            keyStart = exsGroup.startNote;
+        if (exsGroup.endNote != 0 && keyEnd > exsGroup.endNote)
+            keyEnd = exsGroup.endNote;
+
+        auto zone = std::make_unique<engine::Zone>(si);
+        zone->engine = &e;
 
         // Tuning: EXS only respects coarse/fine when the `pitch` flag is set
         // (mirrors the ConvertWithMoss reference). volumeAdjust is in dB.
-        std::optional<float> pitchOffsetSemis;
+        // Global COARSE_TUNE+FINE_TUNE adds on top.
+        float perZoneTune = 0;
         if (z.pitch && (z.coarseTuning != 0 || z.fineTuning != 0))
-            pitchOffsetSemis =
-                z.coarseTuning + import_support::centsToSemitones((float)z.fineTuning);
+            perZoneTune = z.coarseTuning + import_support::centsToSemitones((float)z.fineTuning);
+        float totalTune = perZoneTune + globalTuneSemis;
+        std::optional<float> pitchOffsetSemis;
+        if (totalTune != 0)
+            pitchOffsetSemis = totalTune;
 
         import_support::importZoneMapping(*zone, ctx,
                                           {
                                               .rootKey = z.key,
-                                              .keyStart = z.keyLow,
-                                              .keyEnd = z.keyHigh,
+                                              .keyStart = keyStart,
+                                              .keyEnd = keyEnd,
                                               .velStart = velStart,
                                               .velEnd = velEnd,
                                               .pitchOffsetSemitones = pitchOffsetSemis,
@@ -768,7 +993,9 @@ bool importEXS(const fs::path &p, engine::Engine &e)
             variant.endSample = z.sampleEnd;
 
         variant.playReverse = z.reverse;
-        if (z.oneshot)
+        if (exsGroup.releaseTrigger)
+            variant.playMode = engine::Zone::PlayMode::ON_RELEASE;
+        else if (z.oneshot)
             variant.playMode = engine::Zone::PlayMode::ONE_SHOT;
 
         if (z.loopOn)
@@ -795,6 +1022,31 @@ bool importEXS(const fs::path &p, engine::Engine &e)
                                                .fadeSamples = fadeSamples,
                                                .active = true,
                                            });
+        }
+
+        // Global env1 (AmpEG) / env2 (FilEG) — every zone gets the same
+        // global envelope shape.
+        import_support::EGHandle egAmpHandle, egFilHandle;
+        if (haveParams)
+        {
+            egAmpHandle = import_support::importZoneEnvelope(*zone, ctx, 0, env1Args);
+            egFilHandle = import_support::importZoneEnvelope(*zone, ctx, 1, env2Args);
+        }
+
+        // Global filter + env2-to-cutoff mod route. Logic models env2 as the
+        // filter's cutoff modulator with depth 1.0; SCXT routes it through
+        // the mod matrix.
+        if (filterEnabled)
+        {
+            auto filterHandle = import_support::importZoneFilter(*zone, ctx, 0, filterArgs);
+            import_support::addImportedModRoute(
+                *zone, ctx,
+                {
+                    .source = import_support::ImportedSource::fromEG(egFilHandle),
+                    .target = import_support::ImportedTarget::filter(
+                        filterHandle, import_support::FilterParam::Cutoff),
+                    .depth = 1.0f,
+                });
         }
 
         ctx.addZoneToGroup(gi, std::move(zone));

--- a/src/scxt-core/sample/exs_support/exs_parameters.h
+++ b/src/scxt-core/sample/exs_support/exs_parameters.h
@@ -1,0 +1,263 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_SCXT_CORE_SAMPLE_EXS_SUPPORT_EXS_PARAMETERS_H
+#define SCXT_SRC_SCXT_CORE_SAMPLE_EXS_SUPPORT_EXS_PARAMETERS_H
+
+#include <cstdint>
+
+namespace scxt::exs_support
+{
+
+// Named parameter IDs for the EXS24 "parameters" block. The raw .exs file
+// stores instrument-global settings as (id, value) pairs in a sparse map;
+// these are the IDs the Logic Sampler editor uses for things like filter
+// cutoff, envelope times, LFO rates, mod-matrix slots, etc.
+//
+// All identifiers and values below are reverse-engineered, transcribed from:
+//
+//     ConvertWithMoss by Jürgen Moßgraber
+//     https://github.com/git-moss/ConvertWithMoss
+//     src/main/java/de/mossgrabers/convertwithmoss/format/exs/
+//     EXS24Parameters.java   (LGPL-3.0)
+//
+// Used here under LGPL-3.0; if/when this file gets meaningfully extended
+// please keep the attribution intact. Some IDs only appear in the newer
+// (200-parameter) layout but the ID space is shared with the older one.
+enum class EXSParam : uint16_t
+{
+    // Master / global
+    MASTER_VOLUME = 0x07,
+    MASTER_PAN = 0x160,
+    VOLUME_KEYSCALE = 0x08,
+    PITCH_BEND_UP = 0x03,
+    PITCH_BEND_DOWN = 0x04,
+    MONO_LEGATO = 0x0a,
+    MIDI_MONO_MODE = 0x116,
+    MIDI_MONO_MODE_PITCH_RANGE = 0x11a,
+    POLYPHONY_VOICES = 0x05,
+    TRANSPOSE = 0x2d,
+    COARSE_TUNE = 0x0e,
+    FINE_TUNE = 0x0f,
+    GLIDE = 0x14,
+    PORTA_DOWN = 0x48,
+    PORTA_UP = 0x49,
+
+    // Filter 1
+    FILTER1_TOGGLE = 0x2c,
+    FILTER1_TYPE = 0xf3,
+    FILTER1_FAT = 0xaa,
+    FILTER1_CUTOFF = 0x1e,
+    FILTER1_RESO = 0x1d,
+    FILTER1_DRIVE = 0x4b,
+    FILTER1_KEYTRACK = 0x2e,
+
+    // Filter 2 (later EXS revisions)
+    FILTER2_TOGGLE = 0x174,
+    FILTER2_TYPE = 0x186,
+    FILTER2_CUTOFF = 0x177,
+    FILTER2_RESO = 0x178,
+    FILTER2_DRIVE = 0x179,
+    FILTERS_SERIAL_PARALLEL = 0x173,
+    FILTERS_BLEND = 0x17a,
+
+    // LFO 1
+    LFO_1_FADE = 0x3c,
+    LFO_1_RATE = 0x3d,
+    LFO_1_WAVE_SHAPE = 0x3e,
+    LFO_1_KEY_TRIGGER = 0x14c,
+    LFO_1_MONO_POLY = 0x14d,
+    LFO_1_PHASE = 0x14e,
+    LFO_1_POSITIVE_OR_MIDPOINT = 0x14f,
+    LFO_1_TEMPO_SYNC = 0x150,
+    LFO_1_FADE_IN_OR_OUT = 0x187,
+
+    // LFO 2
+    LFO_2_RATE = 0x3f,
+    LFO_2_WAVE_SHAPE = 0x40,
+    LFO_2_FADE = 0x151,
+    LFO_2_KEY_TRIGGER = 0x152,
+    LFO_2_MONO_POLY = 0x153,
+    LFO_2_PHASE = 0x154,
+    LFO_2_POSITIVE_OR_MIDPOINT = 0x155,
+    LFO_2_TEMPO_SYNC = 0x156,
+    LFO_2_FADE_IN_OR_OUT = 0x188,
+
+    // LFO 3
+    LFO_3_RATE = 0xa7,
+    LFO_3_WAVE_SHAPE = 0x158,
+    LFO_3_FADE = 0x157,
+    LFO_3_KEY_TRIGGER = 0x159,
+    LFO_3_MONO_POLY = 0x15a,
+    LFO_3_PHASE = 0x15b,
+    LFO_3_POSITIVE_OR_MIDPOINT = 0x15c,
+    LFO_3_TEMPO_SYNC = 0x15d,
+    LFO_3_FADE_IN_OR_OUT = 0x189,
+
+    // Envelope 2 (filter env in Logic; 0=AD, 1=AR, 2=ADSR, 3=AHDSR, 4=DADSR, 5=DAHDSR)
+    ENV2_TYPE = 0x16a,
+    ENV2_VEL_SENS = 0x17d,
+    ENV2_DELAY_START = 0x16c,
+    ENV2_ATK_CURVE = 0x192,
+    ENV2_ATK_HI_VEL = 0x4c,
+    ENV2_ATK_LO_VEL = 0x4d,
+    ENV2_HOLD = 0x38,
+    ENV2_DECAY = 0x4e,
+    ENV2_SUSTAIN = 0x4f,
+    ENV2_RELEASE = 0x50,
+    ENV2_TIME_CURVE = 0x5b,
+
+    // Envelope 1 (amp env in Logic; same type-byte enumeration)
+    ENV1_TYPE = 0x6b,
+    ENV1_VEL_SENS = 0x5a,
+    ENV1_VOLUME_HIGH = 0x59,
+    ENV1_DELAY_START = 0x16d,
+    ENV1_ATK_CURVE = 0x195,
+    ENV1_ATK_HI_VEL = 0x52,
+    ENV1_ATK_LO_VEL = 0x53,
+    ENV1_HOLD = 0x58,
+    ENV1_DECAY = 0x54,
+    ENV1_SUSTAIN = 0x51,
+    ENV1_RELEASE = 0x55,
+    // ENV1_TIME_CURVE has no ID per Java reference; intentionally omitted.
+
+    // Velocity / random / xfade / unison
+    AMP_VELOCITY_CURVE = 0x183,
+    VELOCITY_OFFSET = 0x5f,
+    RANDOM_VELOCITY = 0xa4,
+    RANDOM_SAMPLE_SEL = 0xa3,
+    RANDOM_PITCH = 0x62,
+    XFADE_AMOUNT = 0x61,
+    XFADE_TYPE = 0xa5,
+    UNISON_TOGGLE = 0xab,
+    COARSE_TUNE_REMOTE = 0xa6,
+    HOLD_VIA_CONTROL = 0xac,
+
+    // Mod-matrix slots 1..11 (each is 8 contiguous IDs).
+    MOD1_DESTINATION = 0xad,
+    MOD1_SOURCE = 0xae,
+    MOD1_VIA = 0xaf,
+    MOD1_AMOUNT_LOW = 0xb0,
+    MOD1_AMOUNT_HIGH = 0xb1,
+    MOD1_SRC_INVERT = 0xe9,
+    MOD1_VIA_INVERT = 0xb2,
+    MOD1_BYPASS = 0xf4,
+
+    MOD2_DESTINATION = 0xb3,
+    MOD2_SOURCE = 0xb4,
+    MOD2_VIA = 0xb5,
+    MOD2_AMOUNT_LOW = 0xb6,
+    MOD2_AMOUNT_HIGH = 0xb7,
+    MOD2_SRC_INVERT = 0xea,
+    MOD2_VIA_INVERT = 0xb8,
+    MOD2_BYPASS = 0xf5,
+
+    MOD3_DESTINATION = 0xb9,
+    MOD3_SOURCE = 0xba,
+    MOD3_VIA = 0xbb,
+    MOD3_AMOUNT_LOW = 0xbc,
+    MOD3_AMOUNT_HIGH = 0xbd,
+    MOD3_SRC_INVERT = 0xeb,
+    MOD3_VIA_INVERT = 0xbe,
+    MOD3_BYPASS = 0xf6,
+
+    MOD4_DESTINATION = 0xbf,
+    MOD4_SOURCE = 0xc0,
+    MOD4_VIA = 0xc1,
+    MOD4_AMOUNT_LOW = 0xc2,
+    MOD4_AMOUNT_HIGH = 0xc3,
+    MOD4_SRC_INVERT = 0xec,
+    MOD4_VIA_INVERT = 0xc4,
+    MOD4_BYPASS = 0xf7,
+
+    MOD5_DESTINATION = 0xc5,
+    MOD5_SOURCE = 0xc6,
+    MOD5_VIA = 0xc7,
+    MOD5_AMOUNT_LOW = 0xc8,
+    MOD5_AMOUNT_HIGH = 0xc9,
+    MOD5_SRC_INVERT = 0xed,
+    MOD5_VIA_INVERT = 0xca,
+    MOD5_BYPASS = 0xf8,
+
+    MOD6_DESTINATION = 0xcb,
+    MOD6_SOURCE = 0xcc,
+    MOD6_VIA = 0xcd,
+    MOD6_AMOUNT_LOW = 0xce,
+    MOD6_AMOUNT_HIGH = 0xcf,
+    MOD6_SRC_INVERT = 0xee,
+    MOD6_VIA_INVERT = 0xd0,
+    MOD6_BYPASS = 0xf9,
+
+    MOD7_DESTINATION = 0xd1,
+    MOD7_SOURCE = 0xd2,
+    MOD7_VIA = 0xd3,
+    MOD7_AMOUNT_LOW = 0xd4,
+    MOD7_AMOUNT_HIGH = 0xd5,
+    MOD7_SRC_INVERT = 0xef,
+    MOD7_VIA_INVERT = 0xd6,
+    MOD7_BYPASS = 0xfa,
+
+    MOD8_DESTINATION = 0xd7,
+    MOD8_SOURCE = 0xd8,
+    MOD8_VIA = 0xd9,
+    MOD8_AMOUNT_LOW = 0xda,
+    MOD8_AMOUNT_HIGH = 0xdb,
+    MOD8_SRC_INVERT = 0xf0,
+    MOD8_VIA_INVERT = 0xdc,
+    MOD8_BYPASS = 0xfb,
+
+    MOD9_DESTINATION = 0xdd,
+    MOD9_SOURCE = 0xde,
+    MOD9_VIA = 0xdf,
+    MOD9_AMOUNT_LOW = 0xe0,
+    MOD9_AMOUNT_HIGH = 0xe1,
+    MOD9_SRC_INVERT = 0xf1,
+    MOD9_VIA_INVERT = 0xe2,
+    MOD9_BYPASS = 0xfc,
+
+    MOD10_DESTINATION = 0xe3,
+    MOD10_SOURCE = 0xe4,
+    MOD10_VIA = 0xe5,
+    MOD10_AMOUNT_LOW = 0xe6,
+    MOD10_AMOUNT_HIGH = 0xe7,
+    MOD10_SRC_INVERT = 0xf2,
+    MOD10_VIA_INVERT = 0xe8,
+    MOD10_BYPASS = 0xfd,
+
+    MOD11_DESTINATION = 0x19b,
+    MOD11_SOURCE = 0x19c,
+    MOD11_VIA = 0x19d,
+    MOD11_AMOUNT_LOW = 0x19e,
+    MOD11_AMOUNT_HIGH = 0x19f,
+    MOD11_SRC_INVERT = 0x1a0,
+    MOD11_VIA_INVERT = 0x1a1,
+    MOD11_BYPASS = 0x1a2,
+};
+
+} // namespace scxt::exs_support
+
+#endif

--- a/src/scxt-core/sample/import_support/import_numeric.h
+++ b/src/scxt-core/sample/import_support/import_numeric.h
@@ -40,6 +40,13 @@ inline float centibelsToLinear(double cB) { return (float)std::pow(10.0, (-cB / 
 
 // SF2 pan is -64..63 (signed byte) — negative half divides by 64, positive by 63.
 inline float sf2NormalizedPan(int pan) { return pan < 0 ? pan / 64.f : pan / 63.f; }
+
+// Convert dB to the "cubic attenuation" parameter scxt uses on group amplitudes
+// (the runtime applies value*value*value to get linear amplitude, after
+// clamping value to 0..1). To invert: go to linear amplitude first, then
+// cube-root that. Note that group.cpp clamps the cube input to [0, 1] before
+// applying, so positive-dB input here will saturate at 0 dB at runtime.
+inline float dBToCubicAttenuation(float dB) { return (float)std::cbrt(std::pow(10.0, dB / 20.0)); }
 } // namespace scxt::import_support
 
 #endif


### PR DESCRIPTION
Picks up where the prior EXS work left off and wires through the group-level config and the program-wide parameters block that the parser was already reading but the importer was throwing away.

Group-level (Group::outputInfo)
- volume (dB) -> amplitude via new import_support::dBToCubicAttenuation (inverse of scxt's cubic-attenuation param: cbrt(10^(dB/20)) clamped by the audio path)
- pan (-50..50) -> pan via value/50
- polyphony: 1 -> MONO playMode; >1 -> hasIndependentPolyLimit + polyLimit; 0 leaves the defaults
- exclusive (cross-group choke) -> exclusiveGroup, bumping Part::numExclusiveGroups so the UI knows the IDs exist

Per-zone group constraints
- Intersect zone vel/key range with Group.minVelocity/maxVelocity and startNote/endNote. Drop the zone if it falls outside the group's range; otherwise clamp.
- Group.releaseTrigger -> zone playMode = ON_RELEASE (takes precedence over z.oneshot when both are set).

Named parameter constants
- New exs_parameters.h with EXSParam enum class covering ~120 IDs (master vol/pan, pitch bend, tune, filters, envelopes, LFOs, mod-matrix slots, velocity/random/xfade/unison). Transcribed from ConvertWithMoss's EXS24Parameters.java (LGPL-3.0, attribution at the top of the new header).
- EXSParameters gains typed get/has methods so call sites read params->get(EXSParam::FILTER1_CUTOFF, default) instead of indexing raw uint16_t IDs.

Global filter (FILTER1_*)
- FILTER1_TOGGLE > 0 -> CytomicSVF on processor slot 0. Multi-model mapping (LP4/LP3/LP2/LP1/HP2/BP2) left as a TODO; for now everything collapses to CytomicSVF.
- Cutoff: stored as 0..1000 (% in the Logic UI) on a log map across the audio range: hz = 20 * 1000^(raw/1000). Converted to semitones from A4 for SCXT. (Java reference uses a linear 0..20kHz map which is wrong by ~14x at the high end — we match Logic instead.)
- Resonance: 0..1000 -> 0..1.

Global envelopes (ENV1 -> AmpEG, ENV2 -> FilEG)
- Times use a quartic curve calibrated against Logic Sampler: seconds = (raw/127)^4 * 10 (max release = 10s). Java reference uses a linear value/127*10 which over-scales mid values by >10x.
- Sustain: raw/127 -> 0..1 level.
- Each field is has-gated so omitted params leave the zone default rather than overriding to zero — important for sustain, where an omitted param means "full sustain" (1.0) not "silent" (0).
- ENV2 -> filter cutoff wired as a mod route (depth 1.0) whenever the global filter is enabled, mirroring Logic's built-in modulator.

Global tune + pitch bend (E.7)
- COARSE_TUNE + FINE_TUNE/100 added on top of every zone's pitch offset.
- PITCH_BEND_UP/DOWN applied to all groups' outputInfo, honoring the EXS -1 sentinel ("match up") for bend down.

Bug fix: parameters-block parse
- The parser was indexing into the chunk content starting at byte 0, re-reading the 4-byte count it had just consumed. Real param IDs at content[4..] were missed and whatever garbage lived in content[0..3] got stored as a bogus "param". Offset both ID and value lookups by the current position. This is the latent bug that made every envelope, filter, tune, and bend value read as zero / garbage from any patch with a populated parameters block.

Round-robin
- Detected and flagged via ctx.unsupported on first sight. Proper RR requires gathering multiple EXS groups into a single SCXT zone with variants — left as future work; the zone still imports as a regular non-RR zone so it plays.

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>