### PR TITLE
Add abstract FilterType enum for importers and wire up SFZ filters

### DIFF
--- a/src/scxt-core/sample/akai_support/akai_import.cpp
+++ b/src/scxt-core/sample/akai_support/akai_import.cpp
@@ -621,7 +621,9 @@ bool importAKP(const fs::path &path, engine::Engine &e)
                     import_support::importZoneFilter(
                         *zn, ctx, 0,
                         {
-                            .type = dsp::processor::ProcessorType::proct_CytomicSVF,
+                            // TODO: map flt.type (0..25; see akpFilterTypeName)
+                            // to a more specific FilterType than the default LP12.
+                            .type = import_support::FilterType::LP12,
                             .cutoff = akpCutoffToSemis(flt.cutoff),
                             .resonance = flt.resonance / 12.f,
                         });

--- a/src/scxt-core/sample/exs_support/exs_import.cpp
+++ b/src/scxt-core/sample/exs_support/exs_import.cpp
@@ -828,9 +828,35 @@ bool importEXS(const fs::path &p, engine::Engine &e)
     import_support::FilterArgs filterArgs;
     if (filterEnabled)
     {
-        // TODO: map FILTER1_TYPE (0..5: LP4/LP3/LP2/LP1/HP2/BP2) to the best
-        // SCXT processor type rather than always CytomicSVF.
-        filterArgs.type = dsp::processor::ProcessorType::proct_CytomicSVF;
+        // EXS24 FILTER1_TYPE enum (Logic Sampler "Filter Slope" selector):
+        //   0=LP 24dB/oct (4-pole), 1=LP 18dB (3-pole), 2=LP 12dB (2-pole),
+        //   3=LP 6dB (1-pole), 4=HP 12dB (2-pole), 5=BP 12dB (2-pole).
+        switch (params->get(EXSParam::FILTER1_TYPE))
+        {
+        case 0:
+            filterArgs.type = import_support::FilterType::LP24;
+            break;
+        case 1:
+            filterArgs.type = import_support::FilterType::LP18;
+            break;
+        case 2:
+            filterArgs.type = import_support::FilterType::LP12;
+            break;
+        case 3:
+            filterArgs.type = import_support::FilterType::LP6;
+            break;
+        case 4:
+            filterArgs.type = import_support::FilterType::HP12;
+            break;
+        case 5:
+            filterArgs.type = import_support::FilterType::BP12;
+            break;
+        default:
+            filterArgs.type = import_support::FilterType::Other;
+            ctx.unsupported("EXS filter type",
+                            "FILTER1_TYPE=" + std::to_string(params->get(EXSParam::FILTER1_TYPE)));
+            break;
+        }
         int rawCutoff = params->get(EXSParam::FILTER1_CUTOFF, 1000);
         int rawReso = params->get(EXSParam::FILTER1_RESO, 0);
         // Logic Sampler's filter cutoff is stored as 0..1000 (UI shows it as

--- a/src/scxt-core/sample/import_support/import_filter.cpp
+++ b/src/scxt-core/sample/import_support/import_filter.cpp
@@ -32,6 +32,109 @@
 
 namespace scxt::import_support
 {
+namespace
+{
+// Resolved low-level filter config that the helper writes to the processor.
+// The int param values are indices into the per-model passbands/slopes/
+// drives/submodels arrays the FiltersPlusPlus<Model> constructor builds,
+// not raw enum values from filtersplusplus. Today only ipPassband and
+// ipSlope are used here; drives stay at "Standard" (index 0).
+struct ResolvedFilter
+{
+    dsp::processor::ProcessorType processorType{dsp::processor::ProcessorType::proct_CytomicSVF};
+    int passbandIdx{0};
+    int slopeIdx{0};
+    bool bypassWithMixZero{false}; // for the Other fallback
+};
+
+// Per-model passband index assignments. These mirror the FiltersPlusPlus
+// constructors in sst-effects:
+//   VemberClassic: explicit order LP=0, HP=1, BP=2, Notch=3, Allpass=4
+//   CytomicSVF: sorted by Passband enum value — LP=0, HP=1, BP=2, Notch=3,
+//               Peak=4, Allpass=5, LowShelf=6, Bell=7, HighShelf=8
+//   Comb: a single Comb passband
+namespace cytomic
+{
+constexpr int LP = 0;
+constexpr int HP = 1;
+constexpr int BP = 2;
+constexpr int Notch = 3;
+constexpr int Peak = 4;
+constexpr int Allpass = 5;
+} // namespace cytomic
+namespace vember
+{
+constexpr int LP = 0;
+constexpr int HP = 1;
+constexpr int BP = 2;
+constexpr int Notch = 3;
+// Slopes (sorted by enum value): 12dB=0, 24dB=1.
+constexpr int Slope_12dB = 0;
+constexpr int Slope_24dB = 1;
+} // namespace vember
+
+ResolvedFilter resolveFilterType(FilterType t)
+{
+    using Proc = dsp::processor::ProcessorType;
+    switch (t)
+    {
+    // --- exact 12dB Cytomic-backed mappings ---
+    case FilterType::LP12:
+        return {Proc::proct_CytomicSVF, cytomic::LP, 0, false};
+    case FilterType::HP12:
+        return {Proc::proct_CytomicSVF, cytomic::HP, 0, false};
+    case FilterType::BP12:
+        return {Proc::proct_CytomicSVF, cytomic::BP, 0, false};
+    case FilterType::Notch12:
+        return {Proc::proct_CytomicSVF, cytomic::Notch, 0, false};
+    case FilterType::Peak:
+        return {Proc::proct_CytomicSVF, cytomic::Peak, 0, false};
+    case FilterType::Allpass:
+        return {Proc::proct_CytomicSVF, cytomic::Allpass, 0, false};
+
+    // --- exact 24dB Vember-backed mappings ---
+    case FilterType::LP24:
+        return {Proc::proct_VemberClassic, vember::LP, vember::Slope_24dB, false};
+    case FilterType::HP24:
+        return {Proc::proct_VemberClassic, vember::HP, vember::Slope_24dB, false};
+    case FilterType::BP24:
+        return {Proc::proct_VemberClassic, vember::BP, vember::Slope_24dB, false};
+    case FilterType::Notch24:
+        return {Proc::proct_VemberClassic, vember::Notch, vember::Slope_24dB, false};
+
+    // --- approximated slopes (silently rounded to the closest available) ---
+    case FilterType::LP6:
+        return {Proc::proct_CytomicSVF, cytomic::LP, 0, false}; // 6dB → 12dB
+    case FilterType::HP6:
+        return {Proc::proct_CytomicSVF, cytomic::HP, 0, false};
+    case FilterType::BP6:
+        return {Proc::proct_CytomicSVF, cytomic::BP, 0, false};
+    case FilterType::LP18:
+    case FilterType::LP36:
+    case FilterType::LP48:
+        return {Proc::proct_VemberClassic, vember::LP, vember::Slope_24dB, false};
+    case FilterType::HP18:
+    case FilterType::HP36:
+    case FilterType::HP48:
+        return {Proc::proct_VemberClassic, vember::HP, vember::Slope_24dB, false};
+
+    case FilterType::Comb:
+        return {Proc::proct_comb, 0, 0, false};
+
+    case FilterType::Other:
+        return {Proc::proct_CytomicSVF, cytomic::LP, 0, true};
+    }
+    // Defensive: unknown enum value
+    return {Proc::proct_CytomicSVF, cytomic::LP, 0, true};
+}
+
+// Int param slot indices in processorStorage[].intParams, matching the
+// FiltersPlusPlus<>::IntParams enum order.
+constexpr int kIpPassband = 1;
+constexpr int kIpSlope = 2;
+
+} // namespace
+
 FilterHandle importZoneFilter(engine::Zone &zone, ImporterContext &ctx, int procSlot,
                               const FilterArgs &a)
 {
@@ -41,26 +144,26 @@ FilterHandle importZoneFilter(engine::Zone &zone, ImporterContext &ctx, int proc
         return {};
     }
 
-    auto type = *a.type;
+    auto resolved = resolveFilterType(*a.type);
     {
         auto guard = ctx.getEngine().getMessageController()->threadingChecker.bypassChecksInScope();
-        zone.setProcessorType(procSlot, type);
+        zone.setProcessorType(procSlot, resolved.processorType);
     }
 
     auto &ps = zone.processorStorage[procSlot];
-    switch (type)
-    {
-    case dsp::processor::ProcessorType::proct_CytomicSVF:
-        if (a.cutoff)
-            ps.floatParams[0] = *a.cutoff;
-        if (a.resonance)
-            ps.floatParams[2] = *a.resonance;
-        break;
-    default:
-        // Future processor types add their own index mapping here.
-        break;
-    }
+    ps.intParams[kIpPassband] = resolved.passbandIdx;
+    ps.intParams[kIpSlope] = resolved.slopeIdx;
 
-    return {procSlot, type};
+    // CytomicSVF / VemberClassic / Comb all share fpCutoffL=0, fpResonance=2
+    // through the FiltersPlusPlus base class.
+    if (a.cutoff)
+        ps.floatParams[0] = *a.cutoff;
+    if (a.resonance)
+        ps.floatParams[2] = *a.resonance;
+
+    if (resolved.bypassWithMixZero)
+        ps.mix = 0.f;
+
+    return {procSlot, resolved.processorType};
 }
 } // namespace scxt::import_support

--- a/src/scxt-core/sample/import_support/import_filter.h
+++ b/src/scxt-core/sample/import_support/import_filter.h
@@ -36,6 +36,48 @@ namespace scxt::import_support
 {
 class ImporterContext;
 
+// Format-agnostic filter "shape" each importer maps its native filter type
+// onto. The helper translates this into the underlying SCXT processor +
+// passband + slope config. When an importer doesn't know how to map its
+// native type, it should pass `Other` — the helper installs a bypassed
+// (mix=0) CytomicSVF LP and the importer is responsible for surfacing a
+// user-visible warning with format-specific context.
+//
+// Not every slope has a native SCXT model — the helper picks the closest
+// available and any approximation is silent (importers free to warn if they
+// care about fidelity). Today CytomicSVF gives us 12dB LP/HP/BP/Notch/Peak/
+// Allpass; VemberClassic gives us 12dB and 24dB LP/HP/BP/Notch. Anything
+// 6dB rounds up to 12dB; anything 18/36/48dB rounds to 24dB.
+enum class FilterType
+{
+    Other, // Unmapped / unrecognized — helper installs a bypassed LP.
+
+    LP6,
+    LP12,
+    LP18,
+    LP24,
+    LP36,
+    LP48,
+
+    HP6,
+    HP12,
+    HP18,
+    HP24,
+    HP36,
+    HP48,
+
+    BP6,
+    BP12,
+    BP24,
+
+    Notch12,
+    Notch24,
+
+    Peak,
+    Allpass,
+    Comb,
+};
+
 // Handle returned by importZoneFilter; carries the slot index and processor
 // type so the modulation resolver can map FilterParam::Cutoff to the right
 // floatParams index.
@@ -47,11 +89,12 @@ struct FilterHandle
 
 // type is required; the helper logs + asserts + returns if it is unset.
 // cutoff and resonance are left at the processor's current value when unset.
-// Values are in the processor's native units (e.g. for CytomicSVF, cutoff is
-// semitones offset from MIDI 69, resonance is 0..1).
+// Values are in the chosen processor's native units (for CytomicSVF/
+// VemberClassic this is semitones offset from MIDI 69 for cutoff, 0..1 for
+// resonance).
 struct FilterArgs
 {
-    std::optional<dsp::processor::ProcessorType> type;
+    std::optional<FilterType> type;
     std::optional<float> cutoff;
     std::optional<float> resonance;
 };

--- a/src/scxt-core/sample/sf2_support/sf2_import.cpp
+++ b/src/scxt-core/sample/sf2_support/sf2_import.cpp
@@ -203,7 +203,8 @@ bool importSF2(const fs::path &p, engine::Engine &e, int preset)
                         filterHandle = import_support::importZoneFilter(
                             *zn, ctx, 0,
                             {
-                                .type = dsp::processor::ProcessorType::proct_CytomicSVF,
+                                // SF2 spec: -12 dB/oct 2nd-order resonant LP.
+                                .type = import_support::FilterType::LP12,
                                 .cutoff = (float)((fc / 100.0) - 69.0),
                                 .resonance = (float)std::clamp((fq / 100.0), 0., 1.),
                             });

--- a/src/scxt-core/sample/sfz_support/sfz_import.cpp
+++ b/src/scxt-core/sample/sfz_support/sfz_import.cpp
@@ -29,6 +29,7 @@
 #include "sample/import_support/import_harness.h"
 #include "sample/import_support/import_mapping.h"
 #include "sample/import_support/import_envelope.h"
+#include "sample/import_support/import_filter.h"
 #include "sample/import_support/import_loop.h"
 #include "sample/import_support/import_numeric.h"
 #include "selection/selection_manager.h"
@@ -37,6 +38,9 @@
 #include "engine/engine.h"
 #include "configuration.h"
 #include <cctype>
+#include <cmath>
+#include <algorithm>
+#include <unordered_map>
 #include <sstream>
 
 namespace scxt::sfz_support
@@ -278,6 +282,69 @@ void zoneEnvelope(std::unique_ptr<engine::Zone> &zn, import_support::ImporterCon
     import_support::importZoneEnvelope(*zn, ctx, slot, args);
 }
 
+void zoneFilter(std::unique_ptr<engine::Zone> &zn, import_support::ImporterContext &ctx,
+                opCodeMap_t &opCodes, std::set<std::string> &reportedFilTypes)
+{
+    auto cutoffOpc = consumeOpcode(opCodes, "cutoff");
+    auto resoOpc = consumeOpcode(opCodes, "resonance");
+    auto typeOpc = consumeOpcode(opCodes, "fil_type");
+
+    // No filter opcodes set → don't install a filter at all.
+    if (!cutoffOpc.has_value() && !resoOpc.has_value() && !typeOpc.has_value())
+        return;
+
+    // SFZ defaults from the spec.
+    float cutoffHz = cutoffOpc.has_value() ? (float)std::atof(cutoffOpc->c_str()) : 22050.f;
+    float resoDb = resoOpc.has_value() ? (float)std::atof(resoOpc->c_str()) : 0.f;
+    std::string filTypeStr = typeOpc.value_or("lpf_2p");
+
+    static const std::unordered_map<std::string, import_support::FilterType> typeMap{
+        {"lpf_1p", import_support::FilterType::LP6},
+        {"lpf_2p", import_support::FilterType::LP12},
+        {"lpf_2p_sv", import_support::FilterType::LP12},
+        {"lpf_4p", import_support::FilterType::LP24},
+        {"lpf_6p", import_support::FilterType::LP36},
+        {"hpf_1p", import_support::FilterType::HP6},
+        {"hpf_2p", import_support::FilterType::HP12},
+        {"hpf_2p_sv", import_support::FilterType::HP12},
+        {"hpf_4p", import_support::FilterType::HP24},
+        {"hpf_6p", import_support::FilterType::HP36},
+        {"bpf_1p", import_support::FilterType::BP6},
+        {"bpf_2p", import_support::FilterType::BP12},
+        {"bpf_2p_sv", import_support::FilterType::BP12},
+        {"brf_1p", import_support::FilterType::Notch12},
+        {"brf_2p", import_support::FilterType::Notch12},
+        {"brf_2p_sv", import_support::FilterType::Notch12},
+        {"apf_1p", import_support::FilterType::Allpass},
+        {"pkf_2p", import_support::FilterType::Peak},
+        {"comb", import_support::FilterType::Comb},
+    };
+
+    auto fType = import_support::FilterType::Other;
+    if (auto it = typeMap.find(filTypeStr); it != typeMap.end())
+    {
+        fType = it->second;
+    }
+    else if (reportedFilTypes.insert(filTypeStr).second)
+    {
+        ctx.unsupported("SFZ fil_type", filTypeStr + " (using bypassed LP)");
+    }
+
+    // cutoff: SFZ Hz → SCXT semitones from MIDI 69 (A4=440Hz)
+    float cutoffSemis = (cutoffHz > 1.f) ? 12.f * std::log2(cutoffHz / 440.f) : -69.f;
+    cutoffSemis = std::clamp(cutoffSemis, -69.f, 70.f);
+
+    // resonance: SFZ 0..40 dB → SCXT 0..1 (crude linear)
+    float resonance = std::clamp(resoDb / 40.f, 0.f, 1.f);
+
+    import_support::importZoneFilter(*zn, ctx, 0,
+                                     {
+                                         .type = fType,
+                                         .cutoff = cutoffSemis,
+                                         .resonance = resonance,
+                                     });
+}
+
 bool importSFZ(const fs::path &f, engine::Engine &e)
 {
     int octaveOffset{0};
@@ -294,6 +361,7 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
     int regionCount{0};
     SFZParser::opCodes_t currentGroupOpcodes;
     std::set<std::string> unusedZoneOpcodes;
+    std::set<std::string> reportedSfzFilTypes;
     for (const auto &[r, list] : doc)
     {
         if (r.type != SFZParser::Header::region)
@@ -388,6 +456,7 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
                 }
             }
             auto zn = std::make_unique<engine::Zone>(sid);
+            zn->engine = &e; // required by setProcessorType in zoneFilter
             // SFZ default mapping (gets overwritten by zoneGeometry once opcodes are parsed).
             import_support::importZoneMapping(*zn, ctx,
                                               {
@@ -418,6 +487,7 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
             auto loopArgs = zoneLoopParse(mergedOpcodes, loadInfo);
             zoneEnvelope(zn, ctx, mergedOpcodes, 0, "ampeg");
             zoneEnvelope(zn, ctx, mergedOpcodes, 1, "fileg");
+            zoneFilter(zn, ctx, mergedOpcodes, reportedSfzFilTypes);
 
             for (auto &[n, m] : mergedOpcodes)
             {


### PR DESCRIPTION
Introduce an abstract FilterType in import_filter (LP/HP/BP at various slopes, Notch, Peak, Allpass, Comb, Other) that each importer maps its native filter onto. The helper resolves it to a Cytomic or Vember processor with the right passband/slope; Other installs a bypassed LP.

SF2, AKP, and EXS migrate to the new enum. SFZ now parses cutoff, resonance, and fil_type (19 types mapped, unknown → Other with a deduplicated warning).

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>