### PR TITLE
Add check-multi-loadability CLI; surface EXS import errors

### DIFF
--- a/src/clients/cli-tools/CMakeLists.txt
+++ b/src/clients/cli-tools/CMakeLists.txt
@@ -3,12 +3,14 @@ project(cli-tools)
 add_custom_target(${PROJECT_NAME})
 function (add_cli_tool)
     set(oneValueArgs SOURCE)
-    cmake_parse_arguments(CLI "" "${oneValueArgs}" "" ${ARGN})
+    set(multiValueArgs EXTRA_LIBS)
+    cmake_parse_arguments(CLI "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     add_executable(${CLI_SOURCE} ${CLI_SOURCE}.cpp)
     target_link_libraries(${CLI_SOURCE}
             scxt-core
             fmt
+            ${CLI_EXTRA_LIBS}
     )
     add_dependencies(${PROJECT_NAME} ${CLI_SOURCE})
 endfunction()
@@ -19,3 +21,4 @@ add_cli_tool(SOURCE init-maker)
 add_cli_tool(SOURCE riff-dump)
 add_cli_tool(SOURCE sfz-token-dump)
 add_cli_tool(SOURCE scpscm-to-json)
+add_cli_tool(SOURCE check-multi-loadability EXTRA_LIBS console-ui)

--- a/src/clients/cli-tools/check-multi-loadability.cpp
+++ b/src/clients/cli-tools/check-multi-loadability.cpp
@@ -1,0 +1,176 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_CLIENTS_CLI_TOOLS_CHECK_MULTI_LOADABILITY
+#define SCXT_SRC_CLIENTS_CLI_TOOLS_CHECK_MULTI_LOADABILITY
+
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "configuration.h"
+#include "console_harness.h"
+#include "engine/engine.h"
+#include "engine/part.h"
+#include "engine/patch.h"
+#include "messaging/client/client_messages.h"
+
+namespace cmsg = scxt::messaging::client;
+
+namespace
+{
+size_t countZones(const scxt::engine::Engine &eng)
+{
+    size_t n = 0;
+    for (int p = 0; p < scxt::numParts; ++p)
+    {
+        const auto &part = eng.getPatch()->getPart(p);
+        for (const auto &grp : *part)
+            n += grp->getZones().size();
+    }
+    return n;
+}
+
+bool hasSuffix(const std::string &name, const std::string &suffix)
+{
+    if (suffix.size() > name.size())
+        return false;
+    auto a = name.end() - suffix.size();
+    return std::equal(a, name.end(), suffix.begin(),
+                      [](char x, char y) { return std::tolower(x) == std::tolower(y); });
+}
+} // namespace
+
+int main(int argc, char **argv)
+{
+    if (argc < 2)
+    {
+        std::cerr << "Usage: " << argv[0] << " <file>\n"
+                  << "       " << argv[0] << " <directory> <suffix>\n"
+                  << "  Single-file mode: loads <file> and reports zone count + errors.\n"
+                  << "  Directory mode: recursively loads every file under <directory>\n"
+                  << "  whose name ends with <suffix> (case-insensitive, e.g. \".exs\").\n";
+        return 1;
+    }
+
+    std::vector<fs::path> files;
+    if (argc == 2)
+    {
+        fs::path target{argv[1]};
+        if (!fs::exists(target) || !fs::is_regular_file(target))
+        {
+            std::cerr << "Not a regular file: " << target << "\n";
+            return 1;
+        }
+        files.push_back(target);
+        std::cout << "Loading 1 file: " << target << "\n";
+    }
+    else
+    {
+        fs::path root{argv[1]};
+        std::string suffix{argv[2]};
+        if (!suffix.empty() && suffix[0] != '.')
+            suffix = "." + suffix;
+
+        if (!fs::exists(root) || !fs::is_directory(root))
+        {
+            std::cerr << "Not a directory: " << root << "\n";
+            return 1;
+        }
+
+        for (auto &entry :
+             fs::recursive_directory_iterator(root, fs::directory_options::skip_permission_denied))
+        {
+            if (!entry.is_regular_file())
+                continue;
+            if (hasSuffix(entry.path().filename().u8string(), suffix))
+                files.push_back(entry.path());
+        }
+        std::sort(files.begin(), files.end());
+        std::cout << "Found " << files.size() << " " << suffix << " files under " << root << "\n";
+    }
+
+    scxt::clients::console_ui::ConsoleHarness th;
+    th.start();
+    th.stepUI();
+
+    struct FailureRecord
+    {
+        fs::path path;
+        std::vector<scxt::messaging::client::s2cError_t> errors;
+    };
+    std::vector<FailureRecord> failures;
+    std::vector<std::pair<fs::path, size_t>> loaded;
+
+    for (const auto &f : files)
+    {
+        th.editor->clearErrors();
+        size_t before = countZones(*th.engine);
+        th.sendToSerialization(cmsg::AddSample(f.u8string()));
+        th.stepUI(50);
+        size_t after = countZones(*th.engine);
+        size_t added = after - before;
+        auto errs = th.editor->readErrors();
+
+        if (added == 0 || !errs.empty())
+        {
+            failures.push_back({f, errs});
+            std::cout << "FAIL " << added << "\t" << f.u8string();
+            if (!errs.empty())
+                std::cout << "  [" << errs.size() << " error" << (errs.size() == 1 ? "" : "s")
+                          << "]";
+            std::cout << "\n";
+            for (const auto &[title, body, source, line] : errs)
+                std::cout << "       └ " << title << ": " << body << "\n";
+        }
+        else
+        {
+            loaded.emplace_back(f, added);
+            std::cout << "OK   " << added << "\t" << f.u8string() << "\n";
+        }
+    }
+
+    std::cout << "\n=== Summary ===\n"
+              << "Total : " << files.size() << "\n"
+              << "OK    : " << loaded.size() << "\n"
+              << "FAIL  : " << failures.size() << "\n";
+
+    if (!failures.empty())
+    {
+        std::cout << "\nFailures:\n";
+        for (const auto &fr : failures)
+        {
+            std::cout << "  " << fr.path.u8string() << "\n";
+            for (const auto &[title, body, source, line] : fr.errors)
+                std::cout << "      " << title << ": " << body << "\n";
+        }
+    }
+    return failures.empty() ? 0 : 2;
+}
+
+#endif

--- a/src/clients/console-ui/console_ui.h
+++ b/src/clients/console-ui/console_ui.h
@@ -29,8 +29,10 @@
 #define SCXT_SRC_CLIENTS_CONSOLE_UI_CONSOLE_UI_H
 
 #include <memory>
+#include <mutex>
 #include <thread>
 #include <atomic>
+#include <vector>
 
 #include "utils.h"
 #include "configuration.h"
@@ -64,7 +66,32 @@ struct ConsoleUI
     }
 
     // Serialization to Client Messages
-    void onErrorFromEngine(const scxt::messaging::client::s2cError_t &) ON_STUB;
+    void onErrorFromEngine(const scxt::messaging::client::s2cError_t &e)
+    {
+        std::lock_guard<std::mutex> lk(errorMutex);
+        errorStack.push_back(e);
+        if (logMessages)
+            SCLOG_WFUNC_IF(cliTools, "Error from engine");
+    }
+
+    // Error stack accessors — useful for headless tools (e.g.
+    // check-multi-loadability) that want to detect and report per-file
+    // import failures.
+    bool hasErrors()
+    {
+        std::lock_guard<std::mutex> lk(errorMutex);
+        return !errorStack.empty();
+    }
+    std::vector<scxt::messaging::client::s2cError_t> readErrors()
+    {
+        std::lock_guard<std::mutex> lk(errorMutex);
+        return errorStack;
+    }
+    void clearErrors()
+    {
+        std::lock_guard<std::mutex> lk(errorMutex);
+        errorStack.clear();
+    }
     void onEngineStatus(const engine::Engine::EngineStatusMessage &e) ON_STUB;
     void
     onMappingUpdated(const scxt::messaging::client::mappingSelectedZoneViewResposne_t &) ON_STUB;
@@ -136,6 +163,9 @@ struct ConsoleUI
     std::mutex callbackMutex;
     std::queue<std::string> callbackQueue;
     void drainQueue();
+
+    std::mutex errorMutex;
+    std::vector<scxt::messaging::client::s2cError_t> errorStack;
 };
 
 } // namespace scxt::clients::console_ui

--- a/src/scxt-core/sample/exs_support/exs_import.cpp
+++ b/src/scxt-core/sample/exs_support/exs_import.cpp
@@ -938,6 +938,11 @@ bool importEXS(const fs::path &p, engine::Engine &e)
 
     auto info = parseEXS(p);
 
+    if (info.zones.empty())
+        ctx.raise("EXS Parse Warning", "Parsed file contains no zones");
+    if (info.samples.empty())
+        ctx.raise("EXS Parse Warning", "Parsed file contains no sample references");
+
     std::vector<int> groupIndexByOrder;
     std::vector<SampleID> sampleIDByOrder;
 
@@ -945,12 +950,24 @@ bool importEXS(const fs::path &p, engine::Engine &e)
     // the patch is moved between machines that path won't resolve, so we also
     // try the sample filename relative to the .exs's own directory.
     auto exsDir = p.parent_path();
+    // Push a SampleID for every EXS sample so downstream zone lookups by
+    // index stay in range. Failed loads become an invalid SampleID (and a
+    // raised error); zones that reference them will skip with a clear error.
     for (auto &s : info.samples)
     {
         auto absolutePath = fs::path{s.filePath} / s.fileName;
         auto siblingPath = exsDir / s.fileName;
         if (auto lsid = ctx.loadSampleFromDisk({absolutePath, siblingPath}))
+        {
             sampleIDByOrder.push_back(*lsid);
+        }
+        else
+        {
+            ctx.raise("EXS Sample Not Found", "Could not locate '" + s.fileName +
+                                                  "'. Tried: " + absolutePath.u8string() + " and " +
+                                                  siblingPath.u8string());
+            sampleIDByOrder.push_back(SampleID{});
+        }
     }
 
     // Group-level config (volume/pan to GroupOutputInfo, polyphony to playMode,
@@ -1149,6 +1166,16 @@ bool importEXS(const fs::path &p, engine::Engine &e)
     bool warnedAboutRoundRobin = false;
     int zoneOrdinal = 0;
     ExsModWarnings exsModWarnings;
+    // Lazily-created fallback group for zones with groupIndex == -1 (some EXS
+    // files, particularly Logic factory FX presets, store zones without a
+    // group association — Logic itself shows them as one implicit group).
+    int fallbackGroupId = -1;
+    auto fallbackGroup = [&]() {
+        if (fallbackGroupId < 0)
+            fallbackGroupId = ctx.addGroup("Default");
+        return fallbackGroupId;
+    };
+
     for (auto &z : info.zones)
     {
         auto exsgi = z.groupIndex;
@@ -1161,20 +1188,39 @@ bool importEXS(const fs::path &p, engine::Engine &e)
             exssi = zoneOrdinal;
         ++zoneOrdinal;
 
-        if (exsgi < 0 || exsgi >= (int)groupIndexByOrder.size())
+        int gi;
+        if (exsgi == -1)
         {
-            SCLOG_IF(sampleCompoundParsers, "Out-of-bounds group index : " << SCD(exsgi));
+            gi = fallbackGroup();
+        }
+        else if (exsgi < 0 || exsgi >= (int)groupIndexByOrder.size())
+        {
+            ctx.raise("EXS Zone Skipped",
+                      "Zone references out-of-bounds group index " + std::to_string(exsgi));
             continue;
+        }
+        else
+        {
+            gi = groupIndexByOrder[exsgi];
         }
         if (exssi < 0 || exssi >= (int)sampleIDByOrder.size())
         {
-            SCLOG_IF(sampleCompoundParsers,
-                     "Out-of-bounds sample index " << SCD(exsgi) << SCD(exssi));
+            ctx.raise("EXS Zone Skipped", "Zone in group " + std::to_string(exsgi) +
+                                              " references out-of-bounds sample index " +
+                                              std::to_string(exssi));
             continue;
         }
-        auto gi = groupIndexByOrder[exsgi];
         auto si = sampleIDByOrder[exssi];
-        const auto &exsGroup = info.groups[exsgi];
+        if (!si.isValid())
+        {
+            ctx.raise("EXS Zone Skipped", "Zone references sample index " + std::to_string(exssi) +
+                                              " which failed to load");
+            continue;
+        }
+        // Group-dependent config only applies when the zone references a real
+        // EXS group; fallback-group zones (exsgi == -1) have no per-group
+        // clamps or round-robin flags to honor.
+        const EXSGroup *exsGroupPtr = (exsgi >= 0) ? &info.groups[exsgi] : nullptr;
 
         // EXS round-robin: groups flagged with enableByRoundRobin form a
         // sequence keyed by roundRobinGroupPos (-1, 0, 1, …). Each "position"
@@ -1184,7 +1230,7 @@ bool importEXS(const fs::path &p, engine::Engine &e)
         // multiple EXS zones into a single SCXT zone instead of one-per-EXS.
         // Not implemented yet; import the zone as a regular non-RR zone for
         // now so it still plays.
-        if (exsGroup.enableByRoundRobin && !warnedAboutRoundRobin)
+        if (exsGroupPtr && exsGroupPtr->enableByRoundRobin && !warnedAboutRoundRobin)
         {
             ctx.unsupported("EXS round-robin groups",
                             "imported as parallel zones; per-variant RR not yet supported");
@@ -1203,18 +1249,22 @@ bool importEXS(const fs::path &p, engine::Engine &e)
         // range. The "!= 0" guards on the clamps preserve the reference
         // behavior of treating zero as "no bound applied" — see EXS24Detector
         // limitByGroupAttributes.
-        if (velEnd < exsGroup.minVelocity || velStart > exsGroup.maxVelocity)
-            continue;
-        if (keyEnd < exsGroup.startNote || keyStart > exsGroup.endNote)
-            continue;
-        if (exsGroup.minVelocity != 0 && velStart < exsGroup.minVelocity)
-            velStart = exsGroup.minVelocity;
-        if (exsGroup.maxVelocity != 0 && velEnd > exsGroup.maxVelocity)
-            velEnd = exsGroup.maxVelocity;
-        if (exsGroup.startNote != 0 && keyStart < exsGroup.startNote)
-            keyStart = exsGroup.startNote;
-        if (exsGroup.endNote != 0 && keyEnd > exsGroup.endNote)
-            keyEnd = exsGroup.endNote;
+        if (exsGroupPtr)
+        {
+            const auto &exsGroup = *exsGroupPtr;
+            if (velEnd < exsGroup.minVelocity || velStart > exsGroup.maxVelocity)
+                continue;
+            if (keyEnd < exsGroup.startNote || keyStart > exsGroup.endNote)
+                continue;
+            if (exsGroup.minVelocity != 0 && velStart < exsGroup.minVelocity)
+                velStart = exsGroup.minVelocity;
+            if (exsGroup.maxVelocity != 0 && velEnd > exsGroup.maxVelocity)
+                velEnd = exsGroup.maxVelocity;
+            if (exsGroup.startNote != 0 && keyStart < exsGroup.startNote)
+                keyStart = exsGroup.startNote;
+            if (exsGroup.endNote != 0 && keyEnd > exsGroup.endNote)
+                keyEnd = exsGroup.endNote;
+        }
 
         auto zone = std::make_unique<engine::Zone>(si);
         zone->engine = &e;
@@ -1262,7 +1312,7 @@ bool importEXS(const fs::path &p, engine::Engine &e)
             variant.endSample = z.sampleEnd;
 
         variant.playReverse = z.reverse;
-        if (exsGroup.releaseTrigger)
+        if (exsGroupPtr && exsGroupPtr->releaseTrigger)
             variant.playMode = engine::Zone::PlayMode::ON_RELEASE;
         else if (z.oneshot)
             variant.playMode = engine::Zone::PlayMode::ONE_SHOT;


### PR DESCRIPTION
New cli-tool that recursively loads every file matching a suffix under a directory (or a single file) through the real importer harness, reports per-file zone count, and dumps any captured errors. Exit code is non-zero if any file failed.

ConsoleUI gains a thread-safe error stack with hasErrors() / readErrors() / clearErrors() so headless tools can pull errors that previously went only to the (stubbed) onErrorFromEngine.

EXS importer: silent SCLOGs on missing samples and skipped zones are promoted to ctx.raise so they reach the user-visible error stream. Adds a lazy "Default" group fallback for zones whose groupIndex is -1 (Logic factory FX presets do this, e.g. SweepFX/TransitionFX/DiveFX/Tiny Rowing Boat) so those zones land in a real group instead of being skipped.

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>