### PR TITLE
Capture unused SFZ opcodes + cap RR variants + minor SFZ fixes

### DIFF
--- a/src/clients/cli-tools/check-multi-loadability.cpp
+++ b/src/clients/cli-tools/check-multi-loadability.cpp
@@ -30,6 +30,8 @@
 
 #include <algorithm>
 #include <iostream>
+#include <map>
+#include <regex>
 #include <string>
 #include <vector>
 
@@ -64,24 +66,49 @@ bool hasSuffix(const std::string &name, const std::string &suffix)
     return std::equal(a, name.end(), suffix.begin(),
                       [](char x, char y) { return std::tolower(x) == std::tolower(y); });
 }
+
+// Collapse trailing CC number into a literal "N" so a histogram doesn't
+// fragment across cc1..cc127. e.g. cutoff_oncc73 → cutoff_onccN,
+// ampeg_attackcc11 → ampeg_attackccN, locc64 → loccN.
+std::string normalizeUnusedKey(const std::string &key)
+{
+    static const std::regex ccTail{R"(cc\d+$)"};
+    return std::regex_replace(key, ccTail, "ccN");
+}
 } // namespace
 
 int main(int argc, char **argv)
 {
-    if (argc < 2)
+    // Extract optional flags (only --unused-per-file for now), keeping positional args in argv.
+    std::vector<std::string> args(argv + 1, argv + argc);
+    bool unusedPerFile = false;
+    args.erase(std::remove_if(args.begin(), args.end(),
+                              [&](const std::string &a) {
+                                  if (a == "--unused-per-file")
+                                  {
+                                      unusedPerFile = true;
+                                      return true;
+                                  }
+                                  return false;
+                              }),
+               args.end());
+
+    if (args.empty())
     {
-        std::cerr << "Usage: " << argv[0] << " <file>\n"
-                  << "       " << argv[0] << " <directory> <suffix>\n"
+        std::cerr << "Usage: " << argv[0] << " [--unused-per-file] <file>\n"
+                  << "       " << argv[0] << " [--unused-per-file] <directory> <suffix>\n"
                   << "  Single-file mode: loads <file> and reports zone count + errors.\n"
                   << "  Directory mode: recursively loads every file under <directory>\n"
-                  << "  whose name ends with <suffix> (case-insensitive, e.g. \".exs\").\n";
+                  << "  whose name ends with <suffix> (case-insensitive, e.g. \".exs\").\n"
+                  << "  --unused-per-file: list importer-recorded unused tokens per file in\n"
+                  << "      addition to the rolled-up histogram.\n";
         return 1;
     }
 
     std::vector<fs::path> files;
-    if (argc == 2)
+    if (args.size() == 1)
     {
-        fs::path target{argv[1]};
+        fs::path target{args[0]};
         if (!fs::exists(target) || !fs::is_regular_file(target))
         {
             std::cerr << "Not a regular file: " << target << "\n";
@@ -92,8 +119,8 @@ int main(int argc, char **argv)
     }
     else
     {
-        fs::path root{argv[1]};
-        std::string suffix{argv[2]};
+        fs::path root{args[0]};
+        std::string suffix{args[1]};
         if (!suffix.empty() && suffix[0] != '.')
             suffix = "." + suffix;
 
@@ -127,15 +154,30 @@ int main(int argc, char **argv)
     std::vector<FailureRecord> failures;
     std::vector<std::pair<fs::path, size_t>> loaded;
 
+    // (format, normalized-key) → count. Filled from importer recordUnusedItem
+    // calls (see ImporterContext::recordUnusedItem).
+    std::map<std::pair<std::string, std::string>, int> unusedHisto;
+
     for (const auto &f : files)
     {
+        // Print + flush before send so that a crash inside the importer
+        // names the offending file. The OK/FAIL line below will overwrite
+        // visually on successful return (different lead char).
+        std::cerr << ">>> " << f.u8string() << std::endl;
+
         th.editor->clearErrors();
+        th.editor->clearUnusedItems();
         size_t before = countZones(*th.engine);
         th.sendToSerialization(cmsg::AddSample(f.u8string()));
         th.stepUI(50);
         size_t after = countZones(*th.engine);
         size_t added = after - before;
         auto errs = th.editor->readErrors();
+        auto unused = th.editor->readUnusedItems();
+
+        // Aggregate unused tokens (after normalizing cc-suffixes).
+        for (const auto &[format, key, value] : unused)
+            unusedHisto[{format, normalizeUnusedKey(key)}]++;
 
         if (added == 0 || !errs.empty())
         {
@@ -152,6 +194,16 @@ int main(int argc, char **argv)
         {
             loaded.emplace_back(f, added);
             std::cout << "OK   " << added << "\t" << f.u8string() << "\n";
+        }
+
+        if (unusedPerFile && !unused.empty())
+        {
+            // De-dup per file (importer can record the same key in many regions).
+            std::map<std::pair<std::string, std::string>, int> perFile;
+            for (const auto &[format, key, value] : unused)
+                perFile[{format, normalizeUnusedKey(key)}]++;
+            for (const auto &[k, c] : perFile)
+                std::cout << "       · " << k.first << "  " << k.second << "  (x" << c << ")\n";
         }
     }
 
@@ -170,6 +222,22 @@ int main(int argc, char **argv)
                 std::cout << "      " << title << ": " << body << "\n";
         }
     }
+
+    if (!unusedHisto.empty())
+    {
+        // Sort by descending count, then format, then key.
+        std::vector<std::pair<std::pair<std::string, std::string>, int>> sorted(unusedHisto.begin(),
+                                                                                unusedHisto.end());
+        std::sort(sorted.begin(), sorted.end(), [](const auto &a, const auto &b) {
+            if (a.second != b.second)
+                return a.second > b.second;
+            return a.first < b.first;
+        });
+        std::cout << "\n=== Unused-item frequency (count, format, key) ===\n";
+        for (const auto &[k, c] : sorted)
+            std::cout << "  " << c << "\t" << k.first << "\t" << k.second << "\n";
+    }
+
     return failures.empty() ? 0 : 2;
 }
 

--- a/src/clients/console-ui/console_ui.h
+++ b/src/clients/console-ui/console_ui.h
@@ -92,6 +92,31 @@ struct ConsoleUI
         std::lock_guard<std::mutex> lk(errorMutex);
         errorStack.clear();
     }
+
+    // Unused-items channel (importer-recorded tokens we recognized but didn't
+    // route — see ImporterContext::recordUnusedItem).
+    void onUnusedItemsFromEngine(const scxt::messaging::client::s2cUnusedItems_t &items)
+    {
+        std::lock_guard<std::mutex> lk(unusedItemsMutex);
+        for (const auto &it : items)
+            unusedItems.push_back(it);
+    }
+    bool hasUnusedItems()
+    {
+        std::lock_guard<std::mutex> lk(unusedItemsMutex);
+        return !unusedItems.empty();
+    }
+    scxt::messaging::client::s2cUnusedItems_t readUnusedItems()
+    {
+        std::lock_guard<std::mutex> lk(unusedItemsMutex);
+        return unusedItems;
+    }
+    void clearUnusedItems()
+    {
+        std::lock_guard<std::mutex> lk(unusedItemsMutex);
+        unusedItems.clear();
+    }
+
     void onEngineStatus(const engine::Engine::EngineStatusMessage &e) ON_STUB;
     void
     onMappingUpdated(const scxt::messaging::client::mappingSelectedZoneViewResposne_t &) ON_STUB;
@@ -166,6 +191,9 @@ struct ConsoleUI
 
     std::mutex errorMutex;
     std::vector<scxt::messaging::client::s2cError_t> errorStack;
+
+    std::mutex unusedItemsMutex;
+    scxt::messaging::client::s2cUnusedItems_t unusedItems;
 };
 
 } // namespace scxt::clients::console_ui

--- a/src/scxt-core/messaging/client/client_serial.h
+++ b/src/scxt-core/messaging/client/client_serial.h
@@ -222,6 +222,7 @@ enum ClientToSerializationMessagesIds
 enum SerializationToClientMessageIds
 {
     s2c_report_error,
+    s2c_report_unused_items,
     s2c_send_initial_metadata,
     s2c_send_debug_info,
     s2c_send_activity_notification,
@@ -281,6 +282,7 @@ inline bool cacheSerializationMessagesAbsentClient(SerializationToClientMessageI
     switch (id)
     {
     case s2c_report_error:
+    case s2c_report_unused_items:
         return true;
     default:
         break;

--- a/src/scxt-core/messaging/client/interaction_messages.h
+++ b/src/scxt-core/messaging/client/interaction_messages.h
@@ -42,6 +42,14 @@ namespace scxt::messaging::client
 typedef std::tuple<std::string, std::string, std::string, int> s2cError_t;
 SERIAL_TO_CLIENT(ReportError, s2c_report_error, s2cError_t, onErrorFromEngine);
 
+// Behind-the-scenes batch of (format, key, value) triples emitted by an
+// importer at finish() to surface tokens it recognized but didn't route.
+// Not user-facing; used by diagnostic tools (e.g. check-multi-loadability)
+// to aggregate coverage gaps.
+typedef std::vector<std::tuple<std::string, std::string, std::string>> s2cUnusedItems_t;
+SERIAL_TO_CLIENT(ReportUnusedItems, s2c_report_unused_items, s2cUnusedItems_t,
+                 onUnusedItemsFromEngine);
+
 inline void raiseDebugError(MessageController &c, int count)
 {
     for (int i = 0; i < count; ++i)

--- a/src/scxt-core/sample/import_support/import_harness.cpp
+++ b/src/scxt-core/sample/import_support/import_harness.cpp
@@ -29,6 +29,7 @@
 #include "selection/selection_manager.h"
 #include "configuration.h"
 #include "utils.h"
+#include "messaging/client/client_messages.h"
 
 #include <cassert>
 #include <sstream>
@@ -65,6 +66,12 @@ void ImporterContext::unsupported(const std::string &category, const std::string
 {
     unsupportedItems.emplace_back(category, detail);
     SCLOG_IF(sampleCompoundParsers, "Unsupported " << category << ": " << detail);
+}
+
+void ImporterContext::recordUnusedItem(const std::string &format, const std::string &key,
+                                       const std::string &value)
+{
+    unusedItems.emplace_back(format, key, value);
 }
 
 int ImporterContext::addGroup(const std::string &name)
@@ -121,6 +128,13 @@ bool ImporterContext::finish()
             pfx = "; ";
         }
         SCLOG_IF(sampleCompoundParsers, "Unsupported features in this import: " << oss.str());
+    }
+
+    if (!unusedItems.empty())
+    {
+        messaging::client::serializationSendToClient(messaging::client::s2c_report_unused_items,
+                                                     unusedItems,
+                                                     *engineRef.getMessageController());
     }
 
     if (addedZoneAddresses.empty())

--- a/src/scxt-core/sample/import_support/import_harness.h
+++ b/src/scxt-core/sample/import_support/import_harness.h
@@ -72,6 +72,15 @@ class ImporterContext
     // Soft, collected — consolidated and emitted in finish().
     void unsupported(const std::string &category, const std::string &detail);
 
+    // Behind-the-scenes record of a format token we recognized but didn't
+    // route (e.g. SFZ opcodes the parser knew about but no helper consumed,
+    // or in the future XML attributes the multisample parser sees but
+    // doesn't handle). Not surfaced to end users; available via
+    // s2c_unused_items for headless diagnostic tools (see
+    // check-multi-loadability).
+    void recordUnusedItem(const std::string &format, const std::string &key,
+                          const std::string &value);
+
     // Adds a new group to the part and tracks it. Returns the group index.
     int addGroup(const std::string &name = "");
     // Moves the zone into the named group and records its address for the
@@ -101,6 +110,8 @@ class ImporterContext
     std::vector<int> addedGroups;
     std::vector<std::pair<int, int>> addedZoneAddresses; // (groupIdx, zoneIdx)
     std::vector<std::pair<std::string, std::string>> unsupportedItems;
+    // (format, key, value)
+    std::vector<std::tuple<std::string, std::string, std::string>> unusedItems;
 };
 
 // Looks up the SCXT group index for a native key (e.g. sf2::Instrument*, AKP group

--- a/src/scxt-core/sample/sfz_support/sfz_import.cpp
+++ b/src/scxt-core/sample/sfz_support/sfz_import.cpp
@@ -604,7 +604,9 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
     int groupId = -1;
     int regionCount{0};
     SFZParser::opCodes_t currentGroupOpcodes;
-    std::set<std::string> unusedZoneOpcodes;
+    // Captures (opcode -> first observed value) across all regions; flushed
+    // to ctx.recordUnusedItem at the end of the import.
+    std::map<std::string, std::string> unusedZoneOpcodes;
     std::set<std::string> reportedSfzFilTypes;
     for (const auto &[r, list] : doc)
     {
@@ -747,6 +749,22 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
             consumeOpcode(mergedOpcodes, "sample");
             consumeOpcode(mergedOpcodes, "seq_position");
 
+            // Group-level opcodes that may appear in either the <group>
+            // header or a <region> (merged here). Apply to the parent group;
+            // consuming dedups against the unused-opcodes histogram.
+            if (auto v = consumeOpcode(mergedOpcodes, "group_label"); v.has_value())
+                group->name = *v;
+            if (auto v = consumeOpcode(mergedOpcodes, "name"); v.has_value())
+                group->name = *v;
+            if (auto v = consumeOpcode(mergedOpcodes, "amp_veltrack"); v.has_value())
+            {
+                // SCXT velocity sensitivity is a group-level scalar; SFZ
+                // amp_veltrack can sit on either group or region. Apply
+                // last-seen value; (veltrack/127)^2 is the SCXT-side calibration.
+                float vt = (float)std::atof(v->c_str()) / 127.f;
+                group->outputInfo.velocitySensitivity = vt * vt;
+            }
+
             auto onError = [&ctx](const std::string &title, const std::string &msg) {
                 ctx.raise(title, msg);
             };
@@ -824,7 +842,7 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
             {
                 if (m.second)
                     continue;
-                unusedZoneOpcodes.insert(n);
+                unusedZoneOpcodes.emplace(n, m.first);
             }
             int variantIndex{-1};
             if (isVirtual)
@@ -836,6 +854,19 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
             else if (roundRobinPosition > 0)
             {
                 bool attached{false};
+                int idx = roundRobinPosition - 1;
+
+                if (idx >= scxt::maxVariantsPerZone)
+                {
+                    // SCXT zones have a fixed cap on round-robin variants
+                    // (scxt::maxVariantsPerZone). Anything past that would
+                    // OOB-write into Zone::variantData; raise + skip instead.
+                    ctx.raise("SFZ Round Robin",
+                              "SCXT only supports " + std::to_string(scxt::maxVariantsPerZone) +
+                                  " variations in round robin; seq_position=" +
+                                  std::to_string(roundRobinPosition) + " dropped.");
+                    break;
+                }
 
                 for (const auto &z : *group)
                 {
@@ -843,7 +874,6 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
                         z->mapping.keyboardRange == zn->mapping.keyboardRange &&
                         z->mapping.velocityRange == zn->mapping.velocityRange)
                     {
-                        int idx = roundRobinPosition - 1;
                         variantIndex = idx;
                         z->attachToSampleAtVariation(*e.getSampleManager(), sid, idx, loadInfo);
                         attached = true;
@@ -919,8 +949,8 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
         break;
         }
     }
-    for (auto &oc : unusedZoneOpcodes)
-        ctx.unsupported("SFZ opcode", oc);
+    for (auto &[k, v] : unusedZoneOpcodes)
+        ctx.recordUnusedItem("sfz", k, v);
 
     return ctx.finish();
 }

--- a/src/scxt-core/sample/sfz_support/sfz_parse.cpp
+++ b/src/scxt-core/sample/sfz_support/sfz_parse.cpp
@@ -46,12 +46,18 @@ SFZParser::document_t SFZParser::parse(const std::string &s)
     document_t res;
 
     auto lookAheadForOpcode = [&](auto from, auto &opcode) {
+        // Opcodes are case-insensitive per the SFZ spec — `Sample=` and
+        // `sample=` should both parse. Normalize to lower-case at the source
+        // so every downstream consumeOpcode("foo") match works.
         opcode.clear();
         while (from < s.size() && s[from] != ' ' && s[from] != '\n' && s[from] != '\r')
         {
             if (s[from] == '=')
                 return true;
-            opcode += s[from];
+            char c = s[from];
+            if (c >= 'A' && c <= 'Z')
+                c = (char)(c - 'A' + 'a');
+            opcode += c;
             from++;
         }
         return false;

--- a/src/scxt-plugin/app/SCXTEditorReceiver.h
+++ b/src/scxt-plugin/app/SCXTEditorReceiver.h
@@ -70,6 +70,7 @@ struct SCXTEditorReceiver
 
     // Serialization to Client Messages
     void onErrorFromEngine(const scxt::messaging::client::s2cError_t &);
+    void onUnusedItemsFromEngine(const scxt::messaging::client::s2cUnusedItems_t &);
     void onEngineStatus(const engine::Engine::EngineStatusMessage &e);
     void onMappingUpdated(const scxt::messaging::client::mappingSelectedZoneViewResposne_t &);
     void onSamplesUpdated(const scxt::messaging::client::sampleSelectedZoneViewResposne_t &);

--- a/src/scxt-plugin/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -290,6 +290,12 @@ void SCXTEditorReceiver::onErrorFromEngine(const scxt::messaging::client::s2cErr
     editor.displayError(title, msg);
 }
 
+void SCXTEditorReceiver::onUnusedItemsFromEngine(const scxt::messaging::client::s2cUnusedItems_t &)
+{
+    // Intentionally discarded in the UI for now. Headless diagnostic tooling
+    // (e.g. check-multi-loadability) reads this channel via ConsoleUI.
+}
+
 void SCXTEditorReceiver::onSelectionState(const scxt::messaging::client::selectedStateMessage_t &a)
 {
     editor.allZoneSelections = std::get<1>(a);


### PR DESCRIPTION
Adds a behind-the-scenes "unused items" channel:
- ImporterContext gains recordUnusedItem(format, key, value).
- New s2c_report_unused_items message; ImporterContext::finish() emits the batch. ConsoleUI has a thread-safe stack with hasUnusedItems / readUnusedItems / clearUnusedItems. SCXTEditor discards the message for now.
- SFZ importer routes its trailing unused-opcode sweep through recordUnusedItem instead of the user-facing unsupported channel.
- check-multi-loadability aggregates per-(format,key) frequency with tool-side cc<N> normalization, supports --unused-per-file, and prints a sorted histogram at end of run. Single-file mode preserved.

SFZ importer:
- Cap round-robin attach at scxt::maxVariantsPerZone; previously a seq_position past 16 OOB-wrote Zone::variantData and segfaulted on files like "Da Real 110 - All - 48 kHz.sfz" (seq_length=35).
- Lowercase opcode names at parse time (SFZ spec is case-insensitive; files in the wild use "Sample=" etc.).
- Wire group-level group_label / name / amp_veltrack into the parent group, including when they show up in <region> merged opcodes. amp_veltrack maps to GroupOutputInfo::velocitySensitivity via (veltrack/127)^2 per SCXT convention.

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>