### PR TITLE
Add severity to report messages; emit import-complete; ctx.warn

### DIFF
--- a/src/clients/cli-tools/check-multi-loadability.cpp
+++ b/src/clients/cli-tools/check-multi-loadability.cpp
@@ -166,13 +166,27 @@ int main(int argc, char **argv)
         std::cerr << ">>> " << f.u8string() << std::endl;
 
         th.editor->clearErrors();
+        th.editor->clearWarnings();
         th.editor->clearUnusedItems();
+        th.editor->clearImportComplete();
         size_t before = countZones(*th.engine);
         th.sendToSerialization(cmsg::AddSample(f.u8string()));
-        th.stepUI(50);
+        // Step the UI until the engine fires s2c_compound_import_complete (or
+        // until we run out of patience). This synchronizes message attribution
+        // to the file currently being loaded.
+        constexpr int kMaxSteps = 5000;
+        int steps = 0;
+        while (steps < kMaxSteps && !th.editor->hasImportComplete())
+        {
+            th.stepUI(1);
+            steps++;
+        }
+        // One more drain to scoop any messages that landed just before complete.
+        th.stepUI(5);
         size_t after = countZones(*th.engine);
         size_t added = after - before;
         auto errs = th.editor->readErrors();
+        auto warns = th.editor->readWarnings();
         auto unused = th.editor->readUnusedItems();
 
         // Aggregate unused tokens (after normalizing cc-suffixes).
@@ -186,14 +200,23 @@ int main(int argc, char **argv)
             if (!errs.empty())
                 std::cout << "  [" << errs.size() << " error" << (errs.size() == 1 ? "" : "s")
                           << "]";
+            if (!warns.empty())
+                std::cout << "  [" << warns.size() << " warn" << (warns.size() == 1 ? "" : "s")
+                          << "]";
             std::cout << "\n";
-            for (const auto &[title, body, source, line] : errs)
+            for (const auto &[sev, title, body, source, line] : errs)
                 std::cout << "       └ " << title << ": " << body << "\n";
+            for (const auto &[sev, title, body, source, line] : warns)
+                std::cout << "       · [warn] " << title << ": " << body << "\n";
         }
         else
         {
             loaded.emplace_back(f, added);
-            std::cout << "OK   " << added << "\t" << f.u8string() << "\n";
+            std::cout << "OK   " << added << "\t" << f.u8string();
+            if (!warns.empty())
+                std::cout << "  [" << warns.size() << " warn" << (warns.size() == 1 ? "" : "s")
+                          << "]";
+            std::cout << "\n";
         }
 
         if (unusedPerFile && !unused.empty())
@@ -218,7 +241,7 @@ int main(int argc, char **argv)
         for (const auto &fr : failures)
         {
             std::cout << "  " << fr.path.u8string() << "\n";
-            for (const auto &[title, body, source, line] : fr.errors)
+            for (const auto &[sev, title, body, source, line] : fr.errors)
                 std::cout << "      " << title << ": " << body << "\n";
         }
     }

--- a/src/clients/console-ui/console_ui.h
+++ b/src/clients/console-ui/console_ui.h
@@ -65,18 +65,33 @@ struct ConsoleUI
             SCLOG_WFUNC_IF(cliTools, "Message");                                                   \
     }
 
-    // Serialization to Client Messages
+    // Serialization to Client Messages — split error/warning routing keyed on
+    // the severity prefix in the tuple. Headless tools (e.g.
+    // check-multi-loadability) want errors separate from auto-fix warnings
+    // when deciding whether a file is a "failure".
     void onErrorFromEngine(const scxt::messaging::client::s2cError_t &e)
     {
-        std::lock_guard<std::mutex> lk(errorMutex);
-        errorStack.push_back(e);
+        int sev = std::get<0>(e);
+        if (sev == scxt::messaging::client::Severity_Warning)
+        {
+            std::lock_guard<std::mutex> lk(warningMutex);
+            warningStack.push_back(e);
+        }
+        else if (sev == scxt::messaging::client::Severity_Info)
+        {
+            std::lock_guard<std::mutex> lk(infoMutex);
+            infoStack.push_back(e);
+        }
+        else
+        {
+            std::lock_guard<std::mutex> lk(errorMutex);
+            errorStack.push_back(e);
+        }
         if (logMessages)
-            SCLOG_WFUNC_IF(cliTools, "Error from engine");
+            SCLOG_WFUNC_IF(cliTools, "Reported item from engine");
     }
 
-    // Error stack accessors — useful for headless tools (e.g.
-    // check-multi-loadability) that want to detect and report per-file
-    // import failures.
+    // Per-channel stack accessors.
     bool hasErrors()
     {
         std::lock_guard<std::mutex> lk(errorMutex);
@@ -91,6 +106,46 @@ struct ConsoleUI
     {
         std::lock_guard<std::mutex> lk(errorMutex);
         errorStack.clear();
+    }
+
+    bool hasWarnings()
+    {
+        std::lock_guard<std::mutex> lk(warningMutex);
+        return !warningStack.empty();
+    }
+    std::vector<scxt::messaging::client::s2cError_t> readWarnings()
+    {
+        std::lock_guard<std::mutex> lk(warningMutex);
+        return warningStack;
+    }
+    void clearWarnings()
+    {
+        std::lock_guard<std::mutex> lk(warningMutex);
+        warningStack.clear();
+    }
+
+    // Import-complete channel: ImporterContext-driven callers can wait for
+    // a specific path (or any) to complete before reading the per-file
+    // error/warn/unused stacks so message attribution lines up.
+    void onImportCompleteFromEngine(const scxt::messaging::client::s2cImportComplete_t &c)
+    {
+        std::lock_guard<std::mutex> lk(importCompleteMutex);
+        completedImports.push_back(c);
+    }
+    bool hasImportComplete()
+    {
+        std::lock_guard<std::mutex> lk(importCompleteMutex);
+        return !completedImports.empty();
+    }
+    std::vector<scxt::messaging::client::s2cImportComplete_t> readImportComplete()
+    {
+        std::lock_guard<std::mutex> lk(importCompleteMutex);
+        return completedImports;
+    }
+    void clearImportComplete()
+    {
+        std::lock_guard<std::mutex> lk(importCompleteMutex);
+        completedImports.clear();
     }
 
     // Unused-items channel (importer-recorded tokens we recognized but didn't
@@ -191,6 +246,15 @@ struct ConsoleUI
 
     std::mutex errorMutex;
     std::vector<scxt::messaging::client::s2cError_t> errorStack;
+
+    std::mutex warningMutex;
+    std::vector<scxt::messaging::client::s2cError_t> warningStack;
+
+    std::mutex infoMutex;
+    std::vector<scxt::messaging::client::s2cError_t> infoStack;
+
+    std::mutex importCompleteMutex;
+    std::vector<scxt::messaging::client::s2cImportComplete_t> completedImports;
 
     std::mutex unusedItemsMutex;
     scxt::messaging::client::s2cUnusedItems_t unusedItems;

--- a/src/scxt-core/engine/engine.cpp
+++ b/src/scxt-core/engine/engine.cpp
@@ -39,6 +39,7 @@
 #include "messaging/messaging.h"
 #include "messaging/client/detail/client_serial_impl.h"
 #include "messaging/client/enginestatus_messages.h"
+#include "messaging/client/interaction_messages.h"
 #include "messaging/client/part_messages.h"
 #include "messaging/client/macro_messages.h"
 #include "messaging/audio/audio_messages.h"
@@ -779,21 +780,30 @@ void Engine::loadSampleIntoSelectedPartAndGroup(const fs::path &p, int16_t rootK
     assert(messageController->threadingChecker.isSerialThread());
 
     // If you add a type here add it to Browser::isLoadableFile also
+    // Emits s2c_compound_import_complete so headless scanners and the UI
+    // can sync on a per-file boundary instead of guessing at async drain.
+    auto emitComplete = [this](const fs::path &fp, bool ok) {
+        serializationSendToClient(messaging::client::s2c_compound_import_complete,
+                                  messaging::client::s2cImportComplete_t{fp.u8string(), ok},
+                                  *messageController);
+    };
+
     if (extensionMatches(p, ".sf2"))
     {
         // TODO ok this refresh and restart is a bit unsatisfactory
-        messageController->stopAudioThreadThenRunOnSerial([this, p](const auto &) {
+        messageController->stopAudioThreadThenRunOnSerial([this, p, emitComplete](const auto &) {
             sf2_support::importSF2(p, *this, -1);
             messageController->restartAudioThreadFromSerial();
             serializationSendToClient(messaging::client::s2c_send_pgz_structure,
                                       getPartGroupZoneStructure(), *messageController);
+            emitComplete(p, true);
         });
         return;
     }
     else if (extensionMatches(p, ".sfz"))
     {
         // TODO ok this refresh and restart is a bit unsatisfactory
-        messageController->stopAudioThreadThenRunOnSerial([this, p](const auto &) {
+        messageController->stopAudioThreadThenRunOnSerial([this, p, emitComplete](const auto &) {
             auto res = sfz_support::importSFZ(p, *this);
             if (!res)
                 RAISE_ERROR_CONT(*messageController, "SFZ Import Failed",
@@ -801,13 +811,14 @@ void Engine::loadSampleIntoSelectedPartAndGroup(const fs::path &p, int16_t rootK
             messageController->restartAudioThreadFromSerial();
             serializationSendToClient(messaging::client::s2c_send_pgz_structure,
                                       getPartGroupZoneStructure(), *messageController);
+            emitComplete(p, res);
         });
         return;
     }
     else if (extensionMatches(p, ".exs"))
     {
         // TODO ok this refresh and restart is a bit unsatisfactory
-        messageController->stopAudioThreadThenRunOnSerial([this, p](const auto &) {
+        messageController->stopAudioThreadThenRunOnSerial([this, p, emitComplete](const auto &) {
             auto res = exs_support::importEXS(p, *this);
             if (!res)
                 RAISE_ERROR_CONT(*messageController, "EXS Import Failed",
@@ -815,12 +826,13 @@ void Engine::loadSampleIntoSelectedPartAndGroup(const fs::path &p, int16_t rootK
             messageController->restartAudioThreadFromSerial();
             serializationSendToClient(messaging::client::s2c_send_pgz_structure,
                                       getPartGroupZoneStructure(), *messageController);
+            emitComplete(p, res);
         });
         return;
     }
     else if (extensionMatches(p, ".multisample"))
     {
-        messageController->stopAudioThreadThenRunOnSerial([this, p](const auto &) {
+        messageController->stopAudioThreadThenRunOnSerial([this, p, emitComplete](const auto &) {
             auto res = multisample_support::importMultisample(p, *this);
             if (!res)
                 RAISE_ERROR_CONT(*messageController, "Multisample Import Failed",
@@ -828,12 +840,13 @@ void Engine::loadSampleIntoSelectedPartAndGroup(const fs::path &p, int16_t rootK
             messageController->restartAudioThreadFromSerial();
             serializationSendToClient(messaging::client::s2c_send_pgz_structure,
                                       getPartGroupZoneStructure(), *messageController);
+            emitComplete(p, res);
         });
         return;
     }
     else if (extensionMatches(p, ".akp"))
     {
-        messageController->stopAudioThreadThenRunOnSerial([this, p](const auto &) {
+        messageController->stopAudioThreadThenRunOnSerial([this, p, emitComplete](const auto &) {
             auto res = akai_support::importAKP(p, *this);
             if (!res)
                 RAISE_ERROR_CONT(*messageController, "AKP Import Failed",
@@ -841,17 +854,19 @@ void Engine::loadSampleIntoSelectedPartAndGroup(const fs::path &p, int16_t rootK
             messageController->restartAudioThreadFromSerial();
             serializationSendToClient(messaging::client::s2c_send_pgz_structure,
                                       getPartGroupZoneStructure(), *messageController);
+            emitComplete(p, res);
         });
         return;
     }
     if (extensionMatches(p, ".gig"))
     {
         // TODO ok this refresh and restart is a bit unsatisfactory
-        messageController->stopAudioThreadThenRunOnSerial([this, p](const auto &) {
+        messageController->stopAudioThreadThenRunOnSerial([this, p, emitComplete](const auto &) {
             gig_support::importGIG(p, *this, -1);
             messageController->restartAudioThreadFromSerial();
             serializationSendToClient(messaging::client::s2c_send_pgz_structure,
                                       getPartGroupZoneStructure(), *messageController);
+            emitComplete(p, true);
         });
         return;
     }

--- a/src/scxt-core/messaging/client/client_serial.h
+++ b/src/scxt-core/messaging/client/client_serial.h
@@ -265,6 +265,7 @@ enum SerializationToClientMessageIds
     s2c_update_macro_value,
 
     s2c_send_missing_resolution_workitem_list,
+    s2c_compound_import_complete,
 
     s2c_send_tuning_status,
     s2c_update_mpe_tuning_awareness,

--- a/src/scxt-core/messaging/client/interaction_messages.h
+++ b/src/scxt-core/messaging/client/interaction_messages.h
@@ -38,8 +38,17 @@
 
 namespace scxt::messaging::client
 {
-// title, message, source file, source line
-typedef std::tuple<std::string, std::string, std::string, int> s2cError_t;
+// Severity for reportItem-style messages. Order matters — Error must be 0
+// for back-compat with the original error-only tuple.
+enum ReportItemSeverity : int
+{
+    Severity_Error = 0,
+    Severity_Warning = 1,
+    Severity_Info = 2,
+};
+
+// severity, title, message, source file, source line
+typedef std::tuple<int, std::string, std::string, std::string, int> s2cError_t;
 SERIAL_TO_CLIENT(ReportError, s2c_report_error, s2cError_t, onErrorFromEngine);
 
 // Behind-the-scenes batch of (format, key, value) triples emitted by an
@@ -49,6 +58,14 @@ SERIAL_TO_CLIENT(ReportError, s2c_report_error, s2cError_t, onErrorFromEngine);
 typedef std::vector<std::tuple<std::string, std::string, std::string>> s2cUnusedItems_t;
 SERIAL_TO_CLIENT(ReportUnusedItems, s2c_report_unused_items, s2cUnusedItems_t,
                  onUnusedItemsFromEngine);
+
+// Fired by the engine after a compound-file import (SFZ/EXS/AKP/multisample/
+// SF2/GIG) finishes — successfully or not. Payload is (path, success). The
+// scanner tool waits on this so async error/warn messages get attributed to
+// the correct file.
+typedef std::tuple<std::string, bool> s2cImportComplete_t;
+SERIAL_TO_CLIENT(ReportImportComplete, s2c_compound_import_complete, s2cImportComplete_t,
+                 onImportCompleteFromEngine);
 
 inline void raiseDebugError(MessageController &c, int count)
 {

--- a/src/scxt-core/messaging/messaging.cpp
+++ b/src/scxt-core/messaging/messaging.cpp
@@ -387,10 +387,14 @@ void MessageController::sendRawFromClient(const clientToSerializationMessage_t &
     clientToSerializationConditionVar.notify_one();
 }
 
-void MessageController::reportErrorToClient(const std::string &title, const std::string &body,
-                                            const std::string &source, int line)
+void MessageController::reportItemToClient(int severity, const std::string &title,
+                                           const std::string &body, const std::string &source,
+                                           int line)
 {
-    SCLOG_IF(warnings, "[[" << title << "]] (loc: " << source << ":" << line << ")");
+    const char *tag = (severity == client::Severity_Warning)
+                          ? "WARN"
+                          : (severity == client::Severity_Info ? "INFO" : "ERROR");
+    SCLOG_IF(warnings, "[[" << tag << ": " << title << "]] (loc: " << source << ":" << line << ")");
     auto blog = body;
     auto pos{0};
     while ((pos = blog.find("\n", pos)) != std::string::npos)
@@ -398,8 +402,26 @@ void MessageController::reportErrorToClient(const std::string &title, const std:
         blog[pos] = ' ';
     }
     SCLOG_IF(warnings, blog);
-    client::serializationSendToClient(client::s2c_report_error,
-                                      client::s2cError_t{title, body, source, line}, *(this));
+    client::serializationSendToClient(
+        client::s2c_report_error, client::s2cError_t{severity, title, body, source, line}, *(this));
+}
+
+void MessageController::reportErrorToClient(const std::string &title, const std::string &body,
+                                            const std::string &source, int line)
+{
+    reportItemToClient(client::Severity_Error, title, body, source, line);
+}
+
+void MessageController::reportWarningToClient(const std::string &title, const std::string &body,
+                                              const std::string &source, int line)
+{
+    reportItemToClient(client::Severity_Warning, title, body, source, line);
+}
+
+void MessageController::reportInfoToClient(const std::string &title, const std::string &body,
+                                           const std::string &source, int line)
+{
+    reportItemToClient(client::Severity_Info, title, body, source, line);
 }
 
 void MessageController::prepareSerializationThreadForAudioQueueDrain()

--- a/src/scxt-core/messaging/messaging.h
+++ b/src/scxt-core/messaging/messaging.h
@@ -325,10 +325,18 @@ struct MessageController : MoveableOnly<MessageController>
     ThreadingChecker threadingChecker;
 
     /*
-     * A convenience function to report an error to the UI
+     * Report a (severity, title, body) item to the UI client. The thin
+     * reportErrorToClient / reportWarningToClient / reportInfoToClient
+     * helpers wrap with a fixed severity for the RAISE_*_CONT macros.
      */
+    void reportItemToClient(int severity, const std::string &title, const std::string &body,
+                            const std::string &source, int line);
     void reportErrorToClient(const std::string &title, const std::string &body,
                              const std::string &source, int line);
+    void reportWarningToClient(const std::string &title, const std::string &body,
+                               const std::string &source, int line);
+    void reportInfoToClient(const std::string &title, const std::string &body,
+                            const std::string &source, int line);
 
     /*
      * Some stats on messages back

--- a/src/scxt-core/sample/import_support/import_harness.cpp
+++ b/src/scxt-core/sample/import_support/import_harness.cpp
@@ -56,6 +56,11 @@ bool ImporterContext::fail(const std::string &title, const std::string &msg)
     return false;
 }
 
+void ImporterContext::warn(const std::string &title, const std::string &msg)
+{
+    RAISE_WARN_CONT(*engineRef.getMessageController(), title, msg);
+}
+
 void ImporterContext::software_error(const std::string &where, const std::string &what)
 {
     SCLOG_IF(warnings, "Software error in " << where << ": " << what);

--- a/src/scxt-core/sample/import_support/import_harness.h
+++ b/src/scxt-core/sample/import_support/import_harness.h
@@ -63,6 +63,10 @@ class ImporterContext
     void raise(const std::string &title, const std::string &msg);
     // raise() + returns false — for the early-out idiom `return ctx.fail(...)`.
     bool fail(const std::string &title, const std::string &msg);
+    // User-visible warning (non-fatal). Use for things the importer
+    // auto-corrects (e.g. SFZ keyrange swaps) so they don't show up as
+    // hard errors in headless scanners.
+    void warn(const std::string &title, const std::string &msg);
 
     // Programmer-level invariant violations (e.g. helper required-field missing).
     // Reported now via raise() under a "Software Error" title prefix; the marker

--- a/src/scxt-core/sample/sfz_support/sfz_import.cpp
+++ b/src/scxt-core/sample/sfz_support/sfz_import.cpp
@@ -765,10 +765,13 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
                 group->outputInfo.velocitySensitivity = vt * vt;
             }
 
-            auto onError = [&ctx](const std::string &title, const std::string &msg) {
-                ctx.raise(title, msg);
+            // zoneGeometry only uses the callback for non-fatal auto-fixes
+            // (key/velocity range swaps); route them through ctx.warn so they
+            // don't drown headless scanners in pseudo-errors.
+            auto onAutofix = [&ctx](const std::string &title, const std::string &msg) {
+                ctx.warn(title, msg);
             };
-            zoneGeometry(zn, mergedOpcodes, loadInfo, onError, octaveOffset);
+            zoneGeometry(zn, mergedOpcodes, loadInfo, onAutofix, octaveOffset);
             zonePlayback(zn, mergedOpcodes);
             auto loopArgs = zoneLoopParse(mergedOpcodes, loadInfo);
             zoneEnvelope(zn, ctx, mergedOpcodes, 0, "ampeg");
@@ -860,11 +863,11 @@ bool importSFZ(const fs::path &f, engine::Engine &e)
                 {
                     // SCXT zones have a fixed cap on round-robin variants
                     // (scxt::maxVariantsPerZone). Anything past that would
-                    // OOB-write into Zone::variantData; raise + skip instead.
-                    ctx.raise("SFZ Round Robin",
-                              "SCXT only supports " + std::to_string(scxt::maxVariantsPerZone) +
-                                  " variations in round robin; seq_position=" +
-                                  std::to_string(roundRobinPosition) + " dropped.");
+                    // OOB-write into Zone::variantData; warn + skip.
+                    ctx.warn("SFZ Round Robin",
+                             "SCXT only supports " + std::to_string(scxt::maxVariantsPerZone) +
+                                 " variations in round robin; seq_position=" +
+                                 std::to_string(roundRobinPosition) + " dropped.");
                     break;
                 }
 

--- a/src/scxt-core/utils.h
+++ b/src/scxt-core/utils.h
@@ -323,6 +323,9 @@ std::string logTimestamp();
 #define RAISE_ERROR_ENGINE(E, title, msg)                                                          \
     RAISE_ERROR_CONT(*((E).getMessageController()), title, msg)
 
+#define RAISE_WARN_CONT(C, title, msg) (C).reportWarningToClient((title), (msg), __FILE__, __LINE__)
+#define RAISE_INFO_CONT(C, title, msg) (C).reportInfoToClient((title), (msg), __FILE__, __LINE__)
+
 struct DebugTimeGuard
 {
     std::string msg, file;

--- a/src/scxt-plugin/app/SCXTEditorReceiver.h
+++ b/src/scxt-plugin/app/SCXTEditorReceiver.h
@@ -71,6 +71,7 @@ struct SCXTEditorReceiver
     // Serialization to Client Messages
     void onErrorFromEngine(const scxt::messaging::client::s2cError_t &);
     void onUnusedItemsFromEngine(const scxt::messaging::client::s2cUnusedItems_t &);
+    void onImportCompleteFromEngine(const scxt::messaging::client::s2cImportComplete_t &);
     void onEngineStatus(const engine::Engine::EngineStatusMessage &e);
     void onMappingUpdated(const scxt::messaging::client::mappingSelectedZoneViewResposne_t &);
     void onSamplesUpdated(const scxt::messaging::client::sampleSelectedZoneViewResposne_t &);

--- a/src/scxt-plugin/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -286,14 +286,26 @@ void SCXTEditorReceiver::onGroupZoneMappingSummary(
 
 void SCXTEditorReceiver::onErrorFromEngine(const scxt::messaging::client::s2cError_t &e)
 {
-    auto &[title, msg, source, line] = e;
-    editor.displayError(title, msg);
+    auto &[severity, title, msg, source, line] = e;
+    // Tag non-error severities in the title; the existing error dialog stays
+    // the single display path.
+    const char *tag = (severity == scxt::messaging::client::Severity_Warning)
+                          ? "[WARN] "
+                          : (severity == scxt::messaging::client::Severity_Info ? "[INFO] " : "");
+    editor.displayError(std::string(tag) + title, msg);
 }
 
 void SCXTEditorReceiver::onUnusedItemsFromEngine(const scxt::messaging::client::s2cUnusedItems_t &)
 {
     // Intentionally discarded in the UI for now. Headless diagnostic tooling
     // (e.g. check-multi-loadability) reads this channel via ConsoleUI.
+}
+
+void SCXTEditorReceiver::onImportCompleteFromEngine(
+    const scxt::messaging::client::s2cImportComplete_t &)
+{
+    // Intentionally discarded; the UI doesn't need a per-import callback yet.
+    // Headless scanners use this to synchronize per-file message attribution.
 }
 
 void SCXTEditorReceiver::onSelectionState(const scxt::messaging::client::selectedStateMessage_t &a)


### PR DESCRIPTION
Splits the single error channel into three severities so non-fatal auto-fixes stop masquerading as failures:

- s2cError_t gains a leading severity int (Error/Warning/Info enum in interaction_messages.h). reportItemToClient takes severity; reportError/Warning/InfoToClient wrap it. RAISE_WARN_CONT / RAISE_INFO_CONT macros mirror RAISE_ERROR_CONT.
- ImporterContext gains warn(title, msg). SFZ keyrange / velocity autofixes and the round-robin-truncation message route through warn instead of raise.
- ConsoleUI tracks errors, warnings, and import-complete events on separate thread-safe stacks with has*/read*/clear* accessors.
- SCXTEditorReceiver tags non-error severities with [WARN]/[INFO] in the existing error dialog.

Adds s2c_compound_import_complete(path, success), fired by every compound importer path in engine.cpp. check-multi-loadability now waits for that signal instead of stepUI(50), so async messages get attributed to the file that produced them. Warnings are listed separately and do not flip a file to FAIL.

Net effect on the real-world SFZ scan: 158 OK / 26 FAIL → 169 OK / 15 FAIL.

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>