### PR TITLE
Fix Akai Root Key Bug

### DIFF
--- a/src/scxt-core/engine/zone.cpp
+++ b/src/scxt-core/engine/zone.cpp
@@ -263,6 +263,15 @@ bool Zone::attachToSample(const sample::SampleManager &manager, int index, int s
             }
         }
     }
+    else if (sir & ROOTKEY_ONLY)
+    {
+        if (samplePointers[index] && index == 0)
+        {
+            const auto &m = samplePointers[index]->meta;
+            if (m.rootkey_present)
+                mapping.rootKey = m.key_root;
+        }
+    }
     if (sir & (LOOP | ENDPOINTS))
     {
         if (samplePointers[index])

--- a/src/scxt-core/engine/zone.h
+++ b/src/scxt-core/engine/zone.h
@@ -198,6 +198,11 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
         MAPPING = 1 << 0,
         LOOP = 1 << 1,
         ENDPOINTS = 1 << 2,
+        // Subset of MAPPING: pulls just the sample's root key (if present), leaving
+        // keyboard range and velocity range untouched. Useful for formats like AKP
+        // that supply key/vel range themselves but rely on the sample for root pitch.
+        // Ignored when MAPPING is also set.
+        ROOTKEY_ONLY = 1 << 3,
 
         ALL = MAPPING | LOOP | ENDPOINTS
     };

--- a/src/scxt-core/sample/akai_support/akai_import.cpp
+++ b/src/scxt-core/sample/akai_support/akai_import.cpp
@@ -567,13 +567,17 @@ bool importAKP(const fs::path &path, engine::Engine &e)
             if (!lsid)
                 continue;
 
+            // AKP keygroups don't store a root key — the KLOC chunk only has
+            // lo/hi (key range) and semi/fine (tune offsets). Default the root
+            // to the midpoint of the key range; if the sample carries a root
+            // (e.g. WAV smpl chunk), attachToSample below will overwrite via
+            // Zone::ROOTKEY_ONLY.
             auto zn = std::make_unique<engine::Zone>(*lsid);
             zn->engine = &e;
             import_support::importZoneMapping(
                 *zn, ctx,
                 {
-                    // This might be wrong, need to check Akai root key logic
-                    .rootKey = kg.kloc.lo + (kg.kloc.semi - 60),
+                    .rootKey = (kg.kloc.lo + kg.kloc.hi) / 2,
                     .keyStart = kg.kloc.lo,
                     .keyEnd = kg.kloc.hi,
                     .velStart = z.lov,
@@ -730,10 +734,12 @@ bool importAKP(const fs::path &path, engine::Engine &e)
                                                     });
             }
 
-            // MAPPING is masked off because the AKP file already supplied root/key/vel
-            // and we don't want a smpl-chunk in the referenced WAV to clobber them.
+            // AKP authoritatively supplies key/vel range; the root key, however, is
+            // carried by the sample (e.g. WAV smpl chunk), so request ROOTKEY_ONLY
+            // alongside ENDPOINTS/LOOP rather than the full MAPPING set.
             zn->attachToSample(*e.getSampleManager(), 0,
-                               engine::Zone::ENDPOINTS | engine::Zone::LOOP);
+                               engine::Zone::ENDPOINTS | engine::Zone::LOOP |
+                                   engine::Zone::ROOTKEY_ONLY);
 
             ctx.addZoneToGroup(groupId, std::move(zn));
         }


### PR DESCRIPTION
Akai doesn't store root key in the mapping. It comes from the sample file. So (1) Add a ROOT_KEY structure import for attach to sample, (2) default in case an unmapped sample is there to lo + hi / 2, and (3) read it in the akai.