### PR TITLE
Don't 2xOS all groups when importing

### DIFF
--- a/src/scxt-core/sample/import_support/import_harness.cpp
+++ b/src/scxt-core/sample/import_support/import_harness.cpp
@@ -82,8 +82,11 @@ void ImporterContext::recordUnusedItem(const std::string &format, const std::str
 int ImporterContext::addGroup(const std::string &name)
 {
     int idx = partPtr->addGroup() - 1;
+    auto &group = partPtr->getGroup(idx);
     if (!name.empty())
-        partPtr->getGroup(idx)->name = name;
+        group->name = name;
+    // Imported content rarely needs the default 2x oversample
+    group->outputInfo.oversample = false;
     addedGroups.push_back(idx);
     return idx;
 }


### PR DESCRIPTION
The 2xOS default is fine for modelling aplications but in import applications, we really just want 1xOS unless at a pitch extrema using the SC1 threshold. So turn off the force-oversample on groups created via the import paths.