### PR TITLE
bg-main; Header RM; CRLF in json

### DIFF
--- a/src/scxt-plugin/app/SCXTEditor.h
+++ b/src/scxt-plugin/app/SCXTEditor.h
@@ -331,7 +331,7 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel,
         setTooltipContents(title, std::vector<std::string>{display});
     }
 
-    void showMainMenu();
+    void showMainMenu(bool alignWithHeaderButton = true);
     void addTuningMenu(juce::PopupMenu &into, bool addTitle = true);
     void addZoomMenu(juce::PopupMenu &into, bool addTitle = true);
     void addOmniFlavorMenu(juce::PopupMenu &p);

--- a/src/scxt-plugin/app/editor-impl/SCXTEditorMenus.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditorMenus.cpp
@@ -84,7 +84,7 @@ void SCXTEditor::applyThemeFromFile(const fs::path &fp)
         themeEditorWindow->rebuildFromThemeApplier();
 }
 
-void SCXTEditor::showMainMenu()
+void SCXTEditor::showMainMenu(bool alignWithHeaderButton)
 {
     juce::PopupMenu m;
 
@@ -260,7 +260,7 @@ void SCXTEditor::showMainMenu()
 
     m.addSubMenu("Developer", dp);
 
-    if (headerRegion && headerRegion->scMenu)
+    if (alignWithHeaderButton && headerRegion && headerRegion->scMenu)
     {
         m.showMenuAsync(defaultPopupMenuOptions(headerRegion->scMenu.get()));
     }

--- a/src/scxt-plugin/app/shared/HeaderRegion.cpp
+++ b/src/scxt-plugin/app/shared/HeaderRegion.cpp
@@ -245,6 +245,12 @@ HeaderRegion::HeaderRegion(SCXTEditor *e) : HasEditor(e)
     editor->themeApplier.applyHeaderSCButtonTheme(scMenu.get());
 }
 
+void HeaderRegion::mouseDown(const juce::MouseEvent &e)
+{
+    if (e.mods.isPopupMenu())
+        editor->showMainMenu(false);
+}
+
 void HeaderRegion::setShowUndoRedo(bool show)
 {
     if (undoButton)

--- a/src/scxt-plugin/app/shared/HeaderRegion.h
+++ b/src/scxt-plugin/app/shared/HeaderRegion.h
@@ -66,6 +66,7 @@ struct HeaderRegion : juce::Component, HasEditor, juce::FileDragAndDropTarget
     ~HeaderRegion();
 
     void resized() override;
+    void mouseDown(const juce::MouseEvent &) override;
 
     uint32_t voiceCount{0};
     void setVoiceCount(uint32_t vc)

--- a/src/scxt-plugin/json-assets/themes/Celtic.json
+++ b/src/scxt-plugin/json-assets/themes/Celtic.json
@@ -1,7 +1,7 @@
 [
    {
       "hoverfactor": "0.100000",
-      "version": "1"
+      "version": "2"
    },
    {
       "accent_1a": "#ff6C835F",
@@ -17,6 +17,7 @@
       "accent_2b_alpha_a": "#408b8ba6",
       "accent_2b_alpha_b": "#608b8ba6",
       "accent_2b_alpha_c": "#808b8ba6",
+      "bg_main": "#ffC9C8C0",
       "bg_1": "#ffC9C8C0",
       "bg_2": "#ffC5C3BC",
       "bg_3": "#ffB7B6AF",

--- a/src/scxt-plugin/json-assets/themes/Grayllow.json
+++ b/src/scxt-plugin/json-assets/themes/Grayllow.json
@@ -1,7 +1,7 @@
 [
    {
       "hoverfactor": "0.250000",
-      "version": "1"
+      "version": "2"
    },
    {
       "accent_1a": "#ffffb949",
@@ -17,6 +17,7 @@
       "accent_2b_alpha_a": "#20004f8a",
       "accent_2b_alpha_b": "#60004f8a",
       "accent_2b_alpha_c": "#90004f8a",
+      "bg_main": "#ff484a4a",
       "bg_1": "#ff484a4a",
       "bg_2": "#ff404242", 
       "bg_3": "#ff5d5D5d",

--- a/src/scxt-plugin/json-assets/themes/Lux2.json
+++ b/src/scxt-plugin/json-assets/themes/Lux2.json
@@ -1,7 +1,7 @@
 [
    {
       "hoverfactor": "0.100000",
-      "version": "1"
+      "version": "2"
    },
    {
       "accent_1a": "#ff268bd2",
@@ -17,6 +17,7 @@
       "accent_2b_alpha_a": "#14CB3F71",
       "accent_2b_alpha_b": "#52CB3F71",
       "accent_2b_alpha_c": "#80CB3F71",
+      "bg_main": "#ffC9C8C0",
       "bg_1": "#ffC9C8C0",
       "bg_2": "#ffC5C3BC",
       "bg_3": "#ffB7B6AF",

--- a/src/scxt-plugin/json-assets/themes/Oceanor.json
+++ b/src/scxt-plugin/json-assets/themes/Oceanor.json
@@ -1,7 +1,7 @@
 [
    {
       "hoverfactor": "0.100000",
-      "version": "1"
+      "version": "2"
    },
    {
       "accent_1a": "#ff266ba2",
@@ -17,6 +17,7 @@
       "accent_2b_alpha_a": "#60268bd2",
       "accent_2b_alpha_b": "#90268bd2",
       "accent_2b_alpha_c": "#B0268bd2",
+      "bg_main": "#ffa9a9a5",
       "bg_1": "#ffa9a9a5",
       "bg_2": "#ffa5a5a2",
       "bg_3": "#ff9E9E99",

--- a/src/scxt-plugin/json-assets/themes/wireframe-dark.json
+++ b/src/scxt-plugin/json-assets/themes/wireframe-dark.json
@@ -1,6 +1,6 @@
 [
     {
-        "version": "1",
+        "version": "2",
         "hoverfactor": "0.1"
     },
     {
@@ -17,6 +17,7 @@
         "accent_2b_alpha_a": "#14004f8a",
         "accent_2b_alpha_b": "#52004f8a",
         "accent_2b_alpha_c": "#80004f8a",
+        "bg_main": "#ff1b1d20",
         "bg_1": "#ff1b1d20",
         "bg_2": "#ff262a2f",
         "bg_3": "#ff333333",

--- a/src/scxt-plugin/theme/ColorMap.cpp
+++ b/src/scxt-plugin/theme/ColorMap.cpp
@@ -69,6 +69,7 @@ std::string ColorMap::nameOf(ColorMap::Colors c)
         C(accent_2b_alpha_a);
         C(accent_2b_alpha_b);
         C(accent_2b_alpha_c);
+        C(bg_main);
         C(bg_1);
         C(bg_2);
         C(bg_3);
@@ -180,7 +181,7 @@ std::string ColorMap::toJson() const
         colorMap[keys] = cols;
     }
 
-    metadata_t meta{{"version", "1"}, {"hoverfactor", std::to_string(hoverFactor)}};
+    metadata_t meta{{"version", "2"}, {"hoverfactor", std::to_string(hoverFactor)}};
     colormap_t doc{meta, colorMap};
 
     tao::json::value jsonv = doc;
@@ -199,7 +200,17 @@ std::unique_ptr<ColorMap> ColorMap::jsonToColormap(const std::string &json)
 
     auto meta = std::get<0>(cm);
 
-    auto res = std::make_unique<StdMapColormap>(std::get<1>(cm));
+    // Pre-bg_main themes (version "1") split window background from element
+    // background, so map bg_main onto bg_1 if the loaded theme omits it.
+    auto &colors = std::get<1>(cm);
+    if (colors.find("bg_main") == colors.end())
+    {
+        auto bg1 = colors.find("bg_1");
+        if (bg1 != colors.end())
+            colors["bg_main"] = bg1->second;
+    }
+
+    auto res = std::make_unique<StdMapColormap>(colors);
     auto hvi = meta.find("hoverfactor");
     if (hvi != meta.end())
     {

--- a/src/scxt-plugin/theme/ColorMap.h
+++ b/src/scxt-plugin/theme/ColorMap.h
@@ -68,6 +68,7 @@ struct ColorMap
         accent_2b_alpha_a,
         accent_2b_alpha_b,
         accent_2b_alpha_c,
+        bg_main, // window panel background; older themes fall back to bg_1
         bg_1,
         bg_2,
         bg_3,

--- a/src/scxt-plugin/theme/ThemeApplier.cpp
+++ b/src/scxt-plugin/theme/ThemeApplier.cpp
@@ -468,9 +468,9 @@ void applyColors(const sheet_t::ptr_t &base, const ColorMap &cols)
                     cols.get(ColorMap::bg_1));
 
     base->setColour(jcmp::WindowPanel::Styles::styleClass, jcmp::WindowPanel::Styles::bgstart,
-                    cols.get(ColorMap::bg_1));
+                    cols.get(ColorMap::bg_main));
     base->setColour(jcmp::WindowPanel::Styles::styleClass, jcmp::WindowPanel::Styles::bgend,
-                    cols.get(ColorMap::bg_1).darker(0.05));
+                    cols.get(ColorMap::bg_main).darker(0.05));
 
     base->setColour(jcmp::NamedPanel::Styles::styleClass, jcmp::NamedPanel::Styles::background,
                     cols.get(ColorMap::bg_2));


### PR DESCRIPTION
1. Add a bg-main color which separates from bg-1 to control window background. Up version so old skins with just bg-1 pply to both
2. Make it so RMB in an empyt header region also shows main menu to among other things allow escape-from-overzoom
3. Remove CRLF in favor of LF in a few of the factory embedded themes.

Assisted-By: Claude Opus 4.7