### PR TITLE
Group iteration performance updates

### DIFF
--- a/src/clients/perf-harness/perf_main.cpp
+++ b/src/clients/perf-harness/perf_main.cpp
@@ -68,6 +68,19 @@ int main(int argc, char **argv)
         return argc < 2 ? 1 : 0;
     }
 
+#if BUILD_IS_DEBUG
+    fmt::print(stderr, "\n");
+    fmt::print(stderr, "##############################################################\n");
+    fmt::print(stderr, "##                                                          ##\n");
+    fmt::print(stderr, "##   !!!  DEBUG BUILD  !!!  TIMINGS ARE NOT MEANINGFUL  !!! ##\n");
+    fmt::print(stderr, "##                                                          ##\n");
+    fmt::print(stderr, "##   Rebuild with -DCMAKE_BUILD_TYPE=Release (or            ##\n");
+    fmt::print(stderr, "##   RelWithDebInfo) before drawing perf conclusions.       ##\n");
+    fmt::print(stderr, "##                                                          ##\n");
+    fmt::print(stderr, "##############################################################\n");
+    fmt::print(stderr, "\n");
+#endif
+
     std::filesystem::path configPath = argv[1];
     scxt::perf::Config cfg;
     try

--- a/src/scxt-core/engine/group.cpp
+++ b/src/scxt-core/engine/group.cpp
@@ -163,8 +163,11 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
     fGatedCount = 0;
     fVoiceCount = 0;
 
-    for (const auto &z : zones)
+    for (int i = 0; i < activeZones; ++i)
     {
+        auto z = activeZoneWeakRefs[i];
+        assert(z);
+        assert(z->isActive());
         gated = gated || (z->gatedVoiceCount > 0);
         fGatedCount += z->gatedVoiceCount;
         fVoiceCount += z->activeVoices;
@@ -775,10 +778,11 @@ void Group::setupGroupPitch()
     keyTrack.prepare();
     float vc = 0.f;
 
-    for (const auto &z : zones)
+    for (int i = 0; i < activeZones; ++i)
     {
-        if (z->activeVoices == 0)
-            continue;
+        auto z = activeZoneWeakRefs[i];
+        assert(z);
+        assert(z->isActive());
         for (int i = 0; i < z->activeVoices; ++i)
         {
             auto v = z->voiceWeakPointers[i];


### PR DESCRIPTION
Group process had, in the core render, an active zone loop which was correct, but a few helpers to set up modulation still iterated all zones. Which we really don't need to do - no gated voice lives in an inactive zone. This knocks quite a bit of time off of render for groups with very large numbers of zones compared to their polyphony, like library samples.

Actually did this one by hand. No claude here!