### PR TITLE
MultiGroup Mute Behavior Change

### DIFF
--- a/src/scxt-plugin/app/edit-screen/components/GroupZoneTreeControl.h
+++ b/src/scxt-plugin/app/edit-screen/components/GroupZoneTreeControl.h
@@ -171,7 +171,7 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
                 muteProvider->setup();
                 muteProvider->onValueChanged = [this](bool v) {
                     auto shift = juce::ModifierKeys::getCurrentModifiers().isShiftDown();
-                    setMuteTo(v, shift);
+                    setMuteTo(v, !shift);
                 };
                 addAndMakeVisible(*muteProvider->widget);
                 resized();


### PR DESCRIPTION
With multiple groups selected, clicking mute in a selected group mutes all of them. Clicking shift-mute just mutes the one you clicked. Closes #2372