### PR TITLE
Allow selecting and targeting empty groups

### DIFF
--- a/src/scxt-core/selection/selection_manager.cpp
+++ b/src/scxt-core/selection/selection_manager.cpp
@@ -256,6 +256,18 @@ void SelectionManager::adjustInternalStateForAction(
             if (z.distinct)
             {
                 allSelectedGroups[selectedPart].clear();
+                // For an empty group, transformSelectionActions emitted no zone
+                // actions, so clear zone state here to keep the group the sole lead
+                if (za.part >= 0 && za.group >= 0)
+                {
+                    const auto &pt = engine.getPatch()->getPart(za.part);
+                    if (za.group < (int)pt->getGroups().size() &&
+                        pt->getGroup(za.group)->getZones().empty())
+                    {
+                        allSelectedZones[selectedPart].clear();
+                        leadZone[selectedPart] = {};
+                    }
+                }
             }
             allSelectedGroups[selectedPart].insert(za);
             if (z.selectingAsLead)
@@ -386,12 +398,28 @@ void SelectionManager::guaranteeSelectedLeadSomewhereIn(int part, int group, int
 
 void SelectionManager::guaranteeSelectedLead()
 {
+    // If lead group is explicitly an empty group, treat the empty zone state as
+    // intentional and don't auto-pick a zone from somewhere else.
+    bool leadGroupIsEmpty{false};
+    {
+        const auto &lg = leadGroup[selectedPart];
+        if (lg.part >= 0 && lg.group >= 0)
+        {
+            const auto &pt = engine.getPatch()->getPart(lg.part);
+            if (lg.group < (int)pt->getGroups().size() &&
+                pt->getGroup(lg.group)->getZones().empty())
+            {
+                leadGroupIsEmpty = true;
+            }
+        }
+    }
+
     // Now at the end of this the lead zone could not be selected
     if (allSelectedZones[selectedPart].find(leadZone[selectedPart]) ==
         allSelectedZones[selectedPart].end())
     {
         // Nothing is selected. So we need to pick the first zone of the first group
-        if (allSelectedZones[selectedPart].empty())
+        if (allSelectedZones[selectedPart].empty() && !leadGroupIsEmpty)
         {
             SCLOG_IF(selection, "Selected zones is empty. Looking for a candidate");
             auto &pt = engine.getPatch()->getPart(selectedPart);

--- a/src/scxt-plugin/app/edit-screen/components/GroupZoneTreeControl.h
+++ b/src/scxt-plugin/app/edit-screen/components/GroupZoneTreeControl.h
@@ -276,9 +276,23 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
 
                 auto bx = getLocalBounds().withWidth(grouplabelPad);
                 auto nb = getLocalBounds().withTrimmedLeft(grouplabelPad);
-                g.setColour(lowTextColor);
+                auto digitColor = lowTextColor;
+                bool groupIsSelected =
+                    editor->allGroupSelections.find(sg.address) != editor->allGroupSelections.end();
+                if (isLeadGroup)
+                {
+                    digitColor = editor->themeColor(theme::ColorMap::generic_content_highest);
+                    g.setFont(editor->themeApplier.interBoldFor(11));
+                }
+                else if (groupIsSelected)
+                {
+                    digitColor = editor->themeColor(theme::ColorMap::generic_content_high);
+                }
+                g.setColour(digitColor);
                 g.drawText(std::to_string(sg.address.group + 1), bx,
                            juce::Justification::centredLeft);
+                if (isLeadGroup)
+                    g.setFont(groupFont);
                 g.setColour(textColor);
                 g.drawText(sg.name, nb, juce::Justification::centredLeft);
 
@@ -423,6 +437,13 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
                                   auto za = w->getZoneAddress();
                                   w->gsb->sendToSerialization(cmsg::PasteZone(za));
                               });
+                    p.addItem("Create Empty Zone", [w = juce::Component::SafePointer(this)]() {
+                        if (!w)
+                            return;
+                        auto za = w->getZoneAddress();
+                        w->gsb->sendToSerialization(
+                            cmsg::AddBlankZone({za.part, za.group, 48, 72, 0, 127}));
+                    });
                     p.addItem("Delete", [w = juce::Component::SafePointer(this)]() {
                         if (!w)
                             return;

--- a/src/scxt-plugin/app/edit-screen/components/PartGroupSidebar.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/PartGroupSidebar.cpp
@@ -760,13 +760,14 @@ struct ZoneSidebar : GroupZoneSidebarBase<ZoneSidebar, true>
         }
         else if (rowZone.group >= 0)
         {
-            // Group Selection on the server side selects all in the group
+            // forZone=false so empty groups can become the lead group; for non-empty
+            // groups the server still expands this into per-zone selections
             auto se = selection::SelectionManager::SelectActionContents(rowZone);
 
             se.selecting = true;
             se.distinct = !mods.isAltDown();
-            se.selectingAsLead = false;
-            se.forZone = true;
+            se.selectingAsLead = true;
+            se.forZone = false;
             editor->doSelectionAction(se);
         }
         else

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
@@ -376,18 +376,19 @@ void ZoneLayoutDisplay::createEmptyZoneAt(const juce::Point<int> &pos)
             keyMin++;
     }
 
-    auto za{editor->currentLeadZoneSelection};
+    // Prefer the lead group so that selecting an empty group routes here
+    auto ga{editor->currentLeadGroupSelection};
 
     namespace cmsg = scxt::messaging::client;
 
-    if (!za.has_value())
+    if (ga.has_value())
     {
-        sendToSerialization(cmsg::AddBlankZone({-1, -1, keyMin, keyMax, velMin, velMax}));
+        sendToSerialization(
+            cmsg::AddBlankZone({ga->part, ga->group, keyMin, keyMax, velMin, velMax}));
     }
     else
     {
-        sendToSerialization(
-            cmsg::AddBlankZone({za->part, za->group, keyMin, keyMax, velMin, velMax}));
+        sendToSerialization(cmsg::AddBlankZone({-1, -1, keyMin, keyMax, velMin, velMax}));
     }
 }
 
@@ -678,15 +679,16 @@ void ZoneLayoutDisplay::mouseUp(const juce::MouseEvent &e)
         auto ve = (int)std::clamp(127.f - std::ceil(r.getY() / vh), 0.f, 127.f);
 
         namespace cmsg = scxt::messaging::client;
-        auto za{editor->currentLeadZoneSelection};
+        // Prefer lead group so an empty selected group still routes here
+        auto ga{editor->currentLeadGroupSelection};
 
-        if (!za.has_value())
+        if (ga.has_value())
         {
-            sendToSerialization(cmsg::AddBlankZone({-1, -1, ks, ke, vs, ve}));
+            sendToSerialization(cmsg::AddBlankZone({ga->part, ga->group, ks, ke, vs, ve}));
         }
         else
         {
-            sendToSerialization(cmsg::AddBlankZone({za->part, za->group, ks, ke, vs, ve}));
+            sendToSerialization(cmsg::AddBlankZone({-1, -1, ks, ke, vs, ve}));
         }
     }
     mouseState = NONE;

--- a/tests/selection_tests.cpp
+++ b/tests/selection_tests.cpp
@@ -110,3 +110,151 @@ TEST_CASE("Create five zones then multi-select")
     REQUIRE(sm->leadZone[0] == zad{0, 0, 4});
     REQUIRE(sm->allSelectedZones[0].size() == 1);
 }
+
+TEST_CASE("Selecting an empty group makes it the lead group")
+{
+    scxt::clients::console_ui::ConsoleHarness th;
+    th.start();
+    th.stepUI();
+
+    namespace cmsg = scxt::messaging::client;
+    using zad = scxt::selection::SelectionManager::ZoneAddress;
+    using sac = scxt::selection::SelectionManager::SelectActionContents;
+
+    auto selGroup = [&th](int p, int g, bool s, bool d, bool ld) {
+        sac sa(p, g, -1, s, d, ld);
+        sa.forZone = false;
+        th.sendToSerialization(cmsg::ApplySelectActions({sa}));
+    };
+
+    const auto &sm = th.engine->getSelectionManager();
+
+    // group 0 with one zone, plus an empty group 1
+    th.sendToSerialization(cmsg::AddBlankZone({0, 0, 60, 72, 0, 127}));
+    th.sendToSerialization(cmsg::CreateGroup(0));
+    th.stepUI();
+
+    REQUIRE(th.engine->getPatch()->getPart(0)->getGroups().size() == 2);
+    REQUIRE(th.engine->getPatch()->getPart(0)->getGroup(1)->getZones().empty());
+
+    INFO("Distinct-select the empty group as lead");
+    selGroup(0, 1, true, true, true);
+    th.stepUI();
+
+    REQUIRE(sm->leadGroup[0] == zad{0, 1, -1});
+    REQUIRE(sm->allSelectedGroups[0].size() == 1);
+    REQUIRE(sm->allSelectedGroups[0].count(zad{0, 1, -1}) == 1);
+}
+
+TEST_CASE("Selecting an empty group clears prior zone selections")
+{
+    scxt::clients::console_ui::ConsoleHarness th;
+    th.start();
+    th.stepUI();
+
+    namespace cmsg = scxt::messaging::client;
+    using zad = scxt::selection::SelectionManager::ZoneAddress;
+    using sac = scxt::selection::SelectionManager::SelectActionContents;
+
+    auto selGroup = [&th](int p, int g, bool s, bool d, bool ld) {
+        sac sa(p, g, -1, s, d, ld);
+        sa.forZone = false;
+        th.sendToSerialization(cmsg::ApplySelectActions({sa}));
+    };
+
+    const auto &sm = th.engine->getSelectionManager();
+
+    // two zones in group 0, empty group 1
+    th.sendToSerialization(cmsg::AddBlankZone({0, 0, 48, 60, 0, 127}));
+    th.sendToSerialization(cmsg::AddBlankZone({0, 0, 61, 72, 0, 127}));
+    th.sendToSerialization(cmsg::CreateGroup(0));
+    th.stepUI();
+
+    REQUIRE(sm->leadZone[0] == zad{0, 0, 1});
+    REQUIRE(!sm->allSelectedZones[0].empty());
+
+    INFO("Distinct-select the empty group; zone state should clear");
+    selGroup(0, 1, true, true, true);
+    th.stepUI();
+
+    REQUIRE(sm->leadGroup[0] == zad{0, 1, -1});
+    REQUIRE(sm->allSelectedZones[0].empty());
+    REQUIRE(sm->leadZone[0] == zad{});
+}
+
+TEST_CASE("AddBlankZone after selecting empty group lands in that group")
+{
+    scxt::clients::console_ui::ConsoleHarness th;
+    th.start();
+    th.stepUI();
+
+    namespace cmsg = scxt::messaging::client;
+    using zad = scxt::selection::SelectionManager::ZoneAddress;
+    using sac = scxt::selection::SelectionManager::SelectActionContents;
+
+    auto selGroup = [&th](int p, int g, bool s, bool d, bool ld) {
+        sac sa(p, g, -1, s, d, ld);
+        sa.forZone = false;
+        th.sendToSerialization(cmsg::ApplySelectActions({sa}));
+    };
+
+    const auto &sm = th.engine->getSelectionManager();
+
+    th.sendToSerialization(cmsg::AddBlankZone({0, 0, 60, 72, 0, 127}));
+    th.sendToSerialization(cmsg::CreateGroup(0));
+    th.stepUI();
+
+    selGroup(0, 1, true, true, true);
+    th.stepUI();
+
+    REQUIRE(sm->leadGroup[0] == zad{0, 1, -1});
+    REQUIRE(th.engine->getPatch()->getPart(0)->getGroup(1)->getZones().empty());
+
+    INFO("Create a blank zone explicitly targeting the empty group");
+    th.sendToSerialization(cmsg::AddBlankZone({0, 1, 48, 72, 0, 127}));
+    th.stepUI();
+
+    REQUIRE(th.engine->getPatch()->getPart(0)->getGroup(0)->getZones().size() == 1);
+    REQUIRE(th.engine->getPatch()->getPart(0)->getGroup(1)->getZones().size() == 1);
+    REQUIRE(sm->leadZone[0] == zad{0, 1, 0});
+}
+
+TEST_CASE("Switching from empty group to non-empty group selects its zones")
+{
+    scxt::clients::console_ui::ConsoleHarness th;
+    th.start();
+    th.stepUI();
+
+    namespace cmsg = scxt::messaging::client;
+    using zad = scxt::selection::SelectionManager::ZoneAddress;
+    using sac = scxt::selection::SelectionManager::SelectActionContents;
+
+    auto selGroup = [&th](int p, int g, bool s, bool d, bool ld) {
+        sac sa(p, g, -1, s, d, ld);
+        sa.forZone = false;
+        th.sendToSerialization(cmsg::ApplySelectActions({sa}));
+    };
+
+    const auto &sm = th.engine->getSelectionManager();
+
+    th.sendToSerialization(cmsg::AddBlankZone({0, 0, 48, 60, 0, 127}));
+    th.sendToSerialization(cmsg::AddBlankZone({0, 0, 61, 72, 0, 127}));
+    th.sendToSerialization(cmsg::CreateGroup(0));
+    th.stepUI();
+
+    selGroup(0, 1, true, true, true);
+    th.stepUI();
+    REQUIRE(sm->leadGroup[0] == zad{0, 1, -1});
+    REQUIRE(sm->allSelectedZones[0].empty());
+
+    INFO("Now distinct-select the non-empty group 0");
+    selGroup(0, 0, true, true, true);
+    th.stepUI();
+
+    REQUIRE(sm->leadGroup[0] == zad{0, 0, -1});
+    REQUIRE(sm->allSelectedGroups[0].size() == 1);
+    REQUIRE(sm->allSelectedGroups[0].count(zad{0, 0, -1}) == 1);
+    REQUIRE(sm->allSelectedZones[0].size() == 2);
+    REQUIRE(sm->leadZone[0].part == 0);
+    REQUIRE(sm->leadZone[0].group == 0);
+}


### PR DESCRIPTION
In the zone-mode sidebar, clicking an empty group now makes it the lead group and clears prior zone selections. Creating an empty zone (via mapping-pane RMB, cmd+drag, or a new group-RMB "Create Empty Zone" item) routes into the lead group, so an empty selected group finally gets new zones instead of falling back to group 0.

The lead group is rendered with a bolder, brighter digit, and selected-but-not-lead groups get a brighter digit too.

Closes #2445, #2446.

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>