### PR TITLE
Add foldable groups in the group/zone tree sidebar

### DIFF
--- a/src/scxt-core/engine/engine.cpp
+++ b/src/scxt-core/engine/engine.cpp
@@ -527,12 +527,17 @@ Engine::pgzStructure_t Engine::getPartGroupZoneStructure() const
         res.push_back({{partidx, -1, -1}, part->getName()});
 
         int32_t groupidx{0};
+        const auto &sm = *getSelectionManager();
         for (const auto &group : *part)
         {
             int32_t groupFeatures{0};
             if (group->outputInfo.muted)
             {
-                groupFeatures += GroupZoneFeatures::MUTED;
+                groupFeatures |= GroupZoneFeatures::MUTED;
+            }
+            if (sm.isGroupCollapsed(partidx, groupidx))
+            {
+                groupFeatures |= GroupZoneFeatures::FOLDED;
             }
             res.push_back({{partidx, groupidx, -1}, group->getName(), groupFeatures});
             int32_t zoneidx{0};

--- a/src/scxt-core/engine/feature_enums.h
+++ b/src/scxt-core/engine/feature_enums.h
@@ -34,6 +34,7 @@ enum GroupZoneFeatures
 {
     MISSING_SAMPLE = 1 << 0,
     MUTED = 1 << 1,
+    FOLDED = 1 << 2, // group rows only: the group's zones are hidden in the tree sidebar
 };
 }
 

--- a/src/scxt-core/json/selection_traits.h
+++ b/src/scxt-core/json/selection_traits.h
@@ -76,9 +76,13 @@ SC_STREAMDEF(scxt::selection::SelectionManager::ZoneAddress, SC_FROM({
 
 SC_STREAMDEF(selection::SelectionManager, SC_FROM({
                  auto &e = from;
-                 v = {{"zones", e.allSelectedZones},   {"leadZone", e.leadZone},
-                      {"groups", e.allSelectedGroups}, {"dgroups", e.allDisplayGroups},
-                      {"tabs", e.otherTabSelection},   {"selectedPart", e.selectedPart}};
+                 v = {{"zones", e.allSelectedZones},
+                      {"leadZone", e.leadZone},
+                      {"groups", e.allSelectedGroups},
+                      {"dgroups", e.allDisplayGroups},
+                      {"tabs", e.otherTabSelection},
+                      {"selectedPart", e.selectedPart},
+                      {"collapsedGroups", e.collapsedGroupsByPart}};
              }),
              SC_TO({
                  auto &z = to;
@@ -98,6 +102,7 @@ SC_STREAMDEF(selection::SelectionManager, SC_FROM({
                      findIf(v, "dgroups", z.allDisplayGroups);
                      findIf(v, "leadZone", z.leadZone);
                      findIf(v, "selectedPart", z.selectedPart);
+                     findIf(v, "collapsedGroups", z.collapsedGroupsByPart);
                  }
 
                  selection::SelectionManager::ZoneAddress za;

--- a/src/scxt-core/messaging/client/client_serial.h
+++ b/src/scxt-core/messaging/client/client_serial.h
@@ -197,6 +197,8 @@ enum ClientToSerializationMessagesIds
     c2s_macro_begin_end_edit,
 
     c2s_set_othertab_selection,
+    c2s_set_group_collapsed,
+    c2s_set_all_groups_collapsed,
 
     c2s_send_full_part_config,
 

--- a/src/scxt-core/messaging/client/selection_messages.h
+++ b/src/scxt-core/messaging/client/selection_messages.h
@@ -96,5 +96,20 @@ CLIENT_TO_SERIAL(BeginEdit, c2s_begin_edit, editGestureFor_t,
 CLIENT_TO_SERIAL(EndEdit, c2s_end_edit, editGestureFor_t,
                  doBeginEndEdit(false, payload, engine, cont));
 
+// Group/zone tree fold state. Per-part set of collapsed group indices.
+// The result is broadcast back to the client via the regular structure
+// broadcast — the FOLDED bit is stamped onto group-row features.
+using setGroupCollapsedPayload_t = std::tuple<int32_t, int32_t, bool>; // part, group, collapsed
+CLIENT_TO_SERIAL(SetGroupCollapsed, c2s_set_group_collapsed, setGroupCollapsedPayload_t,
+                 engine.getSelectionManager()->setGroupCollapsed(std::get<0>(payload),
+                                                                 std::get<1>(payload),
+                                                                 std::get<2>(payload)));
+
+using setAllGroupsCollapsedPayload_t = std::pair<int32_t, bool>; // part, collapsed
+CLIENT_TO_SERIAL(SetAllGroupsCollapsed, c2s_set_all_groups_collapsed,
+                 setAllGroupsCollapsedPayload_t,
+                 engine.getSelectionManager()->setAllGroupsCollapsed(payload.first,
+                                                                     payload.second));
+
 } // namespace scxt::messaging::client
 #endif // SHORTCIRCUIT_SELECTION_MESSAGES_H

--- a/src/scxt-core/messaging/client/structure_messages.h
+++ b/src/scxt-core/messaging/client/structure_messages.h
@@ -486,7 +486,13 @@ inline void moveGroupTo(const moveGroupAddress_t &payload, engine::Engine &engin
                 pt->moveGroupToAfter(ss.group, tt.group);
             }
         },
-        [tt = tgt](auto &engine) {
+        [ss = src, tt = tgt](auto &engine) {
+            // Keep fold-state index keys aligned with the group reorder.
+            if (tt.zone < 0)
+                engine.getSelectionManager()->remapCollapsedOnSwap(ss.part, ss.group, tt.group);
+            else
+                engine.getSelectionManager()->remapCollapsedOnMoveAfter(ss.part, ss.group,
+                                                                        tt.group);
             serializationSendToClient(s2c_send_pgz_structure, engine.getPartGroupZoneStructure(),
                                       *(engine.getMessageController()));
             serializationSendToClient(s2c_send_selected_group_zone_mapping_summary,

--- a/src/scxt-core/selection/selection_manager.cpp
+++ b/src/scxt-core/selection/selection_manager.cpp
@@ -39,6 +39,7 @@
 #include "messaging/client/modulation_messages.h"
 #include "messaging/client/mixer_messages.h"
 #include "messaging/client/macro_messages.h"
+#include "messaging/client/structure_messages.h"
 
 namespace scxt::selection
 {
@@ -343,6 +344,46 @@ void SelectionManager::guaranteeConsistencyAfterDeletes(const engine::Engine &en
         else
         {
             git++;
+        }
+    }
+
+    // Remap collapsed-group indices to follow the deletion. For a single-group
+    // delete (whatIDeleted.group >= 0) the deleted index drops and any index
+    // above it shifts down by one — the FOLDED bit travels with its group.
+    // For bulk deletes (DeleteEmptyGroups, group == -1) we only know the
+    // post-state, so we fall back to dropping out-of-range entries.
+    if (!zoneDeleted)
+    {
+        auto p = whatIDeleted.part;
+        if (p >= 0 && p < scxt::numParts)
+        {
+            const auto &part = engine.getPatch()->getPart(p);
+            int n = (int)part->getGroups().size();
+            auto &cset = collapsedGroupsByPart[p];
+
+            if (whatIDeleted.group >= 0)
+            {
+                std::unordered_set<int32_t> nset;
+                for (auto i : cset)
+                {
+                    if (i == whatIDeleted.group)
+                        continue;
+                    int j = i > whatIDeleted.group ? i - 1 : i;
+                    if (j >= 0 && j < n)
+                        nset.insert(j);
+                }
+                cset = std::move(nset);
+            }
+            else
+            {
+                for (auto it = cset.begin(); it != cset.end();)
+                {
+                    if (*it < 0 || *it >= n)
+                        it = cset.erase(it);
+                    else
+                        ++it;
+                }
+            }
         }
     }
 
@@ -926,6 +967,112 @@ void SelectionManager::sendOtherTabsSelectionToClient()
     SCLOG_WFUNC_IF(selection, "");
     serializationSendToClient(cms::s2c_send_othertab_selection, otherTabSelection,
                               *(engine.getMessageController()));
+}
+
+// Fold state rides on s2c_send_pgz_structure: getPartGroupZoneStructure() stamps
+// the FOLDED bit onto group-row features using SelectionManager state.
+static void broadcastStructure(const engine::Engine &engine)
+{
+    serializationSendToClient(cms::s2c_send_pgz_structure, engine.getPartGroupZoneStructure(),
+                              *(engine.getMessageController()));
+}
+
+void SelectionManager::setGroupCollapsed(int part, int group, bool collapsed)
+{
+    if (part < 0 || part >= scxt::numParts || group < 0)
+        return;
+    auto &s = collapsedGroupsByPart[part];
+    bool changed = collapsed ? s.insert(group).second : (s.erase(group) > 0);
+    if (changed)
+        broadcastStructure(engine);
+}
+
+void SelectionManager::setAllGroupsCollapsed(int part, bool collapsed)
+{
+    if (part < 0 || part >= scxt::numParts)
+        return;
+    auto &s = collapsedGroupsByPart[part];
+    s.clear();
+    if (collapsed)
+    {
+        const auto &p = engine.getPatch()->getPart(part);
+        int n = (int)p->getGroups().size();
+        for (int g = 0; g < n; ++g)
+            s.insert(g);
+    }
+    broadcastStructure(engine);
+}
+
+void SelectionManager::remapCollapsedOnSwap(int part, int gA, int gB)
+{
+    if (part < 0 || part >= scxt::numParts || gA == gB)
+        return;
+    auto &s = collapsedGroupsByPart[part];
+    bool a = s.count(gA) > 0;
+    bool b = s.count(gB) > 0;
+    if (a == b)
+        return;
+    if (a)
+    {
+        s.erase(gA);
+        s.insert(gB);
+    }
+    else
+    {
+        s.erase(gB);
+        s.insert(gA);
+    }
+}
+
+void SelectionManager::remapCollapsedOnMoveAfter(int part, int whichGroup, int toAfter)
+{
+    if (part < 0 || part >= scxt::numParts || whichGroup == toAfter || whichGroup < 0 ||
+        toAfter < 0)
+        return;
+    auto &s = collapsedGroupsByPart[part];
+
+    // The move only affects indices in a contiguous window; everything else
+    // keeps its FOLDED bit. Snapshot just the affected window and rotate.
+    int lo, hi;
+    if (whichGroup < toAfter)
+    {
+        // src→tgt; range [src, tgt] rotates left by 1 (src lands at tgt).
+        lo = whichGroup;
+        hi = toAfter;
+    }
+    else
+    {
+        // src→tgt+1; range [tgt+1, src] rotates right by 1 (src lands at tgt+1).
+        lo = toAfter + 1;
+        hi = whichGroup;
+    }
+    int len = hi - lo + 1;
+    std::vector<bool> fold(len);
+    for (int i = 0; i < len; ++i)
+        fold[i] = s.count(lo + i) > 0;
+
+    if (whichGroup < toAfter)
+    {
+        bool moved = fold[0];
+        for (int i = 0; i < len - 1; ++i)
+            fold[i] = fold[i + 1];
+        fold[len - 1] = moved;
+    }
+    else
+    {
+        bool moved = fold[len - 1];
+        for (int i = len - 1; i > 0; --i)
+            fold[i] = fold[i - 1];
+        fold[0] = moved;
+    }
+
+    for (int i = 0; i < len; ++i)
+    {
+        if (fold[i])
+            s.insert(lo + i);
+        else
+            s.erase(lo + i);
+    }
 }
 
 void SelectionManager::clearAllSelections()

--- a/src/scxt-core/selection/selection_manager.h
+++ b/src/scxt-core/selection/selection_manager.h
@@ -227,6 +227,26 @@ struct SelectionManager
     std::array<selectedZones_t, scxt::numParts> allSelectedZones, allSelectedGroups,
         allDisplayGroups;
     std::array<ZoneAddress, scxt::numParts> leadZone, leadGroup;
+
+    // Per-part set of collapsed group indices for the group/zone tree sidebar.
+    // Streamed in save/load; broadcast to the client by stamping the FOLDED bit
+    // onto group-row features in getPartGroupZoneStructure.
+    using collapsedGroupSet_t = std::unordered_set<int32_t>;
+    std::array<collapsedGroupSet_t, scxt::numParts> collapsedGroupsByPart;
+
+    bool isGroupCollapsed(int part, int group) const
+    {
+        if (part < 0 || part >= scxt::numParts || group < 0)
+            return false;
+        return collapsedGroupsByPart[part].count(group) > 0;
+    }
+    void setGroupCollapsed(int part, int group, bool collapsed);
+    void setAllGroupsCollapsed(int part, bool collapsed);
+
+    // Index remapping helpers, mirrors Part::swapGroups / Part::moveGroupToAfter.
+    // Caller is responsible for broadcasting structure after the move.
+    void remapCollapsedOnSwap(int part, int gA, int gB);
+    void remapCollapsedOnMoveAfter(int part, int whichGroup, int toAfter);
 };
 } // namespace scxt::selection
 

--- a/src/scxt-plugin/app/edit-screen/components/GroupZoneTreeControl.h
+++ b/src/scxt-plugin/app/edit-screen/components/GroupZoneTreeControl.h
@@ -31,6 +31,8 @@
 #include <juce_graphics/juce_graphics.h>
 #include <juce_core/juce_core.h>
 
+#include <vector>
+
 #include "sst/jucegui/components/GlyphButton.h"
 #include "sst/jucegui/components/Label.h"
 #include "sst/jucegui/components/ListView.h"
@@ -55,18 +57,48 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
     engine::Engine::pgzStructure_t gzData;
     std::set<selection::SelectionManager::ZoneAddress> selectedZones;
 
+    // Indices into gzData of the rows the ListView should actually show.
+    std::vector<size_t> visibleRows;
+
+    // Map a ListView row index to its gzData index.
+    size_t gzIndexForRow(int row) const { return visibleRows[row]; }
+
+    // True if the group at gzData[gzIdx] has at least one zone (next entry is a zone).
+    bool groupHasZones(size_t gzIdx) const
+    {
+        return gzIdx + 1 < gzData.size() && gzData[gzIdx + 1].address.zone >= 0;
+    }
+
+    // Fold state lives on the wire: the FOLDED feature bit on group rows in
+    // gzData. The server stamps it; the widget just reads it.
+    bool isGroupCollapsed(size_t gzIdx) const
+    {
+        if (gzIdx >= gzData.size())
+            return false;
+        return (gzData[gzIdx].features & engine::GroupZoneFeatures::FOLDED) != 0;
+    }
+    void setGroupCollapsedLocal(size_t gzIdx, bool collapsed)
+    {
+        if (gzIdx >= gzData.size())
+            return;
+        if (collapsed)
+            gzData[gzIdx].features |= engine::GroupZoneFeatures::FOLDED;
+        else
+            gzData[gzIdx].features &= ~engine::GroupZoneFeatures::FOLDED;
+    }
+
     GroupZoneSidebarWidget(SidebarParent *sb) : sidebar(sb)
     {
         rebuild();
         setSelectionMode(jcmp::ListView::SelectionMode::MULTI_SELECTION);
-        getRowCount = [this]() { return gzData.size() + 1; };
+        getRowCount = [this]() { return visibleRows.size() + 1; };
         getRowHeight = [this]() { return 18; };
         makeRowComponent = [this]() { return std::make_unique<rowTopComponent>(); };
         assignComponentToRow = [this](const std::unique_ptr<juce::Component> &c, uint32_t row) {
             auto rc = dynamic_cast<rowTopComponent *>(c.get());
             if (rc)
             {
-                if (row == gzData.size())
+                if (row == visibleRows.size())
                 {
                     rc->enableAdd();
                     rc->addRow->gsb = sidebar;
@@ -79,7 +111,8 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
                     rc->gzRow->lbm = this;
                     rc->gzRow->gsb = sidebar;
                     rc->gzRow->isSelected =
-                        selectedZones.find(gzData[row].address) != selectedZones.end();
+                        selectedZones.find(gzData[gzIndexForRow(row)].address) !=
+                        selectedZones.end();
                     rc->gzRow->complete();
                 }
                 rc->resized();
@@ -104,15 +137,36 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
         for (const auto &el : pgz)
             if (el.address.part == sidebar->editor->selectedPart && el.address.group >= 0)
                 gzData.push_back(el);
+        rebuildVisible();
+    }
+
+    // Recompute visibleRows from gzData. Fold state lives on each group row's
+    // features bitfield (FOLDED) — set server-side and stamped on the wire.
+    void rebuildVisible()
+    {
+        visibleRows.clear();
+        visibleRows.reserve(gzData.size());
+        bool skipping{false};
+        for (size_t i = 0; i < gzData.size(); ++i)
+        {
+            const auto &addr = gzData[i].address;
+            if (addr.zone < 0)
+            {
+                visibleRows.push_back(i); // group row: always visible
+                skipping = (gzData[i].features & engine::GroupZoneFeatures::FOLDED) != 0;
+            }
+            else if (!skipping)
+            {
+                visibleRows.push_back(i);
+            }
+        }
     }
 
     selection::SelectionManager::ZoneAddress getZoneAddress(int rowNumber)
     {
-        auto &tgl = gzData;
-        if (rowNumber < 0 || rowNumber >= (int)tgl.size())
+        if (rowNumber < 0 || rowNumber >= (int)visibleRows.size())
             return {};
-        auto &sad = tgl[rowNumber].address;
-        return sad;
+        return gzData[gzIndexForRow(rowNumber)].address;
     }
 
     // Returns the group ZoneAddress (zone==-1) for the row at position (x,y) in this widget's
@@ -130,9 +184,9 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
         if (contentY < 0)
             return std::nullopt;
         int rowIdx = contentY / rh;
-        if (rowIdx < 0 || rowIdx >= (int)gzData.size())
+        if (rowIdx < 0 || rowIdx >= (int)visibleRows.size())
             return std::nullopt;
-        auto addr = gzData[rowIdx].address;
+        auto addr = gzData[gzIndexForRow(rowIdx)].address;
         // If this is a zone row, return the parent group address
         if (addr.zone >= 0)
             addr.zone = -1;
@@ -151,6 +205,7 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
             sst::jucegui::component_adapters::DiscreteToValueReference<jcmp::ToggleButton, bool>;
         std::unique_ptr<bdm_t> muteProvider;
         bool muteValue{false};
+        bool glyphHovered{false};
         rowComponent()
         {
             renameEditor = std::make_unique<juce::TextEditor>();
@@ -158,12 +213,45 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
             renameEditor->addListener(this);
         }
 
+        // Hover-on-glyph: highlight the fold arrow when the mouse is over the gutter
+        // of a foldable group row (empty groups show a status dot, no hover).
+        bool computeGlyphHovered(int x) const
+        {
+            if (!lbm || rowNumber < 0 || rowNumber >= (int)lbm->visibleRows.size())
+                return false;
+            const auto &addr = lbm->gzData[lbm->gzIndexForRow(rowNumber)].address;
+            if (addr.zone >= 0)
+                return false;
+            if (!lbm->groupHasZones(lbm->gzIndexForRow(rowNumber)))
+                return false;
+            return x < grouplabelPad;
+        }
+
+        void mouseMove(const juce::MouseEvent &e) override
+        {
+            bool h = computeGlyphHovered(e.x);
+            if (h != glyphHovered)
+            {
+                glyphHovered = h;
+                repaint();
+            }
+        }
+
+        void mouseExit(const juce::MouseEvent &) override
+        {
+            if (glyphHovered)
+            {
+                glyphHovered = false;
+                repaint();
+            }
+        }
+
         void complete()
         {
             if (!isZone())
             {
                 const auto &tgl = lbm->gzData;
-                const auto &sg = tgl[rowNumber];
+                const auto &sg = tgl[lbm->gzIndexForRow(rowNumber)];
 
                 muteValue = sg.features & engine::GroupZoneFeatures::MUTED;
                 muteProvider = std::make_unique<bdm_t>(muteValue);
@@ -196,7 +284,7 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
         {
             assert(!isZone());
             const auto &tgl = lbm->gzData;
-            const auto &sg = tgl[rowNumber];
+            const auto &sg = tgl[lbm->gzIndexForRow(rowNumber)];
             gsb->sendToSerialization(
                 cmsg::MuteOrSoloGroup({sg.address.part, sg.address.group, v, false, allSel}));
         }
@@ -207,10 +295,10 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
                 return;
 
             const auto &tgl = lbm->gzData;
-            if (rowNumber < 0 || rowNumber >= tgl.size())
+            if (rowNumber < 0 || rowNumber >= (int)lbm->visibleRows.size())
                 return;
 
-            const auto &sg = tgl[rowNumber];
+            const auto &sg = tgl[lbm->gzIndexForRow(rowNumber)];
 
             bool isLeadZone = isZone() && gsb->isLeadZone(sg.address);
             bool isLeadGroup = isGroup() && gsb->isLeadGroup(sg.address);
@@ -222,7 +310,7 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
             auto groupFont = editor->themeApplier.interRegularFor(11);
 
             if (isZone())
-                g.setFont(zoneFont);
+                g.setFont(isLeadZone ? editor->themeApplier.interBoldFor(11) : zoneFont);
             else
                 g.setFont(groupFont);
 
@@ -276,23 +364,23 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
 
                 auto bx = getLocalBounds().withWidth(grouplabelPad);
                 auto nb = getLocalBounds().withTrimmedLeft(grouplabelPad);
-                auto digitColor = lowTextColor;
+                auto glyphColor = lowTextColor;
                 bool groupIsSelected =
                     editor->allGroupSelections.find(sg.address) != editor->allGroupSelections.end();
                 if (isLeadGroup)
-                {
-                    digitColor = editor->themeColor(theme::ColorMap::generic_content_highest);
-                    g.setFont(editor->themeApplier.interBoldFor(11));
-                }
+                    glyphColor = editor->themeColor(theme::ColorMap::generic_content_highest);
                 else if (groupIsSelected)
-                {
-                    digitColor = editor->themeColor(theme::ColorMap::generic_content_high);
-                }
-                g.setColour(digitColor);
-                g.drawText(std::to_string(sg.address.group + 1), bx,
-                           juce::Justification::centredLeft);
-                if (isLeadGroup)
-                    g.setFont(groupFont);
+                    glyphColor = editor->themeColor(theme::ColorMap::generic_content_high);
+
+                bool hasZones = lbm->groupHasZones(lbm->gzIndexForRow(rowNumber));
+                bool collapsed = lbm->isGroupCollapsed(lbm->gzIndexForRow(rowNumber));
+                auto gb = bx.reduced(2);
+                auto glyph = !hasZones ? jcmp::GlyphPainter::MINUS
+                                       : (collapsed ? jcmp::GlyphPainter::JOG_RIGHT
+                                                    : jcmp::GlyphPainter::JOG_DOWN);
+                if (hasZones && glyphHovered)
+                    glyphColor = editor->themeColor(theme::ColorMap::generic_content_high);
+                jcmp::GlyphPainter::paintGlyph(g, gb, glyph, glyphColor);
                 g.setColour(textColor);
                 g.drawText(sg.name, nb, juce::Justification::centredLeft);
 
@@ -344,15 +432,6 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
                 g.drawText(sg.name, getLocalBounds().translated(zonePad + 2, 0),
                            juce::Justification::centredLeft);
 
-                if (isLeadZone && voiceCount == 0)
-                {
-                    auto b = getLocalBounds().withWidth(zonePad).withTrimmedLeft(2);
-                    auto q = b.getHeight() - b.getWidth();
-                    b = b.withTrimmedTop(q / 2).withTrimmedBottom(q / 2);
-                    jcmp::GlyphPainter::paintGlyph(g, b, jcmp::GlyphPainter::JOG_RIGHT,
-                                                   textColor.withAlpha(0.5f));
-                }
-
                 if (voiceCount > 0)
                 {
                     auto b = getLocalBounds()
@@ -370,7 +449,7 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
             }
         }
 
-        bool isDragging{false}, isPopup{false};
+        bool isDragging{false}, isPopup{false}, consumedFoldClick{false};
         selection::SelectionManager::ZoneAddress getZoneAddress()
         {
             return lbm->getZoneAddress(rowNumber);
@@ -381,6 +460,27 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
         void mouseDown(const juce::MouseEvent &e) override
         {
             isPopup = false;
+            consumedFoldClick = false;
+
+            // Left-click in the group-row gutter toggles fold; right-click falls through.
+            // Empty groups show a status dot instead of an arrow — no fold action there.
+            if (!e.mods.isPopupMenu() && isGroup() && e.x < grouplabelPad &&
+                lbm->groupHasZones(lbm->gzIndexForRow(rowNumber)))
+            {
+                auto za = getZoneAddress();
+                auto gzIdx = lbm->gzIndexForRow(rowNumber);
+                bool nowCollapsed = !lbm->isGroupCollapsed(gzIdx);
+                // Optimistic: flip the local FOLDED bit and refresh both sidebars
+                // so the click feels instant. The c2s round-trip will trigger a
+                // structure broadcast that reaffirms the state.
+                lbm->setGroupCollapsedLocal(gzIdx, nowCollapsed);
+                gsb->partGroupSidebar->collapsedGroupsChanged();
+                gsb->sendToSerialization(
+                    cmsg::SetGroupCollapsed({za.part, za.group, nowCollapsed}));
+                consumedFoldClick = true;
+                return;
+            }
+
             if (e.mods.isPopupMenu())
             {
                 juce::PopupMenu p;
@@ -388,7 +488,7 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
                 {
                     auto za = getZoneAddress();
                     const auto &tgl = lbm->gzData;
-                    const auto &sg = tgl[rowNumber];
+                    const auto &sg = tgl[lbm->gzIndexForRow(rowNumber)];
 
                     shared::populateZoneRightMouseMenuForZone(gsb, this, p, za, sg.name);
                     p.addSeparator();
@@ -397,10 +497,10 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
                 else if (isGroup())
                 {
                     const auto &tgl = lbm->gzData;
-                    if (rowNumber < 0 || rowNumber >= tgl.size())
+                    if (rowNumber < 0 || rowNumber >= (int)lbm->visibleRows.size())
                         return;
 
-                    const auto &sg = tgl[rowNumber];
+                    const auto &sg = tgl[lbm->gzIndexForRow(rowNumber)];
 
                     p.addSectionHeader(sg.name);
                     p.addSeparator();
@@ -457,6 +557,20 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
                         w->gsb->sendToSerialization(cmsg::DeleteEmptyGroups(za.part));
                     });
 
+                    p.addSeparator();
+                    p.addItem("Expand All Groups", [w = juce::Component::SafePointer(this)]() {
+                        if (!w)
+                            return;
+                        auto za = w->getZoneAddress();
+                        w->gsb->sendToSerialization(cmsg::SetAllGroupsCollapsed({za.part, false}));
+                    });
+                    p.addItem("Collapse All Groups", [w = juce::Component::SafePointer(this)]() {
+                        if (!w)
+                            return;
+                        auto za = w->getZoneAddress();
+                        w->gsb->sendToSerialization(cmsg::SetAllGroupsCollapsed({za.part, true}));
+                    });
+
                     auto za = getZoneAddress();
 
                     p.addSeparator();
@@ -506,6 +620,11 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
 
         void mouseUp(const juce::MouseEvent &event) override
         {
+            if (consumedFoldClick)
+            {
+                consumedFoldClick = false;
+                return;
+            }
             if (isDragging || isPopup)
             {
                 isDragging = false;
@@ -619,7 +738,7 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
         {
             const auto &tgl = lbm->gzData;
 
-            const auto &sg = tgl[rowNumber];
+            const auto &sg = tgl[lbm->gzIndexForRow(rowNumber)];
             assert(sg.address.zone < 0);
             auto st = gsb->partGroupSidebar->style();
             auto groupFont = gsb->editor->themeApplier.interRegularFor(11);
@@ -636,7 +755,7 @@ template <typename SidebarParent, bool fz> struct GroupZoneSidebarWidget : jcmp:
         {
             const auto &tgl = lbm->gzData;
 
-            const auto &sg = tgl[rowNumber];
+            const auto &sg = tgl[lbm->gzIndexForRow(rowNumber)];
             auto st = gsb->partGroupSidebar->style();
             auto zoneFont = gsb->editor->themeApplier.interLightFor(11);
             renameEditor->setFont(zoneFont);

--- a/src/scxt-plugin/app/edit-screen/components/PartGroupSidebar.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/PartGroupSidebar.cpp
@@ -984,6 +984,20 @@ void PartGroupSidebar::setPartGroupZoneStructure(const engine::Engine::pgzStruct
     repaint();
 }
 
+void PartGroupSidebar::collapsedGroupsChanged()
+{
+    if (groupSidebar && groupSidebar->gzTreeControl)
+    {
+        groupSidebar->gzTreeControl->rebuildVisible();
+        groupSidebar->gzTreeControl->refresh();
+    }
+    if (zoneSidebar && zoneSidebar->gzTreeControl)
+    {
+        zoneSidebar->gzTreeControl->rebuildVisible();
+        zoneSidebar->gzTreeControl->refresh();
+    }
+}
+
 void PartGroupSidebar::selectedPartChanged()
 {
     groupSidebar->showSelectedPart(editor->selectedPart);

--- a/src/scxt-plugin/app/edit-screen/components/PartGroupSidebar.h
+++ b/src/scxt-plugin/app/edit-screen/components/PartGroupSidebar.h
@@ -63,6 +63,8 @@ struct PartGroupSidebar : sst::jucegui::components::NamedPanel,
 
     void partConfigurationChanged(int i);
     void groupTriggerConditionChanged(const scxt::engine::GroupTriggerConditions &);
+    // Refresh both sidebars after a fold-state mutation (no structure change).
+    void collapsedGroupsChanged();
 
     void setAllToOmniFlavor(engine::Engine::OmniFlavor of);
     void updateMidiMenuLabel();

--- a/tests/selection_tests.cpp
+++ b/tests/selection_tests.cpp
@@ -27,6 +27,7 @@
 
 #include "catch2/catch2.hpp"
 #include "engine/engine.h"
+#include "engine/feature_enums.h"
 
 #include "console_harness.h"
 
@@ -257,4 +258,263 @@ TEST_CASE("Switching from empty group to non-empty group selects its zones")
     REQUIRE(sm->allSelectedZones[0].size() == 2);
     REQUIRE(sm->leadZone[0].part == 0);
     REQUIRE(sm->leadZone[0].group == 0);
+}
+
+// ---- Group fold state (sidebar tree) ----
+
+namespace
+{
+// Find the group row for (part, group) in the pgz structure and return its
+// features bitfield. Returns 0 if not found (so feature tests are robust to
+// missing rows).
+int32_t pgzGroupFeatures(scxt::clients::console_ui::ConsoleHarness &th, int part, int group)
+{
+    auto pgz = th.engine->getPartGroupZoneStructure();
+    for (const auto &b : pgz)
+        if (b.address.part == part && b.address.group == group && b.address.zone == -1)
+            return b.features;
+    return 0;
+}
+
+// Make `n` extra groups in part 0 (engine starts with group 0). After calling,
+// part 0 has exactly n+1 groups (indices 0..n).
+void makeGroups(scxt::clients::console_ui::ConsoleHarness &th, int n)
+{
+    namespace cmsg = scxt::messaging::client;
+    for (int i = 0; i < n; ++i)
+        th.sendToSerialization(cmsg::CreateGroup(0));
+    th.stepUI();
+}
+} // namespace
+
+TEST_CASE("Fold: setGroupCollapsed toggles a single group")
+{
+    scxt::clients::console_ui::ConsoleHarness th;
+    th.start();
+    th.stepUI();
+
+    namespace cmsg = scxt::messaging::client;
+    makeGroups(th, 5); // 5 groups: 0..4
+
+    const auto &sm = th.engine->getSelectionManager();
+    REQUIRE(sm->collapsedGroupsByPart[0].empty());
+    REQUIRE(!sm->isGroupCollapsed(0, 2));
+
+    th.sendToSerialization(cmsg::SetGroupCollapsed({0, 2, true}));
+    th.stepUI();
+    REQUIRE(sm->isGroupCollapsed(0, 2));
+    REQUIRE(sm->collapsedGroupsByPart[0].size() == 1);
+
+    INFO("FOLDED bit shows up on the structure broadcast for that group");
+    REQUIRE((pgzGroupFeatures(th, 0, 2) & scxt::engine::GroupZoneFeatures::FOLDED) != 0);
+    REQUIRE((pgzGroupFeatures(th, 0, 1) & scxt::engine::GroupZoneFeatures::FOLDED) == 0);
+
+    th.sendToSerialization(cmsg::SetGroupCollapsed({0, 2, false}));
+    th.stepUI();
+    REQUIRE(!sm->isGroupCollapsed(0, 2));
+    REQUIRE(sm->collapsedGroupsByPart[0].empty());
+    REQUIRE((pgzGroupFeatures(th, 0, 2) & scxt::engine::GroupZoneFeatures::FOLDED) == 0);
+}
+
+TEST_CASE("Fold: setAllGroupsCollapsed true/false")
+{
+    scxt::clients::console_ui::ConsoleHarness th;
+    th.start();
+    th.stepUI();
+
+    namespace cmsg = scxt::messaging::client;
+    makeGroups(th, 5); // 5 groups
+    const auto &sm = th.engine->getSelectionManager();
+
+    th.sendToSerialization(cmsg::SetAllGroupsCollapsed({0, true}));
+    th.stepUI();
+    REQUIRE(sm->collapsedGroupsByPart[0].size() == 5);
+    for (int g = 0; g < 5; ++g)
+        REQUIRE(sm->isGroupCollapsed(0, g));
+
+    th.sendToSerialization(cmsg::SetAllGroupsCollapsed({0, false}));
+    th.stepUI();
+    REQUIRE(sm->collapsedGroupsByPart[0].empty());
+}
+
+TEST_CASE("Fold: deleting a group below a folded group keeps the right group folded")
+{
+    // Bug repro: fold 3, delete group 1. Without remapping, old group 3 (now at
+    // index 2) would appear unfolded and old group 4 (now at index 3) would
+    // appear folded. Fix: shift higher indices down by one on delete.
+    scxt::clients::console_ui::ConsoleHarness th;
+    th.start();
+    th.stepUI();
+
+    namespace cmsg = scxt::messaging::client;
+    using zad = scxt::selection::SelectionManager::ZoneAddress;
+
+    // AddBlankZone creates group 0; makeGroups adds 4 more — total 5 groups (0..4).
+    th.sendToSerialization(cmsg::AddBlankZone({0, 0, 48, 60, 0, 127}));
+    makeGroups(th, 4); // total 5 groups: 0..4
+    const auto &sm = th.engine->getSelectionManager();
+
+    th.sendToSerialization(cmsg::SetGroupCollapsed({0, 3, true}));
+    th.stepUI();
+    REQUIRE(sm->isGroupCollapsed(0, 3));
+
+    th.sendToSerialization(cmsg::DeleteGroup(zad{0, 1, -1}));
+    th.stepUI();
+    REQUIRE(th.engine->getPatch()->getPart(0)->getGroups().size() == 4);
+    // Old group 3 is now at index 2; its FOLDED bit must have travelled.
+    REQUIRE(sm->isGroupCollapsed(0, 2));
+    REQUIRE(!sm->isGroupCollapsed(0, 3));
+}
+
+TEST_CASE("Fold: delete-fixup drops the deleted group's fold bit and clamps out-of-range")
+{
+    scxt::clients::console_ui::ConsoleHarness th;
+    th.start();
+    th.stepUI();
+
+    namespace cmsg = scxt::messaging::client;
+    using zad = scxt::selection::SelectionManager::ZoneAddress;
+
+    // AddBlankZone creates group 0; makeGroups adds 4 more — total 5 groups (0..4).
+    th.sendToSerialization(cmsg::AddBlankZone({0, 0, 48, 60, 0, 127}));
+    makeGroups(th, 4); // total 5 groups: 0..4
+    const auto &sm = th.engine->getSelectionManager();
+
+    th.sendToSerialization(cmsg::SetGroupCollapsed({0, 2, true}));
+    th.sendToSerialization(cmsg::SetGroupCollapsed({0, 4, true}));
+    th.stepUI();
+    REQUIRE(sm->collapsedGroupsByPart[0].size() == 2);
+
+    // Delete the folded group 2. Group 2's bit is gone; group 4's bit shifts to 3.
+    th.sendToSerialization(cmsg::DeleteGroup(zad{0, 2, -1}));
+    th.stepUI();
+    REQUIRE(th.engine->getPatch()->getPart(0)->getGroups().size() == 4);
+    REQUIRE(!sm->isGroupCollapsed(0, 2));
+    REQUIRE(sm->isGroupCollapsed(0, 3));
+    REQUIRE(sm->collapsedGroupsByPart[0].size() == 1);
+}
+
+TEST_CASE("Fold: swap groups remaps fold state")
+{
+    scxt::clients::console_ui::ConsoleHarness th;
+    th.start();
+    th.stepUI();
+
+    namespace cmsg = scxt::messaging::client;
+    using zad = scxt::selection::SelectionManager::ZoneAddress;
+
+    makeGroups(th, 5); // 5 groups
+    const auto &sm = th.engine->getSelectionManager();
+
+    th.sendToSerialization(cmsg::SetGroupCollapsed({0, 2, true}));
+    th.stepUI();
+    REQUIRE(sm->isGroupCollapsed(0, 2));
+    REQUIRE(!sm->isGroupCollapsed(0, 4));
+
+    INFO("Swap group 2 and group 4 (tgt.zone == -1 path)");
+    th.sendToSerialization(cmsg::MoveGroupTo({zad{0, 2, -1}, zad{0, 4, -1}}));
+    th.stepUI();
+
+    REQUIRE(!sm->isGroupCollapsed(0, 2));
+    REQUIRE(sm->isGroupCollapsed(0, 4));
+
+    INFO("Swap again with both endpoints collapsed — both stay collapsed");
+    th.sendToSerialization(cmsg::SetGroupCollapsed({0, 1, true}));
+    th.stepUI();
+    REQUIRE(sm->isGroupCollapsed(0, 1));
+    REQUIRE(sm->isGroupCollapsed(0, 4));
+    th.sendToSerialization(cmsg::MoveGroupTo({zad{0, 1, -1}, zad{0, 4, -1}}));
+    th.stepUI();
+    REQUIRE(sm->isGroupCollapsed(0, 1));
+    REQUIRE(sm->isGroupCollapsed(0, 4));
+}
+
+TEST_CASE("Fold: moveGroupToAfter remaps fold state (src<tgt)")
+{
+    scxt::clients::console_ui::ConsoleHarness th;
+    th.start();
+    th.stepUI();
+
+    namespace cmsg = scxt::messaging::client;
+    using zad = scxt::selection::SelectionManager::ZoneAddress;
+
+    makeGroups(th, 5); // 5 groups: 0..4
+    const auto &sm = th.engine->getSelectionManager();
+
+    // Initial fold state: group 2 collapsed, group 4 expanded.
+    th.sendToSerialization(cmsg::SetGroupCollapsed({0, 2, true}));
+    th.stepUI();
+    REQUIRE(sm->isGroupCollapsed(0, 2));
+    REQUIRE(!sm->isGroupCollapsed(0, 4));
+
+    // Move group 2 to after group 4 (tgt.zone >= 0 triggers moveAfter).
+    // Layout: 0 1 2 3 4 -> 0 1 3 4 2. Original-2 (collapsed) now sits at index 4.
+    // Originals at 3 and 4 shift down to 2 and 3.
+    th.sendToSerialization(cmsg::MoveGroupTo({zad{0, 2, -1}, zad{0, 4, 0}}));
+    th.stepUI();
+
+    REQUIRE(!sm->isGroupCollapsed(0, 2));
+    REQUIRE(!sm->isGroupCollapsed(0, 3));
+    REQUIRE(sm->isGroupCollapsed(0, 4));
+}
+
+TEST_CASE("Fold: moveGroupToAfter remaps fold state (src>tgt)")
+{
+    scxt::clients::console_ui::ConsoleHarness th;
+    th.start();
+    th.stepUI();
+
+    namespace cmsg = scxt::messaging::client;
+    using zad = scxt::selection::SelectionManager::ZoneAddress;
+
+    makeGroups(th, 5); // 5 groups: 0..4
+    const auto &sm = th.engine->getSelectionManager();
+
+    // Mirrors the bug Paul reported: fold 2, then drag 2 past 4. Original-2's
+    // fold state must travel with it.
+    th.sendToSerialization(cmsg::SetGroupCollapsed({0, 4, true}));
+    th.stepUI();
+    REQUIRE(sm->isGroupCollapsed(0, 4));
+    REQUIRE(!sm->isGroupCollapsed(0, 1));
+
+    // Move group 4 to after group 1.
+    // Layout: 0 1 2 3 4 -> 0 1 4 2 3. Original-4 (collapsed) sits at index 2.
+    // Originals at 2,3 shift up to 3,4.
+    th.sendToSerialization(cmsg::MoveGroupTo({zad{0, 4, -1}, zad{0, 1, 0}}));
+    th.stepUI();
+
+    REQUIRE(sm->isGroupCollapsed(0, 2));
+    REQUIRE(!sm->isGroupCollapsed(0, 3));
+    REQUIRE(!sm->isGroupCollapsed(0, 4));
+}
+
+TEST_CASE("Fold: moveGroupToAfter preserves fold state outside the affected window")
+{
+    scxt::clients::console_ui::ConsoleHarness th;
+    th.start();
+    th.stepUI();
+
+    namespace cmsg = scxt::messaging::client;
+    using zad = scxt::selection::SelectionManager::ZoneAddress;
+
+    // 7 groups so we can fold indices both inside and outside the move window.
+    makeGroups(th, 7);
+    const auto &sm = th.engine->getSelectionManager();
+
+    // Fold 1 (outside the move window), 2 (inside, source), and 6 (outside).
+    th.sendToSerialization(cmsg::SetGroupCollapsed({0, 1, true}));
+    th.sendToSerialization(cmsg::SetGroupCollapsed({0, 2, true}));
+    th.sendToSerialization(cmsg::SetGroupCollapsed({0, 6, true}));
+    th.stepUI();
+    REQUIRE(sm->collapsedGroupsByPart[0].size() == 3);
+
+    // Move 2 to after 4. Affected window [2, 4] — group 6 must NOT be lost.
+    th.sendToSerialization(cmsg::MoveGroupTo({zad{0, 2, -1}, zad{0, 4, 0}}));
+    th.stepUI();
+
+    REQUIRE(sm->isGroupCollapsed(0, 1));
+    REQUIRE(!sm->isGroupCollapsed(0, 2));
+    REQUIRE(!sm->isGroupCollapsed(0, 3));
+    REQUIRE(sm->isGroupCollapsed(0, 4));
+    REQUIRE(sm->isGroupCollapsed(0, 6));
 }


### PR DESCRIPTION
Group rows can be collapsed to hide their zones. Adds Expand/Collapse All Groups to the group right-click menu, replaces the lead-zone arrow with bold font on the zone name, and shows a status dot in the gutter of empty groups in place of the fold arrow.

Worth noting this is a bit more involved than a standard UI-side-only tree, since the full engine fold state is stored in the SelectionManager (streamed in save/load, remapped to follow group reorder and delete). The widget roundtrips toggles through the serialization thread and reads fold state back from the FOLDED feature bit stamped onto group rows in the s2c structure broadcast, rather than holding it locally.

Closes #1549

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>