### PR TITLE
Handle SF2 Initial Attenuation

### DIFF
--- a/src/scxt-core/sample/sf2_support/sf2_import.cpp
+++ b/src/scxt-core/sample/sf2_support/sf2_import.cpp
@@ -183,6 +183,16 @@ bool importSF2(const fs::path &p, engine::Engine &e, int preset)
                     if (auto pan = region->GetPan(presetRegion); pan != 0)
                         zn->outputInfo.pan = import_support::sf2NormalizedPan(pan);
 
+                    {
+                        auto attn = region->GetInitialAttenuation(presetRegion);
+                        auto attnInst = region->initialAttenuation;
+                        auto attnPre = presetRegion ? presetRegion->initialAttenuation : sf2::NONE;
+
+                        if (attn > 0)
+                            zn->outputInfo.amplitude =
+                                import_support::dBToCubicAttenuation((float)(-attn / 10.0));
+                    }
+
                     auto me2p = region->GetModEnvToPitch(presetRegion);
                     auto me2f = region->GetModEnvToFilterFc(presetRegion);
                     auto v2p = region->GetVibLfoToPitch(presetRegion);


### PR DESCRIPTION
SF2 has an attenuation per zone which libgig was not parsing. Modify libgig so it hands it to us then aply it to output info for the zone on import. This makes GS General Midi appropriatley not loud. (The grand piano is attenuated by up to 19db!!)

Closes #2471
Assisted-By: Claude Opus 4.7