### PR TITLE
Transpose SelectionManager Topology; Store in SCP

### DIFF
--- a/src/clients/cli-tools/scpscm-to-json.cpp
+++ b/src/clients/cli-tools/scpscm-to-json.cpp
@@ -34,6 +34,9 @@
 #include "json/engine_traits.h"
 
 #include "tao/json/msgpack/to_string.hpp"
+#include "tao/json/msgpack/from_string.hpp"
+#include "tao/json/to_string.hpp"
+#include "tao/json/from_string.hpp"
 
 template <template <typename...> class... Transformers, template <typename...> class Traits>
 void to_pretty_stream(std::ostream &os, const tao::json::basic_value<Traits> &v)

--- a/src/scxt-core/configuration.h
+++ b/src/scxt-core/configuration.h
@@ -33,7 +33,7 @@
 
 namespace scxt
 {
-static constexpr uint64_t currentStreamingVersion{0x2026'05'21};
+static constexpr uint64_t currentStreamingVersion{0x2026'05'29};
 
 static constexpr uint16_t blockSize{16};
 static constexpr uint16_t blockSizeQuad{16 >> 2};

--- a/src/scxt-core/json/engine_traits.h
+++ b/src/scxt-core/json/engine_traits.h
@@ -316,68 +316,103 @@ SC_STREAMDEF(scxt::engine::Part::ZoneMappingItem,
                  findIf(v, "features", to.features);
              }))
 
-SC_STREAMDEF(scxt::engine::Part, SC_FROM({
-                 v = {{"config", from.configuration},
-                      {"groups", from.getGroups()},
-                      {"macros", from.macros},
-                      {"partEffectStorage", from.partEffectStorage}};
-                 if (SC_STREAMING_FOR_PART)
-                 {
-                     addToObject<val_t>(v, "streamingVersion", currentStreamingVersion);
-                     addToObject<val_t>(v, "streamedForPart", true);
-                     assert(from.parentPatch->parentEngine);
-                     addToObject<val_t>(
-                         v, "samplesUsedByPart",
-                         from.parentPatch->parentEngine->getSampleManager()->getSampleAddressesFor(
-                             from.getSamplesUsedByPart()));
-                 }
-             }),
-             SC_TO({
-                 auto &part = to;
-                 part.clearGroups();
+SC_STREAMDEF(
+    scxt::engine::Part, SC_FROM({
+        v = {{"config", from.configuration},
+             {"groups", from.getGroups()},
+             {"macros", from.macros},
+             {"partEffectStorage", from.partEffectStorage}};
+        if (SC_STREAMING_FOR_PART)
+        {
+            addToObject<val_t>(v, "streamingVersion", currentStreamingVersion);
+            addToObject<val_t>(v, "streamedForPart", true);
+            assert(from.parentPatch->parentEngine);
+            addToObject<val_t>(
+                v, "samplesUsedByPart",
+                from.parentPatch->parentEngine->getSampleManager()->getSampleAddressesFor(
+                    from.getSamplesUsedByPart()));
 
-                 std::unique_ptr<engine::Engine::UnstreamGuard> sg;
-                 bool streamedForPart{false};
-                 findOrSet(v, "streamedForPart", false, streamedForPart);
-                 if (streamedForPart)
-                 {
-                     uint64_t partStreamingVersion{0};
-                     findIf(v, "streamingVersion", partStreamingVersion);
-                     SCLOG_IF(streaming, "Unstreaming part state. Stream version : "
-                                             << scxt::humanReadableVersion(partStreamingVersion));
+            // Per-part selection slice, so .scp save/load preserves selection.
+            addToObject<val_t>(
+                v, "selection",
+                from.parentPatch->parentEngine->getSelectionManager()->state[from.partNumber]);
+        }
+    }),
+    SC_TO({
+        auto &part = to;
+        part.clearGroups();
 
-                     scxt::sample::SampleManager::sampleAddressesAndIds_t samples;
-                     findIf(v, "samplesUsedByPart", samples);
-                     to.parentPatch->parentEngine->getSampleManager()
-                         ->restoreFromSampleAddressesAndIDs(samples);
+        std::unique_ptr<engine::Engine::UnstreamGuard> sg;
+        bool streamedForPart{false};
+        findOrSet(v, "streamedForPart", false, streamedForPart);
+        if (streamedForPart)
+        {
+            uint64_t partStreamingVersion{0};
+            findIf(v, "streamingVersion", partStreamingVersion);
+            SCLOG_IF(streaming, "Unstreaming part state. Stream version : "
+                                    << scxt::humanReadableVersion(partStreamingVersion));
 
-                     to.parentPatch->parentEngine->onPartConfigurationUpdated();
-                     sg = std::make_unique<engine::Engine::UnstreamGuard>(partStreamingVersion);
-                 }
+            scxt::sample::SampleManager::sampleAddressesAndIds_t samples;
+            findIf(v, "samplesUsedByPart", samples);
+            to.parentPatch->parentEngine->getSampleManager()->restoreFromSampleAddressesAndIDs(
+                samples);
 
-                 if (SC_UNSTREAMING_FROM_PRIOR_TO(0x2024'08'18))
-                 {
-                     findIf(v, "channel", part.configuration.channel);
-                 }
-                 else
-                 {
-                     findIf(v, "config", part.configuration);
-                 }
-                 findIf(v, "macros", part.macros);
+            to.parentPatch->parentEngine->onPartConfigurationUpdated();
+            sg = std::make_unique<engine::Engine::UnstreamGuard>(partStreamingVersion);
+        }
 
-                 part.partEffectStorage = {};
-                 findIf(v, "partEffectStorage", part.partEffectStorage);
-                 auto vzones = v.at("groups").get_array();
-                 for (const auto vz : vzones)
-                 {
-                     auto idx = part.addGroup() - 1;
-                     vz.to(*(part.getGroup(idx)));
-                 }
-                 if (to.parentPatch->parentEngine)
-                 {
-                     part.setupOnUnstream(*to.parentPatch->parentEngine);
-                 }
-             }))
+        if (SC_UNSTREAMING_FROM_PRIOR_TO(0x2024'08'18))
+        {
+            findIf(v, "channel", part.configuration.channel);
+        }
+        else
+        {
+            findIf(v, "config", part.configuration);
+        }
+        findIf(v, "macros", part.macros);
+
+        part.partEffectStorage = {};
+        findIf(v, "partEffectStorage", part.partEffectStorage);
+        auto vzones = v.at("groups").get_array();
+        for (const auto vz : vzones)
+        {
+            auto idx = part.addGroup() - 1;
+            vz.to(*(part.getGroup(idx)));
+        }
+        // Restore this part's selection slice (.scp part load). After the groups
+        // loop so the referenced zones/groups exist; .part is remapped onto the
+        // part we are loading into.
+        selection::SelectionManager::PerPartState selSlice;
+        if (to.parentPatch->parentEngine && findIf(v, "selection", selSlice))
+        {
+            auto loadTargetPart = to.partNumber;
+            auto remapZA = [&](selection::SelectionManager::ZoneAddress &za) {
+                if (za.part >= 0)
+                    za.part = loadTargetPart;
+            };
+            remapZA(selSlice.leadZone);
+            remapZA(selSlice.leadGroup);
+            auto remapSet = [&](selection::SelectionManager::selectedZones_t &s) {
+                selection::SelectionManager::selectedZones_t out;
+                for (auto za : s)
+                {
+                    remapZA(za);
+                    out.insert(za);
+                }
+                s = std::move(out);
+            };
+            remapSet(selSlice.selectedZones);
+            remapSet(selSlice.selectedGroups);
+            remapSet(selSlice.displayGroups);
+            auto *sm = to.parentPatch->parentEngine->getSelectionManager().get();
+            sm->state[loadTargetPart] = std::move(selSlice);
+        }
+
+        if (to.parentPatch->parentEngine)
+        {
+            part.setupOnUnstream(*to.parentPatch->parentEngine);
+        }
+    }))
 
 STREAM_ENUM(engine::GroupTriggerID, engine::toStringGroupTriggerID,
             engine::fromStringGroupTriggerID);

--- a/src/scxt-core/json/selection_traits.h
+++ b/src/scxt-core/json/selection_traits.h
@@ -74,49 +74,82 @@ SC_STREAMDEF(scxt::selection::SelectionManager::ZoneAddress, SC_FROM({
                  findOrSet(v, {"z", "zone"}, -1, result.zone);
              }));
 
-SC_STREAMDEF(selection::SelectionManager, SC_FROM({
+SC_STREAMDEF(selection::SelectionManager::PerPartState, SC_FROM({
                  auto &e = from;
-                 v = {{"zones", e.allSelectedZones},
-                      {"leadZone", e.leadZone},
-                      {"groups", e.allSelectedGroups},
-                      {"dgroups", e.allDisplayGroups},
-                      {"tabs", e.otherTabSelection},
-                      {"selectedPart", e.selectedPart},
-                      {"collapsedGroups", e.collapsedGroupsByPart}};
+                 v = {{"zones", e.selectedZones},   {"groups", e.selectedGroups},
+                      {"dgroups", e.displayGroups}, {"leadZone", e.leadZone},
+                      {"leadGroup", e.leadGroup},   {"collapsedGroups", e.collapsedGroups}};
              }),
              SC_TO({
                  auto &z = to;
-                 if (SC_UNSTREAMING_FROM_PRIOR_TO(0x2024'07'24))
-                 {
-                     z.selectedPart = 0;
-                     findIf(v, "tabs", z.otherTabSelection);
-                     findIf(v, "zones", z.allSelectedZones[0]);
-                     findIf(v, "groups", z.allSelectedGroups[0]);
-                     findIf(v, "leadZone", z.leadZone[0]);
-                 }
-                 else
-                 {
-                     findIf(v, "tabs", z.otherTabSelection);
-                     findIf(v, "zones", z.allSelectedZones);
-                     findIf(v, "groups", z.allSelectedGroups);
-                     findIf(v, "dgroups", z.allDisplayGroups);
-                     findIf(v, "leadZone", z.leadZone);
-                     findIf(v, "selectedPart", z.selectedPart);
-                     findIf(v, "collapsedGroups", z.collapsedGroupsByPart);
-                 }
-
-                 selection::SelectionManager::ZoneAddress za;
-
-                 if (!z.allSelectedZones[z.selectedPart].empty())
-                 {
-                     selection::SelectionManager::SelectActionContents sac{
-                         z.leadZone[z.selectedPart]};
-                     sac.distinct = false;
-                     sac.selectingAsLead = true;
-                     sac.selecting = true;
-                     z.applySelectActions({sac});
-                 }
+                 findIf(v, "zones", z.selectedZones);
+                 findIf(v, "groups", z.selectedGroups);
+                 findIf(v, "dgroups", z.displayGroups);
+                 findIf(v, "leadZone", z.leadZone);
+                 findIf(v, "leadGroup", z.leadGroup);
+                 findIf(v, "collapsedGroups", z.collapsedGroups);
              }));
+
+SC_STREAMDEF(
+    selection::SelectionManager, SC_FROM({
+        auto &e = from;
+        v = {{"state", e.state}, {"tabs", e.otherTabSelection}, {"selectedPart", e.selectedPart}};
+    }),
+    SC_TO({
+        auto &z = to;
+        if (SC_UNSTREAMING_FROM_PRIOR_TO(0x2024'07'24))
+        {
+            z.selectedPart = 0;
+            findIf(v, "tabs", z.otherTabSelection);
+            findIf(v, "zones", z.state[0].selectedZones);
+            findIf(v, "groups", z.state[0].selectedGroups);
+            findIf(v, "leadZone", z.state[0].leadZone);
+        }
+        else if (SC_UNSTREAMING_FROM_PRIOR_TO(0x2026'05'29))
+        {
+            // Legacy array-of-arrays format (stable 0x2024'07'24 ..
+            // 0x2026'05'21): read each parallel array, then scatter by
+            // part index into z.state[p].field. leadGroup was never
+            // streamed in this era, so it stays default.
+            findIf(v, "tabs", z.otherTabSelection);
+            findIf(v, "selectedPart", z.selectedPart);
+
+            std::array<selection::SelectionManager::selectedZones_t, scxt::numParts> tmpZ, tmpG,
+                tmpDG;
+            std::array<selection::SelectionManager::ZoneAddress, scxt::numParts> tmpLZ;
+            std::array<selection::SelectionManager::collapsedGroupSet_t, scxt::numParts> tmpCG;
+
+            findIf(v, "zones", tmpZ);
+            findIf(v, "groups", tmpG);
+            findIf(v, "dgroups", tmpDG);
+            findIf(v, "leadZone", tmpLZ);
+            findIf(v, "collapsedGroups", tmpCG);
+
+            for (int p = 0; p < scxt::numParts; ++p)
+            {
+                z.state[p].selectedZones = std::move(tmpZ[p]);
+                z.state[p].selectedGroups = std::move(tmpG[p]);
+                z.state[p].displayGroups = std::move(tmpDG[p]);
+                z.state[p].leadZone = tmpLZ[p];
+                z.state[p].collapsedGroups = std::move(tmpCG[p]);
+            }
+        }
+        else
+        {
+            findIf(v, "tabs", z.otherTabSelection);
+            findIf(v, "selectedPart", z.selectedPart);
+            findIf(v, "state", z.state);
+        }
+
+        if (!z.state[z.selectedPart].selectedZones.empty())
+        {
+            selection::SelectionManager::SelectActionContents sac{z.state[z.selectedPart].leadZone};
+            sac.distinct = false;
+            sac.selectingAsLead = true;
+            sac.selecting = true;
+            z.applySelectActions({sac});
+        }
+    }));
 } // namespace scxt::json
 
 #endif // SHORTCIRCUIT_SELECTION_TRAITS_H

--- a/src/scxt-core/messaging/client/group_messages.h
+++ b/src/scxt-core/messaging/client/group_messages.h
@@ -138,7 +138,7 @@ inline void doMuteOrSoloGroup(const muteOrSoloGroup_t &payload, const engine::En
                               messaging::MessageController &cont)
 {
     auto &[p, g, m, s, sel] = payload;
-    auto &gs = engine.getSelectionManager()->allSelectedGroups[p];
+    auto &gs = engine.getSelectionManager()->state[p].selectedGroups;
     bool muteSelected{false};
     if (sel)
     {

--- a/src/scxt-core/messaging/client/structure_messages.h
+++ b/src/scxt-core/messaging/client/structure_messages.h
@@ -228,7 +228,7 @@ inline void removeSelectedZones(const bool &, engine::Engine &engine, MessageCon
 {
     auto part = engine.getSelectionManager()->selectedPart;
 
-    auto zs = engine.getSelectionManager()->allSelectedZones[part];
+    auto zs = engine.getSelectionManager()->state[part].selectedZones;
 
     if (zs.empty())
         return;

--- a/src/scxt-core/messaging/client/zone_messages.h
+++ b/src/scxt-core/messaging/client/zone_messages.h
@@ -80,7 +80,7 @@ inline void doApplyZoneDelta(const applyZoneDeltaPayload_t &payload, const engin
                              MessageController &cont)
 {
     auto part = std::get<2>(payload);
-    auto &sc = engine.getSelectionManager()->allSelectedZones[part];
+    auto &sc = engine.getSelectionManager()->state[part].selectedZones;
     auto lz = engine.getSelectionManager()->currentLeadZone(engine);
     if (!sc.empty())
     {

--- a/src/scxt-core/patch_io/patch_io.cpp
+++ b/src/scxt-core/patch_io/patch_io.cpp
@@ -899,10 +899,16 @@ bool loadPartInto(const fs::path &p, scxt::engine::Engine &engine, int part)
                 nonconste.getSampleManager()->clearMonolithBinaryIndex();
 
                 auto &pt = nonconste.getPatch()->getPart(part);
-                if (!pt->getGroups().empty() &&
-                    part == nonconste.getSelectionManager()->selectedPart)
+                auto &sm = nonconste.getSelectionManager();
+                // Only default-select group 0 when loading into the active part AND
+                // the stream didn't restore a selection of its own. SCPs from
+                // 0x2026'05'29 on carry a per-part selection slice; clobbering it
+                // here would lose the saved selection.
+                if (!pt->getGroups().empty() && part == sm->selectedPart &&
+                    !sm->currentLeadZone(nonconste).has_value() &&
+                    !sm->currentLeadGroup(nonconste).has_value())
                 {
-                    nonconste.getSelectionManager()->applySelectActions({part, 0, -1});
+                    sm->applySelectActions({part, 0, -1});
                 }
                 auto &cont = *e.getMessageController();
                 cont.restartAudioThreadFromSerial();

--- a/src/scxt-core/selection/selection_manager.cpp
+++ b/src/scxt-core/selection/selection_manager.cpp
@@ -54,7 +54,7 @@ void SelectionManager::sendClientDataForLeadSelectionState()
     serializationSendToClient(cms::s2c_send_selected_part, selectedPart,
                               *(engine.getMessageController()));
 
-    auto [p, g, z] = leadZone[selectedPart];
+    auto [p, g, z] = state[selectedPart].leadZone;
     assert(p < 0 || p == selectedPart);
 
     // Check if I deserialized a valid zone and adjust if not
@@ -115,18 +115,18 @@ void SelectionManager::applySelectActions(const std::vector<SelectActionContents
     auto r = transformSelectionActions(v);
     if (v.size() == 1 && v[0].isDeselectSentinel())
     {
-        for (auto &g : allSelectedGroups[selectedPart])
+        for (auto &g : state[selectedPart].selectedGroups)
         {
-            allDisplayGroups[selectedPart].insert(g);
+            state[selectedPart].displayGroups.insert(g);
         }
-        allSelectedGroups[selectedPart].clear();
-        leadGroup[selectedPart] = {};
-        allSelectedZones[selectedPart].clear();
-        leadZone[selectedPart] = {};
+        state[selectedPart].selectedGroups.clear();
+        state[selectedPart].leadGroup = {};
+        state[selectedPart].selectedZones.clear();
+        state[selectedPart].leadZone = {};
     }
     else
     {
-        allDisplayGroups[selectedPart].clear();
+        state[selectedPart].displayGroups.clear();
         for (const auto &z : r)
         {
             if (!z.addr().isInWithPartials(engine))
@@ -211,22 +211,22 @@ void SelectionManager::adjustInternalStateForAction(
         // OK so basically theres a few cases
         if (!z.selecting)
         {
-            allSelectedZones[selectedPart].erase(za);
+            state[selectedPart].selectedZones.erase(za);
         }
         else
         {
             // So we are selecting
             if (z.distinct)
             {
-                allSelectedZones[selectedPart].clear();
-                allSelectedZones[selectedPart].insert(za);
-                leadZone[selectedPart] = za;
+                state[selectedPart].selectedZones.clear();
+                state[selectedPart].selectedZones.insert(za);
+                state[selectedPart].leadZone = za;
             }
             else
             {
-                allSelectedZones[selectedPart].insert(za);
+                state[selectedPart].selectedZones.insert(za);
                 if (z.selectingAsLead)
-                    leadZone[selectedPart] = za;
+                    state[selectedPart].leadZone = za;
             }
         }
 
@@ -236,19 +236,19 @@ void SelectionManager::adjustInternalStateForAction(
          * - lead group is the group of lead zone
          */
         std::set<int32_t> gset;
-        allSelectedGroups[selectedPart].clear();
-        for (const auto &z : allSelectedZones[selectedPart])
+        state[selectedPart].selectedGroups.clear();
+        for (const auto &z : state[selectedPart].selectedZones)
         {
             gset.insert(z.group);
         }
         for (auto g : gset)
         {
-            allSelectedGroups[selectedPart].insert({selectedPart, g, -1});
+            state[selectedPart].selectedGroups.insert({selectedPart, g, -1});
         }
-        leadGroup[selectedPart] = {selectedPart, leadZone[selectedPart].group, -1};
+        state[selectedPart].leadGroup = {selectedPart, state[selectedPart].leadZone.group, -1};
         SCLOG_IF(selection,
                  "AllSelectedGroups[" << selectedPart << "] " << gset.size() << " groups");
-        SCLOG_IF(selection, "LeadGroup[" << selectedPart << "] " << leadGroup[selectedPart]);
+        SCLOG_IF(selection, "LeadGroup[" << selectedPart << "] " << state[selectedPart].leadGroup);
     }
     else
     {
@@ -256,7 +256,7 @@ void SelectionManager::adjustInternalStateForAction(
         {
             if (z.distinct)
             {
-                allSelectedGroups[selectedPart].clear();
+                state[selectedPart].selectedGroups.clear();
                 // For an empty group, transformSelectionActions emitted no zone
                 // actions, so clear zone state here to keep the group the sole lead
                 if (za.part >= 0 && za.group >= 0)
@@ -265,24 +265,24 @@ void SelectionManager::adjustInternalStateForAction(
                     if (za.group < (int)pt->getGroups().size() &&
                         pt->getGroup(za.group)->getZones().empty())
                     {
-                        allSelectedZones[selectedPart].clear();
-                        leadZone[selectedPart] = {};
+                        state[selectedPart].selectedZones.clear();
+                        state[selectedPart].leadZone = {};
                     }
                 }
             }
-            allSelectedGroups[selectedPart].insert(za);
+            state[selectedPart].selectedGroups.insert(za);
             if (z.selectingAsLead)
-                leadGroup[selectedPart] = za;
+                state[selectedPart].leadGroup = za;
         }
         else
         {
-            allSelectedGroups[selectedPart].erase(za);
-            if (leadGroup[selectedPart] == za)
+            state[selectedPart].selectedGroups.erase(za);
+            if (state[selectedPart].leadGroup == za)
             {
                 if (engine.getPatch()->getPart(selectedPart)->getGroups().size() > 0)
-                    leadGroup[selectedPart] = {selectedPart, 0, -1};
+                    state[selectedPart].leadGroup = {selectedPart, 0, -1};
                 else
-                    leadGroup[selectedPart] = {};
+                    state[selectedPart].leadGroup = {};
             }
         }
     }
@@ -304,20 +304,20 @@ void SelectionManager::guaranteeConsistencyAfterDeletes(const engine::Engine &en
                                                         const ZoneAddress &whatIDeleted)
 {
     bool morphed{false};
-    auto zit = allSelectedZones[selectedPart].begin();
-    while (zit != allSelectedZones[selectedPart].end())
+    auto zit = state[selectedPart].selectedZones.begin();
+    while (zit != state[selectedPart].selectedZones.end())
     {
         if (!zit->isIn(engine))
         {
             SCLOG_IF(groupZoneMutation,
                      "Removing zone " << *zit << " from selection on group delete");
-            if (leadZone[selectedPart] == *zit)
+            if (state[selectedPart].leadZone == *zit)
             {
                 SCLOG_IF(groupZoneMutation, "Lead zone removed from selection");
-                leadZone[selectedPart] = {};
+                state[selectedPart].leadZone = {};
             }
             morphed = true;
-            zit = allSelectedZones[selectedPart].erase(zit);
+            zit = state[selectedPart].selectedZones.erase(zit);
         }
         else
         {
@@ -325,21 +325,21 @@ void SelectionManager::guaranteeConsistencyAfterDeletes(const engine::Engine &en
         }
     }
 
-    auto git = allSelectedGroups[selectedPart].begin();
-    while (git != allSelectedGroups[selectedPart].end())
+    auto git = state[selectedPart].selectedGroups.begin();
+    while (git != state[selectedPart].selectedGroups.end())
     {
         if (!git->isIn(engine))
         {
             morphed = true;
             SCLOG_IF(groupZoneMutation,
                      "Removing group " << *git << " from selection on group delete");
-            if (leadGroup[selectedPart] == *git)
+            if (state[selectedPart].leadGroup == *git)
             {
                 SCLOG_IF(groupZoneMutation, "Lead group removed from selection");
-                leadGroup[selectedPart] = {};
+                state[selectedPart].leadGroup = {};
             }
 
-            git = allSelectedGroups[selectedPart].erase(git);
+            git = state[selectedPart].selectedGroups.erase(git);
         }
         else
         {
@@ -359,7 +359,7 @@ void SelectionManager::guaranteeConsistencyAfterDeletes(const engine::Engine &en
         {
             const auto &part = engine.getPatch()->getPart(p);
             int n = (int)part->getGroups().size();
-            auto &cset = collapsedGroupsByPart[p];
+            auto &cset = state[p].collapsedGroups;
 
             if (whatIDeleted.group >= 0)
             {
@@ -400,7 +400,7 @@ void SelectionManager::guaranteeConsistencyAfterDeletes(const engine::Engine &en
 void SelectionManager::guaranteeSelectedLeadSomewhereIn(int part, int group, int zone)
 {
     guaranteeSelectedLead();
-    if (leadZone[selectedPart] == ZoneAddress())
+    if (state[selectedPart].leadZone == ZoneAddress())
     {
         const auto &partO = engine.getPatch()->getPart(part);
         bool gotOne{false};
@@ -411,8 +411,8 @@ void SelectionManager::guaranteeSelectedLeadSomewhereIn(int part, int group, int
                 auto &groupO = partO->getGroup(group);
                 if (!groupO->getZones().empty())
                 {
-                    leadZone[selectedPart] = {part, group, 0};
-                    leadGroup[selectedPart] = {part, group, -1};
+                    state[selectedPart].leadZone = {part, group, 0};
+                    state[selectedPart].leadGroup = {part, group, -1};
                     gotOne = true;
                 }
             }
@@ -423,8 +423,8 @@ void SelectionManager::guaranteeSelectedLeadSomewhereIn(int part, int group, int
                 {
                     if (!partO->getGroup(i)->getZones().empty())
                     {
-                        leadZone[selectedPart] = {part, i, 0};
-                        leadGroup[selectedPart] = {part, group, -1};
+                        state[selectedPart].leadZone = {part, i, 0};
+                        state[selectedPart].leadGroup = {part, group, -1};
                         gotOne = true;
                     }
                 }
@@ -443,7 +443,7 @@ void SelectionManager::guaranteeSelectedLead()
     // intentional and don't auto-pick a zone from somewhere else.
     bool leadGroupIsEmpty{false};
     {
-        const auto &lg = leadGroup[selectedPart];
+        const auto &lg = state[selectedPart].leadGroup;
         if (lg.part >= 0 && lg.group >= 0)
         {
             const auto &pt = engine.getPatch()->getPart(lg.part);
@@ -456,18 +456,18 @@ void SelectionManager::guaranteeSelectedLead()
     }
 
     // Now at the end of this the lead zone could not be selected
-    if (allSelectedZones[selectedPart].find(leadZone[selectedPart]) ==
-        allSelectedZones[selectedPart].end())
+    if (state[selectedPart].selectedZones.find(state[selectedPart].leadZone) ==
+        state[selectedPart].selectedZones.end())
     {
         // Nothing is selected. So we need to pick the first zone of the first group
-        if (allSelectedZones[selectedPart].empty() && !leadGroupIsEmpty)
+        if (state[selectedPart].selectedZones.empty() && !leadGroupIsEmpty)
         {
             SCLOG_IF(selection, "Selected zones is empty. Looking for a candidate");
             auto &pt = engine.getPatch()->getPart(selectedPart);
             if (pt->getGroups().empty())
             {
                 SCLOG_IF(selection, "No groups are present - no lead zone");
-                leadZone = {};
+                state[selectedPart].leadZone = {};
             }
             else
             {
@@ -478,7 +478,7 @@ void SelectionManager::guaranteeSelectedLead()
                     if (!g->getZones().empty())
                     {
                         gotOne = true;
-                        leadZone[selectedPart] = {selectedPart, gidx, 0};
+                        state[selectedPart].leadZone = {selectedPart, gidx, 0};
                         SCLOG_IF(selection, "Lead zone is first zone of group " << gidx);
                         break;
                     }
@@ -487,34 +487,34 @@ void SelectionManager::guaranteeSelectedLead()
                 if (!gotOne)
                 {
                     SCLOG_IF(selection, "No zones in any group - no lead zone");
-                    leadZone[selectedPart] = {};
+                    state[selectedPart].leadZone = {};
                 }
                 else
                 {
-                    SCLOG_IF(selection, "Selected leadZone[" << selectedPart
-                                                             << "]=" << leadZone[selectedPart]);
-                    allSelectedZones[selectedPart].insert(leadZone[selectedPart]);
+                    SCLOG_IF(selection, "Selected state[" << selectedPart << "].leadZone="
+                                                          << state[selectedPart].leadZone);
+                    state[selectedPart].selectedZones.insert(state[selectedPart].leadZone);
                 }
             }
         }
-        else if (!allSelectedZones[selectedPart].empty())
+        else if (!state[selectedPart].selectedZones.empty())
         {
-            leadZone[selectedPart] = *(allSelectedZones[selectedPart].begin());
+            state[selectedPart].leadZone = *(state[selectedPart].selectedZones.begin());
         }
     }
 
     // Still at group single so far
-    if (allSelectedGroups[selectedPart].find(leadGroup[selectedPart]) ==
-        allSelectedGroups[selectedPart].end())
+    if (state[selectedPart].selectedGroups.find(state[selectedPart].leadGroup) ==
+        state[selectedPart].selectedGroups.end())
     {
         SCLOG_IF(selection, "Promoting lead group in guaranteeSelectedLead");
-        leadGroup[selectedPart] = {selectedPart, leadZone[selectedPart].group, -1};
-        if (allSelectedGroups[selectedPart].find(leadGroup[selectedPart]) ==
-                allSelectedGroups[selectedPart].end() &&
-            leadGroup[selectedPart].group >= 0)
+        state[selectedPart].leadGroup = {selectedPart, state[selectedPart].leadZone.group, -1};
+        if (state[selectedPart].selectedGroups.find(state[selectedPart].leadGroup) ==
+                state[selectedPart].selectedGroups.end() &&
+            state[selectedPart].leadGroup.group >= 0)
         {
             SCLOG_IF(selection, "Adding zone lead to AllSelectedGroups");
-            allSelectedGroups[selectedPart].insert(leadGroup[selectedPart]);
+            state[selectedPart].selectedGroups.insert(state[selectedPart].leadGroup);
         }
     }
 }
@@ -525,14 +525,14 @@ void SelectionManager::debugDumpSelectionState()
     {
         SCLOG_IF(selection, "---------------------------");
         SCLOG_IF(selection, "PART: " << selectedPart);
-        SCLOG_IF(selection, "ZONES: Selected=" << allSelectedZones[selectedPart].size());
-        SCLOG_IF(selection, "   LEAD ZONE : " << leadZone[selectedPart]);
-        for (const auto &z : allSelectedZones[selectedPart])
+        SCLOG_IF(selection, "ZONES: Selected=" << state[selectedPart].selectedZones.size());
+        SCLOG_IF(selection, "   LEAD ZONE : " << state[selectedPart].leadZone);
+        for (const auto &z : state[selectedPart].selectedZones)
             SCLOG_IF(selection, "      Z Selected : " << z);
 
-        SCLOG_IF(selection, "GROUPS: Selected=" << allSelectedGroups[selectedPart].size());
-        SCLOG_IF(selection, "   LEAD GROUP : " << leadGroup[selectedPart]);
-        for (const auto &z : allSelectedGroups[selectedPart])
+        SCLOG_IF(selection, "GROUPS: Selected=" << state[selectedPart].selectedGroups.size());
+        SCLOG_IF(selection, "   LEAD GROUP : " << state[selectedPart].leadGroup);
+        for (const auto &z : state[selectedPart].selectedGroups)
             SCLOG_IF(selection, "      G Selected : " << z);
         SCLOG_IF(selection, "---------------------------");
     }
@@ -546,12 +546,12 @@ void SelectionManager::sendSelectedZonesToClient()
         debugDumpSelectionState();
     }
 
-    serializationSendToClient(
-        cms::s2c_send_selection_state,
-        cms::selectedStateMessage_t{leadZone[selectedPart], allSelectedZones[selectedPart],
-                                    leadGroup[selectedPart], allSelectedGroups[selectedPart],
-                                    allDisplayGroups[selectedPart]},
-        *(engine.getMessageController()));
+    serializationSendToClient(cms::s2c_send_selection_state,
+                              cms::selectedStateMessage_t{
+                                  state[selectedPart].leadZone, state[selectedPart].selectedZones,
+                                  state[selectedPart].leadGroup, state[selectedPart].selectedGroups,
+                                  state[selectedPart].displayGroups},
+                              *(engine.getMessageController()));
 }
 
 bool SelectionManager::ZoneAddress::isIn(const engine::Engine &e) const
@@ -606,7 +606,7 @@ std::pair<int, int> SelectionManager::bestPartGroupForNewSample(const engine::En
 
         return {sp, sg};
     }
-    if (allSelectedZones[selectedPart].empty())
+    if (state[selectedPart].selectedZones.empty())
     {
         return {selectedPart, 0};
     }
@@ -615,7 +615,7 @@ std::pair<int, int> SelectionManager::bestPartGroupForNewSample(const engine::En
     auto pt = selectedPart;
     auto gp = 0;
 
-    for (const auto &s : allSelectedZones[selectedPart])
+    for (const auto &s : state[selectedPart].selectedZones)
     {
         if (s.part == pt && s.group >= 0)
             gp = std::max(gp, s.group);
@@ -800,12 +800,12 @@ void SelectionManager::copyZoneOrGroupProcessorLeadToAll(bool forZone, int which
         auto lz = currentLeadZone(engine);
         if (!lz.has_value())
             return;
-        if (allSelectedZones[selectedPart].size() < 2)
+        if (state[selectedPart].selectedZones.size() < 2)
             return;
 
         auto &cont = engine.getMessageController();
         cont->scheduleAudioThreadCallback(
-            [asz = allSelectedZones[selectedPart], from = *lz, which](auto &e) {
+            [asz = state[selectedPart].selectedZones, from = *lz, which](auto &e) {
                 const auto &fz =
                     e.getPatch()->getPart(from.part)->getGroup(from.group)->getZone(from.zone);
                 auto ftype = fz->processorStorage[which].type;
@@ -836,12 +836,12 @@ void SelectionManager::copyZoneOrGroupProcessorLeadToAll(bool forZone, int which
         auto lg = currentLeadGroup(engine);
         if (!lg.has_value())
             return;
-        if (allSelectedGroups[selectedPart].size() < 2)
+        if (state[selectedPart].selectedGroups.size() < 2)
             return;
 
         auto &cont = engine.getMessageController();
         cont->scheduleAudioThreadCallback(
-            [asg = allSelectedGroups[selectedPart], from = *lg, which](auto &e) {
+            [asg = state[selectedPart].selectedGroups, from = *lg, which](auto &e) {
                 const auto &fz = e.getPatch()->getPart(from.part)->getGroup(from.group);
                 auto ftype = fz->processorStorage[which].type;
                 for (const auto &sg : asg)
@@ -981,7 +981,7 @@ void SelectionManager::setGroupCollapsed(int part, int group, bool collapsed)
 {
     if (part < 0 || part >= scxt::numParts || group < 0)
         return;
-    auto &s = collapsedGroupsByPart[part];
+    auto &s = state[part].collapsedGroups;
     bool changed = collapsed ? s.insert(group).second : (s.erase(group) > 0);
     if (changed)
         broadcastStructure(engine);
@@ -991,7 +991,7 @@ void SelectionManager::setAllGroupsCollapsed(int part, bool collapsed)
 {
     if (part < 0 || part >= scxt::numParts)
         return;
-    auto &s = collapsedGroupsByPart[part];
+    auto &s = state[part].collapsedGroups;
     s.clear();
     if (collapsed)
     {
@@ -1007,7 +1007,7 @@ void SelectionManager::remapCollapsedOnSwap(int part, int gA, int gB)
 {
     if (part < 0 || part >= scxt::numParts || gA == gB)
         return;
-    auto &s = collapsedGroupsByPart[part];
+    auto &s = state[part].collapsedGroups;
     bool a = s.count(gA) > 0;
     bool b = s.count(gB) > 0;
     if (a == b)
@@ -1029,7 +1029,7 @@ void SelectionManager::remapCollapsedOnMoveAfter(int part, int whichGroup, int t
     if (part < 0 || part >= scxt::numParts || whichGroup == toAfter || whichGroup < 0 ||
         toAfter < 0)
         return;
-    auto &s = collapsedGroupsByPart[part];
+    auto &s = state[part].collapsedGroups;
 
     // The move only affects indices in a contiguous window; everything else
     // keeps its FOLDED bit. Snapshot just the affected window and rotate.
@@ -1077,15 +1077,13 @@ void SelectionManager::remapCollapsedOnMoveAfter(int part, int whichGroup, int t
 
 void SelectionManager::clearAllSelections()
 {
-    for (auto &s : allSelectedZones)
-        s.clear();
-    for (auto &s : allSelectedGroups)
-        s.clear();
-    for (auto &z : leadZone)
-        z = {};
-    for (auto &g : leadGroup)
-        g = {};
-    selectedPart = 0;
+    for (auto &s : state)
+    {
+        s.selectedZones.clear();
+        s.selectedGroups.clear();
+        s.leadZone = {};
+        s.leadGroup = {};
+    }
 }
 
 bool SelectionManager::acrossSelectionConsistency(bool forZone, ConsistencyCheck whichCheck,
@@ -1130,14 +1128,14 @@ bool SelectionManager::acrossSelectionConsistency(bool forZone, ConsistencyCheck
 
     if (forZone)
     {
-        auto &lza = leadZone[selectedPart];
+        auto &lza = state[selectedPart].leadZone;
         if (!lza.isInWithPartials(engine))
             return true;
 
         const auto &lz =
             engine.getPatch()->getPart(lza.part)->getGroup(lza.group)->getZone(lza.zone);
 
-        for (auto &s : allSelectedZones[selectedPart])
+        for (auto &s : state[selectedPart].selectedZones)
         {
             if (!s.isInWithPartials(engine))
                 continue;
@@ -1148,13 +1146,13 @@ bool SelectionManager::acrossSelectionConsistency(bool forZone, ConsistencyCheck
     }
     else
     {
-        auto &lga = leadGroup[selectedPart];
+        auto &lga = state[selectedPart].leadGroup;
         if (!lga.isInWithPartials(engine))
             return true;
 
         const auto &lg = engine.getPatch()->getPart(lga.part)->getGroup(lga.group);
 
-        for (auto &s : allSelectedGroups[selectedPart])
+        for (auto &s : state[selectedPart].selectedGroups)
         {
             if (!s.isInWithPartials(engine))
                 continue;

--- a/src/scxt-core/selection/selection_manager.h
+++ b/src/scxt-core/selection/selection_manager.h
@@ -187,19 +187,19 @@ struct SelectionManager
   public:
     int16_t selectedPart{0};
     typedef std::unordered_set<ZoneAddress, ZoneAddress::Hash> selectedZones_t;
-    selectedZones_t currentlySelectedZones() { return allSelectedZones[selectedPart]; }
+    selectedZones_t currentlySelectedZones() { return state[selectedPart].selectedZones; }
     // This will have -1 for every zone of course
-    selectedZones_t currentlySelectedGroups() { return allSelectedGroups[selectedPart]; }
+    selectedZones_t currentlySelectedGroups() { return state[selectedPart].selectedGroups; }
     std::optional<ZoneAddress> currentLeadZone(const engine::Engine &e) const
     {
-        if (leadZone[selectedPart].isIn(e))
-            return leadZone[selectedPart];
+        if (state[selectedPart].leadZone.isIn(e))
+            return state[selectedPart].leadZone;
         return std::nullopt;
     }
     std::optional<ZoneAddress> currentLeadGroup(const engine::Engine &e) const
     {
-        if (leadGroup[selectedPart].isInPartGroup(e))
-            return leadGroup[selectedPart];
+        if (state[selectedPart].leadGroup.isInPartGroup(e))
+            return state[selectedPart].leadGroup;
         return std::nullopt;
     }
     std::pair<int, int> bestPartGroupForNewSample(const engine::Engine &e);
@@ -224,21 +224,37 @@ struct SelectionManager
   public:
     using otherTabSelection_t = std::unordered_map<std::string, std::string>;
     otherTabSelection_t otherTabSelection;
-    std::array<selectedZones_t, scxt::numParts> allSelectedZones, allSelectedGroups,
-        allDisplayGroups;
-    std::array<ZoneAddress, scxt::numParts> leadZone, leadGroup;
-
     // Per-part set of collapsed group indices for the group/zone tree sidebar.
     // Streamed in save/load; broadcast to the client by stamping the FOLDED bit
     // onto group-row features in getPartGroupZoneStructure.
     using collapsedGroupSet_t = std::unordered_set<int32_t>;
-    std::array<collapsedGroupSet_t, scxt::numParts> collapsedGroupsByPart;
+
+    // All selection state for a single part, grouped so one part's slice can be
+    // streamed/loaded as a unit (used by .scp part save/load to preserve selection).
+    struct PerPartState
+    {
+        selectedZones_t selectedZones;
+        selectedZones_t selectedGroups;
+        selectedZones_t displayGroups;
+        ZoneAddress leadZone;
+        ZoneAddress leadGroup;
+        collapsedGroupSet_t collapsedGroups;
+
+        bool operator==(const PerPartState &o) const
+        {
+            return selectedZones == o.selectedZones && selectedGroups == o.selectedGroups &&
+                   displayGroups == o.displayGroups && leadZone == o.leadZone &&
+                   leadGroup == o.leadGroup && collapsedGroups == o.collapsedGroups;
+        }
+        bool operator!=(const PerPartState &o) const { return !(*this == o); }
+    };
+    std::array<PerPartState, scxt::numParts> state;
 
     bool isGroupCollapsed(int part, int group) const
     {
         if (part < 0 || part >= scxt::numParts || group < 0)
             return false;
-        return collapsedGroupsByPart[part].count(group) > 0;
+        return state[part].collapsedGroups.count(group) > 0;
     }
     void setGroupCollapsed(int part, int group, bool collapsed);
     void setAllGroupsCollapsed(int part, bool collapsed);

--- a/tests/selection_tests.cpp
+++ b/tests/selection_tests.cpp
@@ -28,8 +28,12 @@
 #include "catch2/catch2.hpp"
 #include "engine/engine.h"
 #include "engine/feature_enums.h"
+#include "engine/zone.h"
+#include "patch_io/patch_io.h"
 
 #include "console_harness.h"
+
+#include <filesystem>
 
 TEST_CASE("Create a Single Blank Zone and it is Selected")
 {
@@ -40,7 +44,7 @@ TEST_CASE("Create a Single Blank Zone and it is Selected")
     th.sendToSerialization(scxt::messaging::client::AddBlankZone({0, 0, 60, 72, 0, 64}));
     th.stepUI();
 
-    REQUIRE(th.engine->getSelectionManager()->leadZone[0] ==
+    REQUIRE(th.engine->getSelectionManager()->state[0].leadZone ==
             scxt::selection::SelectionManager::ZoneAddress{0, 0, 0});
 }
 
@@ -70,46 +74,46 @@ TEST_CASE("Create five zones then multi-select")
     th.sendToSerialization(abz({0, 0, 83, 92, 0, 127}));
     th.stepUI();
 
-    REQUIRE(sm->leadZone[0] == zad{0, 0, 4});
-    REQUIRE(sm->allSelectedZones[0].size() == 1);
+    REQUIRE(sm->state[0].leadZone == zad{0, 0, 4});
+    REQUIRE(sm->state[0].selectedZones.size() == 1);
 
     INFO("Single select other zones");
     // remember SAC is p/g/z select, distinct, as-lead
     sel(0, 0, 2, true, true, true);
     th.stepUI();
-    REQUIRE(sm->leadZone[0] == zad{0, 0, 2});
-    REQUIRE(sm->allSelectedZones[0].size() == 1);
+    REQUIRE(sm->state[0].leadZone == zad{0, 0, 2});
+    REQUIRE(sm->state[0].selectedZones.size() == 1);
 
     INFO("Single select a second zone not as lead");
     sel(0, 0, 0, true, false, false);
     th.stepUI();
-    REQUIRE(sm->leadZone[0] == zad{0, 0, 2});
-    REQUIRE(sm->allSelectedZones[0].size() == 2);
+    REQUIRE(sm->state[0].leadZone == zad{0, 0, 2});
+    REQUIRE(sm->state[0].selectedZones.size() == 2);
 
     INFO("Swap the lead");
     sel(0, 0, 0, true, false, true);
     th.stepUI();
-    REQUIRE(sm->leadZone[0] == zad{0, 0, 0});
-    REQUIRE(sm->allSelectedZones[0].size() == 2);
+    REQUIRE(sm->state[0].leadZone == zad{0, 0, 0});
+    REQUIRE(sm->state[0].selectedZones.size() == 2);
 
     INFO("Unselect the non-lead");
     sel(0, 0, 2, false, false, false);
     th.stepUI();
-    REQUIRE(sm->leadZone[0] == zad{0, 0, 0});
-    REQUIRE(sm->allSelectedZones[0].size() == 1);
+    REQUIRE(sm->state[0].leadZone == zad{0, 0, 0});
+    REQUIRE(sm->state[0].selectedZones.size() == 1);
 
     INFO("Select two more groups as non-lead and lead");
     sel(0, 0, 1, true, false, true);
     sel(0, 0, 3, true, false, false);
     th.stepUI();
-    REQUIRE(sm->leadZone[0] == zad{0, 0, 1});
-    REQUIRE(sm->allSelectedZones[0].size() == 3);
+    REQUIRE(sm->state[0].leadZone == zad{0, 0, 1});
+    REQUIRE(sm->state[0].selectedZones.size() == 3);
 
     INFO("Select a different zone disticnt and get it lead with set clear");
     sel(0, 0, 4, true, true, true);
     th.stepUI();
-    REQUIRE(sm->leadZone[0] == zad{0, 0, 4});
-    REQUIRE(sm->allSelectedZones[0].size() == 1);
+    REQUIRE(sm->state[0].leadZone == zad{0, 0, 4});
+    REQUIRE(sm->state[0].selectedZones.size() == 1);
 }
 
 TEST_CASE("Selecting an empty group makes it the lead group")
@@ -142,9 +146,9 @@ TEST_CASE("Selecting an empty group makes it the lead group")
     selGroup(0, 1, true, true, true);
     th.stepUI();
 
-    REQUIRE(sm->leadGroup[0] == zad{0, 1, -1});
-    REQUIRE(sm->allSelectedGroups[0].size() == 1);
-    REQUIRE(sm->allSelectedGroups[0].count(zad{0, 1, -1}) == 1);
+    REQUIRE(sm->state[0].leadGroup == zad{0, 1, -1});
+    REQUIRE(sm->state[0].selectedGroups.size() == 1);
+    REQUIRE(sm->state[0].selectedGroups.count(zad{0, 1, -1}) == 1);
 }
 
 TEST_CASE("Selecting an empty group clears prior zone selections")
@@ -171,16 +175,16 @@ TEST_CASE("Selecting an empty group clears prior zone selections")
     th.sendToSerialization(cmsg::CreateGroup(0));
     th.stepUI();
 
-    REQUIRE(sm->leadZone[0] == zad{0, 0, 1});
-    REQUIRE(!sm->allSelectedZones[0].empty());
+    REQUIRE(sm->state[0].leadZone == zad{0, 0, 1});
+    REQUIRE(!sm->state[0].selectedZones.empty());
 
     INFO("Distinct-select the empty group; zone state should clear");
     selGroup(0, 1, true, true, true);
     th.stepUI();
 
-    REQUIRE(sm->leadGroup[0] == zad{0, 1, -1});
-    REQUIRE(sm->allSelectedZones[0].empty());
-    REQUIRE(sm->leadZone[0] == zad{});
+    REQUIRE(sm->state[0].leadGroup == zad{0, 1, -1});
+    REQUIRE(sm->state[0].selectedZones.empty());
+    REQUIRE(sm->state[0].leadZone == zad{});
 }
 
 TEST_CASE("AddBlankZone after selecting empty group lands in that group")
@@ -208,7 +212,7 @@ TEST_CASE("AddBlankZone after selecting empty group lands in that group")
     selGroup(0, 1, true, true, true);
     th.stepUI();
 
-    REQUIRE(sm->leadGroup[0] == zad{0, 1, -1});
+    REQUIRE(sm->state[0].leadGroup == zad{0, 1, -1});
     REQUIRE(th.engine->getPatch()->getPart(0)->getGroup(1)->getZones().empty());
 
     INFO("Create a blank zone explicitly targeting the empty group");
@@ -217,7 +221,7 @@ TEST_CASE("AddBlankZone after selecting empty group lands in that group")
 
     REQUIRE(th.engine->getPatch()->getPart(0)->getGroup(0)->getZones().size() == 1);
     REQUIRE(th.engine->getPatch()->getPart(0)->getGroup(1)->getZones().size() == 1);
-    REQUIRE(sm->leadZone[0] == zad{0, 1, 0});
+    REQUIRE(sm->state[0].leadZone == zad{0, 1, 0});
 }
 
 TEST_CASE("Switching from empty group to non-empty group selects its zones")
@@ -245,19 +249,19 @@ TEST_CASE("Switching from empty group to non-empty group selects its zones")
 
     selGroup(0, 1, true, true, true);
     th.stepUI();
-    REQUIRE(sm->leadGroup[0] == zad{0, 1, -1});
-    REQUIRE(sm->allSelectedZones[0].empty());
+    REQUIRE(sm->state[0].leadGroup == zad{0, 1, -1});
+    REQUIRE(sm->state[0].selectedZones.empty());
 
     INFO("Now distinct-select the non-empty group 0");
     selGroup(0, 0, true, true, true);
     th.stepUI();
 
-    REQUIRE(sm->leadGroup[0] == zad{0, 0, -1});
-    REQUIRE(sm->allSelectedGroups[0].size() == 1);
-    REQUIRE(sm->allSelectedGroups[0].count(zad{0, 0, -1}) == 1);
-    REQUIRE(sm->allSelectedZones[0].size() == 2);
-    REQUIRE(sm->leadZone[0].part == 0);
-    REQUIRE(sm->leadZone[0].group == 0);
+    REQUIRE(sm->state[0].leadGroup == zad{0, 0, -1});
+    REQUIRE(sm->state[0].selectedGroups.size() == 1);
+    REQUIRE(sm->state[0].selectedGroups.count(zad{0, 0, -1}) == 1);
+    REQUIRE(sm->state[0].selectedZones.size() == 2);
+    REQUIRE(sm->state[0].leadZone.part == 0);
+    REQUIRE(sm->state[0].leadZone.group == 0);
 }
 
 // ---- Group fold state (sidebar tree) ----
@@ -297,13 +301,13 @@ TEST_CASE("Fold: setGroupCollapsed toggles a single group")
     makeGroups(th, 5); // 5 groups: 0..4
 
     const auto &sm = th.engine->getSelectionManager();
-    REQUIRE(sm->collapsedGroupsByPart[0].empty());
+    REQUIRE(sm->state[0].collapsedGroups.empty());
     REQUIRE(!sm->isGroupCollapsed(0, 2));
 
     th.sendToSerialization(cmsg::SetGroupCollapsed({0, 2, true}));
     th.stepUI();
     REQUIRE(sm->isGroupCollapsed(0, 2));
-    REQUIRE(sm->collapsedGroupsByPart[0].size() == 1);
+    REQUIRE(sm->state[0].collapsedGroups.size() == 1);
 
     INFO("FOLDED bit shows up on the structure broadcast for that group");
     REQUIRE((pgzGroupFeatures(th, 0, 2) & scxt::engine::GroupZoneFeatures::FOLDED) != 0);
@@ -312,7 +316,7 @@ TEST_CASE("Fold: setGroupCollapsed toggles a single group")
     th.sendToSerialization(cmsg::SetGroupCollapsed({0, 2, false}));
     th.stepUI();
     REQUIRE(!sm->isGroupCollapsed(0, 2));
-    REQUIRE(sm->collapsedGroupsByPart[0].empty());
+    REQUIRE(sm->state[0].collapsedGroups.empty());
     REQUIRE((pgzGroupFeatures(th, 0, 2) & scxt::engine::GroupZoneFeatures::FOLDED) == 0);
 }
 
@@ -328,13 +332,13 @@ TEST_CASE("Fold: setAllGroupsCollapsed true/false")
 
     th.sendToSerialization(cmsg::SetAllGroupsCollapsed({0, true}));
     th.stepUI();
-    REQUIRE(sm->collapsedGroupsByPart[0].size() == 5);
+    REQUIRE(sm->state[0].collapsedGroups.size() == 5);
     for (int g = 0; g < 5; ++g)
         REQUIRE(sm->isGroupCollapsed(0, g));
 
     th.sendToSerialization(cmsg::SetAllGroupsCollapsed({0, false}));
     th.stepUI();
-    REQUIRE(sm->collapsedGroupsByPart[0].empty());
+    REQUIRE(sm->state[0].collapsedGroups.empty());
 }
 
 TEST_CASE("Fold: deleting a group below a folded group keeps the right group folded")
@@ -383,7 +387,7 @@ TEST_CASE("Fold: delete-fixup drops the deleted group's fold bit and clamps out-
     th.sendToSerialization(cmsg::SetGroupCollapsed({0, 2, true}));
     th.sendToSerialization(cmsg::SetGroupCollapsed({0, 4, true}));
     th.stepUI();
-    REQUIRE(sm->collapsedGroupsByPart[0].size() == 2);
+    REQUIRE(sm->state[0].collapsedGroups.size() == 2);
 
     // Delete the folded group 2. Group 2's bit is gone; group 4's bit shifts to 3.
     th.sendToSerialization(cmsg::DeleteGroup(zad{0, 2, -1}));
@@ -391,7 +395,7 @@ TEST_CASE("Fold: delete-fixup drops the deleted group's fold bit and clamps out-
     REQUIRE(th.engine->getPatch()->getPart(0)->getGroups().size() == 4);
     REQUIRE(!sm->isGroupCollapsed(0, 2));
     REQUIRE(sm->isGroupCollapsed(0, 3));
-    REQUIRE(sm->collapsedGroupsByPart[0].size() == 1);
+    REQUIRE(sm->state[0].collapsedGroups.size() == 1);
 }
 
 TEST_CASE("Fold: swap groups remaps fold state")
@@ -506,7 +510,7 @@ TEST_CASE("Fold: moveGroupToAfter preserves fold state outside the affected wind
     th.sendToSerialization(cmsg::SetGroupCollapsed({0, 2, true}));
     th.sendToSerialization(cmsg::SetGroupCollapsed({0, 6, true}));
     th.stepUI();
-    REQUIRE(sm->collapsedGroupsByPart[0].size() == 3);
+    REQUIRE(sm->state[0].collapsedGroups.size() == 3);
 
     // Move 2 to after 4. Affected window [2, 4] — group 6 must NOT be lost.
     th.sendToSerialization(cmsg::MoveGroupTo({zad{0, 2, -1}, zad{0, 4, 0}}));
@@ -517,4 +521,94 @@ TEST_CASE("Fold: moveGroupToAfter preserves fold state outside the affected wind
     REQUIRE(!sm->isGroupCollapsed(0, 3));
     REQUIRE(sm->isGroupCollapsed(0, 4));
     REQUIRE(sm->isGroupCollapsed(0, 6));
+}
+
+TEST_CASE("SCP preserves selection across parts", "[selection]")
+{
+    namespace cmsg = scxt::messaging::client;
+    using zad = scxt::selection::SelectionManager::ZoneAddress;
+
+    auto tmp = std::filesystem::temp_directory_path() / "scxt_scp_selection_test.scp";
+
+    // --- Source: three zones in part 3, with a distinctive selection on it. ---
+    {
+        scxt::clients::console_ui::ConsoleHarness srcH;
+        srcH.start();
+        srcH.stepUI();
+
+        // Select part 3 first, then add zones into it (the natural UI flow).
+        srcH.sendToSerialization(cmsg::SelectPart(3));
+        srcH.sendToSerialization(cmsg::AddBlankZone({3, 0, 48, 60, 0, 127}));
+        srcH.sendToSerialization(cmsg::AddBlankZone({3, 0, 61, 72, 0, 127}));
+        srcH.sendToSerialization(cmsg::AddBlankZone({3, 0, 73, 84, 0, 127}));
+        srcH.stepUI();
+
+        srcH.sendToSerialization(cmsg::ApplySelectActions({{3, 0, 1, true, true, true}}));
+        srcH.sendToSerialization(cmsg::SetGroupCollapsed({3, 0, true}));
+        srcH.stepUI();
+
+        const auto &sm = srcH.engine->getSelectionManager();
+        REQUIRE(sm->selectedPart == 3);
+        REQUIRE(sm->state[3].leadZone == zad{3, 0, 1});
+        REQUIRE(sm->state[3].selectedZones.size() == 1);
+        REQUIRE(sm->isGroupCollapsed(3, 0));
+
+        srcH.sendToSerialization(
+            cmsg::SavePart({tmp.u8string(), 3, scxt::patch_io::SaveStyles::NO_SAMPLES}));
+        srcH.stepUI();
+    }
+    REQUIRE(std::filesystem::exists(tmp));
+
+    // --- Dest: load the .scp into part 7 and verify the selection came along. ---
+    {
+        scxt::clients::console_ui::ConsoleHarness dstH;
+        dstH.start();
+        dstH.stepUI();
+
+        const auto &dsm = dstH.engine->getSelectionManager();
+        auto preState0 = dsm->state[0];
+        auto preState5 = dsm->state[5];
+
+        dstH.sendToSerialization(cmsg::LoadPartInto({tmp.u8string(), (int16_t)7}));
+        dstH.stepUI();
+        dstH.stepUI();
+
+        // Structure loaded into part 7, and the selection slice landed at state[7]
+        // with every .part remapped onto part 7.
+        REQUIRE(dstH.engine->getPatch()->getPart(7)->getGroups().size() == 1);
+        REQUIRE(dsm->state[7].leadZone == zad{7, 0, 1});
+        REQUIRE(dsm->isGroupCollapsed(7, 0));
+        REQUIRE(dsm->state[7].selectedZones.size() == 1);
+        for (const auto &za : dsm->state[7].selectedZones)
+            REQUIRE(za.part == 7);
+
+        // SCP load leaves other parts alone.
+        REQUIRE(dsm->state[0] == preState0);
+        REQUIRE(dsm->state[5] == preState5);
+    }
+
+    // --- Load into the *currently selected* part: the restored selection must
+    //     survive (loadPartInto used to force-select group 0 in this case). ---
+    {
+        scxt::clients::console_ui::ConsoleHarness dstH;
+        dstH.start();
+        dstH.stepUI();
+
+        const auto &dsm = dstH.engine->getSelectionManager();
+        dstH.sendToSerialization(cmsg::SelectPart(2));
+        dstH.stepUI();
+        REQUIRE(dsm->selectedPart == 2);
+
+        dstH.sendToSerialization(cmsg::LoadPartInto({tmp.u8string(), (int16_t)2}));
+        dstH.stepUI();
+        dstH.stepUI();
+
+        // The saved selection (one zone, lead {2,0,1}) survived; we did NOT fall
+        // back to "all of group 0 selected".
+        REQUIRE(dsm->state[2].leadZone == zad{2, 0, 1});
+        REQUIRE(dsm->state[2].selectedZones.size() == 1);
+        REQUIRE(dsm->isGroupCollapsed(2, 0));
+    }
+
+    std::filesystem::remove(tmp);
 }


### PR DESCRIPTION
The selection manager used to be n arrays of size parts. This changes it to one array of structs of size parts. As such you get changes like mgr.allfoos[part].bar becoming mgr.slice[part].foo.bar.

This allows us to change the streaming such that engine streaming and multi streaming still streams the entire manager but streaming the per part features is easier, so as a result SCP files can contain a selection subset.

And similarly when unstreaming from SCP which has this new streaming in it, we can also apply that selection to the unstreamed part directly.

Closes #2485
Assisted-By: Claude Opus 4.8