### PR TITLE
Stack alt-dropped samples as variants of one zone

### DIFF
--- a/src/scxt-core/engine/engine.cpp
+++ b/src/scxt-core/engine/engine.cpp
@@ -954,6 +954,80 @@ void Engine::loadSampleIntoSelectedPartAndGroup(const fs::path &p, int16_t rootK
     }
 }
 
+void Engine::loadSamplesIntoNewZoneAsVariants(const std::vector<fs::path> &paths, int16_t rootKey,
+                                              KeyboardRange krange, VelocityRange vrange)
+{
+    assert(messageController->threadingChecker.isSerialThread());
+
+    // The UI guards this too, but don't trust the caller — a zone can't hold more than
+    // maxVariantsPerZone variants.
+    if (paths.size() > maxVariantsPerZone)
+    {
+        RAISE_ERROR_CONT(*messageController, "Too many samples",
+                         "Cannot stack " + std::to_string(paths.size()) +
+                             " samples as variants; a zone holds at most " +
+                             std::to_string(maxVariantsPerZone) + ".");
+        return;
+    }
+
+    // Load each plain sample on this thread, collecting the ones that succeed
+    std::vector<SampleID> sids;
+    for (const auto &p : paths)
+    {
+        if (sids.size() >= maxVariantsPerZone)
+            break;
+        auto sid = sampleManager->loadSampleByPath(p);
+        if (!sid.has_value())
+        {
+            RAISE_ERROR_CONT(*messageController, "Unable to load Sample",
+                             "Sample load failed:\n\n" + p.u8string() + "\n\n" +
+                                 "It is either an unsupported format or invalid file. "
+                                 "More information may be available in the log file (menu/log)");
+            continue;
+        }
+        sids.push_back(*sid);
+    }
+
+    if (sids.empty())
+        return;
+
+    // Per-variant we only read loop/endpoint info so each sample's metadata doesn't
+    // clobber the zone's keyboard/velocity mapping.
+    auto sir = (int)Zone::SampleInformationRead::LOOP | (int)Zone::SampleInformationRead::ENDPOINTS;
+
+    auto zptr = std::make_unique<Zone>(sids[0]);
+    zptr->mapping.keyboardRange = krange;
+    zptr->mapping.velocityRange = vrange;
+    zptr->mapping.rootKey = rootKey;
+    zptr->attachToSample(*sampleManager, 0, sir);
+    for (size_t i = 1; i < sids.size(); ++i)
+        zptr->attachToSampleAtVariation(*sampleManager, sids[i], (int16_t)i, sir);
+
+    auto [sp, sg] = selectionManager->bestPartGroupForNewSample(*this);
+
+    // Push an undo step for the group before modifying it
+    {
+        auto undoItem = std::make_unique<undo::GroupChangeItem>();
+        undoItem->store(*this, sp, sg);
+        undoManager.storeUndoStep(std::move(undoItem));
+    }
+
+    messageController->scheduleAudioThreadCallbackUnderStructureLock(
+        [sp = sp, sg = sg, zone = zptr.release()](auto &e) {
+            std::unique_ptr<Zone> zptr;
+            zptr.reset(zone);
+            e.getPatch()->getPart(sp)->guaranteeGroupCount(sg + 1);
+            e.getPatch()->getPart(sp)->getGroup(sg)->addZone(zptr);
+
+            messaging::audio::sendStructureRefresh(*(e.getMessageController()));
+        },
+        [sp = sp, sg = sg](auto &e) {
+            auto &g = e.getPatch()->getPart(sp)->getGroup(sg);
+            int32_t zi = g->getZones().size() - 1;
+            e.getSelectionManager()->applySelectActions({sp, sg, zi, true, true, true});
+        });
+}
+
 void Engine::loadSampleIntoGroup(const fs::path &p, int part, int group)
 {
     assert(messageController->threadingChecker.isSerialThread());

--- a/src/scxt-core/engine/engine.h
+++ b/src/scxt-core/engine/engine.h
@@ -592,6 +592,11 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     // Drop a single audio file into an explicit group, bypassing selection
     void loadSampleIntoGroup(const fs::path &p, int part, int group);
 
+    // Build a single new zone in the selected part/group whose variants are the given
+    // plain sample files (Alt-drop stacking). Paths beyond maxVariantsPerZone are ignored.
+    void loadSamplesIntoNewZoneAsVariants(const std::vector<fs::path> &paths, int16_t rootKey,
+                                          KeyboardRange krange, VelocityRange vrange);
+
     void loadCompoundElementIntoSelectedPartAndGroup(
         const scxt::sample::compound::CompoundElement &, int16_t rootKey = 60,
         KeyboardRange krange = {48, 72}, VelocityRange vrange = {0, 127});

--- a/src/scxt-core/messaging/client/client_serial.h
+++ b/src/scxt-core/messaging/client/client_serial.h
@@ -140,6 +140,7 @@ enum ClientToSerializationMessagesIds
 
     c2s_add_sample,
     c2s_add_sample_with_range,
+    c2s_add_samples_as_variants_with_range,
     c2s_add_sample_to_group,
     c2s_add_sample_in_zone,
     c2s_add_compound_element_with_range,

--- a/src/scxt-core/messaging/client/structure_messages.h
+++ b/src/scxt-core/messaging/client/structure_messages.h
@@ -91,6 +91,25 @@ inline void addSampleWithRange(const addSampleWithRange_t &payload, engine::Engi
 CLIENT_TO_SERIAL(AddSampleWithRange, c2s_add_sample_with_range, addSampleWithRange_t,
                  addSampleWithRange(payload, engine, cont);)
 
+// samples, root, midi start end, vel start end — stack all samples as variants of one zone
+using addSamplesAsVariantsWithRange_t =
+    std::tuple<std::vector<std::string>, int, int, int, int, int>;
+inline void addSamplesAsVariantsWithRange(const addSamplesAsVariantsWithRange_t &payload,
+                                          engine::Engine &engine, MessageController &cont)
+{
+    assert(cont.threadingChecker.isSerialThread());
+    std::vector<fs::path> paths;
+    for (const auto &s : std::get<0>(payload))
+        paths.push_back(fs::path(fs::u8path(s)));
+    auto rk = std::get<1>(payload);
+    auto kr = engine::KeyboardRange(std::get<2>(payload), std::get<3>(payload));
+    auto vr = engine::VelocityRange(std::get<4>(payload), std::get<5>(payload));
+    engine.loadSamplesIntoNewZoneAsVariants(paths, rk, kr, vr);
+}
+CLIENT_TO_SERIAL(AddSamplesAsVariantsWithRange, c2s_add_samples_as_variants_with_range,
+                 addSamplesAsVariantsWithRange_t,
+                 addSamplesAsVariantsWithRange(payload, engine, cont);)
+
 // path, part, group — drops the sample into an explicit group bypassing selection
 using addSampleToGroupPayload_t = std::tuple<std::string, int, int>;
 inline void addSampleToGroupFn(const addSampleToGroupPayload_t &payload, engine::Engine &engine,

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
@@ -453,27 +453,58 @@ void MappingDisplay::itemDropped(const juce::DragAndDropTarget::SourceDetails &d
         auto r = mappingZones->rootAndRangeForPosition(dragSourceDetails.localPosition,
                                                        dropElementCount, false);
         assert(r.size() > 0);
-        assert(r.size() == dropElementCount);
         if (wsi->encompassesMultipleSampleInfos())
         {
             auto els = wsi->getMultipleSampleInfos();
             auto nEls = els.size();
             assert(nEls == dropElementCount);
-            int idx{0};
-            for (auto e : els)
-            {
-                auto &loc = r[std::min(idx++, (int)nEls - 1)];
 
-                if (e->getCompoundElement().has_value())
+            // Alt held: rootAndRangeForPosition collapses to a single range, signalling
+            // "stack all dropped samples as variants of one zone" (plain files only).
+            bool altStack = (r.size() == 1 && dropElementCount > 1);
+            bool allPlainFiles = true;
+            for (auto e : els)
+                allPlainFiles &=
+                    (!e->getCompoundElement().has_value() && e->getDirEnt().has_value());
+
+            if (altStack && allPlainFiles)
+            {
+                if (nEls > engine::Zone::maxVariantsPerZone)
                 {
-                    sendToSerialization(cmsg::AddCompoundElementWithRange(
-                        {*e->getCompoundElement(), loc.root, loc.lo, loc.hi, loc.vlo, loc.vhi}));
+                    editor->displayError("Too many samples",
+                                         "You tried to stack " + std::to_string(nEls) +
+                                             " samples as variants, but a zone can hold at most " +
+                                             std::to_string(engine::Zone::maxVariantsPerZone) +
+                                             ".");
+                    return;
                 }
-                else if (e->getDirEnt().has_value())
+                std::vector<std::string> paths;
+                for (auto e : els)
+                    paths.push_back(e->getDirEnt()->path().u8string());
+                auto &loc = r[0];
+                sendToSerialization(cmsg::AddSamplesAsVariantsWithRange(
+                    {paths, loc.root, loc.lo, loc.hi, loc.vlo, loc.vhi}));
+            }
+            else
+            {
+                assert(r.size() == dropElementCount);
+                int idx{0};
+                for (auto e : els)
                 {
-                    sendToSerialization(
-                        cmsg::AddSampleWithRange({e->getDirEnt()->path().u8string(), loc.root,
-                                                  loc.lo, loc.hi, loc.vlo, loc.vhi}));
+                    auto &loc = r[std::min(idx++, (int)nEls - 1)];
+
+                    if (e->getCompoundElement().has_value())
+                    {
+                        sendToSerialization(
+                            cmsg::AddCompoundElementWithRange({*e->getCompoundElement(), loc.root,
+                                                               loc.lo, loc.hi, loc.vlo, loc.vhi}));
+                    }
+                    else if (e->getDirEnt().has_value())
+                    {
+                        sendToSerialization(
+                            cmsg::AddSampleWithRange({e->getDirEnt()->path().u8string(), loc.root,
+                                                      loc.lo, loc.hi, loc.vlo, loc.vhi}));
+                    }
                 }
             }
         }
@@ -692,10 +723,48 @@ void MappingDisplay::filesDropped(const juce::StringArray &files, int x, int y)
         sendToSerialization(cmsg::ClearPart(editor->selectedPart));
 
     auto regions = mappingZones->rootAndRangeForPosition({x, y}, files.size(), false);
+
+    // Alt held: a single region means "stack all dropped files as variants of one zone".
+    // Only plain audio files (not instrument containers) are stacked.
+    if (regions.size() == 1 && files.size() > 1)
+    {
+        bool allPlain = true;
+        std::vector<std::string> paths;
+        for (auto f : files)
+        {
+            auto p = fs::path{(const char *)(f.toUTF8())};
+            if (!browser::Browser::getMultiInstrumentElements(p).empty())
+            {
+                allPlain = false;
+                break;
+            }
+            paths.push_back(f.toStdString());
+        }
+        if (allPlain)
+        {
+            if ((int)paths.size() > engine::Zone::maxVariantsPerZone)
+            {
+                editor->displayError("Too many samples",
+                                     "You tried to stack " + std::to_string(paths.size()) +
+                                         " samples as variants, but a zone can hold at most " +
+                                         std::to_string(engine::Zone::maxVariantsPerZone) + ".");
+                repaint();
+                return;
+            }
+            auto &loc = regions[0];
+            sendToSerialization(cmsg::AddSamplesAsVariantsWithRange(
+                {paths, loc.root, loc.lo, loc.hi, loc.vlo, loc.vhi}));
+            if (editor->editScreen->partSidebar)
+                editor->editScreen->partSidebar->setSelectedTab(2);
+            repaint();
+            return;
+        }
+    }
+
     int lidx{0};
     for (auto f : files)
     {
-        auto &loc = regions[lidx++];
+        auto &loc = regions[std::min(lidx++, (int)regions.size() - 1)];
         auto p = fs::path{(const char *)(f.toUTF8())};
         auto inst = browser::Browser::getMultiInstrumentElements(p);
         if (inst.empty())

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
@@ -927,6 +927,16 @@ void ZoneLayoutDisplay::paint(juce::Graphics &g)
             }
             first = false;
         }
+
+        // Alt-stack: a single range covering multiple dropped samples becomes one zone
+        // whose variants are those samples. Label it so the user knows what they'll get.
+        if (display->dropElementCount > 1 && ranges.size() == 1)
+        {
+            auto &rr = ranges[0];
+            auto rb = rectangleForRange(rr.lo, rr.hi, rr.vlo, rr.vhi);
+            labelZoneRectangle(g, rb, std::to_string(display->dropElementCount) + " variants",
+                               editor->themeColor(theme::ColorMap::accent_1a));
+        }
     }
 
     if (mouseState == MULTI_SELECT || mouseState == CREATE_EMPTY_ZONE)


### PR DESCRIPTION
Holding alt while dropping multiple samples onto the mapping display now builds a single zone whose variants are those samples, instead of spreading them across the keyboard. A preview labels the target zone with the variant count, and dropping more than a zone can hold reports an error rather than proceeding.

Closes #2213

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>