### PR TITLE
Add a valueFromString error path

### DIFF
--- a/src/scxt-plugin/app/HasEditor.h
+++ b/src/scxt-plugin/app/HasEditor.h
@@ -30,6 +30,7 @@
 
 #include <cstdint>
 #include <cassert>
+#include <string>
 #include <type_traits>
 
 namespace scxt::ui::app
@@ -55,13 +56,17 @@ struct HasEditor
     }
 
     template <typename T> void updateValueTooltip(const T &attachment);
-    template <typename W, typename A>
-    void setupWidgetForValueTooltip(W *widget, const A &attachment);
+    template <typename W, typename A> void setupFloatWidget(W *widget, const A &attachment);
 
-    template <typename W, typename A>
-    void setupIntAttachedWidgetForValueMenu(W *widget, const A &attachment);
+    template <typename W, typename A> void setupIntWidget(W *widget, const A &attachment);
 
     template <typename P, typename A> void addSubscription(const P &, A &);
+
+    // shows a user-visible error overlay; non-template shim over SCXTEditor::displayError
+    void reportError(const std::string &title, const std::string &message) const;
+
+    // wires an attachment's onError (if it has one) to reportError
+    template <typename A> void wireErrorReporter(A &att);
 };
 } // namespace scxt::ui::app
 #endif // SHORTCIRCUIT_HASEDITOR_H

--- a/src/scxt-plugin/app/SCXTEditor.h
+++ b/src/scxt-plugin/app/SCXTEditor.h
@@ -401,6 +401,16 @@ template <typename T> inline void HasEditor::sendToSerialization(const T &msg)
     editor->sendToSerialization(msg);
 }
 
+template <typename A> inline void HasEditor::wireErrorReporter(A &att)
+{
+    if constexpr (requires { att.onError; })
+    {
+        att.onError = [this](const std::string &title, const std::string &message) {
+            reportError(title, message);
+        };
+    }
+}
+
 template <typename T>
 concept HasValueAlternate = requires(T a) {
     { a.getValueAlternateAsString() } -> std::convertible_to<std::optional<std::string>>;
@@ -425,9 +435,9 @@ template <typename T> inline void HasEditor::updateValueTooltip(const T &at)
     editor->setTooltipContents(at.getLabel(), vas);
 }
 
-template <typename W, typename A>
-inline void HasEditor::setupWidgetForValueTooltip(W *w, const A &a)
+template <typename W, typename A> inline void HasEditor::setupFloatWidget(W *w, const A &a)
 {
+    wireErrorReporter(*a);
     w->onBeginEdit = [this, &slRef = *w, &atRef = *a]() {
         updateValueTooltip(atRef);
         editor->showTooltip(slRef);
@@ -453,9 +463,9 @@ inline void HasEditor::setupWidgetForValueTooltip(W *w, const A &a)
     }
 }
 
-template <typename W, typename A>
-inline void HasEditor::setupIntAttachedWidgetForValueMenu(W *w, const A &a)
+template <typename W, typename A> inline void HasEditor::setupIntWidget(W *w, const A &a)
 {
+    wireErrorReporter(*a);
     w->onPopupMenu = [this, q = juce::Component::SafePointer(w)](auto &mods) {
         auto qc = dynamic_cast<sst::jucegui::components::ContinuousParamEditor *>(q.getComponent());
         if (qc)

--- a/src/scxt-plugin/app/edit-screen/components/AdsrPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/AdsrPane.cpp
@@ -180,7 +180,7 @@ void AdsrPane::rebuildPanelComponents(int useIdx)
         gateToggle->setDrawMode(sst::jucegui::components::ToggleButton::DrawMode::LABELED);
         gateToggle->setLabel(u8"\xE2\x88\x80");
         gateToggle->setSource(gateToggleA.get());
-        setupWidgetForValueTooltip(gateToggle.get(), gateToggleA.get());
+        setupFloatWidget(gateToggle.get(), gateToggleA.get());
         getContentAreaComponent()->addAndMakeVisible(*gateToggle);
     }
 

--- a/src/scxt-plugin/app/edit-screen/components/LFOPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/LFOPane.cpp
@@ -1851,7 +1851,7 @@ void LfoPane::rebuildPanelComponents()
     tsfac::attach(ms, ms.temposync, this, tempoSyncA, tsb, forZone, selectedTab);
     tsb->setDrawMode(jcmp::ToggleButton::DrawMode::GLYPH);
     tsb->setGlyph(jcmp::GlyphPainter::METRONOME);
-    setupWidgetForValueTooltip(tsb.get(), tempoSyncA);
+    setupFloatWidget(tsb.get(), tempoSyncA);
 
     clearAdditionalHamburgerComponents();
     addAdditionalHamburgerComponent(std::move(tsb));

--- a/src/scxt-plugin/app/edit-screen/components/ProcessorPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/ProcessorPane.cpp
@@ -721,7 +721,7 @@ void ProcessorPane::rebuildControlsFromDescription()
         kta->setDrawMode(sst::jucegui::components::ToggleButton::DrawMode::GLYPH);
         kta->setGlyph(sst::jucegui::components::GlyphPainter::KEYBOARD);
         kta->setSource(keytrackAttackment.get());
-        setupWidgetForValueTooltip(kta.get(), keytrackAttackment);
+        setupFloatWidget(kta.get(), keytrackAttackment);
         addAdditionalHamburgerComponent(std::move(kta));
     }
 
@@ -737,7 +737,7 @@ void ProcessorPane::rebuildControlsFromDescription()
         ts->setDrawMode(sst::jucegui::components::ToggleButton::DrawMode::GLYPH);
         ts->setGlyph(sst::jucegui::components::GlyphPainter::METRONOME);
         ts->setSource(temposyncAttachment.get());
-        setupWidgetForValueTooltip(ts.get(), temposyncAttachment);
+        setupFloatWidget(ts.get(), temposyncAttachment);
         addAdditionalHamburgerComponent(std::move(ts));
     }
 
@@ -748,7 +748,7 @@ void ProcessorPane::rebuildControlsFromDescription()
                                  bool_attachment_t::onGui_t>(*bypassAttachment, processorView, this,
                                                              forZone, index);
     setToggleDataSource(bypassAttachment.get());
-    setupWidgetForValueTooltip(toggleButton.get(), bypassAttachment);
+    setupFloatWidget(toggleButton.get(), bypassAttachment);
     connectors::addGuiStep(*bypassAttachment,
                            [this](auto &a) { editor->processorBypassToggled(index); });
 
@@ -935,7 +935,7 @@ void ProcessorPane::createHamburgerStereo(int attachmentId)
     stereo->setDrawMode(jcmp::ToggleButton::DrawMode::DUAL_GLYPH);
     stereo->setGlyph(jcmp::GlyphPainter::STEREO);
     stereo->setOffGlyph(jcmp::GlyphPainter::MONO);
-    setupWidgetForValueTooltip(stereo.get(), intAttachments[attachmentId]);
+    setupFloatWidget(stereo.get(), intAttachments[attachmentId]);
     addAdditionalHamburgerComponent(std::move(stereo));
     attachRebuildToIntAttachment(attachmentId);
 }

--- a/src/scxt-plugin/app/edit-screen/components/ProcessorPane.h
+++ b/src/scxt-plugin/app/edit-screen/components/ProcessorPane.h
@@ -116,7 +116,7 @@ struct ProcessorPane : sst::jucegui::components::NamedPanel,
             theme::layout::Labeled<sst::jucegui::components::ContinuousParamEditor>>();
         auto kn = std::make_unique<T>();
         kn->setSource(at.get());
-        setupWidgetForValueTooltip(kn.get(), at);
+        setupFloatWidget(kn.get(), at);
         kn->setTitle(at->getLabel());
         kn->setDescription(at->getLabel());
         getContentAreaComponent()->addAndMakeVisible(*kn);

--- a/src/scxt-plugin/app/edit-screen/components/RoutingPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/RoutingPane.cpp
@@ -553,7 +553,7 @@ RoutingPane<RPTraits>::RoutingPane(SCXTEditor *e)
         oversampleButton->setLabel("2xOS");
         oversampleButton->setLabelDrawsBackground(false);
 
-        setupWidgetForValueTooltip(oversampleButton.get(), oversampleAttachment);
+        setupFloatWidget(oversampleButton.get(), oversampleAttachment);
         addAdditionalHamburgerComponent(std::move(oversampleButton), 28);
     }
 

--- a/src/scxt-plugin/app/editor-impl/HasEditor.cpp
+++ b/src/scxt-plugin/app/editor-impl/HasEditor.cpp
@@ -32,4 +32,8 @@ namespace scxt::ui::app
 {
 HasEditor::HasEditor(SCXTEditor *e) : editor(e) {}
 HasEditor::HasEditor(HasEditor *e) : editor(e->editor) {}
+void HasEditor::reportError(const std::string &title, const std::string &message) const
+{
+    editor->displayError(title, message);
+}
 } // namespace scxt::ui::app

--- a/src/scxt-plugin/app/mixer-screen/components/ChannelStrip.cpp
+++ b/src/scxt-plugin/app/mixer-screen/components/ChannelStrip.cpp
@@ -224,7 +224,7 @@ ChannelStrip::ChannelStrip(SCXTEditor *e, MixerScreen *m, int bi, BusType t)
             axs->setSource(ava.get());
             addAndMakeVisible(*axs);
             auxAttachments[idx] = std::move(ava);
-            setupWidgetForValueTooltip(axs.get(), auxAttachments[idx]);
+            setupFloatWidget(axs.get(), auxAttachments[idx]);
             idx++;
         }
         idx = 0;
@@ -258,14 +258,14 @@ ChannelStrip::ChannelStrip(SCXTEditor *e, MixerScreen *m, int bi, BusType t)
     panKnob = std::make_unique<jcmp::Knob>();
     panKnob->setSource(panAttachment.get());
     addAndMakeVisible(*panKnob);
-    setupWidgetForValueTooltip(panKnob.get(), panAttachment);
+    setupFloatWidget(panKnob.get(), panAttachment);
 
     vcaAttachment = std::make_unique<attachment_t>(
         datamodel::pmd().asCubicDecibelAttenuation().withName("Level").withDefault(1.0), onChange,
         mixer->busSendData[busIndex].level);
     vcaSlider = std::make_unique<jcmp::VSlider>();
     vcaSlider->setSource(vcaAttachment.get());
-    setupWidgetForValueTooltip(vcaSlider.get(), vcaAttachment);
+    setupFloatWidget(vcaSlider.get(), vcaAttachment);
     addAndMakeVisible(*vcaSlider);
 
     if (t != BusType::MAIN)

--- a/src/scxt-plugin/app/shared/PartEffectsPane.cpp
+++ b/src/scxt-plugin/app/shared/PartEffectsPane.cpp
@@ -222,7 +222,7 @@ template <bool forBus> void PartEffectsPane<forBus>::rebuild()
         auto at = std::make_unique<boolAttachment_t>("Temposync", onGuiChange,
                                                      getPartFXStorage().second.isTemposync);
         res->setSource(at.get());
-        setupWidgetForValueTooltip(res.get(), at);
+        setupFloatWidget(res.get(), at);
         addAndMakeVisible(*res);
 
         boolAttachments.insert(std::move(at));
@@ -253,7 +253,7 @@ template <bool forBus> void PartEffectsPane<forBus>::rebuild()
             std::make_unique<boolAttachment_t>(effectDisplayName(t, true) + " Active", onGuiChange,
                                                getPartFXStorage().second.isActive);
         setToggleDataSource(at.get());
-        setupWidgetForValueTooltip(toggleButton.get(), at);
+        setupFloatWidget(toggleButton.get(), at);
         boolAttachments.insert(std::move(at));
         addAndMakeVisible(*toggleButton);
     }
@@ -295,7 +295,7 @@ T *PartEffectsPane<forBus>::attachWidgetToFloat(int pidx)
         w->setEnabled(true);
     }
 
-    setupWidgetForValueTooltip(w.get(), at);
+    setupFloatWidget(w.get(), at);
     addAndMakeVisible(*w);
 
     if constexpr (std::is_same_v<T, jcmp::Knob>)

--- a/src/scxt-plugin/app/shared/PartSidebarCard.cpp
+++ b/src/scxt-plugin/app/shared/PartSidebarCard.cpp
@@ -114,7 +114,7 @@ PartSidebarCard::PartSidebarCard(int p, SCXTEditor *e) : part(p), HasEditor(e)
 
         wid = std::make_unique<typename std::remove_reference_t<decltype(wid)>::element_type>();
         wid->setSource(att.get());
-        setupWidgetForValueTooltip(wid.get(), att.get());
+        setupFloatWidget(wid.get(), att.get());
         addAndMakeVisible(*wid);
     };
     att(editor->partConfigurations[part].level, level, levelAtt);

--- a/src/scxt-plugin/connectors/JsonLayoutEngineSupport.h
+++ b/src/scxt-plugin/connectors/JsonLayoutEngineSupport.h
@@ -380,7 +380,7 @@ void attachAndPosition(P *parent, const std::unique_ptr<W> &ed, const std::uniqu
         return;
     if (ctrl.binding->type == "float" || cls.controlType == "integer-knob")
     {
-        parent->setupWidgetForValueTooltip(ed.get(), att);
+        parent->setupFloatWidget(ed.get(), att);
     }
     applyTooltipPositionFromExtra(*ed, ctrl, cls);
     ed->setSource(att.get());

--- a/src/scxt-plugin/connectors/PayloadDataAttachment.h
+++ b/src/scxt-plugin/connectors/PayloadDataAttachment.h
@@ -102,6 +102,7 @@ inline void configureUpdater(A &att, const typename A::payload_t &p, app::HasEdi
                              Args... args)
 {
     att.onGuiValueChanged = makeUpdater<M, A, ABase>(att, p, e, std::forward<Args>(args)...);
+    e->wireErrorReporter(att);
 }
 
 template <typename A, typename F> inline void addGuiStepBeforeSend(A &att, F preStep)
@@ -132,6 +133,8 @@ struct PayloadDataAttachment : sst::jucegui::data::Continuous
     std::string label;
     std::function<void(const PayloadDataAttachment &at)> onGuiValueChanged{nullptr};
     std::function<bool(const PayloadDataAttachment &at)> isTemposynced{nullptr};
+    // reports a user-visible error (title, message); set by configureUpdater
+    std::function<void(const std::string &, const std::string &)> onError{nullptr};
 
     PayloadDataAttachment(const datamodel::pmd &cd,
                           std::function<void(const PayloadDataAttachment &at)> oGVC, ValueType &v)
@@ -257,6 +260,14 @@ struct PayloadDataAttachment : sst::jucegui::data::Continuous
                 setValueFromGUI(*res);
                 return;
             }
+            else
+            {
+                if (onError)
+                    onError(label + ": Invalid Value", em);
+                else
+                    SCLOG_IF(debug, em);
+                return;
+            }
         }
         if (stringToValue)
         {
@@ -353,6 +364,8 @@ struct DiscretePayloadDataAttachment : sst::jucegui::data::Discrete
     ValueType prevValue;
     std::string label;
     std::function<void(const onGui_t &at)> onGuiValueChanged;
+    // reports a user-visible error (title, message); set by configureUpdater
+    std::function<void(const std::string &, const std::string &)> onError{nullptr};
 
     DiscretePayloadDataAttachment(const datamodel::pmd &cd,
                                   std::function<void(const onGui_t &at)> oGVC, ValueType &v)
@@ -568,11 +581,11 @@ template <typename A, typename Msg, typename ABase = A> struct SingleValueFactor
         }
         else if (showTT)
         {
-            e->setupWidgetForValueTooltip(wid.get(), att.get());
+            e->setupFloatWidget(wid.get(), att.get());
         }
         else
         {
-            e->setupIntAttachedWidgetForValueMenu(wid.get(), att.get());
+            e->setupIntWidget(wid.get(), att.get());
         }
         e->addSubscription(val, att);
 


### PR DESCRIPTION
This commit adds a valueFromString error path to PayloadDataAttachment. It is a larger looking change than it appears since i renamed the setWidgetForTooltip method to the far better named setupFloatWidget.

The core changes are

1. If vfs fails we now bail out instead of continuing to default behavior
2. That bailout shows the error to the user and
3. That error message is clearer (the sst-bb change)

Closes #2444
Assisted-By: Claude Opus 4.8