### PR TITLE
Remember the browser's selected directory across editor reloads

### DIFF
--- a/src/scxt-plugin/app/browser-ui/BrowserPane.cpp
+++ b/src/scxt-plugin/app/browser-ui/BrowserPane.cpp
@@ -384,6 +384,40 @@ struct DriveFSArea : juce::Component, HasEditor
         for (auto &c : lcontents)
             contents.emplace_back(c);
         listView->refresh();
+
+        // Persist the directory so it survives editor recreation (see GH #2070)
+        editor->setTabSelection(BrowserPane::browserPathKey, currentPath.u8string());
+    }
+
+    // Restore a previously persisted directory, recovering the device root so
+    // ".." navigation stops at the right place.
+    void restoreFromSavedPath(const fs::path &p)
+    {
+        auto isAncestorOrEqual = [](const fs::path &anc, const fs::path &desc) {
+            auto a = anc.begin();
+            auto d = desc.begin();
+            for (; a != anc.end() && d != desc.end(); ++a, ++d)
+            {
+                if (*a != *d)
+                    return false;
+            }
+            return a == anc.end();
+        };
+
+        fs::path bestRoot;
+        for (const auto &r : browserPane->roots)
+        {
+            const auto &rp = std::get<0>(r);
+            if (isAncestorOrEqual(rp, p) && std::distance(rp.begin(), rp.end()) >=
+                                                std::distance(bestRoot.begin(), bestRoot.end()))
+                bestRoot = rp;
+        }
+        if (!bestRoot.empty())
+        {
+            rootPath = bestRoot;
+            currentPath = p;
+            recalcContents();
+        }
     }
 
     void resized() override
@@ -1150,6 +1184,17 @@ void BrowserPane::selectPane(int i, bool updatePrefs)
     {
         editor->setTabSelection("browser.source", std::to_string(i));
     }
+    repaint();
+}
+
+void BrowserPane::restoreSelectedPath(const std::string &u8path)
+{
+    if (u8path.empty() || !devicesPane || !devicesPane->driveFSArea)
+        return;
+    auto p = fs::path(fs::u8path(u8path));
+    if (!fs::exists(p) || !fs::is_directory(p))
+        return;
+    devicesPane->driveFSArea->restoreFromSavedPath(p);
     repaint();
 }
 

--- a/src/scxt-plugin/app/browser-ui/BrowserPane.h
+++ b/src/scxt-plugin/app/browser-ui/BrowserPane.h
@@ -67,6 +67,11 @@ struct BrowserPane : public app::HasEditor, sst::jucegui::components::NamedPanel
     void selectPane(int, bool updatePrefs = false);
     int selectedPane{0};
 
+    // Tab-selection key under which the browser's current directory is persisted
+    static constexpr const char *browserPathKey{"browser.path"};
+    // Restore the current directory from a persisted utf8 path (no-op if it doesn't exist)
+    void restoreSelectedPath(const std::string &u8path);
+
     int lastClickedPotentialSample{-1};
     float previewAmplitude{1.f};
     bool autoPreviewEnabled{true};

--- a/src/scxt-plugin/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -517,6 +517,12 @@ void SCXTEditorReceiver::onOtherTabSelection(
         auto v = std::atoi(bs.c_str());
         editor.editScreen->browser->selectPane(v);
     }
+
+    auto bp = editor.queryTabSelection(browser_ui::BrowserPane::browserPathKey);
+    if (!bp.empty() && editor.editScreen && editor.editScreen->browser)
+    {
+        editor.editScreen->browser->restoreSelectedPath(bp);
+    }
 }
 
 void SCXTEditorReceiver::onPartConfiguration(


### PR DESCRIPTION
The current browser directory is now persisted via the tab-selection mechanism, so it survives the editor being destroyed and recreated (as Bitwig and Reaper do).

Closes #2070

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>