### PR TITLE
AEG/EG1..N get temposync support

### DIFF
--- a/src/scxt-core/engine/group.cpp
+++ b/src/scxt-core/engine/group.cpp
@@ -277,7 +277,8 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
                 egiGate = getEnvSpecificGate(envGate, gegStorage[i], eg[i].stage, false);
             }
             eg[i].processBlockWithDelay(*aegp.dlyP, *aegp.aP, *aegp.hP, *aegp.dP, *aegp.sP,
-                                        *aegp.rP, *aegp.asP, *aegp.dsP, *aegp.rsP, egiGate, false);
+                                        *aegp.rP, *aegp.asP, *aegp.dsP, *aegp.rsP, egiGate, false,
+                                        gegStorage[i].isTemposync, e.transport.tempo / 120.f);
         }
     }
 

--- a/src/scxt-core/json/modulation_traits.h
+++ b/src/scxt-core/json/modulation_traits.h
@@ -120,6 +120,7 @@ SC_STREAMDEF(modulation::modulators::AdsrStorage, SC_FROM({
                  addUnlessDefault<val_t>(v, "dShape", 0.f, from.dShape);
                  addUnlessDefault<val_t>(v, "rShape", 0.f, from.rShape);
                  addUnlessDefault<val_t>(v, "groupGate", false, from.gateGroupEGOnAnyPlaying);
+                 addUnlessDefault<val_t>(v, "tsync", false, from.isTemposync);
                  addUnlessDefault<val_t>(v, "gateMode",
                                          modulation::modulators::AdsrStorage::GateMode::GATED,
                                          from.gateMode);
@@ -135,6 +136,7 @@ SC_STREAMDEF(modulation::modulators::AdsrStorage, SC_FROM({
                  findOrSet(v, "dShape", 0.f, result.dShape);
                  findOrSet(v, "rShape", 0.f, result.rShape);
                  findOrSet(v, "groupGate", false, result.gateGroupEGOnAnyPlaying);
+                 findOrSet(v, "tsync", false, result.isTemposync);
                  findOrSet(v, "gateMode", modulation::modulators::AdsrStorage::GateMode::GATED,
                            result.gateMode);
              }))

--- a/src/scxt-core/modulation/modulator_storage.h
+++ b/src/scxt-core/modulation/modulator_storage.h
@@ -71,6 +71,11 @@ struct AdsrStorage
      * Gate mode (only used by group)
      */
     bool gateGroupEGOnAnyPlaying{false};
+
+    /*
+     * Blanket temposync for the envelope times. All-or-none.
+     */
+    bool isTemposync{false};
 };
 
 using StepLFOStorage = sst::basic_blocks::modulators::StepLFO<scxt::blockSize>::Storage;
@@ -277,7 +282,10 @@ inline scxt::datamodel::pmd envelopeThirtyTwo()
 }
 
 // New way
-inline scxt::datamodel::pmd envTime() { return scxt::datamodel::pmd().as25SecondExpTime(); }
+inline scxt::datamodel::pmd envTime()
+{
+    return scxt::datamodel::pmd().as25SecondTemposyncableEnvTime();
+}
 
 SC_DESCRIBE(scxt::modulation::modulators::AdsrStorage, {
     SC_FIELD(dly, envTime().withDefault(0.f).withName("Delay"));
@@ -291,6 +299,7 @@ SC_DESCRIBE(scxt::modulation::modulators::AdsrStorage, {
     SC_FIELD(rShape, pmd().asPercentBipolar().withName("Release Shape"));
     SC_FIELD(gateGroupEGOnAnyPlaying,
              pmd().asOnOffBool().withName("Gated if ungated voices sounding"));
+    SC_FIELD(isTemposync, pmd().asOnOffBool().withName("Temposync"));
 })
 
 // We describe modulator storage as a compound since we address

--- a/src/scxt-core/voice/voice.cpp
+++ b/src/scxt-core/voice/voice.cpp
@@ -338,7 +338,9 @@ template <bool OS> bool Voice::processWithOS()
         }
         // we need the aegOS for the curve in oversample space
         aegOS.processBlockWithDelay(*aegp.dlyP, *aegp.aP, *aegp.hP, *aegp.dP, *aegp.sP, *aegp.rP,
-                                    *aegp.asP, *aegp.dsP, *aegp.rsP, aegGate, true);
+                                    *aegp.asP, *aegp.dsP, *aegp.rsP, aegGate, true,
+                                    zone->egStorage[0].isTemposync,
+                                    engine->transport.tempo / 120.f);
     }
 
     // But We need to run the undersample AEG no matter what since it is a modulation source
@@ -348,7 +350,8 @@ template <bool OS> bool Voice::processWithOS()
         aegGate = getEnvSpecificGate(envGate, zone->egStorage[0], aeg.stage, isAnyGeneratorRunning);
     }
     aeg.processBlockWithDelay(*aegp.dlyP, *aegp.aP, *aegp.hP, *aegp.dP, *aegp.sP, *aegp.rP,
-                              *aegp.asP, *aegp.dsP, *aegp.rsP, aegGate, true);
+                              *aegp.asP, *aegp.dsP, *aegp.rsP, aegGate, true,
+                              zone->egStorage[0].isTemposync, engine->transport.tempo / 120.f);
     // TODO: And output is non zero once we are past attack
     isAEGRunning = (aeg.stage != ahdsrenv_t ::s_complete);
 
@@ -370,7 +373,9 @@ template <bool OS> bool Voice::processWithOS()
             }
 
             eg[i].processBlockWithDelay(*eg2p.dlyP, *eg2p.aP, *eg2p.hP, *eg2p.dP, *eg2p.sP,
-                                        *eg2p.rP, *eg2p.asP, *eg2p.dsP, *eg2p.rsP, egiGate, false);
+                                        *eg2p.rP, *eg2p.asP, *eg2p.dsP, *eg2p.rsP, egiGate, false,
+                                        zone->egStorage[i].isTemposync,
+                                        engine->transport.tempo / 120.f);
         }
     }
     updateTransportPhasors();

--- a/src/scxt-plugin/app/edit-screen/components/AdsrPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/AdsrPane.cpp
@@ -146,6 +146,8 @@ void AdsrPane::rebuildPanelComponents(int useIdx)
     // c++ partial application is a bummer
     auto attc = [&](auto &t, auto &a, auto &w) {
         fac::attach(adsrView, t, this, a, w, forZone, useIdx);
+        if (a->description.canTemposync)
+            setAttachmentAsTemposync(*a);
         getContentAreaComponent()->addAndMakeVisible(*w);
     };
     attc(adsrView.dly, attachments.dly, sliders.dly);
@@ -184,6 +186,19 @@ void AdsrPane::rebuildPanelComponents(int useIdx)
         getContentAreaComponent()->addAndMakeVisible(*gateToggle);
     }
 
+    {
+        // blanket temposync toggle in the panel header (mirrors the LFO metronome)
+        using tsfac = connectors::BooleanSingleValueFactory<boolAttachment_t,
+                                                            cmsg::UpdateZoneOrGroupEGBoolValue>;
+        std::unique_ptr<comp::ToggleButton> tsb;
+        tsfac::attach(adsrView, adsrView.isTemposync, this, tempoSyncA, tsb, forZone, useIdx);
+        tsb->setDrawMode(comp::ToggleButton::DrawMode::GLYPH);
+        tsb->setGlyph(comp::GlyphPainter::METRONOME);
+        setupFloatWidget(tsb.get(), tempoSyncA);
+        clearAdditionalHamburgerComponents();
+        addAdditionalHamburgerComponent(std::move(tsb));
+    }
+
     if (forZone)
     {
         editor->themeApplier.applyZoneMultiScreenModulationTheme(this);
@@ -216,6 +231,7 @@ void AdsrPane::updateSustainBreakpoint()
 
 void AdsrPane::resized()
 {
+    NamedPanel::resized();
     auto r = getContentArea();
     getContentAreaComponent()->setBounds(r);
 

--- a/src/scxt-plugin/app/edit-screen/components/AdsrPane.h
+++ b/src/scxt-plugin/app/edit-screen/components/AdsrPane.h
@@ -65,6 +65,17 @@ struct AdsrPane : sst::jucegui::components::NamedPanel, HasEditor
     std::unique_ptr<sst::jucegui::components::ToggleButton> gateToggle;
     std::unique_ptr<boolAttachment_t> gateToggleA;
 
+    // blanket temposync toggle (all-or-none) shown in the panel header
+    std::unique_ptr<boolAttachment_t> tempoSyncA;
+    template <typename T> void setAttachmentAsTemposync(T &t)
+    {
+        t.setTemposyncFunction([w = juce::Component::SafePointer(this)](const auto &) {
+            if (w)
+                return w->adsrView.isTemposync;
+            return false;
+        });
+    }
+
     modulation::modulators::AdsrStorage adsrView;
     std::array<modulation::modulators::AdsrStorage, scxt::egsPerZone - 1> zoneAdsrCache;
     size_t displayedTabIndex{0};


### PR DESCRIPTION
The envelope generators (AEG, EG2..N, GEG1/2) get temposync support for stages, using the same 'all or nothing' approach that the LFO rate uses.

Most of the work is in sst-basic-blocks. Changes here are just plumbing and UI

Addresses #1570 but still need to do the in-lfo envelope and the lfo envelope mode to finish it.

Assisted-By: Claude Opus 4.8