### PR TITLE
Temposync Modulation in Percent; PMD Features in ModMatrix

### DIFF
--- a/src/scxt-core/json/datamodel_traits.h
+++ b/src/scxt-core/json/datamodel_traits.h
@@ -54,6 +54,8 @@ SC_STREAMDEF(datamodel::pmd, SC_FROM({
                       {"ab", t.canAbsolute},
                       {"enb", t.enabled},
                       {"tsm", t.temposyncMultiplier},
+                      {"tsf", (int)t.temposyncFlavor},
+                      {"tsz", t.temposyncZeroStage},
                       {"ssc", t.supportsStringConversion},
                       {"dsc", (int)t.displayScale},
                       {"unit", t.unit},
@@ -90,6 +92,8 @@ SC_STREAMDEF(datamodel::pmd, SC_FROM({
                  findIf(v, "ftr", to.features);
                  findOrSet(v, "enb", true, to.enabled);
                  findIf(v, "tsm", to.temposyncMultiplier);
+                 findEnumIf(v, "tsf", to.temposyncFlavor);
+                 findIf(v, "tsz", to.temposyncZeroStage);
                  findIf(v, "ssc", to.supportsStringConversion);
                  findEnumIf(v, "dsc", to.displayScale);
                  findEnumIf(v, "qt", to.quantization);
@@ -116,6 +120,19 @@ SC_STREAMDEF(datamodel::pmd, SC_FROM({
                  findIf(v, "asu", to.alternateScaleUnits);
                  findIf(v, "asd", to.alternateScaleIsDefaultFromString);
                  findIf(v, "asdp", to.alternateScaleDecimalPlaces);
+             }));
+
+SC_STREAMDEF(datamodel::pmd::FeatureState, SC_FROM({
+                 v = {{"hp", t.isHighPrecision}, {"ex", t.isExtended}, {"ab", t.isAbsolute},
+                      {"ts", t.isTemposynced},   {"nu", t.isNoUnits},  {"mc", t.modulationClamped}};
+             }),
+             SC_TO({
+                 findIf(v, "hp", to.isHighPrecision);
+                 findIf(v, "ex", to.isExtended);
+                 findIf(v, "ab", to.isAbsolute);
+                 findIf(v, "ts", to.isTemposynced);
+                 findIf(v, "nu", to.isNoUnits);
+                 findIf(v, "mc", to.modulationClamped);
              }));
 } // namespace scxt::json
 #endif // SHORTCIRCUIT_DATAMODEL_TRAITS_H

--- a/src/scxt-core/json/modulation_traits.h
+++ b/src/scxt-core/json/modulation_traits.h
@@ -271,12 +271,14 @@ SC_STREAMDEF(scxt::modulation::shared::SourceIdentifier,
 SC_STREAMDEF(scxt::modulation::shared::RoutingExtraPayload, SC_FROM({
                  v = {{"selC", t.selConsistent},
                       {"targetMetadata", t.targetMetadata},
-                      {"targetBaseValue", t.targetBaseValue}};
+                      {"targetBaseValue", t.targetBaseValue},
+                      {"targetFS", t.targetFeatureState}};
              }),
              SC_TO({
                  findIf(v, "selC", result.selConsistent);
                  findIf(v, "targetMetadata", result.targetMetadata);
                  findIf(v, "targetBaseValue", result.targetBaseValue);
+                 findIf(v, "targetFS", result.targetFeatureState);
              }));
 
 // Its a mild bummer we have to dup this for group and zone but they differ by trait so have

--- a/src/scxt-core/messaging/client/group_or_zone_messages.h
+++ b/src/scxt-core/messaging/client/group_or_zone_messages.h
@@ -46,12 +46,19 @@ CLIENT_TO_SERIAL_CONSTRAINED(UpdateZoneOrGroupEGFloatValue, c2s_update_zone_or_g
                              detail::updateZoneOrGroupIndexedMemberValue(&engine::Zone::egStorage,
                                                                          &engine::Group::gegStorage,
                                                                          payload, engine, cont));
-CLIENT_TO_SERIAL_CONSTRAINED(UpdateZoneOrGroupEGBoolValue, c2s_update_zone_or_group_eg_bool_value,
-                             detail::indexedZoneOrGroupDiffMsg_t<bool>,
-                             modulation::modulators::AdsrStorage,
-                             detail::updateZoneOrGroupIndexedMemberValue(&engine::Zone::egStorage,
-                                                                         &engine::Group::gegStorage,
-                                                                         payload, engine, cont));
+// Toggling temposync (a blanket bool on EG/modulator storage) changes how the affected time
+// targets display and modulate, so we restate the mod matrix metadata. The changed member's byte
+// offset rides in the diff payload (get<2>), so we only re-send on a temposync toggle.
+CLIENT_TO_SERIAL_CONSTRAINED(
+    UpdateZoneOrGroupEGBoolValue, c2s_update_zone_or_group_eg_bool_value,
+    detail::indexedZoneOrGroupDiffMsg_t<bool>, modulation::modulators::AdsrStorage,
+    detail::updateZoneOrGroupIndexedMemberValue(
+        &engine::Zone::egStorage, &engine::Group::gegStorage, payload, engine, cont,
+        [payload](const engine::Engine &eng) {
+            if (std::get<2>(payload) ==
+                (ptrdiff_t)offsetof(modulation::modulators::AdsrStorage, isTemposync))
+                eng.getSelectionManager()->sendDisplayDataForLeadSelection(std::get<0>(payload));
+        }));
 
 using fullAdsrStoragePayload_t = std::tuple<bool, int, modulation::modulators::AdsrStorage>;
 inline void doFullAdsrStorageUpdateForGroupsOrZones(const fullAdsrStoragePayload_t &payload,
@@ -123,9 +130,13 @@ CLIENT_TO_SERIAL_CONSTRAINED(
 CLIENT_TO_SERIAL_CONSTRAINED(
     UpdateZoneOrGroupModStorageBoolValue, c2s_update_zone_or_group_modstorage_bool_value,
     detail::indexedZoneOrGroupDiffMsg_t<bool>, modulation::ModulatorStorage,
-    detail::updateZoneOrGroupIndexedMemberValue(&engine::Zone::modulatorStorage,
-                                                &engine::Group::modulatorStorage, payload, engine,
-                                                cont));
+    detail::updateZoneOrGroupIndexedMemberValue(
+        &engine::Zone::modulatorStorage, &engine::Group::modulatorStorage, payload, engine, cont,
+        [payload](const engine::Engine &eng) {
+            if (std::get<2>(payload) ==
+                (ptrdiff_t)offsetof(modulation::ModulatorStorage, temposync))
+                eng.getSelectionManager()->sendDisplayDataForLeadSelection(std::get<0>(payload));
+        }));
 
 // int updates can change shape. For now lets just always assume they do
 CLIENT_TO_SERIAL_CONSTRAINED(

--- a/src/scxt-core/modulation/group_matrix.h
+++ b/src/scxt-core/modulation/group_matrix.h
@@ -97,6 +97,8 @@ struct GroupMatrix : sst::basic_blocks::mod_matrix::FixedMatrix<GroupMatrixConfi
     bool forUIMode{false};
     std::unordered_map<GroupMatrixConfig::TargetIdentifier, datamodel::pmd> activeTargetsToPMD;
     std::unordered_map<GroupMatrixConfig::TargetIdentifier, float> activeTargetsToBaseValue;
+    std::unordered_map<GroupMatrixConfig::TargetIdentifier, datamodel::pmd::FeatureState>
+        activeTargetsToFeatureState;
 };
 
 struct GroupMatrixEndpoints

--- a/src/scxt-core/modulation/matrix_shared.h
+++ b/src/scxt-core/modulation/matrix_shared.h
@@ -93,7 +93,8 @@ struct RoutingExtraPayload
 {
     bool selConsistent{false};
     datamodel::pmd targetMetadata;
-    float targetBaseValue; // only valid on UI thread
+    float targetBaseValue;                           // only valid on UI thread
+    datamodel::pmd::FeatureState targetFeatureState; // runtime feature state of target (UI thread)
 };
 
 inline std::string u2s(uint32_t u)
@@ -247,15 +248,17 @@ template <typename TG, uint32_t gn> struct ProcessorTargetEndpointData
 template <typename Matrix, typename P>
 void bindEl(Matrix &m, const P &payload, typename Matrix::TR::TargetIdentifier &tg,
             float &baseValue, const float *&p,
-            std::optional<datamodel::pmd> providedMetadata = std::nullopt)
+            std::optional<datamodel::pmd> providedMetadata = std::nullopt,
+            std::optional<datamodel::pmd::FeatureState> featureState = std::nullopt)
 {
-    bindEl(m, payload, tg, baseValue, baseValue, p, providedMetadata);
+    bindEl(m, payload, tg, baseValue, baseValue, p, providedMetadata, featureState);
 }
 
 template <typename Matrix, typename P>
 void bindEl(Matrix &m, const P &payload, typename Matrix::TR::TargetIdentifier &tg,
             float &baseValue, float &unmodulatedBase, const float *&p,
-            std::optional<datamodel::pmd> providedMetadata = std::nullopt)
+            std::optional<datamodel::pmd> providedMetadata = std::nullopt,
+            std::optional<datamodel::pmd::FeatureState> featureState = std::nullopt)
 {
     assert(tg.gid != 0); // hit this? You forgot to init your target ctor
     assert(tg.tid != 0);
@@ -273,6 +276,7 @@ void bindEl(Matrix &m, const P &payload, typename Matrix::TR::TargetIdentifier &
         }
         m.activeTargetsToPMD[tg] = tmd;
         m.activeTargetsToBaseValue[tg] = baseValue;
+        m.activeTargetsToFeatureState[tg] = featureState.value_or(datamodel::pmd::FeatureState{});
         return;
     }
 
@@ -345,12 +349,13 @@ template <typename TG, uint32_t gn>
 template <typename M, typename EG>
 inline void EGTargetEndpointData<TG, gn>::baseBind(M &m, EG &eg)
 {
-    bindEl(m, eg, dlyT, eg.dly, dlyP);
-    bindEl(m, eg, aT, eg.a, aP);
-    bindEl(m, eg, hT, eg.h, hP);
-    bindEl(m, eg, dT, eg.d, dP);
+    auto fs = datamodel::pmd::FeatureState{}.withTemposync(eg.isTemposync);
+    bindEl(m, eg, dlyT, eg.dly, dlyP, std::nullopt, fs);
+    bindEl(m, eg, aT, eg.a, aP, std::nullopt, fs);
+    bindEl(m, eg, hT, eg.h, hP, std::nullopt, fs);
+    bindEl(m, eg, dT, eg.d, dP, std::nullopt, fs);
     bindEl(m, eg, sT, eg.s, sP);
-    bindEl(m, eg, rT, eg.r, rP);
+    bindEl(m, eg, rT, eg.r, rP, std::nullopt, fs);
     bindEl(m, eg, asT, eg.aShape, asP);
     bindEl(m, eg, dsT, eg.dShape, dsP);
     bindEl(m, eg, rsT, eg.rShape, rsP);
@@ -363,26 +368,27 @@ template <typename M, typename Z>
 inline void LFOTargetEndpointData<TG, gn>::baseBind(M &m, Z &z)
 {
     auto &ms = z.modulatorStorage[index];
+    auto fs = datamodel::pmd::FeatureState{}.withTemposync(ms.temposync);
 
-    bindEl(m, ms, rateT, ms.rate, rateP);
+    bindEl(m, ms, rateT, ms.rate, rateP, std::nullopt, fs);
     bindEl(m, ms, amplitudeT, ms.amplitude, amplitudeP);
     bindEl(m, ms, retriggerT, zeroBase, retriggerP,
            datamodel::pmd().withName("Retrigger").asPercent());
 
     bindEl(m, ms, curve.deformT, ms.curveLfoStorage.deform, curve.deformP);
     bindEl(m, ms, curve.angleT, ms.curveLfoStorage.angle, curve.angleP);
-    bindEl(m, ms, curve.delayT, ms.curveLfoStorage.delay, curve.delayP);
-    bindEl(m, ms, curve.attackT, ms.curveLfoStorage.attack, curve.attackP);
-    bindEl(m, ms, curve.releaseT, ms.curveLfoStorage.release, curve.releaseP);
+    bindEl(m, ms, curve.delayT, ms.curveLfoStorage.delay, curve.delayP, std::nullopt, fs);
+    bindEl(m, ms, curve.attackT, ms.curveLfoStorage.attack, curve.attackP, std::nullopt, fs);
+    bindEl(m, ms, curve.releaseT, ms.curveLfoStorage.release, curve.releaseP, std::nullopt, fs);
 
     bindEl(m, ms, step.smoothT, ms.stepLfoStorage.smooth, step.smoothP);
 
-    bindEl(m, ms, env.delayT, ms.envLfoStorage.delay, env.delayP);
-    bindEl(m, ms, env.attackT, ms.envLfoStorage.attack, env.attackP);
-    bindEl(m, ms, env.holdT, ms.envLfoStorage.hold, env.holdP);
-    bindEl(m, ms, env.decayT, ms.envLfoStorage.decay, env.decayP);
+    bindEl(m, ms, env.delayT, ms.envLfoStorage.delay, env.delayP, std::nullopt, fs);
+    bindEl(m, ms, env.attackT, ms.envLfoStorage.attack, env.attackP, std::nullopt, fs);
+    bindEl(m, ms, env.holdT, ms.envLfoStorage.hold, env.holdP, std::nullopt, fs);
+    bindEl(m, ms, env.decayT, ms.envLfoStorage.decay, env.decayP, std::nullopt, fs);
     bindEl(m, ms, env.sustainT, ms.envLfoStorage.sustain, env.sustainP);
-    bindEl(m, ms, env.releaseT, ms.envLfoStorage.release, env.releaseP);
+    bindEl(m, ms, env.releaseT, ms.envLfoStorage.release, env.releaseP, std::nullopt, fs);
     bindEl(m, ms, env.aShapeT, ms.envLfoStorage.aShape, env.aShapeP);
     bindEl(m, ms, env.dShapeT, ms.envLfoStorage.dShape, env.dShapeP);
     bindEl(m, ms, env.rShapeT, ms.envLfoStorage.rShape, env.rShapeP);

--- a/src/scxt-core/modulation/voice_matrix.h
+++ b/src/scxt-core/modulation/voice_matrix.h
@@ -104,6 +104,8 @@ struct Matrix : sst::basic_blocks::mod_matrix::FixedMatrix<MatrixConfig>
     bool forUIMode{false};
     std::unordered_map<MatrixConfig::TargetIdentifier, datamodel::pmd> activeTargetsToPMD;
     std::unordered_map<MatrixConfig::TargetIdentifier, float> activeTargetsToBaseValue;
+    std::unordered_map<MatrixConfig::TargetIdentifier, datamodel::pmd::FeatureState>
+        activeTargetsToFeatureState;
 };
 
 struct MatrixEndpoints

--- a/src/scxt-core/selection/selection_manager.cpp
+++ b/src/scxt-core/selection/selection_manager.cpp
@@ -774,6 +774,22 @@ void SelectionManager::sendDisplayDataForGroupsBasedOnLead(int part, int group)
                               *(engine.getMessageController()));
 }
 
+void SelectionManager::sendDisplayDataForLeadSelection(bool forZone)
+{
+    if (forZone)
+    {
+        auto lz = currentLeadZone(engine);
+        if (lz.has_value())
+            sendDisplayDataForZonesBasedOnLead(lz->part, lz->group, lz->zone);
+    }
+    else
+    {
+        auto lg = currentLeadGroup(engine);
+        if (lg.has_value())
+            sendDisplayDataForGroupsBasedOnLead(lg->part, lg->group);
+    }
+}
+
 void SelectionManager::sendDisplayDataForNoGroupSelected()
 {
     SCLOG_WFUNC_IF(selection, "");
@@ -883,6 +899,7 @@ void SelectionManager::configureMatrixInternal(bool forZone, Mat &mat, RT &rt)
             {
                 r.extraPayload->targetMetadata = mat.activeTargetsToPMD.at(*r.target);
                 r.extraPayload->targetBaseValue = mat.activeTargetsToBaseValue.at(*r.target);
+                r.extraPayload->targetFeatureState = mat.activeTargetsToFeatureState.at(*r.target);
             }
         }
         else

--- a/src/scxt-core/selection/selection_manager.h
+++ b/src/scxt-core/selection/selection_manager.h
@@ -213,6 +213,8 @@ struct SelectionManager
     void sendDisplayDataForNoZoneSelected();
     void sendDisplayDataForGroupsBasedOnLead(int part, int group);
     void sendDisplayDataForNoGroupSelected();
+    // Re-send display data (and so reconfigure mod matrix metadata) for the lead zone or group.
+    void sendDisplayDataForLeadSelection(bool forZone);
     void sendSelectedPartMacrosToClient();
     void sendOtherTabsSelectionToClient();
     void configureAndSendZoneOrGroupModMatrixMetadata(int p, int g, int z);

--- a/src/scxt-plugin/app/edit-screen/components/ModPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/ModPane.cpp
@@ -410,8 +410,9 @@ template <typename GZTrait> struct ModRow : juce::Component, HasEditor, juce::Dr
         datamodel::pmd &md = ep.targetMetadata;
 
         bool isSourceBipolar{false}; // fixme - we shoudl determine this one day
-        auto v = md.modulationNaturalToString(ep.targetBaseValue,
-                                              at.value * (md.maxVal - md.minVal), isSourceBipolar);
+        auto v =
+            md.modulationNaturalToString(ep.targetBaseValue, at.value * (md.maxVal - md.minVal),
+                                         isSourceBipolar, ep.targetFeatureState);
 
         auto rDepth = jcmp::ToolTip::Row();
         auto rDelta = jcmp::ToolTip::Row();
@@ -830,7 +831,8 @@ template <typename GZTrait> struct ModRow : juce::Component, HasEditor, juce::Dr
             auto md = ep->targetMetadata;
 
             auto v = md.modulationNaturalToString(
-                ep->targetBaseValue, row->depthAttachment->value * (md.maxVal - md.minVal), false);
+                ep->targetBaseValue, row->depthAttachment->value * (md.maxVal - md.minVal), false,
+                ep->targetFeatureState);
 
             return v->value;
         }
@@ -843,7 +845,8 @@ template <typename GZTrait> struct ModRow : juce::Component, HasEditor, juce::Dr
             auto md = ep->targetMetadata;
 
             std::string emsg;
-            auto v = md.modulationNaturalFromString(s, ep->targetBaseValue, emsg);
+            auto v = md.modulationNaturalFromString(s, ep->targetBaseValue, emsg,
+                                                    ep->targetFeatureState);
 
             if (!v.has_value())
             {


### PR DESCRIPTION
The reason for this commit is to make modulation of temposynced envelope stages show up in percentages as opposed to miliseconds which is a really easy change to basic blocks, and then just requires the Mod Row know the target is temposynced.

That "just" though is some lifting. There were a few ways to do this but the most general is to have a pmd::FeatureState optionally transmitted to the row UI and used, which is what we do here, making the change look bigger than it is. Its mostly just transmitting an extra strctureu.

The other change though is toggling temposync has to reset the mod matrix display, so we need a post-temposync-set handler to reblast the selection information. That's the other change

So tiny functional change, but 2 mid sized architectural additions.

Closes #2506
Assisted-By: Claude Opus 4.8