### PR TITLE
Implement ZoneLock for mouse drags

### DIFF
--- a/src/scxt-plugin/app/edit-screen/components/MacroMappingVariantPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/MacroMappingVariantPane.cpp
@@ -163,6 +163,11 @@ void MacroMappingVariantPane::setGroupZoneMappingSummary(
     mappingDisplay->setGroupZoneMappingSummary(d);
 }
 
+void MacroMappingVariantPane::setMappingLockFromModel(bool b)
+{
+    mappingDisplay->zoneHeader->lockButton->setValueFromModel(b);
+}
+
 void MacroMappingVariantPane::editorSelectionChanged()
 {
     if (editor->currentLeadZoneSelection.has_value())
@@ -202,7 +207,7 @@ void MacroMappingVariantPane::macroDataChanged(int part, int index)
     macroDisplay->macroDataChanged(part, index);
 }
 
-MappingZoneHeader::MappingZoneHeader(scxt::ui::app::SCXTEditor *ed) : HasEditor(ed)
+MappingZoneHeader::MappingZoneHeader(MappingDisplay *d) : HasEditor(d->editor)
 {
     autoMap = std::make_unique<sst::jucegui::components::TextPushButton>();
     autoMap->setLabel("AUTO-MAP");
@@ -245,12 +250,18 @@ MappingZoneHeader::MappingZoneHeader(scxt::ui::app::SCXTEditor *ed) : HasEditor(
         zoneSolo->setLabel("ZONE SOLO");
         zoneSolo->setOnCallback(editor->makeComingSoon());
         addAndMakeVisible(*zoneSolo);
-
-        lockButton = std::make_unique<sst::jucegui::components::GlyphButton>(
-            sst::jucegui::components::GlyphPainter::GlyphType::LOCK);
-        lockButton->setOnCallback(editor->makeComingSoon());
-        addAndMakeVisible(*lockButton);
     }
+
+    lockButton = std::make_unique<sst::jucegui::component_adapters::DiscreteToValueReference<
+        sst::jucegui::components::ToggleButton, bool>>(d->mappingLocked);
+    lockButton->widget->setGlyph(sst::jucegui::components::GlyphPainter::GlyphType::LOCK);
+    lockButton->widget->setDrawMode(
+        sst::jucegui::components::ToggleButton::DrawMode::GLYPH_WITH_BG);
+    lockButton->onValueChanged = [w = juce::Component::SafePointer(this)](bool v) {
+        if (w)
+            w->editor->setTabSelection("mapping.lock", v ? "1" : "0");
+    };
+    addAndMakeVisible(*(lockButton->widget));
 
     fileLabel = std::make_unique<sst::jucegui::components::Label>();
     fileLabel->setText("FILE");

--- a/src/scxt-plugin/app/edit-screen/components/MacroMappingVariantPane.h
+++ b/src/scxt-plugin/app/edit-screen/components/MacroMappingVariantPane.h
@@ -56,6 +56,9 @@ struct MacroMappingVariantPane : sst::jucegui::components::NamedPanel, HasEditor
     void setActive(bool b);
     void setSelectedTab(int i);
 
+    // Restore the mapping-grid lock toggle from the persisted tab selection
+    void setMappingLockFromModel(bool b);
+
     std::unique_ptr<MappingDisplay> mappingDisplay;
     std::unique_ptr<VariantDisplay> sampleDisplay;
     std::unique_ptr<MacroDisplay> macroDisplay;

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
@@ -52,7 +52,7 @@ MappingDisplay::MappingDisplay(MacroMappingVariantPane *p)
     zoneLayoutViewport->setVZoomFloor(32.f / 128.f);
     addAndMakeVisible(*zoneLayoutViewport);
 
-    zoneHeader = std::make_unique<MappingZoneHeader>(editor);
+    zoneHeader = std::make_unique<MappingZoneHeader>(this);
     addAndMakeVisible(*zoneHeader);
 
     using ffac =

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.h
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.h
@@ -37,7 +37,9 @@
 #include "sst/jucegui/components/GlyphButton.h"
 #include "sst/jucegui/components/MenuButton.h"
 #include "sst/jucegui/components/TickSeparatorLabel.h"
+#include "sst/jucegui/components/ToggleButton.h"
 #include "sst/jucegui/components/ZoomContainer.h"
+#include "sst/jucegui/component-adapters/DiscreteToReference.h"
 #include "engine/part.h"
 #include "engine/engine.h"
 #include "selection/selection_manager.h"
@@ -51,17 +53,20 @@ namespace scxt::ui::app::edit_screen
 
 struct ZoneLayoutDisplay;
 struct ZoneLayoutKeyboard;
+struct MappingDisplay;
 
 struct MappingZoneHeader : HasEditor, juce::Component
 {
     std::unique_ptr<sst::jucegui::components::TextPushButton> autoMap, fixOverlap, fadeOverlap,
         zoneSolo;
-    std::unique_ptr<sst::jucegui::components::GlyphButton> midiButton, midiLRButton, midiUDButton,
+    std::unique_ptr<sst::jucegui::components::GlyphButton> midiButton, midiLRButton, midiUDButton;
+    std::unique_ptr<sst::jucegui::component_adapters::DiscreteToValueReference<
+        sst::jucegui::components::ToggleButton, bool>>
         lockButton;
     std::unique_ptr<sst::jucegui::components::Label> fileLabel;
     std::unique_ptr<sst::jucegui::components::MenuButton> fileMenu;
 
-    MappingZoneHeader(SCXTEditor *ed);
+    MappingZoneHeader(MappingDisplay *d);
 
     void initiateMidiZoneAction(engine::Engine::MidiZoneAction);
 
@@ -78,8 +83,8 @@ struct MappingZoneHeader : HasEditor, juce::Component
             fixOverlap->setBounds(b.withTrimmedLeft(181).withWidth(85));
             fadeOverlap->setBounds(b.withTrimmedLeft(181 + 87).withWidth(85));
             zoneSolo->setBounds(b.withTrimmedLeft(181 + 2 * 87).withWidth(85));
-            lockButton->setBounds(b.withTrimmedLeft(181 + 3 * 87).withWidth(16));
         }
+        lockButton->widget->setBounds(b.withTrimmedLeft(181 + 3 * 87).withWidth(16));
         fileLabel->setBounds(b.withTrimmedLeft(181 + 3 * 87 + 20).withWidth(40));
         fileMenu->setBounds(b.withTrimmedLeft(500));
     }
@@ -122,6 +127,9 @@ struct MappingDisplay : juce::Component,
     bool isResizingZones{false};
 
     bool mayBeAboutToMutate{false};
+
+    // When set, drags in the zone grid select only; they don't move or resize zones
+    bool mappingLocked{false};
 
     std::unique_ptr<MappingZoneHeader> zoneHeader;
 

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
@@ -486,6 +486,59 @@ template <typename MAP> void constrainMappingFade(MAP &kr, bool startChanged)
     }
 }
 
+void ZoneLayoutDisplay::mouseMove(const juce::MouseEvent &e)
+{
+    // When locked we don't drag-edit zones, so don't advertise the resize/move cursors
+    if (display->mappingLocked)
+    {
+        setMouseCursor(juce::MouseCursor::NormalCursor);
+        return;
+    }
+
+    for (const auto &h : keyboardHotZones)
+    {
+        if (h.contains(e.position))
+        {
+            setMouseCursor(juce::MouseCursor::LeftRightResizeCursor);
+            return;
+        }
+    }
+    for (const auto &h : velocityHotZones)
+    {
+        if (h.contains(e.position))
+        {
+            setMouseCursor(juce::MouseCursor::UpDownResizeCursor);
+            return;
+        }
+    }
+    auto hzCOrder = std::vector({juce::MouseCursor::TopLeftCornerResizeCursor,
+                                 juce::MouseCursor::TopRightCornerResizeCursor,
+                                 juce::MouseCursor::BottomRightCornerResizeCursor,
+                                 juce::MouseCursor::BottomLeftCornerResizeCursor});
+
+    int idx{0};
+    for (const auto &h : bothHotZones)
+    {
+        if (h.contains(e.position))
+        {
+            setMouseCursor(hzCOrder[idx]);
+            return;
+        }
+        idx++;
+    }
+
+    if (cacheLastZone.has_value())
+    {
+        auto r = rectangleForZone(*cacheLastZone);
+        if (r.contains(e.position))
+        {
+            setMouseCursor(juce::MouseCursor::DraggingHandCursor);
+            return;
+        }
+    }
+    setMouseCursor(juce::MouseCursor::NormalCursor);
+}
+
 void ZoneLayoutDisplay::mouseDrag(const juce::MouseEvent &e)
 {
     if (e.getDistanceFromDragStart() <= 1)
@@ -504,7 +557,7 @@ void ZoneLayoutDisplay::mouseDrag(const juce::MouseEvent &e)
     auto deltaX = (int)(dx / kw);
     auto deltaY = (int)(dy / vh);
 
-    if (mouseState == DRAG_SELECTED_ZONE)
+    if (mouseState == DRAG_SELECTED_ZONE && !display->mappingLocked)
     {
         if (e.getDistanceFromDragStart() <= 2)
         {
@@ -524,7 +577,7 @@ void ZoneLayoutDisplay::mouseDrag(const juce::MouseEvent &e)
         }
     }
 
-    if (mouseState == DRAG_VELOCITY)
+    if (mouseState == DRAG_VELOCITY && !display->mappingLocked)
     {
         auto dd = engine::Zone::ChangeDimension::VEL_RANGE_END;
         if (dragFrom[1] == FROM_START)
@@ -542,7 +595,7 @@ void ZoneLayoutDisplay::mouseDrag(const juce::MouseEvent &e)
         }
     }
 
-    if (mouseState == DRAG_KEY)
+    if (mouseState == DRAG_KEY && !display->mappingLocked)
     {
         auto dd = engine::Zone::ChangeDimension::KEY_RANGE_END;
         if (dragFrom[0] == FROM_START)
@@ -560,7 +613,7 @@ void ZoneLayoutDisplay::mouseDrag(const juce::MouseEvent &e)
         }
     }
 
-    if (mouseState == DRAG_KEY_AND_VEL)
+    if (mouseState == DRAG_KEY_AND_VEL && !display->mappingLocked)
     {
         int dd = engine::Zone::ChangeDimension::VEL_RANGE_END;
         if (dragFrom[1] == FROM_START)

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.h
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.h
@@ -67,51 +67,7 @@ struct ZoneLayoutDisplay : juce::Component, HasEditor
     void mouseDown(const juce::MouseEvent &e) override;
     void mouseUp(const juce::MouseEvent &e) override;
     void mouseDrag(const juce::MouseEvent &e) override;
-    void mouseMove(const juce::MouseEvent &e) override
-    {
-        for (const auto &h : keyboardHotZones)
-        {
-            if (h.contains(e.position))
-            {
-                setMouseCursor(juce::MouseCursor::LeftRightResizeCursor);
-                return;
-            }
-        }
-        for (const auto &h : velocityHotZones)
-        {
-            if (h.contains(e.position))
-            {
-                setMouseCursor(juce::MouseCursor::UpDownResizeCursor);
-                return;
-            }
-        }
-        auto hzCOrder = std::vector({juce::MouseCursor::TopLeftCornerResizeCursor,
-                                     juce::MouseCursor::TopRightCornerResizeCursor,
-                                     juce::MouseCursor::BottomRightCornerResizeCursor,
-                                     juce::MouseCursor::BottomLeftCornerResizeCursor});
-
-        int idx{0};
-        for (const auto &h : bothHotZones)
-        {
-            if (h.contains(e.position))
-            {
-                setMouseCursor(hzCOrder[idx]);
-                return;
-            }
-            idx++;
-        }
-
-        if (cacheLastZone.has_value())
-        {
-            auto r = rectangleForZone(*cacheLastZone);
-            if (r.contains(e.position))
-            {
-                setMouseCursor(juce::MouseCursor::DraggingHandCursor);
-                return;
-            }
-        }
-        setMouseCursor(juce::MouseCursor::NormalCursor);
-    }
+    void mouseMove(const juce::MouseEvent &e) override;
     void mouseDoubleClick(const juce::MouseEvent &e) override;
     void createEmptyZoneAt(const juce::Point<int> &);
 

--- a/src/scxt-plugin/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -523,6 +523,12 @@ void SCXTEditorReceiver::onOtherTabSelection(
     {
         editor.editScreen->browser->restoreSelectedPath(bp);
     }
+
+    auto ml = editor.queryTabSelection("mapping.lock");
+    if (!ml.empty() && editor.editScreen && editor.editScreen->mappingPane)
+    {
+        editor.editScreen->mappingPane->setMappingLockFromModel(std::atoi(ml.c_str()) != 0);
+    }
 }
 
 void SCXTEditorReceiver::onPartConfiguration(


### PR DESCRIPTION
- Implement zone lock button
- Lock button means in-region drags do nothing to edit, but zone creation, selection, and edit-in-typeins still all work
- Lock state is stored in the tab selection mechanism so survivse open and close browser etc...

Closes #2250
Assisted-By: Claude Opus 4.8