### PR TITLE
Implement Heirarchical Poly Groups

### DIFF
--- a/src/scxt-core/engine/engine.cpp
+++ b/src/scxt-core/engine/engine.cpp
@@ -428,12 +428,15 @@ bool Engine::processAudio()
                      ((pav != 0) && sendSamplePosition &&
                       (lastUpdateVoiceDisplayState >= updateVoiceDisplayStateEvery)) ||
                      // Midi has arrived
-                     (midiNoteStateCounter != lastMidiNoteStateCounter));
+                     (midiNoteStateCounter != lastMidiNoteStateCounter) ||
+                     // a voice was created since the last write (e.g. a steal that left the
+                     // total unchanged but moved a voice between zones)
+                     (nextVoiceCreationId != lastVoiceDisplayCreationId));
     if (doUpdate)
     {
-        forceVoiceUpdate = false;
         lastUpdateVoiceDisplayState = 0;
         lastMidiNoteStateCounter = midiNoteStateCounter;
+        lastVoiceDisplayCreationId = nextVoiceCreationId;
 
         int i{0};
         for (const auto *v : voices)
@@ -460,6 +463,8 @@ bool Engine::processAudio()
         }
         sharedUIMemoryState.voiceCount = pav;
         sharedUIMemoryState.voiceDisplayStateWriteCounter++;
+        sharedUIMemoryState.forceCount += forceVoiceUpdate;
+        forceVoiceUpdate = false;
     }
     lastUpdateVoiceDisplayState++;
 
@@ -1648,6 +1653,11 @@ void Engine::onPartConfigurationUpdated()
 
         voiceManager.setPolyphonyGroupVoiceLimit((uint64_t)p.get(),
                                                  p->configuration.polyLimitVoices);
+
+        // The part limit changing (gained or lost) flips whether its groups parent under
+        // it, so re-bind each group's polyphony group to the part (or detach to root).
+        for (auto &g : *p)
+            g->updatePolyphonyGroupParent(*this);
     }
 
     voiceManager.dialect = midiM;

--- a/src/scxt-core/engine/engine.h
+++ b/src/scxt-core/engine/engine.h
@@ -503,6 +503,7 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
         };
         std::atomic<int32_t> voiceCount;
         std::array<VoiceDisplayStateItem, maxVoices> voiceDisplayItems;
+        std::atomic<uint32_t> forceCount{0};
 
         struct TransportDisplayState
         {
@@ -566,6 +567,10 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     int32_t updateVoiceDisplayStateEvery{10000000};
     int32_t lastUpdateVoiceDisplayState{0};
     int64_t midiNoteStateCounter{0}, lastMidiNoteStateCounter{0};
+    // A steal terminates one voice and creates another, so activeVoices can be unchanged
+    // across a block while the per-zone distribution shifts. Track the creation counter so
+    // the display refreshes whenever a voice was created since the last write.
+    uint64_t lastVoiceDisplayCreationId{0};
     bool forceVoiceUpdate{false};
     bool sendSamplePosition{true};
 

--- a/src/scxt-core/engine/group.cpp
+++ b/src/scxt-core/engine/group.cpp
@@ -942,6 +942,20 @@ void Group::resetPolyAndPlaymode(engine::Engine &e)
         e.voiceManager.setPlaymode(pgrp, Engine::voiceManager_t::PlayMode::MONO_NOTES, features);
         e.voiceManager.setMonoPriorityMode(pgrp, mpm);
     }
+
+    updatePolyphonyGroupParent(e);
+}
+
+void Group::updatePolyphonyGroupParent(engine::Engine &e)
+{
+    if (!parentPart)
+        return;
+
+    auto pgrp = (uint64_t)this;
+    auto parentPoly = parentPart->configuration.polyLimitVoices
+                          ? (uint64_t)parentPart
+                          : Engine::voiceManager_t::noPolyphonyGroupParent;
+    e.voiceManager.setPolyphonyGroupParent(pgrp, parentPoly);
 }
 
 std::string Group::toStringGlideRateMode(const GlideRateMode &m)

--- a/src/scxt-core/engine/group.h
+++ b/src/scxt-core/engine/group.h
@@ -218,6 +218,9 @@ struct Group : MoveableOnly<Group>,
     void onSampleRateChanged() override;
 
     void resetPolyAndPlaymode(engine::Engine &);
+    // Bind this group's polyphony group under the part's (so per-group voices also count
+    // against the part limit), or detach it to root when the part is unlimited.
+    void updatePolyphonyGroupParent(engine::Engine &);
 
     /*
      * Only call this if you have *already* checked the part containing

--- a/src/scxt-core/engine/part.cpp
+++ b/src/scxt-core/engine/part.cpp
@@ -252,6 +252,9 @@ size_t Part::addGroup()
 
     g->name = cn;
 
+    // A fresh group inherits whether the part has a limit, so parent its polyphony group now.
+    g->updatePolyphonyGroupParent(*parentPatch->parentEngine);
+
     groups.push_back(std::move(g));
     return groups.size();
 }

--- a/src/scxt-core/voice/voice.cpp
+++ b/src/scxt-core/voice/voice.cpp
@@ -940,7 +940,7 @@ template <bool OS> bool Voice::processWithOS()
     if (terminationSequence == 0)
     {
         SCLOG_IF(voiceLifecycle, "Voice terminating due to termiantion sequence " << SCD(key));
-
+        engine->forceVoiceUpdate = true;
         isVoicePlaying = false;
     }
 

--- a/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
@@ -260,9 +260,11 @@ void SCXTEditor::idle()
     if (sharedUiMemoryState.voiceDisplayStateWriteCounter != lastVoiceDisplayWriteCounter)
     {
         lastVoiceDisplayWriteCounter = sharedUiMemoryState.voiceDisplayStateWriteCounter;
-        if (headerRegion->voiceCount != sharedUiMemoryState.voiceCount)
+        if ((headerRegion->voiceCount != sharedUiMemoryState.voiceCount) ||
+            (sharedUiMemoryState.forceCount != headerRegion->forceCount))
         {
             headerRegion->setVoiceCount(sharedUiMemoryState.voiceCount);
+            headerRegion->forceCount = sharedUiMemoryState.forceCount;
 
             if (editScreen->isVisible())
             {

--- a/src/scxt-plugin/app/shared/HeaderRegion.h
+++ b/src/scxt-plugin/app/shared/HeaderRegion.h
@@ -69,6 +69,7 @@ struct HeaderRegion : juce::Component, HasEditor, juce::FileDragAndDropTarget
     void mouseDown(const juce::MouseEvent &) override;
 
     uint32_t voiceCount{0};
+    uint32_t forceCount{0};
     void setVoiceCount(uint32_t vc)
     {
         if (vc != voiceCount)


### PR DESCRIPTION
The voice manager now has infinitely hierarchical polyphony groups which we use in SCXT to make sure groups also obey their parent part polyphony with appropriate stealing.

Closes #2511
Assisted-By: Claude Opus 4.8