### PR TITLE
Fix clap note fallthrough

### DIFF
--- a/src/scxt-core/engine/macros.h
+++ b/src/scxt-core/engine/macros.h
@@ -128,8 +128,11 @@ struct Macro
                   "If you hit this you need to figure out what to do with those higher macros");
     static bool isMacroID(uint32_t id)
     {
-        return id >= firstMacroParam &&
-               id < firstMacroParam + macroParamPartStride * (scxt::numParts + 1);
+        if (id < firstMacroParam)
+            return false;
+        auto off = id - firstMacroParam;
+        return (off / macroParamPartStride) < scxt::numParts &&
+               (off % macroParamPartStride) < scxt::macrosPerPart;
     }
     static int macroIDToPart(uint32_t id) { return (id - firstMacroParam) / macroParamPartStride; }
     static int macroIDToIndex(uint32_t id) { return (id - firstMacroParam) % macroParamPartStride; }

--- a/src/scxt-plugin/clap/scxt-plugin.cpp
+++ b/src/scxt-plugin/clap/scxt-plugin.cpp
@@ -437,6 +437,7 @@ bool SCXTPlugin::handleEvent(const clap_event_header_t *nextEvent)
             engine->processNoteOffEvent(nevt->port_index, nevt->channel, nevt->key, nevt->note_id,
                                         nevt->velocity);
         }
+        break;
 
         case CLAP_EVENT_PARAM_VALUE:
         {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(scxt-test
 		undo_tests.cpp
 		importer_tests.cpp
 		midi_channel_tests.cpp
+		macro_id_tests.cpp
 )
 
 target_compile_definitions(scxt-test PRIVATE

--- a/tests/macro_id_tests.cpp
+++ b/tests/macro_id_tests.cpp
@@ -1,0 +1,65 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "catch2/catch2.hpp"
+
+#include "engine/macros.h"
+
+using mac = scxt::engine::Macro;
+
+TEST_CASE("Macro CLAP Param IDs", "[macros]")
+{
+    SECTION("Valid IDs round trip")
+    {
+        for (uint32_t p = 0; p < scxt::numParts; ++p)
+        {
+            for (uint32_t m = 0; m < scxt::macrosPerPart; ++m)
+            {
+                auto id = mac::partIndexToMacroID(p, m);
+                REQUIRE(mac::isMacroID(id));
+                REQUIRE(mac::macroIDToPart(id) == (int)p);
+                REQUIRE(mac::macroIDToIndex(id) == (int)m);
+            }
+        }
+    }
+
+    SECTION("Out of range IDs are rejected")
+    {
+        REQUIRE_FALSE(mac::isMacroID(0));
+        REQUIRE_FALSE(mac::isMacroID(mac::firstMacroParam - 1));
+
+        // index past macrosPerPart within an otherwise valid part stride
+        REQUIRE_FALSE(mac::isMacroID(mac::partIndexToMacroID(0, scxt::macrosPerPart)));
+        REQUIRE_FALSE(mac::isMacroID(mac::partIndexToMacroID(3, mac::macroParamPartStride - 1)));
+
+        // part at and past numParts
+        REQUIRE_FALSE(mac::isMacroID(mac::partIndexToMacroID(scxt::numParts, 0)));
+        REQUIRE_FALSE(mac::isMacroID(mac::partIndexToMacroID(scxt::numParts + 1, 0)));
+
+        REQUIRE_FALSE(mac::isMacroID(0xFFFFFFFF));
+    }
+}


### PR DESCRIPTION
Clap note off fell through to clap param. Fix that but also that made it clear the guard which left it mostly harmless was also incorrect so fix that.

Aassisted-By: Claude Fable 5