### PR TITLE
Make patch save/load error paths recover cleanly

### DIFF
--- a/src/scxt-core/messaging/client/enginestatus_messages.h
+++ b/src/scxt-core/messaging/client/enginestatus_messages.h
@@ -56,36 +56,38 @@ inline void doUnstreamEngineState(const unstreamEngineStatePayload_t &payload,
     if (cont.isAudioRunning)
     {
         cont.stopAudioThreadThenRunOnSerial([payload, &nonconste = engine](auto &e) {
+            auto &cont = *e.getMessageController();
             try
             {
                 nonconste.immediatelyTerminateAllVoices();
                 scxt::json::unstreamEngineState(nonconste, payload);
-                auto &cont = *e.getMessageController();
-                cont.restartAudioThreadFromSerial();
-                cont.sendStreamCompleteNotification();
             }
             catch (std::exception &err)
             {
                 RAISE_ERROR_ENGINE(nonconste, "Unstreaming Error",
                                    std::string("Unable to unstream engine state ") + err.what());
             }
+            // Restart then notify on every path: a failed unstream must neither
+            // wedge audio nor hang a setState waiter.
+            cont.restartAudioThreadFromSerial();
+            cont.sendStreamCompleteNotification();
         });
     }
     else
     {
+        engine.stopEngineRequests++;
         try
         {
-            engine.stopEngineRequests++;
             engine.immediatelyTerminateAllVoices();
             scxt::json::unstreamEngineState(engine, payload);
-            engine.stopEngineRequests--;
-            cont.sendStreamCompleteNotification();
         }
         catch (std::exception &err)
         {
             RAISE_ERROR_ENGINE(engine, "Unstreaming Error",
                                std::string("Unable to unstream engine state ") + err.what());
         }
+        engine.stopEngineRequests--;
+        cont.sendStreamCompleteNotification();
     }
 }
 CLIENT_TO_SERIAL(UnstreamEngineState, c2s_unstream_engine_state, unstreamEngineStatePayload_t,

--- a/src/scxt-core/patch_io/patch_io.cpp
+++ b/src/scxt-core/patch_io/patch_io.cpp
@@ -543,6 +543,8 @@ bool saveMulti(const fs::path &p, scxt::engine::Engine &e, SaveStyles style)
         else
         {
             RAISE_ERROR_ENGINE(e, "Unable to create collect dir", emsg);
+            e.getSampleManager()->remapIds.clear();
+            return false;
         }
     }
 
@@ -593,9 +595,17 @@ bool saveMulti(const fs::path &p, scxt::engine::Engine &e, SaveStyles style)
         }
         e.getSampleManager()->remapIds.clear();
     }
-    catch (const RIFF::Exception &e)
+    catch (const RIFF::Exception &exc)
     {
-        SCLOG_IF(patchIO, e.Message);
+        SCLOG_IF(patchIO, exc.Message);
+        RAISE_ERROR_ENGINE(e, "Exception saving Multi",
+                           riffPath.u8string() + " threw " + exc.Message);
+        // A failed save must report failure and leave the SampleManager out of
+        // reparent mode, else subsequent saves corrupt their paths.
+        if (style == SaveStyles::WITH_COLLECTED_SAMPLES)
+            e.getSampleManager()->clearReparenting();
+        e.getSampleManager()->remapIds.clear();
+        return false;
     }
     return true;
 }
@@ -627,6 +637,8 @@ bool savePart(const fs::path &p, scxt::engine::Engine &e, int part, patch_io::Sa
         else
         {
             RAISE_ERROR_ENGINE(e, "Unable to create collect dir", emsg);
+            e.getSampleManager()->remapIds.clear();
+            return false;
         }
     }
 
@@ -715,9 +727,17 @@ bool savePart(const fs::path &p, scxt::engine::Engine &e, int part, patch_io::Sa
         }
         e.getSampleManager()->remapIds.clear();
     }
-    catch (const RIFF::Exception &e)
+    catch (const RIFF::Exception &exc)
     {
-        SCLOG_IF(patchIO, e.Message);
+        SCLOG_IF(patchIO, exc.Message);
+        RAISE_ERROR_ENGINE(e, "Exception saving Part",
+                           riffPath.u8string() + " threw " + exc.Message);
+        // A failed save must report failure and leave the SampleManager out of
+        // reparent mode, else subsequent saves corrupt their paths.
+        if (style == SaveStyles::WITH_COLLECTED_SAMPLES)
+            e.getSampleManager()->clearReparenting();
+        e.getSampleManager()->remapIds.clear();
+        return false;
     }
     return true;
 }
@@ -746,13 +766,13 @@ bool initFromResourceBundle(scxt::engine::Engine &engine, const std::string &fil
             {
                 nonconste.immediatelyTerminateAllVoices();
                 scxt::json::unstreamEngineState(nonconste, payload, true);
-                auto &cont = *e.getMessageController();
-                cont.restartAudioThreadFromSerial();
             }
             catch (std::exception &err)
             {
                 SCLOG_IF(patchIO, "Unable to load [" << err.what() << "]");
             }
+            // Always restart, else a failed load leaves audio permanently stopped.
+            e.getMessageController()->restartAudioThreadFromSerial();
         });
     }
     else
@@ -829,14 +849,16 @@ bool loadMulti(const fs::path &p, scxt::engine::Engine &engine)
                     nonconste.getSampleManager()->clearReparenting();
                     nonconste.getSampleManager()->clearMonolithBinaryIndex();
                     nonconste.getSampleManager()->purgeUnreferencedSamples();
-
-                    auto &cont = *e.getMessageController();
-                    cont.restartAudioThreadFromSerial();
                 }
                 catch (std::exception &err)
                 {
                     SCLOG_IF(patchIO, "Unable to load [" << err.what() << "]");
+                    RAISE_ERROR_ENGINE(e, "Unable to load Multi", err.what());
+                    nonconste.getSampleManager()->clearReparenting();
+                    nonconste.getSampleManager()->clearMonolithBinaryIndex();
                 }
+                // Always restart, else a failed load leaves audio permanently stopped.
+                e.getMessageController()->restartAudioThreadFromSerial();
             });
     }
     else
@@ -910,13 +932,16 @@ bool loadPartInto(const fs::path &p, scxt::engine::Engine &engine, int part)
                 {
                     sm->applySelectActions({part, 0, -1});
                 }
-                auto &cont = *e.getMessageController();
-                cont.restartAudioThreadFromSerial();
             }
             catch (std::exception &err)
             {
                 SCLOG_IF(patchIO, "Unable to load [" << err.what() << "]");
+                RAISE_ERROR_ENGINE(e, "Unable to load Part", err.what());
+                nonconste.getSampleManager()->clearReparenting();
+                nonconste.getSampleManager()->clearMonolithBinaryIndex();
             }
+            // Always restart, else a failed load leaves audio permanently stopped.
+            e.getMessageController()->restartAudioThreadFromSerial();
         });
     }
     else


### PR DESCRIPTION
A failed patch load left the audio thread permanently stopped because the restart only ran on the success path; it now always restarts so the engine recovers. Unstreaming the engine state likewise always restarts audio and sends the stream-complete notification, so a failed setState no longer hangs its waiter.

A failed multi/part save now reports failure instead of returning success, and resets the sample manager out of reparent mode so later saves aren't corrupted. A failed collect-directory setup now bails instead of continuing with an empty directory.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>