### PR TITLE
Default int controls to no label; let layouts request label-source none

### DIFF
--- a/src/scxt-plugin/app/edit-screen/components/ProcessorPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/ProcessorPane.cpp
@@ -1219,11 +1219,12 @@ void ProcessorPane::createBindAndPosition(const sst::jucegui::layouts::json_docu
         ed->setEnabled(en);
 
         std::optional<std::string> labelOverride;
-        // Default policy: if the JSON specifies neither "label" nor "label-source", use
-        // pmd.shortName
+        // label-source policy: float controls default to the param short name when the JSON
+        // gives neither a label nor a label-source. "none" suppresses the label entirely.
         auto labelSource = ctrl.labelSource;
         if (!labelSource.has_value() && !ctrl.label.has_value())
             labelSource = "short";
+        bool suppressLabel{false};
         if (labelSource.has_value())
         {
             const auto &pmd = processorControlDescription.floatControlDescriptions[idx];
@@ -1231,12 +1232,17 @@ void ProcessorPane::createBindAndPosition(const sst::jucegui::layouts::json_docu
                 labelOverride = pmd.shortName;
             else if (*labelSource == "name")
                 labelOverride = pmd.name;
+            else if (*labelSource == "none")
+                suppressLabel = true;
         }
-        if (auto lab =
-                connectors::jsonlayout::createControlLabel(ctrl, cls, *this, {0, 0}, labelOverride))
+        if (!suppressLabel)
         {
-            getContentAreaComponent()->addAndMakeVisible(*lab);
-            jsonLabels.push_back(std::move(lab));
+            if (auto lab = connectors::jsonlayout::createControlLabel(ctrl, cls, *this, {0, 0},
+                                                                      labelOverride))
+            {
+                getContentAreaComponent()->addAndMakeVisible(*lab);
+                jsonLabels.push_back(std::move(lab));
+            }
         }
 
         jsonFloatEditors[idx] = std::move(ed);
@@ -1299,11 +1305,10 @@ void ProcessorPane::createBindAndPosition(const sst::jucegui::layouts::json_docu
         connectors::jsonlayout::attachAndPosition(this, ed, att, ctrl, cls);
 
         std::optional<std::string> labelOverride;
-        // Default policy: if the JSON specifies neither "label" nor "label-source", use
-        // pmd.shortName
+        // label-source policy: int controls default to no label; the pmd short/name is only
+        // used when the JSON asks via label-source. "none" suppresses the label explicitly.
         auto labelSource = ctrl.labelSource;
-        if (!labelSource.has_value() && !ctrl.label.has_value())
-            labelSource = "short";
+        bool suppressLabel{false};
         if (labelSource.has_value())
         {
             const auto &pmd = processorControlDescription.intControlDescriptions[idx];
@@ -1311,12 +1316,17 @@ void ProcessorPane::createBindAndPosition(const sst::jucegui::layouts::json_docu
                 labelOverride = pmd.shortName;
             else if (*labelSource == "name")
                 labelOverride = pmd.name;
+            else if (*labelSource == "none")
+                suppressLabel = true;
         }
-        if (auto lab =
-                connectors::jsonlayout::createControlLabel(ctrl, cls, *this, {0, 0}, labelOverride))
+        if (!suppressLabel)
         {
-            getContentAreaComponent()->addAndMakeVisible(*lab);
-            jsonLabels.push_back(std::move(lab));
+            if (auto lab = connectors::jsonlayout::createControlLabel(ctrl, cls, *this, {0, 0},
+                                                                      labelOverride))
+            {
+                getContentAreaComponent()->addAndMakeVisible(*lab);
+                jsonLabels.push_back(std::move(lab));
+            }
         }
 
         jsonIntEditors[idx] = std::move(ed);

--- a/src/scxt-plugin/json-assets/voicefx-layouts/eq/3-band-eq.json
+++ b/src/scxt-plugin/json-assets/voicefx-layouts/eq/3-band-eq.json
@@ -39,6 +39,7 @@
         },
         "gain1": {
             "class": "textedit40",
+            "label-source": "none",
             "binding": {
                 "type": "float",
                 "index": 0
@@ -50,6 +51,7 @@
         },
         "freq1": {
             "class": "textedit40",
+            "label-source": "none",
             "binding": {
                 "type": "float",
                 "index": 1
@@ -61,6 +63,7 @@
         },
         "bw1": {
             "class": "textedit40",
+            "label-source": "none",
             "binding": {
                 "type": "float",
                 "index": 2
@@ -72,6 +75,7 @@
         },
         "gain2": {
             "class": "textedit40",
+            "label-source": "none",
             "binding": {
                 "type": "float",
                 "index": 3
@@ -83,6 +87,7 @@
         },
         "freq2": {
             "class": "textedit40",
+            "label-source": "none",
             "binding": {
                 "type": "float",
                 "index": 4
@@ -94,6 +99,7 @@
         },
         "bw2": {
             "class": "textedit40",
+            "label-source": "none",
             "binding": {
                 "type": "float",
                 "index": 5
@@ -105,6 +111,7 @@
         },
         "gain3": {
             "class": "textedit40",
+            "label-source": "none",
             "binding": {
                 "type": "float",
                 "index": 6
@@ -116,6 +123,7 @@
         },
         "freq3": {
             "class": "textedit40",
+            "label-source": "none",
             "binding": {
                 "type": "float",
                 "index": 7
@@ -127,6 +135,7 @@
         },
         "bw3": {
             "class": "textedit40",
+            "label-source": "none",
             "binding": {
                 "type": "float",
                 "index": 8

--- a/src/scxt-plugin/json-assets/voicefx-layouts/generators/sineplus.json
+++ b/src/scxt-plugin/json-assets/voicefx-layouts/generators/sineplus.json
@@ -78,6 +78,7 @@
     "ob": {
       "class": "textedit40",
       "tooltip-position": "vcenter-left",
+      "label-source": "none",
       "binding": {
         "type": "float",
         "index": 1
@@ -90,6 +91,7 @@
     "oa": {
       "class": "textedit40",
       "tooltip-position": "vcenter-left",
+      "label-source": "none",
       "binding": {
         "type": "float",
         "index": 2


### PR DESCRIPTION
Float controls keep defaulting to the param short name, but integer controls now draw no label unless the layout asks for one, and any control can suppress its label with "label-source": "none". Applied none to the SinePlus overtone typeins and the 3-band EQ cells so they no longer pick up auto labels.

Assisted-by: Claude Opus 4.8