### PR TITLE
Use long/short display names for group LFO and EG mod targets

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -14,14 +14,14 @@ jobs:
       matrix:
         include:
           - name: "windows msvc"
-            os: windows-latest
+            os: windows-2022
             target: shortcircuit-products
             cmakeConfig: -G"Visual Studio 17 2022" -A x64 -DCMAKE_UNITY_BUILD=TRUE
             runTests: false
             clapValidate: false
 
             #- name: "windows clang VST3"
-            #  os: windows-latest
+            #  os: windows-2022
             #  target: scxt_clapfirst_vst3
             # LLVM
             # cmakeConfig: -GNinja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
@@ -30,7 +30,7 @@ jobs:
           #  clapValidate: false
 
           - name: "windows arm64ec"
-            os: windows-latest
+            os: windows-2022
             target: shortcircuit-products
             cmakeConfig: -G"Visual Studio 17 2022" -A arm64ec -DCMAKE_SYSTEM_VERSION=10 -DCMAKE_UNITY_BUILD=TRUE
             runTests: false
@@ -60,7 +60,7 @@ jobs:
             clapValidate: false
 
           - name: "win unity"
-            os: windows-latest
+            os: windows-2022
             target: shortcircuit-products
             # LLVM
             # cmakeConfig: -GNinja -DCMAKE_UNITY_BUILD=TRUE -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
@@ -74,7 +74,7 @@ jobs:
 
 
           - name: "win unity Clang CL"
-            os: windows-latest
+            os: windows-2022
             target: shortcircuit-products
             # LLVM
             # cmakeConfig: -GNinja -DCMAKE_UNITY_BUILD=TRUE -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-latest
+          - os: windows-2022
             name: windows-x86
             # MSVC
             # cmakeArgs: -G"Visual Studio 17 2022" -A x64
@@ -26,7 +26,7 @@ jobs:
             # LLVM
             # cmakeArgs: -GNinja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
 
-          - os: windows-latest
+          - os: windows-2022
             name: windows-arm64ec
             cmakeArgs: -G"Visual Studio 17 2022" -A arm64ec -DCMAKE_SYSTEM_VERSION=10 -DCMAKE_UNITY_BUILD=TRUE
 

--- a/src/scxt-core/modulation/group_matrix.cpp
+++ b/src/scxt-core/modulation/group_matrix.cpp
@@ -156,8 +156,13 @@ GroupMatrixEndpoints::LFOTarget::LFOTarget(engine::Engine *e, uint32_t p)
 {
     if (e)
     {
+        // Long path goes in the menu; short path in the matrix row
         auto ptFn = [](const engine::Group &g, const auto &t) -> std::string {
-            return "GLFO " + std::to_string(t.index + 1);
+            return "Group LFO " + std::to_string(t.index + 1);
+        };
+
+        auto ptShortFn = [](const engine::Group &g, const auto &t) -> std::string {
+            return "GLFO" + std::to_string(t.index + 1);
         };
 
         auto conditionLabel =
@@ -194,25 +199,30 @@ GroupMatrixEndpoints::LFOTarget::LFOTarget(engine::Engine *e, uint32_t p)
         auto ms = scxt::modulation::ModulatorStorage();
         auto nm = [&ms](auto &v) { return datamodel::describeValue(ms, v).name; };
 
-        registerGroupModTarget(e, rateT, ptFn, notEnvLabel(nm(ms.rate)));
-        registerGroupModTarget(e, amplitudeT, ptFn, allLabel(nm(ms.amplitude)), true);
-        registerGroupModTarget(e, retriggerT, ptFn, allLabel("Retrigger"));
-        registerGroupModTarget(e, curve.deformT, ptFn, curveLabel(nm(ms.curveLfoStorage.deform)));
-        registerGroupModTarget(e, curve.angleT, ptFn, curveLabel(nm(ms.curveLfoStorage.angle)));
-        registerGroupModTarget(e, curve.delayT, ptFn, curveLabel(nm(ms.curveLfoStorage.delay)));
-        registerGroupModTarget(e, curve.attackT, ptFn, curveLabel(nm(ms.curveLfoStorage.attack)));
-        registerGroupModTarget(e, curve.releaseT, ptFn, curveLabel(nm(ms.curveLfoStorage.release)));
-        registerGroupModTarget(e, step.smoothT, ptFn, stepLabel(nm(ms.stepLfoStorage.smooth)));
-        registerGroupModTarget(e, env.delayT, ptFn, envLabel(nm(ms.envLfoStorage.delay)));
-        registerGroupModTarget(e, env.attackT, ptFn, envLabel(nm(ms.envLfoStorage.attack)));
-        registerGroupModTarget(e, env.holdT, ptFn, envLabel(nm(ms.envLfoStorage.hold)));
-        registerGroupModTarget(e, env.decayT, ptFn, envLabel(nm(ms.envLfoStorage.decay)));
-        registerGroupModTarget(e, env.sustainT, ptFn, envLabel(nm(ms.envLfoStorage.sustain)));
-        registerGroupModTarget(e, env.releaseT, ptFn, envLabel(nm(ms.envLfoStorage.release)));
-        registerGroupModTarget(e, env.aShapeT, ptFn, envLabel(nm(ms.envLfoStorage.aShape)));
-        registerGroupModTarget(e, env.dShapeT, ptFn, envLabel(nm(ms.envLfoStorage.dShape)));
-        registerGroupModTarget(e, env.rShapeT, ptFn, envLabel(nm(ms.envLfoStorage.rShape)));
-        registerGroupModTarget(e, env.rateMulT, ptFn, envLabel(nm(ms.envLfoStorage.rateMul)));
+        // Short name matches long name; only the path differs between menu and row
+        auto reg = [&](const auto &t, auto nameFn, bool mul = false) {
+            registerGroupModTarget(e, t, ptFn, nameFn, mul, ptShortFn, nameFn);
+        };
+
+        reg(rateT, notEnvLabel(nm(ms.rate)));
+        reg(amplitudeT, allLabel(nm(ms.amplitude)), true);
+        reg(retriggerT, allLabel("Retrigger"));
+        reg(curve.deformT, curveLabel(nm(ms.curveLfoStorage.deform)));
+        reg(curve.angleT, curveLabel(nm(ms.curveLfoStorage.angle)));
+        reg(curve.delayT, curveLabel(nm(ms.curveLfoStorage.delay)));
+        reg(curve.attackT, curveLabel(nm(ms.curveLfoStorage.attack)));
+        reg(curve.releaseT, curveLabel(nm(ms.curveLfoStorage.release)));
+        reg(step.smoothT, stepLabel(nm(ms.stepLfoStorage.smooth)));
+        reg(env.delayT, envLabel(nm(ms.envLfoStorage.delay)));
+        reg(env.attackT, envLabel(nm(ms.envLfoStorage.attack)));
+        reg(env.holdT, envLabel(nm(ms.envLfoStorage.hold)));
+        reg(env.decayT, envLabel(nm(ms.envLfoStorage.decay)));
+        reg(env.sustainT, envLabel(nm(ms.envLfoStorage.sustain)));
+        reg(env.releaseT, envLabel(nm(ms.envLfoStorage.release)));
+        reg(env.aShapeT, envLabel(nm(ms.envLfoStorage.aShape)));
+        reg(env.dShapeT, envLabel(nm(ms.envLfoStorage.dShape)));
+        reg(env.rShapeT, envLabel(nm(ms.envLfoStorage.rShape)));
+        reg(env.rateMulT, envLabel(nm(ms.envLfoStorage.rateMul)));
     }
 }
 
@@ -233,8 +243,8 @@ GroupMatrixEndpoints::Sources::Sources(engine::Engine *e)
       envFollowerSources(e), macroSources(e), subordinateVoiceSources(e), midiSources(e),
       keyAndPitchSources(e)
 {
-    registerGroupModSource(e, egSource[0], "EG", "EG1");
-    registerGroupModSource(e, egSource[1], "EG", "EG2");
+    registerGroupModSource(e, egSource[0], "Group EG", "GEG1");
+    registerGroupModSource(e, egSource[1], "Group EG", "GEG2");
 
     for (int i = 0; i < randomsPerGroupOrZone; ++i)
         registerGroupModSource(

--- a/src/scxt-core/modulation/group_matrix.h
+++ b/src/scxt-core/modulation/group_matrix.h
@@ -124,17 +124,22 @@ struct GroupMatrixEndpoints
         {
             if (e)
             {
-                std::string envnm = (p == 0 ? "EG1" : "EG2");
-                registerGroupModTarget(e, dlyT, envnm, "Delay");
-                registerGroupModTarget(e, aT, envnm, "Attack");
-                registerGroupModTarget(e, hT, envnm, "Hold");
-                registerGroupModTarget(e, dT, envnm, "Decay");
-                registerGroupModTarget(e, sT, envnm, "Sustain");
-                registerGroupModTarget(e, rT, envnm, "Release");
-                registerGroupModTarget(e, asT, envnm, "Attack Shape");
-                registerGroupModTarget(e, dsT, envnm, "Decay Shape");
-                registerGroupModTarget(e, rsT, envnm, "Release Shape");
-                registerGroupModTarget(e, retriggerT, envnm, "Retrigger");
+                // Long path/name go in the menu; short path/name in the matrix row
+                std::string longPath = "Group EG " + std::to_string(p + 1);
+                std::string shortPath = "GEG" + std::to_string(p + 1);
+                auto reg = [&](const auto &t, const std::string &nm) {
+                    registerGroupModTarget(e, t, longPath, nm, false, shortPath, nm);
+                };
+                reg(dlyT, "Delay");
+                reg(aT, "Attack");
+                reg(hT, "Hold");
+                reg(dT, "Decay");
+                reg(sT, "Sustain");
+                reg(rT, "Release");
+                reg(asT, "Attack Shape");
+                reg(dsT, "Decay Shape");
+                reg(rsT, "Release Shape");
+                reg(retriggerT, "Retrigger");
             }
         }
         void bind(GroupMatrix &m, engine::Group &g);


### PR DESCRIPTION
Group LFO and EG matrix targets now show a long name in the popup menu (e.g. "Group LFO 1/Rate", "Group EG 1/Attack") and a short name in the matrix row (e.g. "GLFO1: Rate", "GEG1: Attack"), matching how processors already work. The EG sources read GEG1/GEG2.

Closes #2520

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>