### PR TITLE
Add group EGs as zone modulation sources

### DIFF
--- a/src/scxt-core/engine/group.cpp
+++ b/src/scxt-core/engine/group.cpp
@@ -113,6 +113,10 @@ void Group::rePrepareAndBindGroupMatrix()
         {
             lfosActive[i] = lfosActive[i] || z->glfosActive[i];
         }
+        for (int i = 0; i < egsPerGroup; ++i)
+        {
+            egsActive[i] = egsActive[i] || z->gegsActive[i];
+        }
     }
 }
 

--- a/src/scxt-core/engine/zone.cpp
+++ b/src/scxt-core/engine/zone.cpp
@@ -428,6 +428,8 @@ void Zone::onRoutingChanged()
     std::fill(lfosActive.begin(), lfosActive.end(), false);
     auto pglfo = glfosActive;
     std::fill(glfosActive.begin(), glfosActive.end(), false);
+    auto pgeg = gegsActive;
+    std::fill(gegsActive.begin(), gegsActive.end(), false);
     std::fill(envFollowersActive.begin(), envFollowersActive.end(), false);
 
     for (int i = 0; i < egsPerZone; ++i)
@@ -448,6 +450,14 @@ void Zone::onRoutingChanged()
             if (src == usedForScanning.glfoSources.sources[i])
             {
                 glfosActive[i] = true;
+            }
+        }
+
+        for (int i = 0; i < egsPerGroup; ++i)
+        {
+            if (src == usedForScanning.gegSources[i])
+            {
+                gegsActive[i] = true;
             }
         }
 
@@ -493,7 +503,7 @@ void Zone::onRoutingChanged()
             doCheck(*r.sourceVia);
     }
 
-    if (pglfo != glfosActive)
+    if (pglfo != glfosActive || pgeg != gegsActive)
     {
         if (parentGroup)
             parentGroup->rePrepareAndBindGroupMatrix();

--- a/src/scxt-core/engine/zone.h
+++ b/src/scxt-core/engine/zone.h
@@ -260,6 +260,7 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
 
     std::array<bool, lfosPerZone> lfosActive{};
     std::array<bool, lfosPerGroup> glfosActive{};
+    std::array<bool, egsPerGroup> gegsActive{};
     std::array<bool, egsPerZone> egsActive{};
     std::array<bool, envFollowersPerGroupOrZone> envFollowersActive{};
     bool phasorsActive{};

--- a/src/scxt-core/modulation/voice_matrix.cpp
+++ b/src/scxt-core/modulation/voice_matrix.cpp
@@ -122,6 +122,9 @@ void MatrixEndpoints::Sources::bind(scxt::voice::modulation::Matrix &m, engine::
     for (int i = 0; i < egsPerZone; ++i)
         m.bindSourceValue(egSources[i], v.eg[i].outBlock0);
 
+    for (int i = 0; i < egsPerGroup; ++i)
+        m.bindSourceValue(gegSources[i], z.parentGroup->eg[i].outBlock0);
+
     m.bindSourceValue(midiSources.modWheelSource, z.parentGroup->parentPart->midiCCValues[1]);
     m.bindSourceValue(midiSources.chanATSource, z.parentGroup->parentPart->channelAT);
     m.bindSourceValue(midiSources.pbpm1Source, z.parentGroup->parentPart->pitchBendValue);
@@ -449,7 +452,7 @@ MatrixEndpoints::LFOTarget::LFOTarget(engine::Engine *e, uint32_t p)
 }
 
 MatrixEndpoints::Sources::Sources(engine::Engine *e)
-    : lfoSources(e), glfoSources(e, "LFO (Group)", "GLFO"), midiCCSources(e), midiSources(e),
+    : lfoSources(e), glfoSources(e, "Group", "GLFO"), midiCCSources(e), midiSources(e),
       noteExpressions(e), egSources{{eg1A, eg2A, eg3A, eg4A, eg5A}}, transportSources(e),
       rngSources(e), envFollowerSources(e), macroSources(e), mpeSources(e), voiceSources(e),
       keyAndPitchSources(e)
@@ -457,6 +460,12 @@ MatrixEndpoints::Sources::Sources(engine::Engine *e)
     registerVoiceModSource(e, egSources[0], "EG", "AEG");
     for (int i = 1; i < egsPerZone; ++i)
         registerVoiceModSource(e, egSources[i], "EG", "EG" + std::to_string(i + 1));
+
+    for (int i = 0; i < egsPerGroup; ++i)
+    {
+        gegSources[i] = SR{'zgeg', 'outp', (uint32_t)i};
+        registerVoiceModSource(e, gegSources[i], "Group", "GEG " + std::to_string(i + 1));
+    }
 
     for (int i = 0; i < randomsPerGroupOrZone; ++i)
         registerVoiceModSource(

--- a/src/scxt-core/modulation/voice_matrix.h
+++ b/src/scxt-core/modulation/voice_matrix.h
@@ -421,6 +421,7 @@ struct MatrixEndpoints
         } macroSources;
 
         std::array<SR, egsPerZone> egSources;
+        std::array<SR, egsPerGroup> gegSources;
 
         void bind(Matrix &m, engine::Zone &z, voice::Voice &v);
 


### PR DESCRIPTION
GEG1 and GEG2 are now available in the zone modulation matrix alongside the group LFOs. Subscribing a zone to a group EG marks it active so the group runs the envelope, and the source menu now groups GLFO and GEG entries under a single "Group" submenu.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>