### PR TITLE
Add envelope rate multiplier as a modulation target

### DIFF
--- a/src/scxt-core/engine/group.cpp
+++ b/src/scxt-core/engine/group.cpp
@@ -280,9 +280,11 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
                 eg[i].attackFromWithDelay(eg[i].outBlock0, *aegp.dlyP, *aegp.aP);
                 egiGate = getEnvSpecificGate(envGate, gegStorage[i], eg[i].stage, false);
             }
-            eg[i].processBlockWithDelay(*aegp.dlyP, *aegp.aP, *aegp.hP, *aegp.dP, *aegp.sP,
-                                        *aegp.rP, *aegp.asP, *aegp.dsP, *aegp.rsP, egiGate, false,
-                                        gegStorage[i].isTemposync, e.transport.tempo / 120.f);
+            auto egiRM = dsp::twoToTheXTable.twoToThe(*aegp.rateMulP);
+            eg[i].processBlockWithDelayAndRateMul(
+                *aegp.dlyP, *aegp.aP, *aegp.hP, *aegp.dP, *aegp.sP, *aegp.rP, *aegp.asP, *aegp.dsP,
+                *aegp.rsP, egiRM, egiGate, false, gegStorage[i].isTemposync,
+                e.transport.tempo / 120.f);
         }
     }
 

--- a/src/scxt-core/json/modulation_traits.h
+++ b/src/scxt-core/json/modulation_traits.h
@@ -121,6 +121,7 @@ SC_STREAMDEF(modulation::modulators::AdsrStorage, SC_FROM({
                  addUnlessDefault<val_t>(v, "rShape", 0.f, from.rShape);
                  addUnlessDefault<val_t>(v, "groupGate", false, from.gateGroupEGOnAnyPlaying);
                  addUnlessDefault<val_t>(v, "tsync", false, from.isTemposync);
+                 addUnlessDefault<val_t>(v, "rateMul", 0.f, from.rateMul);
                  addUnlessDefault<val_t>(v, "gateMode",
                                          modulation::modulators::AdsrStorage::GateMode::GATED,
                                          from.gateMode);
@@ -137,6 +138,7 @@ SC_STREAMDEF(modulation::modulators::AdsrStorage, SC_FROM({
                  findOrSet(v, "rShape", 0.f, result.rShape);
                  findOrSet(v, "groupGate", false, result.gateGroupEGOnAnyPlaying);
                  findOrSet(v, "tsync", false, result.isTemposync);
+                 findOrSet(v, "rateMul", 0.f, result.rateMul);
                  findOrSet(v, "gateMode", modulation::modulators::AdsrStorage::GateMode::GATED,
                            result.gateMode);
              }))

--- a/src/scxt-core/modulation/group_matrix.h
+++ b/src/scxt-core/modulation/group_matrix.h
@@ -140,6 +140,7 @@ struct GroupMatrixEndpoints
                 reg(dsT, "Decay Shape");
                 reg(rsT, "Release Shape");
                 reg(retriggerT, "Retrigger");
+                reg(rateMulT, "Rate Multiplier");
             }
         }
         void bind(GroupMatrix &m, engine::Group &g);

--- a/src/scxt-core/modulation/matrix_shared.h
+++ b/src/scxt-core/modulation/matrix_shared.h
@@ -145,20 +145,22 @@ template <typename TG, uint32_t gn> struct EGTargetEndpointData
     static constexpr TG decayShapeA(uint32_t slot) { return TG{gn, 'dcSH', slot}; }
     static constexpr TG releaseShapeA(uint32_t slot) { return TG{gn, 'rlSH', slot}; }
     static constexpr TG retriggerA(uint32_t slot) { return TG{gn, 'rtrg', slot}; }
+    static constexpr TG rateMulA(uint32_t slot) { return TG{gn, 'erml', slot}; }
 
     uint32_t index{0};
     EGTargetEndpointData(uint32_t p)
         : index(p), dlyT(delayA(p)), aT(attackA(p)), hT(holdA(p)), dT(decayA(p)), sT(sustainA(p)),
           rT(releaseA(p)), asT(attackShapeA(p)), dsT(decayShapeA(p)), rsT(releaseShapeA(p)),
-          retriggerT(retriggerA(p))
+          retriggerT(retriggerA(p)), rateMulT(rateMulA(p))
     {
     }
 
-    TG dlyT, aT, hT, dT, sT, rT, asT, dsT, rsT, retriggerT;
+    TG dlyT, aT, hT, dT, sT, rT, asT, dsT, rsT, retriggerT, rateMulT;
     const float *dlyP{nullptr}, *aP{nullptr}, *hP{nullptr}, *dP{nullptr}, *sP{nullptr},
         *rP{nullptr};
     const float *asP{nullptr}, *dsP{nullptr}, *rsP{nullptr};
     const float *retriggerP{nullptr};
+    const float *rateMulP{nullptr};
 
     float zeroBase{0.f};
 
@@ -360,6 +362,7 @@ inline void EGTargetEndpointData<TG, gn>::baseBind(M &m, EG &eg)
     bindEl(m, eg, rsT, eg.rShape, rsP);
     bindEl(m, eg, retriggerT, zeroBase, retriggerP,
            datamodel::pmd().withName("Retrigger").asPercent());
+    bindEl(m, eg, rateMulT, eg.rateMul, rateMulP);
 }
 
 template <typename TG, uint32_t gn>

--- a/src/scxt-core/modulation/modulator_storage.h
+++ b/src/scxt-core/modulation/modulator_storage.h
@@ -76,6 +76,12 @@ struct AdsrStorage
      * Blanket temposync for the envelope times. All-or-none.
      */
     bool isTemposync{false};
+
+    /*
+     * Modulation-only rate multiplier. -3..3 maps to 1/8..8x via 2^x. No UI control;
+     * exposed purely as a modulation target.
+     */
+    float rateMul{0.f};
 };
 
 using StepLFOStorage = sst::basic_blocks::modulators::StepLFO<scxt::blockSize>::Storage;
@@ -300,6 +306,15 @@ SC_DESCRIBE(scxt::modulation::modulators::AdsrStorage, {
     SC_FIELD(gateGroupEGOnAnyPlaying,
              pmd().asOnOffBool().withName("Gated if ungated voices sounding"));
     SC_FIELD(isTemposync, pmd().asOnOffBool().withName("Temposync"));
+    SC_FIELD(rateMul, pmd()
+                          .asFloat()
+                          .withRange(-3, 3)
+                          .withATwoToTheBFormatting(1, 1, "x")
+                          .withDecimalPlaces(4)
+                          .withDefault(0.0)
+                          .withFeature(pmd::Features::BELOW_ONE_IS_INVERSE_FRACTION)
+                          .withFeature(pmd::Features::ALLOW_FRACTIONAL_TYPEINS)
+                          .withName("Rate Multiplier"));
 })
 
 // We describe modulator storage as a compound since we address

--- a/src/scxt-core/modulation/voice_matrix.h
+++ b/src/scxt-core/modulation/voice_matrix.h
@@ -157,6 +157,7 @@ struct MatrixEndpoints
             registerVoiceModTarget(e, dsT, group, "Decay Shape");
             registerVoiceModTarget(e, rsT, group, "Release Shape");
             registerVoiceModTarget(e, retriggerT, group, "Retrigger");
+            registerVoiceModTarget(e, rateMulT, group, "Rate Multiplier");
         }
 
         void bind(Matrix &m, engine::Zone &z);

--- a/src/scxt-core/voice/voice.cpp
+++ b/src/scxt-core/voice/voice.cpp
@@ -327,6 +327,7 @@ template <bool OS> bool Voice::processWithOS()
     doEGRetrigger[0] = false;
     auto aegGate =
         getEnvSpecificGate(envGate, zone->egStorage[0], aeg.stage, isAnyGeneratorRunning);
+    auto aegRM = dsp::twoToTheXTable.twoToThe(*aegp.rateMulP);
     if constexpr (OS)
     {
         if (rtaeg)
@@ -337,10 +338,10 @@ template <bool OS> bool Voice::processWithOS()
                                    (ahdsrenv_t::Stage)((int)aegOS.stage), isAnyGeneratorRunning);
         }
         // we need the aegOS for the curve in oversample space
-        aegOS.processBlockWithDelay(*aegp.dlyP, *aegp.aP, *aegp.hP, *aegp.dP, *aegp.sP, *aegp.rP,
-                                    *aegp.asP, *aegp.dsP, *aegp.rsP, aegGate, true,
-                                    zone->egStorage[0].isTemposync,
-                                    engine->transport.tempo / 120.f);
+        aegOS.processBlockWithDelayAndRateMul(*aegp.dlyP, *aegp.aP, *aegp.hP, *aegp.dP, *aegp.sP,
+                                              *aegp.rP, *aegp.asP, *aegp.dsP, *aegp.rsP, aegRM,
+                                              aegGate, true, zone->egStorage[0].isTemposync,
+                                              engine->transport.tempo / 120.f);
     }
 
     // But We need to run the undersample AEG no matter what since it is a modulation source
@@ -349,9 +350,10 @@ template <bool OS> bool Voice::processWithOS()
         aeg.attackFromWithDelay(aeg.outBlock0, *aegp.dlyP, *aegp.aP);
         aegGate = getEnvSpecificGate(envGate, zone->egStorage[0], aeg.stage, isAnyGeneratorRunning);
     }
-    aeg.processBlockWithDelay(*aegp.dlyP, *aegp.aP, *aegp.hP, *aegp.dP, *aegp.sP, *aegp.rP,
-                              *aegp.asP, *aegp.dsP, *aegp.rsP, aegGate, true,
-                              zone->egStorage[0].isTemposync, engine->transport.tempo / 120.f);
+    aeg.processBlockWithDelayAndRateMul(*aegp.dlyP, *aegp.aP, *aegp.hP, *aegp.dP, *aegp.sP,
+                                        *aegp.rP, *aegp.asP, *aegp.dsP, *aegp.rsP, aegRM, aegGate,
+                                        true, zone->egStorage[0].isTemposync,
+                                        engine->transport.tempo / 120.f);
     // TODO: And output is non zero once we are past attack
     isAEGRunning = (aeg.stage != ahdsrenv_t ::s_complete);
 
@@ -372,10 +374,11 @@ template <bool OS> bool Voice::processWithOS()
                                              isAnyGeneratorRunning);
             }
 
-            eg[i].processBlockWithDelay(*eg2p.dlyP, *eg2p.aP, *eg2p.hP, *eg2p.dP, *eg2p.sP,
-                                        *eg2p.rP, *eg2p.asP, *eg2p.dsP, *eg2p.rsP, egiGate, false,
-                                        zone->egStorage[i].isTemposync,
-                                        engine->transport.tempo / 120.f);
+            auto egiRM = dsp::twoToTheXTable.twoToThe(*eg2p.rateMulP);
+            eg[i].processBlockWithDelayAndRateMul(
+                *eg2p.dlyP, *eg2p.aP, *eg2p.hP, *eg2p.dP, *eg2p.sP, *eg2p.rP, *eg2p.asP, *eg2p.dsP,
+                *eg2p.rsP, egiRM, egiGate, false, zone->egStorage[i].isTemposync,
+                engine->transport.tempo / 120.f);
         }
     }
     updateTransportPhasors();


### PR DESCRIPTION
Exposes a per-EG rate multiplier (1/8x to 8x) for voice and group envelopes. It has no on-screen control and is reachable only as a modulation target.

Closes #2504

Assisted-by: Claude <noreply@anthropic.com>