### PR TITLE
Make mod matrix menu order optionally explicit

### DIFF
--- a/src/scxt-core/CMakeLists.txt
+++ b/src/scxt-core/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library(${PROJECT_NAME} STATIC
 
         modulation/group_matrix.cpp
         modulation/voice_matrix.cpp
+        modulation/matrix_shared.cpp
         modulation/mod_curves.cpp
         modulation/modulator_storage.cpp
 

--- a/src/scxt-core/engine/engine.cpp
+++ b/src/scxt-core/engine/engine.cpp
@@ -1396,14 +1396,18 @@ void Engine::registerVoiceModTarget(const voice::modulation::MatrixConfig::Targe
                                     vmodTgtIntFn_t additiveFn, vmodTgtBoolFn_t enabledFn,
                                     vmodTgtStrFn_t shortPathFn, vmodTgtStrFn_t shortNameFn)
 {
-    voiceModTargets.emplace(
-        t, std::make_tuple(pathFn, nameFn, shortPathFn, shortNameFn, additiveFn, enabledFn));
+    bool sep{false};
+    auto ord = nextMenuOrder(sep);
+    voiceModTargets.emplace(t, VoiceModTarget{pathFn, nameFn, shortPathFn, shortNameFn, additiveFn,
+                                              enabledFn, ord, sep});
 }
 
 void Engine::registerVoiceModSource(const voice::modulation::MatrixConfig::SourceIdentifier &t,
                                     vmodSrcStrFn_t pathFn, vmodSrcStrFn_t nameFn)
 {
-    voiceModSources.emplace(t, std::make_pair(pathFn, nameFn));
+    bool sep{false};
+    auto ord = nextMenuOrder(sep);
+    voiceModSources.emplace(t, VoiceModSource{pathFn, nameFn, ord});
 }
 
 void Engine::registerGroupModTarget(const modulation::GroupMatrixConfig::TargetIdentifier &t,
@@ -1411,14 +1415,18 @@ void Engine::registerGroupModTarget(const modulation::GroupMatrixConfig::TargetI
                                     gmodTgtIntFn_t additiveFn, gmodTgtBoolFn_t enabledFn,
                                     gmodTgtStrFn_t shortPathFn, gmodTgtStrFn_t shortNameFn)
 {
-    groupModTargets.emplace(
-        t, std::make_tuple(pathFn, nameFn, shortPathFn, shortNameFn, additiveFn, enabledFn));
+    bool sep{false};
+    auto ord = nextMenuOrder(sep);
+    groupModTargets.emplace(t, GroupModTarget{pathFn, nameFn, shortPathFn, shortNameFn, additiveFn,
+                                              enabledFn, ord, sep});
 }
 
 void Engine::registerGroupModSource(const modulation::GroupMatrixConfig::SourceIdentifier &t,
                                     gmodSrcStrFn_t pathFn, gmodSrcStrFn_t nameFn)
 {
-    groupModSources.emplace(t, std::make_pair(pathFn, nameFn));
+    bool sep{false};
+    auto ord = nextMenuOrder(sep);
+    groupModSources.emplace(t, GroupModSource{pathFn, nameFn, ord});
 }
 
 void Engine::terminateVoicesForZone(scxt::engine::Zone &z) { z.terminateAllVoices(); }

--- a/src/scxt-core/engine/engine.h
+++ b/src/scxt-core/engine/engine.h
@@ -703,23 +703,80 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     using gmodSrcStrFn_t = std::function<std::string(
         const Group &, const voice::modulation::MatrixConfig::SourceIdentifier &)>;
 
-    // Function order: pathFn, nameFn, shortPathFn, shortNameFn, additiveFn, enabledFn.
     // shortPathFn/shortNameFn may be empty; consumers should fall back to pathFn/nameFn.
-    std::unordered_map<voice::modulation::MatrixConfig::TargetIdentifier,
-                       std::tuple<vmodTgtStrFn_t, vmodTgtStrFn_t, vmodTgtStrFn_t, vmodTgtStrFn_t,
-                                  vmodTgtIntFn_t, vmodTgtBoolFn_t>>
+    // regOrder drives menu/sort order: -1 (the default) means sort alphabetically; a value >= 0
+    // is an explicit order assigned within a shared::ExplicitMenuOrder guard scope.
+    struct VoiceModTarget
+    {
+        vmodTgtStrFn_t pathFn, nameFn, shortPathFn, shortNameFn;
+        vmodTgtIntFn_t additiveFn;
+        vmodTgtBoolFn_t enabledFn;
+        int32_t regOrder{-1};
+        bool separatorBefore{false};
+    };
+    struct GroupModTarget
+    {
+        gmodTgtStrFn_t pathFn, nameFn, shortPathFn, shortNameFn;
+        gmodTgtIntFn_t additiveFn;
+        gmodTgtBoolFn_t enabledFn;
+        int32_t regOrder{-1};
+        bool separatorBefore{false};
+    };
+    struct VoiceModSource
+    {
+        vmodSrcStrFn_t pathFn, nameFn;
+        int32_t regOrder{-1};
+    };
+    struct GroupModSource
+    {
+        gmodSrcStrFn_t pathFn, nameFn;
+        int32_t regOrder{-1};
+    };
+
+    std::unordered_map<voice::modulation::MatrixConfig::TargetIdentifier, VoiceModTarget>
         voiceModTargets;
-    std::unordered_map<modulation::GroupMatrixConfig::TargetIdentifier,
-                       std::tuple<gmodTgtStrFn_t, gmodTgtStrFn_t, gmodTgtStrFn_t, gmodTgtStrFn_t,
-                                  gmodTgtIntFn_t, gmodTgtBoolFn_t>>
+    std::unordered_map<modulation::GroupMatrixConfig::TargetIdentifier, GroupModTarget>
         groupModTargets;
 
-    std::unordered_map<voice::modulation::MatrixConfig::SourceIdentifier,
-                       std::pair<vmodSrcStrFn_t, vmodSrcStrFn_t>>
+    std::unordered_map<voice::modulation::MatrixConfig::SourceIdentifier, VoiceModSource>
         voiceModSources;
-    std::unordered_map<modulation::GroupMatrixConfig::SourceIdentifier,
-                       std::pair<gmodSrcStrFn_t, gmodSrcStrFn_t>>
+    std::unordered_map<modulation::GroupMatrixConfig::SourceIdentifier, GroupModSource>
         groupModSources;
+
+    // Explicit menu-order state. While active (inside a shared::ExplicitMenuOrder guard), each
+    // registered target/source is stamped with an incrementing regOrder; outside, regOrder is -1
+    // and the item sorts alphabetically. See nextMenuOrder().
+    int32_t menuOrderCounter{0};
+    bool menuOrderActive{false};
+    bool menuOrderPendingSeparator{false};
+    void beginExplicitMenuOrder()
+    {
+        menuOrderActive = true;
+        menuOrderPendingSeparator = false;
+    }
+    void endExplicitMenuOrder()
+    {
+        menuOrderActive = false;
+        menuOrderPendingSeparator = false;
+    }
+    void requestMenuSeparator()
+    {
+        if (menuOrderActive)
+            menuOrderPendingSeparator = true;
+    }
+    // Returns the next explicit order (and whether a separator precedes this item) if a guard is
+    // active, else -1 / false for alphabetical ordering.
+    int32_t nextMenuOrder(bool &separatorBefore)
+    {
+        if (!menuOrderActive)
+        {
+            separatorBefore = false;
+            return -1;
+        }
+        separatorBefore = menuOrderPendingSeparator;
+        menuOrderPendingSeparator = false;
+        return menuOrderCounter++;
+    }
 
     // shortPathFn / shortNameFn may be empty std::function; in that case the metadata builder
     // falls back to pathFn / nameFn.

--- a/src/scxt-core/modulation/group_matrix.cpp
+++ b/src/scxt-core/modulation/group_matrix.cpp
@@ -84,9 +84,7 @@ GroupMatrixEndpoints::ProcessorTarget::ProcessorTarget(engine::Engine *e, uint32
             return "Out Lvl";
         };
 
-        registerGroupModTarget(e, mixT, ptFn, mixFn, false, ptShortFn, mixFn);
-        registerGroupModTarget(e, outputLevelDbT, ptFn, levFn, true, ptShortFn, levShortFn);
-
+        auto order = scxt::modulation::shared::ExplicitMenuOrder(e);
         for (int i = 0; i < scxt::maxProcessorFloatParams; ++i)
         {
             auto elFn = [icopy = i](const engine::Group &z,
@@ -119,6 +117,10 @@ GroupMatrixEndpoints::ProcessorTarget::ProcessorTarget(engine::Engine *e, uint32
             };
             registerGroupModTarget(e, fpT[i], ptFn, elFn, adFn, ptShortFn, elShortFn);
         }
+
+        order.separator();
+        registerGroupModTarget(e, mixT, ptFn, mixFn, false, ptShortFn, mixFn);
+        registerGroupModTarget(e, outputLevelDbT, ptFn, levFn, true, ptShortFn, levShortFn);
     }
 }
 
@@ -204,24 +206,30 @@ GroupMatrixEndpoints::LFOTarget::LFOTarget(engine::Engine *e, uint32_t p)
             registerGroupModTarget(e, t, ptFn, nameFn, mul, ptShortFn, nameFn);
         };
 
+        auto orderGuard = scxt::modulation::shared::ExplicitMenuOrder(e);
         reg(rateT, notEnvLabel(nm(ms.rate)));
         reg(amplitudeT, allLabel(nm(ms.amplitude)), true);
         reg(retriggerT, allLabel("Retrigger"));
+        orderGuard.separator();
         reg(curve.deformT, curveLabel(nm(ms.curveLfoStorage.deform)));
         reg(curve.angleT, curveLabel(nm(ms.curveLfoStorage.angle)));
         reg(curve.delayT, curveLabel(nm(ms.curveLfoStorage.delay)));
         reg(curve.attackT, curveLabel(nm(ms.curveLfoStorage.attack)));
         reg(curve.releaseT, curveLabel(nm(ms.curveLfoStorage.release)));
+        orderGuard.separator();
         reg(step.smoothT, stepLabel(nm(ms.stepLfoStorage.smooth)));
+        orderGuard.separator();
         reg(env.delayT, envLabel(nm(ms.envLfoStorage.delay)));
         reg(env.attackT, envLabel(nm(ms.envLfoStorage.attack)));
         reg(env.holdT, envLabel(nm(ms.envLfoStorage.hold)));
         reg(env.decayT, envLabel(nm(ms.envLfoStorage.decay)));
         reg(env.sustainT, envLabel(nm(ms.envLfoStorage.sustain)));
         reg(env.releaseT, envLabel(nm(ms.envLfoStorage.release)));
+        orderGuard.separator();
         reg(env.aShapeT, envLabel(nm(ms.envLfoStorage.aShape)));
         reg(env.dShapeT, envLabel(nm(ms.envLfoStorage.dShape)));
         reg(env.rShapeT, envLabel(nm(ms.envLfoStorage.rShape)));
+        orderGuard.separator();
         reg(env.rateMulT, envLabel(nm(ms.envLfoStorage.rateMul)));
     }
 }
@@ -352,7 +360,7 @@ groupMatrixMetadata_t getGroupMatrixMetadata(const engine::Group &g)
     namedSourceVector_t sr;
     namedCurveVector_t cr;
 
-    auto identCmp = [](const auto &a, const auto &b) {
+    auto identCmp = [e](const auto &a, const auto &b) {
         const auto &srca = std::get<0>(a);
         const auto &srcb = std::get<0>(b);
         const auto &ida = std::get<1>(a);
@@ -364,28 +372,33 @@ groupMatrixMetadata_t getGroupMatrixMetadata(const engine::Group &g)
             return srca.index < srcb.index;
         }
 
-        if (ida.first == idb.first)
+        // categories (paths) sort alphabetically, keeping same-path items contiguous
+        if (ida.first != idb.first)
+            return strnatcasecmp(ida.first.c_str(), idb.first.c_str()) < 0;
+
+        // within a category: explicit regOrder (>= 0) wins and precedes alphabetical items
+        auto ordOf = [e](const auto &s) -> int32_t {
+            auto it = e->groupModSources.find(s);
+            return it == e->groupModSources.end() ? -1 : it->second.regOrder;
+        };
+        auto oa = ordOf(srca);
+        auto ob = ordOf(srcb);
+        if (oa >= 0 || ob >= 0)
         {
-            if (ida.second == idb.second)
-            {
-                return std::hash<
-                           std::remove_cv_t<std::remove_reference_t<decltype(std::get<0>(a))>>>{}(
-                           std::get<0>(a)) <
-                       std::hash<
-                           std::remove_cv_t<std::remove_reference_t<decltype(std::get<0>(b))>>>{}(
-                           std::get<0>(b));
-            }
-            else
-            {
-                return strnatcasecmp(ida.second.c_str(), idb.second.c_str()) < 0;
-            }
+            if (oa >= 0 && ob >= 0)
+                return oa < ob;
+            return oa >= 0;
         }
-        return strnatcasecmp(ida.first.c_str(), idb.first.c_str()) < 0;
+
+        if (ida.second != idb.second)
+            return strnatcasecmp(ida.second.c_str(), idb.second.c_str()) < 0;
+        return std::hash<std::remove_cv_t<std::remove_reference_t<decltype(srca)>>>{}(srca) <
+               std::hash<std::remove_cv_t<std::remove_reference_t<decltype(srcb)>>>{}(srcb);
     };
 
-    // Targets carry a 4-tuple displayName (path, name, shortPath, shortName); sort by long
-    // path/name
-    auto tgtCmp = [](const namedTarget_t &a, const namedTarget_t &b) {
+    // Targets carry a 4-tuple displayName (path, name, shortPath, shortName); categories sort
+    // alphabetically by long path, items within a category by explicit regOrder then long name.
+    auto tgtCmp = [e](const namedTarget_t &a, const namedTarget_t &b) {
         const auto &ta = std::get<0>(a);
         const auto &tb = std::get<0>(b);
         if (ta.gid == 'gprc' && tb.gid == ta.gid && tb.index == ta.index)
@@ -394,37 +407,48 @@ groupMatrixMetadata_t getGroupMatrixMetadata(const engine::Group &g)
         }
         const auto &dna = std::get<1>(a);
         const auto &dnb = std::get<1>(b);
-        if (displayPath(dna) == displayPath(dnb))
+        if (displayPath(dna) != displayPath(dnb))
+            return strnatcasecmp(displayPath(dna).c_str(), displayPath(dnb).c_str()) < 0;
+
+        auto ordOf = [e](const GroupMatrixConfig::TargetIdentifier &t) -> int32_t {
+            auto it = e->groupModTargets.find(t);
+            return it == e->groupModTargets.end() ? -1 : it->second.regOrder;
+        };
+        auto oa = ordOf(ta);
+        auto ob = ordOf(tb);
+        if (oa >= 0 || ob >= 0)
         {
-            if (displayName(dna) == displayName(dnb))
-            {
-                return std::hash<GroupMatrixConfig::TargetIdentifier>{}(ta) <
-                       std::hash<GroupMatrixConfig::TargetIdentifier>{}(tb);
-            }
-            return strnatcasecmp(displayName(dna).c_str(), displayName(dnb).c_str()) < 0;
+            if (oa >= 0 && ob >= 0)
+                return oa < ob;
+            return oa >= 0;
         }
-        return strnatcasecmp(displayPath(dna).c_str(), displayPath(dnb).c_str()) < 0;
+
+        if (displayName(dna) != displayName(dnb))
+            return strnatcasecmp(displayName(dna).c_str(), displayName(dnb).c_str()) < 0;
+        return std::hash<GroupMatrixConfig::TargetIdentifier>{}(ta) <
+               std::hash<GroupMatrixConfig::TargetIdentifier>{}(tb);
     };
 
     for (const auto &[t, fns] : e->groupModTargets)
     {
-        const auto &pathFn = std::get<0>(fns);
-        const auto &nameFn = std::get<1>(fns);
-        const auto &shortPathFn = std::get<2>(fns);
-        const auto &shortNameFn = std::get<3>(fns);
-        const auto &additiveFn = std::get<4>(fns);
-        const auto &enabledFn = std::get<5>(fns);
+        const auto &pathFn = fns.pathFn;
+        const auto &nameFn = fns.nameFn;
+        const auto &shortPathFn = fns.shortPathFn;
+        const auto &shortNameFn = fns.shortNameFn;
+        const auto &additiveFn = fns.additiveFn;
+        const auto &enabledFn = fns.enabledFn;
         auto p = pathFn(g, t);
         auto n = nameFn(g, t);
         auto sp = shortPathFn ? shortPathFn(g, t) : p;
         auto sn = shortNameFn ? shortNameFn(g, t) : n;
-        tg.emplace_back(t, targetDisplayName_t{p, n, sp, sn}, additiveFn(g, t), enabledFn(g, t));
+        tg.emplace_back(t, targetDisplayName_t{p, n, sp, sn}, additiveFn(g, t), enabledFn(g, t),
+                        fns.separatorBefore);
     }
     std::sort(tg.begin(), tg.end(), tgtCmp);
 
     for (const auto &[s, fns] : e->groupModSources)
     {
-        sr.emplace_back(s, identifierDisplayName_t{fns.first(g, s), fns.second(g, s)});
+        sr.emplace_back(s, identifierDisplayName_t{fns.pathFn(g, s), fns.nameFn(g, s)});
     }
     std::sort(sr.begin(), sr.end(), identCmp);
 

--- a/src/scxt-core/modulation/group_matrix.h
+++ b/src/scxt-core/modulation/group_matrix.h
@@ -130,17 +130,20 @@ struct GroupMatrixEndpoints
                 auto reg = [&](const auto &t, const std::string &nm) {
                     registerGroupModTarget(e, t, longPath, nm, false, shortPath, nm);
                 };
+                auto orderGuard = scxt::modulation::shared::ExplicitMenuOrder(e);
                 reg(dlyT, "Delay");
                 reg(aT, "Attack");
                 reg(hT, "Hold");
                 reg(dT, "Decay");
                 reg(sT, "Sustain");
                 reg(rT, "Release");
+                orderGuard.separator();
                 reg(asT, "Attack Shape");
                 reg(dsT, "Decay Shape");
                 reg(rsT, "Release Shape");
+                orderGuard.separator();
                 reg(retriggerT, "Retrigger");
-                reg(rateMulT, "Rate Multiplier");
+                reg(rateMulT, "Env Times");
             }
         }
         void bind(GroupMatrix &m, engine::Group &g);
@@ -369,9 +372,10 @@ inline const std::string &displayName(const targetDisplayName_t &d) { return std
 inline const std::string &displayShortPath(const targetDisplayName_t &d) { return std::get<2>(d); }
 inline const std::string &displayShortName(const targetDisplayName_t &d) { return std::get<3>(d); }
 
-// The last two are "multiplicative" and "enabled"
-// "multiplicative" uses first bit as can and second bit as should
-typedef std::tuple<GroupMatrixConfig::TargetIdentifier, targetDisplayName_t, int32_t, bool>
+// Fields after the display name are "multiplicative", "enabled", and "separatorBefore".
+// "multiplicative" uses first bit as can and second bit as should. "separatorBefore" asks the
+// menu to draw a separator before this item (set via explicit menu ordering).
+typedef std::tuple<GroupMatrixConfig::TargetIdentifier, targetDisplayName_t, int32_t, bool, bool>
     namedTarget_t;
 typedef std::vector<namedTarget_t> namedTargetVector_t;
 typedef std::pair<GroupMatrixConfig::SourceIdentifier, identifierDisplayName_t> namedSource_t;

--- a/src/scxt-core/modulation/matrix_shared.cpp
+++ b/src/scxt-core/modulation/matrix_shared.cpp
@@ -1,0 +1,49 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+// engine.h transitively pulls in matrix_shared.h together with all the prerequisites the header
+// relies on (configuration, datamodel, <sstream>, ...); matrix_shared.h is not standalone.
+#include "engine/engine.h"
+
+namespace scxt::modulation::shared
+{
+ExplicitMenuOrder::ExplicitMenuOrder(engine::Engine *e) : engine(e)
+{
+    if (engine)
+        engine->beginExplicitMenuOrder();
+}
+ExplicitMenuOrder::~ExplicitMenuOrder()
+{
+    if (engine)
+        engine->endExplicitMenuOrder();
+}
+void ExplicitMenuOrder::separator()
+{
+    if (engine)
+        engine->requestMenuSeparator();
+}
+} // namespace scxt::modulation::shared

--- a/src/scxt-core/modulation/matrix_shared.h
+++ b/src/scxt-core/modulation/matrix_shared.h
@@ -40,6 +40,27 @@ struct Engine;
 
 namespace scxt::modulation::shared
 {
+/*
+ * RAII guard: while in scope, mod targets/sources registered with the engine get an incrementing
+ * explicit menu order (instead of the default -1, which sorts alphabetically). Call separator()
+ * to mark that the next registered item should have a menu separator before it.
+ *
+ *     auto orderGuard = scxt::modulation::shared::ExplicitMenuOrder(e);
+ *     registerTarget(...); registerTarget(...);
+ *     orderGuard.separator();
+ *     registerTarget(...);
+ */
+struct ExplicitMenuOrder
+{
+    scxt::engine::Engine *engine{nullptr};
+    explicit ExplicitMenuOrder(scxt::engine::Engine *e);
+    ~ExplicitMenuOrder();
+    void separator();
+
+    ExplicitMenuOrder(const ExplicitMenuOrder &) = delete;
+    ExplicitMenuOrder &operator=(const ExplicitMenuOrder &) = delete;
+};
+
 struct SourceIdentifier
 {
     uint32_t gid{0};

--- a/src/scxt-core/modulation/voice_matrix.cpp
+++ b/src/scxt-core/modulation/voice_matrix.cpp
@@ -217,7 +217,7 @@ voiceMatrixMetadata_t getVoiceMatrixMetadata(const engine::Zone &z)
     namedSourceVector_t sr;
     namedCurveVector_t cr;
 
-    auto identCmp = [](const auto &a, const auto &b) {
+    auto identCmp = [e](const auto &a, const auto &b) {
         const auto &srca = std::get<0>(a);
         const auto &srcb = std::get<0>(b);
         const auto &ida = std::get<1>(a);
@@ -227,28 +227,33 @@ voiceMatrixMetadata_t getVoiceMatrixMetadata(const engine::Zone &z)
             return srca.index < srcb.index;
         }
 
-        if (ida.first == idb.first)
+        // categories (paths) sort alphabetically, keeping same-path items contiguous
+        if (ida.first != idb.first)
+            return strnatcasecmp(ida.first.c_str(), idb.first.c_str()) < 0;
+
+        // within a category: explicit regOrder (>= 0) wins and precedes alphabetical items
+        auto ordOf = [e](const auto &s) -> int32_t {
+            auto it = e->voiceModSources.find(s);
+            return it == e->voiceModSources.end() ? -1 : it->second.regOrder;
+        };
+        auto oa = ordOf(srca);
+        auto ob = ordOf(srcb);
+        if (oa >= 0 || ob >= 0)
         {
-            if (ida.second == idb.second)
-            {
-                return std::hash<
-                           std::remove_cv_t<std::remove_reference_t<decltype(std::get<0>(a))>>>{}(
-                           std::get<0>(a)) <
-                       std::hash<
-                           std::remove_cv_t<std::remove_reference_t<decltype(std::get<0>(b))>>>{}(
-                           std::get<0>(b));
-            }
-            else
-            {
-                return strnatcasecmp(ida.second.c_str(), idb.second.c_str()) < 0;
-            }
+            if (oa >= 0 && ob >= 0)
+                return oa < ob;
+            return oa >= 0;
         }
-        return strnatcasecmp(ida.first.c_str(), idb.first.c_str()) < 0;
+
+        if (ida.second != idb.second)
+            return strnatcasecmp(ida.second.c_str(), idb.second.c_str()) < 0;
+        return std::hash<std::remove_cv_t<std::remove_reference_t<decltype(srca)>>>{}(srca) <
+               std::hash<std::remove_cv_t<std::remove_reference_t<decltype(srcb)>>>{}(srcb);
     };
 
-    // Targets carry a 4-tuple displayName (path, name, shortPath, shortName); sort by long
-    // path/name
-    auto tgtCmp = [](const namedTarget_t &a, const namedTarget_t &b) {
+    // Targets carry a 4-tuple displayName (path, name, shortPath, shortName); categories sort
+    // alphabetically by long path, items within a category by explicit regOrder then long name.
+    auto tgtCmp = [e](const namedTarget_t &a, const namedTarget_t &b) {
         const auto &ta = std::get<0>(a);
         const auto &tb = std::get<0>(b);
         if (ta.gid == 'proc' && tb.gid == ta.gid && tb.index == ta.index)
@@ -257,37 +262,48 @@ voiceMatrixMetadata_t getVoiceMatrixMetadata(const engine::Zone &z)
         }
         const auto &dna = std::get<1>(a);
         const auto &dnb = std::get<1>(b);
-        if (displayPath(dna) == displayPath(dnb))
+        if (displayPath(dna) != displayPath(dnb))
+            return strnatcasecmp(displayPath(dna).c_str(), displayPath(dnb).c_str()) < 0;
+
+        auto ordOf = [e](const MatrixConfig::TargetIdentifier &t) -> int32_t {
+            auto it = e->voiceModTargets.find(t);
+            return it == e->voiceModTargets.end() ? -1 : it->second.regOrder;
+        };
+        auto oa = ordOf(ta);
+        auto ob = ordOf(tb);
+        if (oa >= 0 || ob >= 0)
         {
-            if (displayName(dna) == displayName(dnb))
-            {
-                return std::hash<MatrixConfig::TargetIdentifier>{}(ta) <
-                       std::hash<MatrixConfig::TargetIdentifier>{}(tb);
-            }
-            return strnatcasecmp(displayName(dna).c_str(), displayName(dnb).c_str()) < 0;
+            if (oa >= 0 && ob >= 0)
+                return oa < ob;
+            return oa >= 0;
         }
-        return strnatcasecmp(displayPath(dna).c_str(), displayPath(dnb).c_str()) < 0;
+
+        if (displayName(dna) != displayName(dnb))
+            return strnatcasecmp(displayName(dna).c_str(), displayName(dnb).c_str()) < 0;
+        return std::hash<MatrixConfig::TargetIdentifier>{}(ta) <
+               std::hash<MatrixConfig::TargetIdentifier>{}(tb);
     };
 
     for (const auto &[t, fns] : e->voiceModTargets)
     {
-        const auto &pathFn = std::get<0>(fns);
-        const auto &nameFn = std::get<1>(fns);
-        const auto &shortPathFn = std::get<2>(fns);
-        const auto &shortNameFn = std::get<3>(fns);
-        const auto &additiveFn = std::get<4>(fns);
-        const auto &enabledFn = std::get<5>(fns);
+        const auto &pathFn = fns.pathFn;
+        const auto &nameFn = fns.nameFn;
+        const auto &shortPathFn = fns.shortPathFn;
+        const auto &shortNameFn = fns.shortNameFn;
+        const auto &additiveFn = fns.additiveFn;
+        const auto &enabledFn = fns.enabledFn;
         auto p = pathFn(z, t);
         auto n = nameFn(z, t);
         auto sp = shortPathFn ? shortPathFn(z, t) : p;
         auto sn = shortNameFn ? shortNameFn(z, t) : n;
-        tg.emplace_back(t, targetDisplayName_t{p, n, sp, sn}, additiveFn(z, t), enabledFn(z, t));
+        tg.emplace_back(t, targetDisplayName_t{p, n, sp, sn}, additiveFn(z, t), enabledFn(z, t),
+                        fns.separatorBefore);
     }
     std::sort(tg.begin(), tg.end(), tgtCmp);
 
     for (const auto &[s, fns] : e->voiceModSources)
     {
-        sr.emplace_back(s, identifierDisplayName_t{fns.first(z, s), fns.second(z, s)});
+        sr.emplace_back(s, identifierDisplayName_t{fns.pathFn(z, s), fns.nameFn(z, s)});
     }
     std::sort(sr.begin(), sr.end(), identCmp);
 
@@ -341,8 +357,7 @@ MatrixEndpoints::ProcessorTarget::ProcessorTarget(engine::Engine *e, uint32_t p)
         return "Out Lvl";
     };
 
-    registerVoiceModTarget(e, mixT, ptFn, mixFn, false, ptShortFn, mixFn);
-    registerVoiceModTarget(e, outputLevelDbT, ptFn, levFn, true, ptShortFn, levShortFn);
+    auto order = scxt::modulation::shared::ExplicitMenuOrder(e);
 
     for (int i = 0; i < scxt::maxProcessorFloatParams; ++i)
     {
@@ -382,6 +397,10 @@ MatrixEndpoints::ProcessorTarget::ProcessorTarget(engine::Engine *e, uint32_t p)
 
         registerVoiceModTarget(e, fpT[i], ptFn, elFn, adFn, enFn, ptShortFn, elShortFn);
     }
+
+    order.separator();
+    registerVoiceModTarget(e, mixT, ptFn, mixFn, false, ptShortFn, mixFn);
+    registerVoiceModTarget(e, outputLevelDbT, ptFn, levFn, true, ptShortFn, levShortFn);
 }
 
 MatrixEndpoints::LFOTarget::LFOTarget(engine::Engine *e, uint32_t p)
@@ -429,24 +448,30 @@ MatrixEndpoints::LFOTarget::LFOTarget(engine::Engine *e, uint32_t p)
         auto ms = scxt::modulation::ModulatorStorage();
         auto nm = [&ms](auto &v) { return datamodel::describeValue(ms, v).name; };
 
+        auto orderGuard = scxt::modulation::shared::ExplicitMenuOrder(e);
         registerVoiceModTarget(e, rateT, ptFn, notEnvLabel(nm(ms.rate)));
         registerVoiceModTarget(e, amplitudeT, ptFn, allLabel(nm(ms.amplitude)), true);
         registerVoiceModTarget(e, retriggerT, ptFn, allLabel("Retrigger"));
+        orderGuard.separator();
         registerVoiceModTarget(e, curve.deformT, ptFn, curveLabel(nm(ms.curveLfoStorage.deform)));
         registerVoiceModTarget(e, curve.angleT, ptFn, curveLabel(nm(ms.curveLfoStorage.angle)));
         registerVoiceModTarget(e, curve.delayT, ptFn, curveLabel(nm(ms.curveLfoStorage.delay)));
         registerVoiceModTarget(e, curve.attackT, ptFn, curveLabel(nm(ms.curveLfoStorage.attack)));
         registerVoiceModTarget(e, curve.releaseT, ptFn, curveLabel(nm(ms.curveLfoStorage.release)));
+        orderGuard.separator();
         registerVoiceModTarget(e, step.smoothT, ptFn, stepLabel(nm(ms.stepLfoStorage.smooth)));
+        orderGuard.separator();
         registerVoiceModTarget(e, env.delayT, ptFn, envLabel(nm(ms.envLfoStorage.delay)));
         registerVoiceModTarget(e, env.attackT, ptFn, envLabel(nm(ms.envLfoStorage.attack)));
         registerVoiceModTarget(e, env.holdT, ptFn, envLabel(nm(ms.envLfoStorage.hold)));
         registerVoiceModTarget(e, env.decayT, ptFn, envLabel(nm(ms.envLfoStorage.decay)));
         registerVoiceModTarget(e, env.sustainT, ptFn, envLabel(nm(ms.envLfoStorage.sustain)));
         registerVoiceModTarget(e, env.releaseT, ptFn, envLabel(nm(ms.envLfoStorage.release)));
+        orderGuard.separator();
         registerVoiceModTarget(e, env.aShapeT, ptFn, envLabel(nm(ms.envLfoStorage.aShape)));
         registerVoiceModTarget(e, env.dShapeT, ptFn, envLabel(nm(ms.envLfoStorage.dShape)));
         registerVoiceModTarget(e, env.rShapeT, ptFn, envLabel(nm(ms.envLfoStorage.rShape)));
+        orderGuard.separator();
         registerVoiceModTarget(e, env.rateMulT, ptFn, envLabel(nm(ms.envLfoStorage.rateMul)));
     }
 }

--- a/src/scxt-core/modulation/voice_matrix.h
+++ b/src/scxt-core/modulation/voice_matrix.h
@@ -146,6 +146,7 @@ struct MatrixEndpoints
         EGTarget(engine::Engine *e, uint32_t p)
             : scxt::modulation::shared::EGTargetEndpointData<TG, 'envg'>(p)
         {
+            auto orderGuard = scxt::modulation::shared::ExplicitMenuOrder(e);
             std::string group = (index == 0 ? "AEG" : std::string("EG") + std::to_string(p + 1));
             registerVoiceModTarget(e, dlyT, group, "Delay");
             registerVoiceModTarget(e, aT, group, "Attack");
@@ -153,11 +154,13 @@ struct MatrixEndpoints
             registerVoiceModTarget(e, dT, group, "Decay");
             registerVoiceModTarget(e, sT, group, "Sustain");
             registerVoiceModTarget(e, rT, group, "Release");
+            orderGuard.separator();
             registerVoiceModTarget(e, asT, group, "Attack Shape");
             registerVoiceModTarget(e, dsT, group, "Decay Shape");
             registerVoiceModTarget(e, rsT, group, "Release Shape");
+            orderGuard.separator();
             registerVoiceModTarget(e, retriggerT, group, "Retrigger");
-            registerVoiceModTarget(e, rateMulT, group, "Rate Multiplier");
+            registerVoiceModTarget(e, rateMulT, group, "Env Times");
         }
 
         void bind(Matrix &m, engine::Zone &z);
@@ -513,9 +516,10 @@ inline const std::string &displayName(const targetDisplayName_t &d) { return std
 inline const std::string &displayShortPath(const targetDisplayName_t &d) { return std::get<2>(d); }
 inline const std::string &displayShortName(const targetDisplayName_t &d) { return std::get<3>(d); }
 
-// The last two are "multiplcative" and "enabled"
-// "multiplcaitve" uses first bit as can and second bit as should
-typedef std::tuple<MatrixConfig::TargetIdentifier, targetDisplayName_t, int32_t, bool>
+// Fields after the display name are "multiplicative", "enabled", and "separatorBefore".
+// "multiplicative" uses first bit as can and second bit as should. "separatorBefore" asks the
+// menu to draw a separator before this item (set via explicit menu ordering).
+typedef std::tuple<MatrixConfig::TargetIdentifier, targetDisplayName_t, int32_t, bool, bool>
     namedTarget_t;
 typedef std::vector<namedTarget_t> namedTargetVector_t;
 typedef std::pair<MatrixConfig::SourceIdentifier, identifierDisplayName_t> namedSource_t;

--- a/src/scxt-plugin/app/edit-screen/components/ModPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/ModPane.cpp
@@ -296,7 +296,7 @@ template <typename GZTrait> struct ModRow : juce::Component, HasEditor, juce::Dr
                     c = cn.second;
             }
 
-            for (const auto &[di, dn, ca, isen] : dsts)
+            for (const auto &[di, dn, ca, isen, sep] : dsts)
             {
                 // long name in the multi-select consistency banner (room for full text)
                 if (di == row.target)
@@ -348,7 +348,7 @@ template <typename GZTrait> struct ModRow : juce::Component, HasEditor, juce::Dr
             }
         }
 
-        for (const auto &[di, dn, ca, en] : dsts)
+        for (const auto &[di, dn, ca, en, sep] : dsts)
         {
             if (di == row.target)
             {
@@ -772,11 +772,22 @@ template <typename GZTrait> struct ModRow : juce::Component, HasEditor, juce::Dr
         bool checkPath{false};
         juce::PopupMenu subMenu;
 
-        for (const auto &[ti, tn, mulConfig, isEnabled] : tgts)
+        // Separators are deferred so conditionally-hidden items don't leave doubled or leading
+        // separators: a requested separator is only emitted right before the next visible item,
+        // and only if content precedes it. We note the request even for hidden items so it carries
+        // to the next visible one rather than being lost. Tracked per-menu (top level / submenu).
+        bool subPendingSep{false}, subHasContent{false};
+        bool topPendingSep{false}, topHasContent{true}; // p already has the "Off" item
+
+        for (const auto &[ti, tn, mulConfig, isEnabled, sepBefore] : tgts)
         {
             // tn is targetDisplayName_t = tuple<path, name, shortPath, shortName>; menu shows longs
             const auto &tnPath = std::get<0>(tn);
             const auto &tnName = std::get<1>(tn);
+
+            if (sepBefore)
+                (tnPath.empty() ? topPendingSep : subPendingSep) = true;
+
             if (tnName.empty())
                 continue;
 
@@ -804,7 +815,11 @@ template <typename GZTrait> struct ModRow : juce::Component, HasEditor, juce::Dr
 
             if (tnPath.empty())
             {
+                if (topPendingSep && topHasContent)
+                    p.addSeparator();
+                topPendingSep = false;
                 p.addItem(tnName, isEnabled, selected, mop);
+                topHasContent = true;
             }
             else
             {
@@ -819,8 +834,14 @@ template <typename GZTrait> struct ModRow : juce::Component, HasEditor, juce::Dr
                     subMenu = juce::PopupMenu();
                     subMenu.addSectionHeader(tnPath);
                     subMenu.addSeparator();
+                    subPendingSep = false; // header separator already present
+                    subHasContent = false;
                 }
+                if (subPendingSep && subHasContent)
+                    subMenu.addSeparator();
+                subPendingSep = false;
                 subMenu.addItem(tnName, isEnabled, selected, mop);
+                subHasContent = true;
                 checkPath = checkPath || selected;
             }
         }


### PR DESCRIPTION
Source and target menus in the mod matrix can now be ordered explicitly rather than always alphabetically. Registration inside an ExplicitMenuOrder guard stamps an incrementing order onto each target or source; outside a guard items keep the default and sort alphabetically. The envelope lfo and proc targets use this to present their parameters in a natural order.

The change is larger than the feature alone implies because we took the opportunity to convert the mod registration structures from anonymous tuples into proper named classes. That gives the targets and sources a shared home for the new ordering (and separator) fields and makes the registration and comparator code far easier to read.

Closes #2525
Assisted-By: Claude Opus 4.8