### PR TITLE
Add a panic button, per wireframe

### DIFF
--- a/src/scxt-plugin/app/shared/HeaderRegion.cpp
+++ b/src/scxt-plugin/app/shared/HeaderRegion.cpp
@@ -28,6 +28,7 @@
 #include "HeaderRegion.h"
 #include "app/SCXTEditor.h"
 #include "messaging/client/interaction_messages.h"
+#include "messaging/client/enginestatus_messages.h"
 #include "messaging/client/patch_io_messages.h"
 #include "messaging/client/structure_messages.h"
 #include "infrastructure/user_defaults.h"
@@ -190,6 +191,27 @@ HeaderRegion::HeaderRegion(SCXTEditor *e) : HasEditor(e)
     });
     addAndMakeVisible(*omniButton);
 
+    panicButton = std::make_unique<jcmp::TextPushButton>();
+    panicButton->setLabel("!");
+    panicButton->setTitle("Panic");
+    panicButton->setOnCallback([w = juce::Component::SafePointer(this)]() {
+        if (!w)
+            return;
+        juce::PopupMenu p;
+        p.addSectionHeader("Panic");
+        p.addSeparator();
+        p.addItem("All Sounds Off", [w]() {
+            if (w)
+                w->sendToSerialization(cmsg::StopSounds{true});
+        });
+        p.addItem("All Notes Off", [w]() {
+            if (w)
+                w->sendToSerialization(cmsg::StopSounds{false});
+        });
+        p.showMenuAsync(w->editor->defaultPopupMenuOptions(w->panicButton.get()));
+    });
+    addAndMakeVisible(*panicButton);
+
     if (hasFeature::memoryUsageExplanation)
     {
         chipButton = std::make_unique<jcmp::GlyphButton>(jcmp::GlyphPainter::MEMORY);
@@ -243,6 +265,7 @@ HeaderRegion::HeaderRegion(SCXTEditor *e) : HasEditor(e)
     editor->themeApplier.setLabelToHighlight(cpuLevel.get());
     editor->themeApplier.setLabelToHighlight(ramLevel.get());
     editor->themeApplier.applyHeaderSCButtonTheme(scMenu.get());
+    editor->themeApplier.applyHeaderPanicButtonTheme(panicButton.get());
 }
 
 void HeaderRegion::mouseDown(const juce::MouseEvent &e)
@@ -286,6 +309,8 @@ void HeaderRegion::resized()
     activityDisplay->setBounds(multiMenuButton->getBounds());
 
     scMenu->setBounds(b.withTrimmedLeft(1248).withWidth(24));
+
+    panicButton->setBounds(b.withTrimmedLeft(988).withWidth(28).withHeight(28));
 
     cpuLabel->setBounds(b.withTrimmedLeft(1022).withWidth(25).withHeight(14));
     ramLabel->setBounds(b.withTrimmedLeft(1022).withWidth(25).withHeight(14).translated(0, 14));

--- a/src/scxt-plugin/app/shared/HeaderRegion.h
+++ b/src/scxt-plugin/app/shared/HeaderRegion.h
@@ -54,7 +54,7 @@ struct HeaderRegion : juce::Component, HasEditor, juce::FileDragAndDropTarget
     std::unique_ptr<sst::jucegui::data::Discrete> selectedPageData;
     std::unique_ptr<sst::jucegui::components::VUMeter> vuMeter;
     std::unique_ptr<sst::jucegui::components::TextPushButton> undoButton, redoButton, tuningButton,
-        omniButton;
+        omniButton, panicButton;
     std::unique_ptr<sst::jucegui::components::Label> cpuLevel, ramLevel;
     std::unique_ptr<sst::jucegui::components::Label> cpuLabel, ramLabel;
 

--- a/src/scxt-plugin/theme/ThemeApplier.cpp
+++ b/src/scxt-plugin/theme/ThemeApplier.cpp
@@ -163,6 +163,7 @@ static constexpr sheet_t::Class ToggleButton{"header.togglebutton"};
 static constexpr sheet_t::Class MenuButton{"header.menubutton"};
 static constexpr sheet_t::Class GlyphButton{"header.menubutton"};
 static constexpr sheet_t::Class GlyphButtonAccent{"header.menubutton.accent"};
+static constexpr sheet_t::Class PanicButton{"header.textbutton.panic"};
 void applyColorsAndFonts(const sheet_t::ptr_t &, const ColorMap &, const ThemeApplier &);
 void init()
 {
@@ -171,6 +172,7 @@ void init()
     sheet_t::addClass(MenuButton).withBaseClass(jcmp::MenuButton::Styles::styleClass);
     sheet_t::addClass(GlyphButton).withBaseClass(jcmp::GlyphButton::Styles::styleClass);
     sheet_t::addClass(GlyphButtonAccent).withBaseClass(GlyphButton);
+    sheet_t::addClass(PanicButton).withBaseClass(TextPushButton);
 }
 } // namespace header
 
@@ -326,6 +328,11 @@ void ThemeApplier::setLabelToHighlight(sst::jucegui::style::StyleConsumer *s)
 void ThemeApplier::applyHeaderSCButtonTheme(sst::jucegui::style::StyleConsumer *s)
 {
     s->setCustomClass(detail::header::GlyphButtonAccent);
+}
+
+void ThemeApplier::applyHeaderPanicButtonTheme(sst::jucegui::style::StyleConsumer *s)
+{
+    s->setCustomClass(detail::header::PanicButton);
 }
 
 void ThemeApplier::applyChannelStripTheme(juce::Component *toThis)
@@ -753,6 +760,11 @@ void applyColorsAndFonts(const sheet_t::ptr_t &base, const ColorMap &cols, const
     base->setColour(GlyphButtonAccent, jcmp::GlyphButton::Styles::labelcolor,
                     cols.get(ColorMap::accent_1a));
     base->setColour(GlyphButtonAccent, jcmp::GlyphButton::Styles::labelcolor_hover,
+                    cols.get(ColorMap::accent_1a));
+
+    base->setColour(PanicButton, jcmp::TextPushButton::Styles::labelcolor,
+                    cols.get(ColorMap::accent_1a));
+    base->setColour(PanicButton, jcmp::TextPushButton::Styles::labelcolor_hover,
                     cols.get(ColorMap::accent_1a));
 }
 } // namespace header

--- a/src/scxt-plugin/theme/ThemeApplier.h
+++ b/src/scxt-plugin/theme/ThemeApplier.h
@@ -62,6 +62,7 @@ struct ThemeApplier
     void applyMixerChannelTheme(juce::Component *toThis);
     void applyHeaderTheme(juce::Component *toThis);
     void applyHeaderSCButtonTheme(sst::jucegui::style::StyleConsumer *);
+    void applyHeaderPanicButtonTheme(sst::jucegui::style::StyleConsumer *);
     void applyChannelStripTheme(juce::Component *toThis);
     void applyAuxChannelStripTheme(juce::Component *toThis);
 


### PR DESCRIPTION
Even though allsounds/allnotes is in the main menu add a panic button front and center which you can use, per wireframe

Closes #879
Assisted-By: Claude Opus 4.8