### PR TITLE
Small cleanups from code review

### DIFF
--- a/src/scxt-core/engine/group_and_zone_impl.h
+++ b/src/scxt-core/engine/group_and_zone_impl.h
@@ -263,11 +263,11 @@ std::string HasGroupZoneProcessors<T>::toStringProcRoutingPath(
     case procRoute_ser3:
         return "procRoute_ser3";
     case procRoute_par1:
-        return "procRoete_par1";
+        return "procRoute_par1";
     case procRoute_par2:
-        return "procRoete_par2";
+        return "procRoute_par2";
     case procRoute_par3:
-        return "procRoete_par3";
+        return "procRoute_par3";
     case procRoute_bypass:
         return "procRoute_bypass";
     }
@@ -282,9 +282,18 @@ HasGroupZoneProcessors<T>::fromStringProcRoutingPath(const std::string &s)
         makeEnumInverse<ProcRoutingPath, HasGroupZoneProcessors<T>::toStringProcRoutingPath>(
             procRoute_linear, procRoute_bypass);
     auto p = inverse.find(s);
-    if (p == inverse.end())
-        return procRoute_linear;
-    return p->second;
+    if (p != inverse.end())
+        return p->second;
+
+    // Legacy alias: pre-1.0 patches streamed the par paths with a typo
+    if (s == "procRoete_par1")
+        return procRoute_par1;
+    if (s == "procRoete_par2")
+        return procRoute_par2;
+    if (s == "procRoete_par3")
+        return procRoute_par3;
+
+    return procRoute_linear;
 }
 
 template <typename T>

--- a/src/scxt-core/engine/group_triggers.cpp
+++ b/src/scxt-core/engine/group_triggers.cpp
@@ -37,7 +37,7 @@ namespace scxt::engine
 
 std::string toStringGroupTriggerID(const GroupTriggerID &p)
 {
-    if (p >= GroupTriggerID::MACRO && (int)p <= (int)GroupTriggerID::MACRO + scxt::macrosPerPart)
+    if (p >= GroupTriggerID::MACRO && (int)p < (int)GroupTriggerID::MACRO + scxt::macrosPerPart)
     {
         return fmt::format("macro{}", (int)p - (int)GroupTriggerID::MACRO);
     }
@@ -206,7 +206,7 @@ struct GTKeyswitchMomentary : GroupTrigger
 GroupTrigger *makeGroupTrigger(GroupTriggerID id, GroupTriggerInstrumentState &gis,
                                GroupTriggerStorage &st, GroupTriggerBuffer &bf)
 {
-    if (id >= GroupTriggerID::MACRO && (int)id <= (int)GroupTriggerID::MACRO + scxt::macrosPerPart)
+    if (id >= GroupTriggerID::MACRO && (int)id < (int)GroupTriggerID::MACRO + scxt::macrosPerPart)
     {
         static_assert(sizeof(GTMacro) < sizeof(GroupTriggerBuffer));
         return new (bf) GTMacro(id, gis, st, (int)id - (int)GroupTriggerID::MACRO);
@@ -234,7 +234,7 @@ GroupTrigger *makeGroupTrigger(GroupTriggerID id, GroupTriggerInstrumentState &g
 
 std::string getGroupTriggerDisplayName(GroupTriggerID id)
 {
-    if (id >= GroupTriggerID::MACRO && (int)id <= (int)GroupTriggerID::MACRO + scxt::macrosPerPart)
+    if (id >= GroupTriggerID::MACRO && (int)id < (int)GroupTriggerID::MACRO + scxt::macrosPerPart)
     {
         return fmt::format("MACRO {}", (int)id - (int)GroupTriggerID::MACRO + 1);
     }

--- a/src/scxt-core/json/modulation_traits.h
+++ b/src/scxt-core/json/modulation_traits.h
@@ -85,7 +85,7 @@ SC_STREAMDEF(scxt::modulation::modulators::EnvLFOStorage, SC_FROM({
                  addUnlessDefault<val_t>(v, "aShape", 0.f, from.aShape);
                  addUnlessDefault<val_t>(v, "dShape", 0.f, from.dShape);
                  addUnlessDefault<val_t>(v, "rShape", 0.f, from.rShape);
-                 addUnlessDefault<val_t>(v, "rateMul", 1.f, from.rateMul);
+                 addUnlessDefault<val_t>(v, "rateMul", 0.f, from.rateMul);
                  addUnlessDefault<val_t>(v, "loop", false, from.loop);
              }),
              SC_TO({

--- a/src/scxt-core/messaging/client/enginestatus_messages.h
+++ b/src/scxt-core/messaging/client/enginestatus_messages.h
@@ -140,14 +140,14 @@ CLIENT_TO_SERIAL(SetMpeTuningAwareness, c2s_set_mpe_tuning_awareness, bool,
 SERIAL_TO_CLIENT(UpdateMpeTuningAwareness, s2c_update_mpe_tuning_awareness, bool,
                  onMpeTuningAwarenessFromEngine);
 
-inline void applyPitchBendTuningAwarenessPayload(const bool &paylaod,
+inline void applyPitchBendTuningAwarenessPayload(const bool &payload,
                                                  messaging::MessageController &cont)
 {
     cont.scheduleAudioThreadCallback(
-        [payload = paylaod](scxt::engine::Engine &e) { e.setPBTuningAwareness(payload); });
+        [payload](scxt::engine::Engine &e) { e.setPBTuningAwareness(payload); });
 }
 CLIENT_TO_SERIAL(SetPitchBendTuningAwareness, c2s_set_pitchbend_tuning_awareness, bool,
-                 applyMPETuningAwarenessPayload(payload, cont));
+                 applyPitchBendTuningAwarenessPayload(payload, cont));
 SERIAL_TO_CLIENT(UpdatePitchBendTuningAwareness, s2c_update_pitchbend_tuning_awareness, bool,
                  onPitchBendTuningAwarenessFromEngine);
 


### PR DESCRIPTION
- Fix group trigger range check so MIDICC no longer reads macros out of bounds
- Stop envelope rate multiplier from corrupting on patch round-trip
- Wire up pitch bend tuning awareness instead of the MPE toggle
- Correct the saved name for parallel processor routing, reading old patches via an alias

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>