### PR TITLE
Fix leaks and stale UI state when reloading samples and effects

### DIFF
--- a/src/scxt-core/sample/sample.cpp
+++ b/src/scxt-core/sample/sample.cpp
@@ -45,6 +45,8 @@ Sample::~Sample()
         free(sampleData[0]);
     if (sampleData[1])
         free(sampleData[1]);
+    delete[] meta.slice_start;
+    delete[] meta.slice_end;
 }
 
 bool Sample::load(const fs::path &path)

--- a/src/scxt-core/sample/sample_manager.h
+++ b/src/scxt-core/sample/sample_manager.h
@@ -196,6 +196,13 @@ struct SampleManager : MoveableOnly<SampleManager>
             samples.clear();
         }
         sf2FilesByPath.clear();
+        sf2MD5ByPath.clear();
+        gigFilesByPath.clear();
+        gigMD5ByPath.clear();
+        scxtMonolithFilesByPath.clear();
+        scxtMonolithMD5ByPath.clear();
+        zipArchives.clear();
+        idAliases.clear();
         streamingVersion = 0x2112'01'01;
         updateSampleMemory();
     }

--- a/src/scxt-plugin/app/edit-screen/components/ProcessorPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/ProcessorPane.cpp
@@ -1048,6 +1048,8 @@ void ProcessorPane::layoutControlsWithJsonEngine(const std::string &jsonpath)
     for (auto &f : jsonDeactEditors)
         f.reset();
     jsonLabels.clear();
+    eqDisplays.clear();
+    sineDisplays.clear();
 
     auto eng = sst::jucegui::layouts::JsonLayoutEngine(*this);
 

--- a/src/scxt-plugin/app/shared/PartEffectsPane.cpp
+++ b/src/scxt-plugin/app/shared/PartEffectsPane.cpp
@@ -156,9 +156,11 @@ template <bool forBus> void PartEffectsPane<forBus>::rebuild()
     name = effectDisplayName(t, false);
 
     removeAllChildren();
+    // order matters: components own pointers into the attachments, so clear them first
     components.clear();
-    // intAttachments.clear();
-    // floatAttachments.clear();
+    floatAttachments.clear();
+    boolAttachments.clear();
+    jsonLabels.clear();
 
     if (getHeight() < 10)
         return;


### PR DESCRIPTION
- Free a sample's slice markers when the sample is destroyed
- Clear the cached file, MD5, zip and id-alias maps when the sample manager resets, so they no longer accumulate across patch reloads
- Drop stale EQ and sine displays when a processor pane re-lays out
- Drop stale control attachments when a part effect rebuilds

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>