### PR TITLE
Keep parameter metadata allocation off the audio thread

### DIFF
--- a/src/scxt-core/datamodel/metadata.h
+++ b/src/scxt-core/datamodel/metadata.h
@@ -40,10 +40,11 @@ namespace scxt::datamodel
 {
 using pmd = sst::basic_blocks::params::ParamMetaData;
 
-template <typename P, typename V> pmd describeValue(const P &p, const V &l)
+template <typename P, typename V>
+const pmd &describeValue(const P &p, const V &l, bool realtime = false)
 {
     auto pd = detail::offV(p, l);
-    return detail::descFor<P>(p, pd);
+    return detail::descFor<P>(p, pd, realtime);
 }
 } // namespace scxt::datamodel
 

--- a/src/scxt-core/datamodel/metadata_detail.h
+++ b/src/scxt-core/datamodel/metadata_detail.h
@@ -42,67 +42,130 @@ template <typename P, typename V> ptrdiff_t offV(const P &p, const V &l)
     auto pd = (uint8_t *)&(l) - (uint8_t *)&p;
     return pd;
 }
-template <typename P> sst::basic_blocks::params::ParamMetaData descFor(const P &, ptrdiff_t pd)
+// Sentinel pd matching no field: passed at static-init so a single descFor call flows through
+// every SC_FIELD block and seeds each field's static (off the realtime thread).
+static constexpr ptrdiff_t kSeedAll = -1;
+
+template <typename P>
+const sst::basic_blocks::params::ParamMetaData &descFor(const P &, ptrdiff_t pd, bool realtime)
 {
     // If you hit this assert you need an SC_DESCRIBE for a w.r.t b
     assert(false);
-    return sst::basic_blocks::params::ParamMetaData()
-        .withType(sst::basic_blocks::params::ParamMetaData::NONE)
-        .withName("ERROR");
+    static const sst::basic_blocks::params::ParamMetaData err =
+        sst::basic_blocks::params::ParamMetaData()
+            .withType(sst::basic_blocks::params::ParamMetaData::NONE)
+            .withName("ERROR");
+    return err;
+}
+
+// Deferred seeding. Each SC_DESCRIBE self-registers a seed node at static-init time, but that is
+// only a cheap pointer link into this intrusive list - no ParamMetaData is built. seedAllMetadata()
+// (call once, off the realtime thread, e.g. from the Engine ctor) walks the list and forces each
+// descFor<T> to construct its field statics. This keeps the heavy pmd construction out of DLL load
+// so it doesn't slow DAW plugin scanning.
+struct MetadataSeed;
+inline MetadataSeed *&metadataSeedHead()
+{
+    static MetadataSeed *head{nullptr};
+    return head;
+}
+struct MetadataSeed
+{
+    using Fn = void (*)();
+    explicit MetadataSeed(Fn f) : fn(f), next(metadataSeedHead()) { metadataSeedHead() = this; }
+    Fn fn;
+    MetadataSeed *next;
+};
+inline void seedAllMetadata()
+{
+    static const bool once = []() {
+        for (auto *n = metadataSeedHead(); n; n = n->next)
+            n->fn();
+        return true;
+    }();
+    (void)once;
 }
 
 } // namespace scxt::datamodel::detail
 
+// Token-paste helpers so the per-SC_DESCRIBE seed object gets a unique (__COUNTER__-based) name.
+// __COUNTER__ rather than __LINE__ so two SC_DESCRIBE on the same line in different headers can't
+// collide within a translation unit.
+#define SC_DESC_CAT2(a, b) a##b
+#define SC_DESC_CAT(a, b) SC_DESC_CAT2(a, b)
+
 #define SC_DESCRIBE(T, ...)                                                                        \
     template <>                                                                                    \
-    inline sst::basic_blocks::params::ParamMetaData scxt::datamodel::detail::descFor<T>(           \
-        const T &payload, ptrdiff_t(pd))                                                           \
+    inline const sst::basic_blocks::params::ParamMetaData &scxt::datamodel::detail::descFor<T>(    \
+        const T &payload, ptrdiff_t(pd), bool realtime)                                            \
     {                                                                                              \
         using data = T;                                                                            \
         static_assert(std::is_standard_layout_v<T>);                                               \
         __VA_ARGS__;                                                                               \
                                                                                                    \
-        SCLOG_IF(warnings, "Failed to bind " << pd << " position element of " << #T);              \
-        assert(false);                                                                             \
-        return pmd();                                                                              \
+        if (pd != scxt::datamodel::detail::kSeedAll)                                               \
+        {                                                                                          \
+            SCLOG_IF(warnings, "Failed to bind " << pd << " position element of " << #T);          \
+            assert(false);                                                                         \
+        }                                                                                          \
+        static const pmd scEmpty;                                                                  \
+        return scEmpty;                                                                            \
+    }                                                                                              \
+    namespace                                                                                      \
+    {                                                                                              \
+    /* Registers (does not run) the seed; descFor<T> is forced from seedAllMetadata(). */          \
+    [[maybe_unused]] const scxt::datamodel::detail::MetadataSeed SC_DESC_CAT(scSeed_,              \
+                                                                             __COUNTER__){[]() {   \
+        scxt::datamodel::detail::descFor<T>(T{}, scxt::datamodel::detail::kSeedAll, false);        \
+    }};                                                                                            \
     }
 
+// The pmd is built once into a block-scoped static (block scope -> a fixed name works even for
+// nested/dotted field names like keyboardRange.fadeEnd, which are only valid inside offsetof).
+// descFor returns it by const ref, so binding never builds or copies a pmd on the realtime thread.
 #define SC_FIELD(x, ...)                                                                           \
-    if (pd == offsetof(data, x))                                                                   \
     {                                                                                              \
-        return __VA_ARGS__;                                                                        \
+        static const pmd scField = __VA_ARGS__;                                                    \
+        if (pd == offsetof(data, x))                                                               \
+            return scField;                                                                        \
     }
 
-#define SC_FIELD_COMPUTED(x, ...)                                                                  \
-    if (pd == offsetof(data, x))                                                                   \
+// Payload-dependent field. base is the static (range etc.); dyn is a narrow member write (e.g.
+// scField.defaultVal = ...) done only off the realtime thread - the realtime path reads the
+// seeded range and never writes, so its min/max reads never race the (distinct) default write.
+#define SC_FIELD_COMPUTED(x, base, dyn)                                                            \
     {                                                                                              \
-        __VA_ARGS__;                                                                               \
+        static pmd scField = base;                                                                 \
+        if (pd == offsetof(data, x))                                                               \
+        {                                                                                          \
+            if (!realtime)                                                                         \
+            {                                                                                      \
+                dyn;                                                                               \
+            }                                                                                      \
+            return scField;                                                                        \
+        }                                                                                          \
     }
 
-// Describe x[i] as elements for i 0...N
+// Describe x[i] as elements for i 0...N (the description must not depend on the index fai)
 #define SC_FIELD_ARRAY(x, N, ...)                                                                  \
     {                                                                                              \
+        static const pmd scField = __VA_ARGS__;                                                    \
         auto bsOff = offsetof(data, x);                                                            \
         auto szof = sizeof(decltype(data::x)::value_type);                                         \
         for (size_t fai = 0; fai < N; fai++)                                                       \
             if (pd == bsOff + fai * szof)                                                          \
-            {                                                                                      \
-                return __VA_ARGS__;                                                                \
-            }                                                                                      \
+                return scField;                                                                    \
     }
 
-// Describe x[i].y as elements for i 0...N
+// Describe x[i].y as elements for i 0...N (the description must not depend on the index fai)
 #define SC_FIELD_ARRAY_MEMBER(x, y, N, ...)                                                        \
     {                                                                                              \
+        static const pmd scField = __VA_ARGS__;                                                    \
         auto bsOff = offsetof(data, x);                                                            \
         auto memOff = offsetof(decltype(data::x)::value_type, y);                                  \
         auto szof = sizeof(decltype(data::x)::value_type);                                         \
         for (size_t fai = 0; fai < N; fai++)                                                       \
-        {                                                                                          \
             if (pd == bsOff + fai * szof + memOff)                                                 \
-            {                                                                                      \
-                return __VA_ARGS__;                                                                \
-            }                                                                                      \
-        }                                                                                          \
+                return scField;                                                                    \
     }
 #endif // SHORTCIRCUITXT_METADATA_DETAIL_H

--- a/src/scxt-core/dsp/processor/processor.h
+++ b/src/scxt-core/dsp/processor/processor.h
@@ -376,16 +376,13 @@ template <ProcessorType ft> struct ProcessorForGroupOnly
 
 } // namespace scxt::dsp::processor
 
-SC_DESCRIBE(scxt::dsp::processor::ProcessorStorage,
-            SC_FIELD_COMPUTED(mix,
-                              {
-                                  auto dr = dsp::processor::getProcessorDefaultMix(payload.type);
-                                  return datamodel::pmd().asPercent().withName("Mix").withDefault(
-                                      dr);
-                              });
-            SC_FIELD(outputCubAmp,
-                     pmd()
-                         .asCubicDecibelUpTo(scxt::dsp::processor::ProcessorStorage::maxOutputDB)
-                         .withName("Output")););
+SC_DESCRIBE(
+    scxt::dsp::processor::ProcessorStorage,
+    SC_FIELD_COMPUTED(mix, datamodel::pmd().asPercent().withName("Mix"),
+                      scField.defaultVal = dsp::processor::getProcessorDefaultMix(payload.type));
+    SC_FIELD(outputCubAmp,
+             pmd()
+                 .asCubicDecibelUpTo(scxt::dsp::processor::ProcessorStorage::maxOutputDB)
+                 .withName("Output")););
 
 #endif // __SCXT_DSP_PROCESSOR_PROCESSOR_H

--- a/src/scxt-core/engine/engine.cpp
+++ b/src/scxt-core/engine/engine.cpp
@@ -30,6 +30,7 @@
 #include "sst/plugininfra/version_information.h"
 
 #include "configuration.h"
+#include "datamodel/metadata.h"
 #include "messaging/audio/audio_serial.h"
 #include "part.h"
 #include "sst/cpputils/iterators.h"
@@ -154,6 +155,11 @@ Engine::Engine()
     browserDb->writeDebugMessage(std::string("SCXT Startup ") +
                                  sst::plugininfra::VersionInformation::project_version_and_hash);
 
+    // Build all SC_DESCRIBE field-metadata statics now, off the audio thread. The seeds only
+    // self-register at DLL load (cheap); this is the first call that actually constructs the
+    // ParamMetaData, keeping that work out of plugin scanning.
+    datamodel::detail::seedAllMetadata();
+
     // This forces metadata init of the mod matrix
     modulation::ModulationCurves::initializeCurves();
     voice::modulation::MatrixEndpoints usedForInit(this);
@@ -175,6 +181,10 @@ Engine::Engine()
         mm = std::make_unique<voice::modulation::Matrix>();
         mm->warmup(this);
     }
+
+    // Force the shared scanning Sources to build now, off the audio thread, so the first
+    // Zone::onRoutingChanged (which may run on the audio thread) is allocation-free.
+    voice::modulation::sourcesForScanning();
 
     previewVoice = std::make_unique<voice::PreviewVoice>();
 

--- a/src/scxt-core/engine/zone.cpp
+++ b/src/scxt-core/engine/zone.cpp
@@ -424,7 +424,9 @@ void Zone::terminateAllVoices()
 }
 void Zone::onRoutingChanged()
 {
-    voice::modulation::MatrixEndpoints::Sources usedForScanning(nullptr);
+    // Shared, read-only Sources used purely for identifier comparison below. Built once off the
+    // audio thread (see sourcesForScanning) so this runs allocation-free on the audio thread.
+    const auto &usedForScanning = voice::modulation::sourcesForScanning();
     std::fill(lfosActive.begin(), lfosActive.end(), false);
     auto pglfo = glfosActive;
     std::fill(glfosActive.begin(), glfosActive.end(), false);

--- a/src/scxt-core/messaging/client/modulation_messages.h
+++ b/src/scxt-core/messaging/client/modulation_messages.h
@@ -58,8 +58,10 @@ typedef std::tuple<int, voice::modulation::Matrix::RoutingTable::Routing, bool>
 inline void doUpdateZoneRoutingRow(const zoneRoutingRowPayload_t &payload, engine::Engine &engine,
                                    MessageController &cont)
 {
-    // TODO Selected Zone State
-    const auto &[i, r, b] = payload;
+    auto [i, r, b] = payload;
+
+    // the extra payload is a selection -> ui item. We don't need it in the audio thread.
+    r.extraPayload = std::nullopt;
 
     auto sz = engine.getSelectionManager()->currentlySelectedZones();
     if (!sz.empty())
@@ -102,8 +104,9 @@ typedef std::tuple<int, modulation::GroupMatrix::RoutingTable::Routing, bool>
 inline void doUpdateGroupRoutingRow(const updateGroupRoutingRowPayload_t &payload,
                                     engine::Engine &engine, MessageController &cont)
 {
-    // TODO Selected Zone State
-    const auto &[i, r, b] = payload;
+    auto [i, r, b] = payload;
+    // extraPayload is selection -> ui. We don't need it in audio thread.
+    r.extraPayload = std::nullopt;
     auto sg = engine.getSelectionManager()->currentlySelectedGroups();
     if (!sg.empty())
     {

--- a/src/scxt-core/modulation/group_matrix.cpp
+++ b/src/scxt-core/modulation/group_matrix.cpp
@@ -159,7 +159,7 @@ void GroupMatrixEndpoints::ProcessorTarget::bind(scxt::modulation::GroupMatrix &
 
     for (int i = 0; i < scxt::maxProcessorFloatParams; ++i)
     {
-        shmo::bindEl(m, p, fpT[i], p.floatParams[i], floatP[i], d.floatControlDescriptions[i]);
+        shmo::bindEl(m, p, fpT[i], p.floatParams[i], floatP[i], &d.floatControlDescriptions[i]);
     }
 }
 

--- a/src/scxt-core/modulation/matrix_shared.h
+++ b/src/scxt-core/modulation/matrix_shared.h
@@ -270,17 +270,19 @@ template <typename TG, uint32_t gn> struct ProcessorTargetEndpointData
 
 template <typename Matrix, typename P>
 void bindEl(Matrix &m, const P &payload, typename Matrix::TR::TargetIdentifier &tg,
-            float &baseValue, const float *&p,
-            std::optional<datamodel::pmd> providedMetadata = std::nullopt,
+            float &baseValue, const float *&p, const datamodel::pmd *providedMetadata = nullptr,
             std::optional<datamodel::pmd::FeatureState> featureState = std::nullopt)
 {
     bindEl(m, payload, tg, baseValue, baseValue, p, providedMetadata, featureState);
 }
 
+// providedMetadata is borrowed (not owned/copied): pass a pointer to a persistent pmd - the
+// processor's floatControlDescriptions[i] member, or a static override. On the realtime bind
+// path we only read minVal/maxVal/supportsMultiplicative through it, never build or copy a pmd.
 template <typename Matrix, typename P>
 void bindEl(Matrix &m, const P &payload, typename Matrix::TR::TargetIdentifier &tg,
             float &baseValue, float &unmodulatedBase, const float *&p,
-            std::optional<datamodel::pmd> providedMetadata = std::nullopt,
+            const datamodel::pmd *providedMetadata = nullptr,
             std::optional<datamodel::pmd::FeatureState> featureState = std::nullopt)
 {
     assert(tg.gid != 0); // hit this? You forgot to init your target ctor
@@ -288,15 +290,9 @@ void bindEl(Matrix &m, const P &payload, typename Matrix::TR::TargetIdentifier &
 
     if (m.forUIMode)
     {
-        datamodel::pmd tmd;
-        if (!providedMetadata.has_value())
-        {
-            tmd = datamodel::describeValue(payload, baseValue);
-        }
-        else
-        {
-            tmd = *providedMetadata;
-        }
+        // UI thread: the full pmd (name/labels/default) is wanted; copying it here is fine.
+        const auto &tmd =
+            providedMetadata ? *providedMetadata : datamodel::describeValue(payload, baseValue);
         m.activeTargetsToPMD[tg] = tmd;
         m.activeTargetsToBaseValue[tg] = baseValue;
         m.activeTargetsToFeatureState[tg] = featureState.value_or(datamodel::pmd::FeatureState{});
@@ -313,33 +309,30 @@ void bindEl(Matrix &m, const P &payload, typename Matrix::TR::TargetIdentifier &
     }
     p = m.getTargetValuePointer(tg);
 
-#if BUILD_IS_DEBUG && !BUILD_IS_RTSAN
+#if BUILD_IS_DEBUG
     /* Make sure every element has a description or a value provided.
      * This could be in an assert but you know, figure I'll just do it this
      * way (inasmuch as the describe will fail miserably if theres no
      * metadata in debug mode here but not in release).
      *
-     * describeValue allocates (ParamMetaData owns a string/vector), so this is
-     * compiled out under rtsan even though it is otherwise debug-only.
+     * realtime=true so this stays read-only - describeValue returns a const ref
+     * to a seeded static, so it neither allocates nor writes the computed default.
      * */
-    if (!providedMetadata.has_value())
+    if (!providedMetadata)
     {
-        auto metaData = datamodel::describeValue(payload, baseValue);
+        [[maybe_unused]] const auto &metaData =
+            datamodel::describeValue(payload, baseValue, /*realtime*/ true);
     }
 #endif
 
     auto idxIt = m.targetToOutputIndex.find(tg);
     if (idxIt != m.targetToOutputIndex.end())
     {
-        datamodel::pmd tmd;
-        if (!providedMetadata.has_value())
-        {
-            tmd = datamodel::describeValue(payload, baseValue);
-        }
-        else
-        {
-            tmd = *providedMetadata;
-        }
+        // Realtime bind: read the three scalars through a reference; describeValue returns a
+        // const ref to a seeded static, so nothing is built or copied here.
+        const auto &tmd = providedMetadata
+                              ? *providedMetadata
+                              : datamodel::describeValue(payload, baseValue, /*realtime*/ true);
         bool nonAdditive = tmd.hasSupportsMultiplicativeModulation();
 
         auto pt = m.getTargetValuePointer(tg);
@@ -370,22 +363,25 @@ void bindEl(Matrix &m, const P &payload, typename Matrix::TR::TargetIdentifier &
     }
 };
 
+// Persistent metadata for the (always percent) retrigger targets, so baseBind doesn't construct
+// a pmd on the audio thread. inline const -> built once at static-init, off the realtime thread.
+inline const datamodel::pmd retriggerMetadata = datamodel::pmd().withName("Retrigger").asPercent();
+
 template <typename TG, uint32_t gn>
 template <typename M, typename EG>
 inline void EGTargetEndpointData<TG, gn>::baseBind(M &m, EG &eg)
 {
     auto fs = datamodel::pmd::FeatureState{}.withTemposync(eg.isTemposync);
-    bindEl(m, eg, dlyT, eg.dly, dlyP, std::nullopt, fs);
-    bindEl(m, eg, aT, eg.a, aP, std::nullopt, fs);
-    bindEl(m, eg, hT, eg.h, hP, std::nullopt, fs);
-    bindEl(m, eg, dT, eg.d, dP, std::nullopt, fs);
+    bindEl(m, eg, dlyT, eg.dly, dlyP, nullptr, fs);
+    bindEl(m, eg, aT, eg.a, aP, nullptr, fs);
+    bindEl(m, eg, hT, eg.h, hP, nullptr, fs);
+    bindEl(m, eg, dT, eg.d, dP, nullptr, fs);
     bindEl(m, eg, sT, eg.s, sP);
-    bindEl(m, eg, rT, eg.r, rP, std::nullopt, fs);
+    bindEl(m, eg, rT, eg.r, rP, nullptr, fs);
     bindEl(m, eg, asT, eg.aShape, asP);
     bindEl(m, eg, dsT, eg.dShape, dsP);
     bindEl(m, eg, rsT, eg.rShape, rsP);
-    bindEl(m, eg, retriggerT, zeroBase, retriggerP,
-           datamodel::pmd().withName("Retrigger").asPercent());
+    bindEl(m, eg, retriggerT, zeroBase, retriggerP, &retriggerMetadata);
     bindEl(m, eg, rateMulT, eg.rateMul, rateMulP);
 }
 
@@ -396,25 +392,24 @@ inline void LFOTargetEndpointData<TG, gn>::baseBind(M &m, Z &z)
     auto &ms = z.modulatorStorage[index];
     auto fs = datamodel::pmd::FeatureState{}.withTemposync(ms.temposync);
 
-    bindEl(m, ms, rateT, ms.rate, rateP, std::nullopt, fs);
+    bindEl(m, ms, rateT, ms.rate, rateP, nullptr, fs);
     bindEl(m, ms, amplitudeT, ms.amplitude, amplitudeP);
-    bindEl(m, ms, retriggerT, zeroBase, retriggerP,
-           datamodel::pmd().withName("Retrigger").asPercent());
+    bindEl(m, ms, retriggerT, zeroBase, retriggerP, &retriggerMetadata);
 
     bindEl(m, ms, curve.deformT, ms.curveLfoStorage.deform, curve.deformP);
     bindEl(m, ms, curve.angleT, ms.curveLfoStorage.angle, curve.angleP);
-    bindEl(m, ms, curve.delayT, ms.curveLfoStorage.delay, curve.delayP, std::nullopt, fs);
-    bindEl(m, ms, curve.attackT, ms.curveLfoStorage.attack, curve.attackP, std::nullopt, fs);
-    bindEl(m, ms, curve.releaseT, ms.curveLfoStorage.release, curve.releaseP, std::nullopt, fs);
+    bindEl(m, ms, curve.delayT, ms.curveLfoStorage.delay, curve.delayP, nullptr, fs);
+    bindEl(m, ms, curve.attackT, ms.curveLfoStorage.attack, curve.attackP, nullptr, fs);
+    bindEl(m, ms, curve.releaseT, ms.curveLfoStorage.release, curve.releaseP, nullptr, fs);
 
     bindEl(m, ms, step.smoothT, ms.stepLfoStorage.smooth, step.smoothP);
 
-    bindEl(m, ms, env.delayT, ms.envLfoStorage.delay, env.delayP, std::nullopt, fs);
-    bindEl(m, ms, env.attackT, ms.envLfoStorage.attack, env.attackP, std::nullopt, fs);
-    bindEl(m, ms, env.holdT, ms.envLfoStorage.hold, env.holdP, std::nullopt, fs);
-    bindEl(m, ms, env.decayT, ms.envLfoStorage.decay, env.decayP, std::nullopt, fs);
+    bindEl(m, ms, env.delayT, ms.envLfoStorage.delay, env.delayP, nullptr, fs);
+    bindEl(m, ms, env.attackT, ms.envLfoStorage.attack, env.attackP, nullptr, fs);
+    bindEl(m, ms, env.holdT, ms.envLfoStorage.hold, env.holdP, nullptr, fs);
+    bindEl(m, ms, env.decayT, ms.envLfoStorage.decay, env.decayP, nullptr, fs);
     bindEl(m, ms, env.sustainT, ms.envLfoStorage.sustain, env.sustainP);
-    bindEl(m, ms, env.releaseT, ms.envLfoStorage.release, env.releaseP, std::nullopt, fs);
+    bindEl(m, ms, env.releaseT, ms.envLfoStorage.release, env.releaseP, nullptr, fs);
     bindEl(m, ms, env.aShapeT, ms.envLfoStorage.aShape, env.aShapeP);
     bindEl(m, ms, env.dShapeT, ms.envLfoStorage.dShape, env.dShapeP);
     bindEl(m, ms, env.rShapeT, ms.envLfoStorage.rShape, env.rShapeP);

--- a/src/scxt-core/modulation/voice_matrix.cpp
+++ b/src/scxt-core/modulation/voice_matrix.cpp
@@ -86,6 +86,20 @@ void MatrixEndpoints::EGTarget::bind(scxt::voice::modulation::Matrix &m, engine:
     baseBind(m, z.egStorage[index]);
 }
 
+// Persistent metadata for the targets that override their description. inline const -> built
+// once at static-init (off the realtime thread); bind passes a pointer so nothing is constructed
+// on the audio thread.
+namespace
+{
+const datamodel::pmd playbackRatioMetadata =
+    datamodel::pmd().asFloat().withRange(0, 2).withLinearScaleFormatting("x");
+const datamodel::pmd startPosMetadata =
+    datamodel::pmd().asPercentBipolar().withName("Start Pos Adjustment");
+const datamodel::pmd playSampleMetadata = datamodel::pmd().asBool().withName("Sample Playing Gate");
+const datamodel::pmd sampleTuneMetadata =
+    datamodel::pmd().asSemitoneRange().withName("Sample Tune").withDefault(0.0);
+} // namespace
+
 void MatrixEndpoints::MappingTarget::bind(scxt::voice::modulation::Matrix &m, engine::Zone &z)
 {
     auto &mt = z.mapping;
@@ -94,8 +108,7 @@ void MatrixEndpoints::MappingTarget::bind(scxt::voice::modulation::Matrix &m, en
     shmo::bindEl(m, mt, ampT, mt.amplitude, ampP);
     shmo::bindEl(m, mt, panT, mt.pan, panP);
     // This is a true oddity. We can modulate but not specify it
-    shmo::bindEl(m, mt, playbackRatioT, zeroBase, playbackRatioP,
-                 datamodel::pmd().asFloat().withRange(0, 2).withLinearScaleFormatting("x"));
+    shmo::bindEl(m, mt, playbackRatioT, zeroBase, playbackRatioP, &playbackRatioMetadata);
 }
 
 void MatrixEndpoints::OutputTarget::bind(scxt::voice::modulation::Matrix &m, engine::Zone &z)
@@ -108,13 +121,10 @@ void MatrixEndpoints::OutputTarget::bind(scxt::voice::modulation::Matrix &m, eng
 void MatrixEndpoints::SampleTarget::bind(Matrix &m, engine::Zone &z)
 {
     auto &mt = z.mapping;
-    shmo::bindEl(m, mt, startPosT, zeroBase, startPosP,
-                 datamodel::pmd().asPercentBipolar().withName("Start Pos Adjustment"));
+    shmo::bindEl(m, mt, startPosT, zeroBase, startPosP, &startPosMetadata);
     // need a bindEl with an extra nonmod default value
-    shmo::bindEl(m, mt, playSampleT, zeroBase, oneBase, playSampleP,
-                 datamodel::pmd().asBool().withName("Sample Playing Gate"));
-    shmo::bindEl(m, mt, sampleTuneT, zeroBase, sampleTuneP,
-                 datamodel::pmd().asSemitoneRange().withName("Sample Tune").withDefault(0.0));
+    shmo::bindEl(m, mt, playSampleT, zeroBase, oneBase, playSampleP, &playSampleMetadata);
+    shmo::bindEl(m, mt, sampleTuneT, zeroBase, sampleTuneP, &sampleTuneMetadata);
 }
 
 void MatrixEndpoints::ProcessorTarget::bind(scxt::voice::modulation::Matrix &m, engine::Zone &z)
@@ -126,7 +136,7 @@ void MatrixEndpoints::ProcessorTarget::bind(scxt::voice::modulation::Matrix &m, 
 
     for (int i = 0; i < scxt::maxProcessorFloatParams; ++i)
     {
-        shmo::bindEl(m, p, fpT[i], p.floatParams[i], floatP[i], d.floatControlDescriptions[i]);
+        shmo::bindEl(m, p, fpT[i], p.floatParams[i], floatP[i], &d.floatControlDescriptions[i]);
     }
 }
 
@@ -226,6 +236,12 @@ void MatrixEndpoints::registerVoiceModSource(
         return;
 
     e->registerVoiceModSource(t, pathFn, nameFn);
+}
+
+const MatrixEndpoints::Sources &sourcesForScanning()
+{
+    static const MatrixEndpoints::Sources s(nullptr);
+    return s;
 }
 
 voiceMatrixMetadata_t getVoiceMatrixMetadata(const engine::Zone &z)

--- a/src/scxt-core/modulation/voice_matrix.h
+++ b/src/scxt-core/modulation/voice_matrix.h
@@ -506,6 +506,11 @@ struct MatrixEndpoints
             nameFn);
 };
 
+// A single shared, read-only Sources used purely to enumerate source identifiers (e.g. the
+// scanning in Zone::onRoutingChanged). Constructing Sources allocates, so we build it once off
+// the audio thread and reuse it. Call once during engine warmup to force off-thread init.
+const MatrixEndpoints::Sources &sourcesForScanning();
+
 /*
  * Metadata functions return a path (or empty for top level) and name.
  * These are bad implementations for now


### PR DESCRIPTION
Binding the modulation matrix and editing modulation routing no longer allocate on the audio thread:

- Reading a parameter's range when binding a routed target reuses shared, pre-built metadata instead of constructing and copying it.
- Zone routing rescans reuse one shared source list rather than rebuilding the whole set on every routing edit.
- Routing row edits drop their UI-only selection payload before the audio-thread row assignment so the copy stays allocation-free.

Parameter metadata is now built once when the first engine is constructed not at plugin load, so plugin scanning is unimpacted.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>