### PR TITLE
Warmup Processor Classes; Fix F++ RTSAN Issue

### DIFF
--- a/src/scxt-core/dsp/processor/processor.cpp
+++ b/src/scxt-core/dsp/processor/processor.cpp
@@ -196,6 +196,22 @@ template <size_t I> remapFn_t implGetRemapFn()
         return PT::remapParametersForStreamingVersion;
 }
 
+template <typename T>
+concept HasWarmUpCache = requires { T::warmUpCache(); };
+
+template <size_t I> void implWarmUpProcessor()
+{
+    if constexpr (I != ProcessorType::proct_none)
+    {
+        using PT = typename ProcessorImplementor<(ProcessorType)I>::T;
+        if constexpr (!std::is_same<PT, unimpl_t>::value)
+        {
+            if constexpr (HasWarmUpCache<PT>)
+                PT::warmUpCache();
+        }
+    }
+}
+
 template <size_t I>
 Processor *returnSpawnOnto(engine::Engine *e, uint8_t *m, engine::MemoryPool *mp,
                            const ProcessorStorage &ps, float *f, int *i, bool needsMetadata)
@@ -382,6 +398,13 @@ std::optional<ProcessorType> fromProcessorStreamingName(const std::string &s)
             return (ProcessorType)i;
     }
     return {};
+}
+
+void warmUpAllProcessors()
+{
+    []<size_t... Is>(std::index_sequence<Is...>) {
+        (detail::implWarmUpProcessor<Is>(), ...);
+    }(std::make_index_sequence<(size_t)ProcessorType::proct_num_types>());
 }
 
 processorList_t getAllProcessorDescriptions()

--- a/src/scxt-core/dsp/processor/processor.h
+++ b/src/scxt-core/dsp/processor/processor.h
@@ -157,6 +157,14 @@ typedef std::vector<ProcessorDescription> processorList_t;
 processorList_t getAllProcessorDescriptions();
 
 /**
+ * Some processors cache configuration which is expensive (and allocating) to build but is
+ * a pure function of their compile-time type. Those expose a static warmUpCache() which this
+ * populates once. Call off the audio thread (engine construction) so the first audio-thread
+ * spawn reads warmed data instead of allocating.
+ */
+void warmUpAllProcessors();
+
+/**
  * If you choose to spawnProcessorOnto you need a block at least this size.
  * This should be a multiple of 16 if you enlarge it.
  */

--- a/src/scxt-core/engine/engine.cpp
+++ b/src/scxt-core/engine/engine.cpp
@@ -29,6 +29,8 @@
 
 #include "sst/plugininfra/version_information.h"
 
+#include "sst/cpputils/rtsan_support.h"
+
 #include "configuration.h"
 #include "datamodel/metadata.h"
 #include "messaging/audio/audio_serial.h"
@@ -100,6 +102,10 @@ Engine::Engine()
     dsp::twoToTheXTable.init();
     dsp::twentyFiveSecondExpTable.init();
     tuning::equalTuning.init();
+
+    // Build any processor config caches now, off the audio thread, so spawning a
+    // processor later (which happens on the audio thread) reads warmed data.
+    dsp::processor::warmUpAllProcessors();
 
     sampleManager = std::make_unique<sample::SampleManager>(messageController->threadingChecker);
     sampleManager->raiseError = [this](auto a, auto b) {
@@ -379,6 +385,8 @@ bool Engine::processAudio()
         break;
         case messaging::audio::s2a_dispatch_to_pointer_under_structurelock:
         {
+            // We know this will lock and potentailly allocate so for now don't add rtsan noise
+            SST_CPPUTILS_RTSAN_DISABLE;
             std::lock_guard<std::mutex> structG(modifyStructureMutex);
             auto cb =
                 static_cast<messaging::MessageController::AudioThreadCallback *>(msgopt->payload.p);


### PR DESCRIPTION
If a processor implementation has static warmupCache, call that on the class at engine construction time, allowing configuration and so on to pre-allocate.

Use this in Filters++ to avoid an allocation at note on from configuration.

Assisted-By: Claude Opus 4.8