### PR TITLE
Null-check SafePointers in async UI callbacks to prevent use-after-free

### DIFF
--- a/src/scxt-plugin/app/browser-ui/BrowserPane.cpp
+++ b/src/scxt-plugin/app/browser-ui/BrowserPane.cpp
@@ -176,7 +176,9 @@ struct DriveArea : juce::Component, HasEditor
                     ed->fileChooser = std::make_unique<juce::FileChooser>("Add Location");
                     ed->fileChooser->launchAsync(
                         juce::FileBrowserComponent::canSelectDirectories,
-                        [idxxx = idxx, w, ed](const auto &c) {
+                        [idxxx = idxx, w](const auto &c) {
+                            if (!w)
+                                return;
                             auto result = c.getResults();
                             if (result.size() != 1)
                             {

--- a/src/scxt-plugin/app/edit-screen/components/LFOPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/LFOPane.cpp
@@ -1980,6 +1980,8 @@ void LfoPane::doLoadPreset()
     fileChooser->launchAsync(juce::FileBrowserComponent::canSelectFiles |
                                  juce::FileBrowserComponent::openMode,
                              [w = juce::Component::SafePointer(this)](const juce::FileChooser &c) {
+                                 if (!w)
+                                     return;
                                  auto result = c.getResults();
                                  if (result.isEmpty() || result.size() > 1)
                                  {
@@ -2002,6 +2004,8 @@ void LfoPane::doSavePreset()
                                  juce::FileBrowserComponent::saveMode |
                                  juce::FileBrowserComponent::warnAboutOverwriting,
                              [w = juce::Component::SafePointer(this)](const juce::FileChooser &c) {
+                                 if (!w)
+                                     return;
                                  auto result = c.getResults();
                                  if (result.isEmpty() || result.size() > 1)
                                  {

--- a/src/scxt-plugin/app/edit-screen/components/PartGroupSidebar.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/PartGroupSidebar.cpp
@@ -78,6 +78,8 @@ struct PartSidebar : juce::Component,
         addPartButton = std::make_unique<jcmp::TextPushButton>();
         addPartButton->setLabel("Add Part");
         addPartButton->setOnCallback([w = juce::Component::SafePointer(this)]() {
+            if (!w)
+                return;
             w->sendToSerialization(cmsg::ActivateNextPart(true));
         });
         viewportContents->addChildComponent(*addPartButton);
@@ -554,6 +556,8 @@ struct GroupZoneSidebarBase : juce::Component,
             {
                 p.addItem("Part " + std::to_string(i + 1), true, i == editor->selectedPart,
                           [w = juce::Component::SafePointer(this), index = i]() {
+                              if (!w)
+                                  return;
                               w->sendToSerialization(cmsg::SelectPart(index));
                           });
             }

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
@@ -741,19 +741,22 @@ void VariantDisplay::showFileBrowser()
 
     fileChooser->launchAsync(
         juce::FileBrowserComponent::openMode | juce::FileBrowserComponent::canSelectFiles,
-        [this](const juce::FileChooser &fc) mutable {
+        [w = juce::Component::SafePointer(this)](const juce::FileChooser &fc) {
+            if (!w)
+                return;
             if (fc.getURLResults().size() > 0)
             {
                 const auto u = shared::juceFileToFSPath(fc.getResult());
 
                 namespace cmsg = scxt::messaging::client;
-                auto za{editor->currentLeadZoneSelection};
-                auto sampleID{selectedVariation};
-                sendToSerialization(
-                    cmsg::AddSampleInZone({u.u8string(), za->part, za->group, za->zone, sampleID}));
+                auto za{w->editor->currentLeadZoneSelection};
+                auto sampleID{w->selectedVariation};
+                if (za.has_value())
+                    w->sendToSerialization(cmsg::AddSampleInZone(
+                        {u.u8string(), za->part, za->group, za->zone, sampleID}));
             }
 
-            fileChooser = nullptr;
+            w->fileChooser = nullptr;
         },
         nullptr);
 }

--- a/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
@@ -814,8 +814,11 @@ void SCXTEditor::devSweepKeys(int msBetween, int key)
     }
 
     sendToSerialization(cmsg::NoteFromGUI({key, 0.9, true}));
-    juce::Timer::callAfterDelay(msBetween,
-                                [this, nk = key + 1, ms = msBetween]() { devSweepKeys(ms, nk); });
+    juce::Timer::callAfterDelay(
+        msBetween, [w = juce::Component::SafePointer(this), nk = key + 1, ms = msBetween]() {
+            if (w)
+                w->devSweepKeys(ms, nk);
+        });
 }
 
 } // namespace scxt::ui::app

--- a/src/scxt-plugin/app/shared/MenuValueTypein.h
+++ b/src/scxt-plugin/app/shared/MenuValueTypein.h
@@ -49,13 +49,16 @@ struct MenuValueTypeinBase : HasEditor, juce::PopupMenu::CustomComponent, juce::
 
     void visibilityChanged() override
     {
-        juce::Timer::callAfterDelay(2, [this]() {
-            if (textEditor->isVisible())
+        juce::Timer::callAfterDelay(2, [w = juce::Component::SafePointer(this)]() {
+            if (!w)
+                return;
+            if (w->textEditor->isVisible())
             {
-                textEditor->setText(getInitialText(), juce::NotificationType::dontSendNotification);
-                setupTextEditorStyle();
-                textEditor->grabKeyboardFocus();
-                textEditor->selectAll();
+                w->textEditor->setText(w->getInitialText(),
+                                       juce::NotificationType::dontSendNotification);
+                w->setupTextEditorStyle();
+                w->textEditor->grabKeyboardFocus();
+                w->textEditor->selectAll();
             }
         });
     }
@@ -83,7 +86,9 @@ struct MenuValueTypein : MenuValueTypeinBase
 
     std::string getInitialText() const override
     {
-        return underComp->continuous()->getValueAsString();
+        if (underComp && underComp->continuous())
+            return underComp->continuous()->getValueAsString();
+        return "";
     }
 
     void setValueString(const std::string &s) override

--- a/src/scxt-plugin/app/shared/PatchMultiIO.h
+++ b/src/scxt-plugin/app/shared/PatchMultiIO.h
@@ -60,6 +60,8 @@ void doSaveMulti(T *that, std::unique_ptr<juce::FileChooser> &fileChooser,
         title, juce::File(that->editor->browser.patchIODirectory.u8string()), "*.scm");
     fileChooser->launchAsync(
         flags, [style, w = juce::Component::SafePointer(that)](const juce::FileChooser &c) {
+            if (!w)
+                return;
             auto result = c.getResults();
             if (result.isEmpty() || result.size() > 1)
             {
@@ -80,6 +82,8 @@ template <typename T> void doLoadMulti(T *that, std::unique_ptr<juce::FileChoose
     fileChooser->launchAsync(juce::FileBrowserComponent::canSelectFiles |
                                  juce::FileBrowserComponent::openMode,
                              [w = juce::Component::SafePointer(that)](const juce::FileChooser &c) {
+                                 if (!w)
+                                     return;
                                  auto result = c.getResults();
                                  if (result.isEmpty() || result.size() > 1)
                                  {
@@ -115,6 +119,8 @@ void doSavePart(T *that, std::unique_ptr<juce::FileChooser> &fileChooser, int pa
         title, juce::File(that->editor->browser.patchIODirectory.u8string()), ext);
     fileChooser->launchAsync(
         flags, [style, part, w = juce::Component::SafePointer(that)](const juce::FileChooser &c) {
+            if (!w)
+                return;
             auto result = c.getResults();
             if (result.isEmpty() || result.size() > 1)
             {
@@ -136,6 +142,8 @@ void doLoadPartInto(T *that, std::unique_ptr<juce::FileChooser> &fileChooser, in
     fileChooser->launchAsync(
         juce::FileBrowserComponent::canSelectFiles | juce::FileBrowserComponent::openMode,
         [part, w = juce::Component::SafePointer(that)](const juce::FileChooser &c) {
+            if (!w)
+                return;
             auto result = c.getResults();
             if (result.isEmpty() || result.size() > 1)
             {


### PR DESCRIPTION
File-chooser and timer callbacks could outlive their components when the editor is closed mid-dialog, dereferencing dangling pointers. Guard each captured SafePointer before use, and check the lead-zone selection optional in the variant sample chooser.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>