### PR TITLE
Harden the WAV/RIFF reader against malformed files

### DIFF
--- a/src/scxt-core/sample/loaders/load_riff_wave.cpp
+++ b/src/scxt-core/sample/loaders/load_riff_wave.cpp
@@ -32,8 +32,10 @@
 #include "riff_memfile.h"
 #include "riff_wave.h"
 // #include "sampler_state.h"
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <cstring>
 
 #define ADD_ERROR_MESSAGE(...)                                                                     \
     {                                                                                              \
@@ -89,13 +91,17 @@ bool Sample::parse_riff_wave(void *data, size_t filesize, bool skip_riffchunk)
         return false;
     }
 
-    int32_t WaveDataSize = datasize;
+    size_t WaveDataSize = datasize;
     if (!WaveDataSize)
     {
         ADD_ERROR_MESSAGE("Failed to load wav: datasize is zero");
         return false;
     }
-    int32_t WaveDataSamples = 8 * WaveDataSize / (wh.wBitsPerSample * wh.nChannels);
+    // 64-bit intermediate: 8 * WaveDataSize overflows int32 for a data chunk over
+    // 256MB (a few minutes of hi-res stereo). (SMP-3)
+    unsigned int WaveDataSamples =
+        (unsigned int)((uint64_t)8 * WaveDataSize /
+                       ((uint64_t)(uint16_t)wh.wBitsPerSample * (uint16_t)wh.nChannels));
 
     /* get pointer to the sampledata */
 
@@ -266,8 +272,19 @@ bool Sample::parse_riff_wave(void *data, size_t filesize, bool skip_riffchunk)
             switch (tag)
             {
             case 'INAM':
-                strncpy(name, (char *)mf.RIFFReadChunk(), 64);
-                break;
+            {
+                // RIFFReadChunk can return null; chunk data isn't NUL-terminated
+                // and may be longer than name[], so copy bounded and terminate. (SMP-4)
+                size_t inamLen = 0;
+                auto *inam = (char *)mf.RIFFReadChunk(nullptr, &inamLen);
+                if (inam)
+                {
+                    size_t n = std::min(inamLen, sizeof(name) - 1);
+                    memcpy(name, inam, n);
+                    name[n] = 0;
+                }
+            }
+            break;
             default:
                 mf.RIFFSkipChunk();
                 break;
@@ -284,8 +301,18 @@ bool Sample::parse_riff_wave(void *data, size_t filesize, bool skip_riffchunk)
 
         if (cuepoints > 1)
         {
-            meta.slice_start = new int[cuepoints];
-            meta.slice_end = new int[cuepoints];
+            // Don't trust the count: a hostile file can request a giant alloc.
+            // Cap to the cue points the file can actually contain. (SMP-5)
+            size_t maxCue = mf.bytesRemaining() / sizeof(loaders::CuePoint);
+            if ((size_t)cuepoints > maxCue)
+                cuepoints = (int32_t)maxCue;
+        }
+
+        if (cuepoints > 1)
+        {
+            // zero-init so a truncated read leaves 0, not uninitialized slices
+            meta.slice_start = new int[cuepoints]();
+            meta.slice_end = new int[cuepoints]();
             meta.slice_end[cuepoints - 1] = sampleLengthPerChannel;
             meta.n_slices = cuepoints;
             meta.playmode = pm_forward_hitpoints;
@@ -294,7 +321,8 @@ bool Sample::parse_riff_wave(void *data, size_t filesize, bool skip_riffchunk)
             for (int i = 0; i < cuepoints; i++)
             {
                 loaders::CuePoint cp;
-                mf.Read(&cp, sizeof(loaders::CuePoint));
+                if (!mf.Read(&cp, sizeof(loaders::CuePoint)))
+                    break;
                 meta.slice_start[i] = cp.dwSampleOffset;
                 if (i)
                     meta.slice_end[i - 1] = cp.dwSampleOffset;
@@ -308,13 +336,26 @@ bool Sample::parse_riff_wave(void *data, size_t filesize, bool skip_riffchunk)
         if (mf.riff_descend('strc', &datasize))
         {
             loaders::wave_strc_header header;
-            mf.Read(&header, sizeof(header));
+            // audio is already loaded; slices are optional, so a truncated strc
+            // chunk just means "no slices", not a failed sample load
+            if (!mf.Read(&header, sizeof(header)))
+                return true;
             int32_t subchunks = header.subchunks - 1; // first entry seem different
 
             if (subchunks > 1)
             {
-                meta.slice_start = new int[subchunks];
-                meta.slice_end = new int[subchunks];
+                // Cap by what the file holds: one skipped first entry + subchunks. (SMP-5)
+                size_t maxEntries = mf.bytesRemaining() / sizeof(loaders::wave_strc_entry);
+                size_t cap = (maxEntries > 0) ? (maxEntries - 1) : 0;
+                if ((size_t)subchunks > cap)
+                    subchunks = (int32_t)cap;
+            }
+
+            if (subchunks > 1)
+            {
+                // zero-init so a truncated read leaves 0, not uninitialized slices
+                meta.slice_start = new int[subchunks]();
+                meta.slice_end = new int[subchunks]();
                 meta.slice_end[subchunks - 1] = sampleLengthPerChannel;
                 meta.n_slices = subchunks;
                 meta.playmode = pm_forward_hitpoints;
@@ -326,7 +367,8 @@ bool Sample::parse_riff_wave(void *data, size_t filesize, bool skip_riffchunk)
                 for (int i = 0; i < subchunks; i++)
                 {
                     loaders::wave_strc_entry entry;
-                    mf.Read(&entry, sizeof(loaders::wave_strc_entry));
+                    if (!mf.Read(&entry, sizeof(loaders::wave_strc_entry)))
+                        break;
                     meta.slice_start[i] = entry.spos1;
                     if (i)
                         meta.slice_end[i - 1] = entry.spos1;

--- a/src/scxt-core/sample/loaders/riff_memfile.h
+++ b/src/scxt-core/sample/loaders/riff_memfile.h
@@ -62,7 +62,7 @@ class RIFFMemFile
         size = 0;
         loc = 0;
     }
-    RIFFMemFile(const void *data, int datasize)
+    RIFFMemFile(const void *data, size_t datasize)
     {
         assert(data);
         assert(datasize);
@@ -108,6 +108,8 @@ class RIFFMemFile
 
     bool SkipPSTRING()
     {
+        if (loc >= size)
+            return false;
         unsigned char length = (*(unsigned char *)(data + loc)) + 1;
         if (length & 1)
             length++; // IFF 16-bit alignment
@@ -181,6 +183,20 @@ class RIFFMemFile
     }
 
     size_t TellI() const { return loc; }
+
+    size_t bytesRemaining() const { return (loc < size) ? (size - loc) : 0; }
+
+    // Never trust a file-supplied chunk size: clamp a proposed child-chunk end
+    // offset to the enclosing chunk's end and the file size. (SMP-1)
+    size_t clampChildEnd(size_t proposedEnd) const
+    {
+        size_t parentEnd = EndStack.empty() ? size : EndStack.front();
+        if (proposedEnd > parentEnd)
+            proposedEnd = parentEnd;
+        if (proposedEnd > size)
+            proposedEnd = size;
+        return proposedEnd;
+    }
 
     size_t SeekI(size_t pos, int mode = mf_FromStart)
     {
@@ -394,7 +410,7 @@ class RIFFMemFile
         if (Tag)
             *Tag = sst::basic_blocks::mechanics::endian_read_int32BE(int32FromPointer(data + loc));
         if (DataSize)
-            *DataSize = size;
+            *DataSize = chunksize;
         void *dataptr = data + loc + 8;
         if ((loc + 8 + chunksize) > EndStack.front())
         {
@@ -456,12 +472,14 @@ class RIFFMemFile
         if ((Tag != 'LIST') && (Tag != 'RIFF'))
             return false;
         size_t chunksize = readWaveEndianLittle(int32FromPointer(data + loc + 4));
+        if (chunksize < 4) // must hold at least the 4-byte LIST/RIFF subtype
+            return false;
         int LISTTag =
             sst::basic_blocks::mechanics::endian_read_int32BE(int32FromPointer(data + loc + 8));
         loc += 12;
 
         StartStack.push_front(loc);
-        EndStack.push_front(loc + chunksize - 4);
+        EndStack.push_front(clampChildEnd(loc + (chunksize - 4)));
 
         if (datasize)
             *datasize = chunksize - 4;
@@ -498,10 +516,12 @@ class RIFFMemFile
                     }
                     else
                     {
+                        if (rh.datasize < 4) // must hold at least the 4-byte subtype
+                            return false;
                         if (datasize)
                             *datasize = rh.datasize - 4; // don't include the subid
                         StartStack.push_front(loc);
-                        EndStack.push_front(loc + rh.datasize - 4);
+                        EndStack.push_front(clampChildEnd(loc + (rh.datasize - 4)));
                         return true;
                     }
                 }
@@ -520,7 +540,9 @@ class RIFFMemFile
 
     uint32_t RIFFGetFileType() // Read the ID of the RIFF chunk
     {
-        return sst::basic_blocks::mechanics::endian_read_int32BE(*(uint32_t *)(data + 8));
+        if (size < 12)
+            return 0;
+        return sst::basic_blocks::mechanics::endian_read_int32BE(int32FromPointer(data + 8));
     };
 
     bool RIFFCreateChunk(uint32_t tag, void *indata, size_t datasize)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(scxt-test
         streaming.cpp
 		sample_analytics.cpp
 		sample_load.cpp
+		sample_fuzz.cpp
 		processors_and_fx.cpp
 
 		ui_basics.cpp

--- a/tests/sample_fuzz.cpp
+++ b/tests/sample_fuzz.cpp
@@ -1,0 +1,287 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+/*
+ * In-memory fuzz harness for the binary sample-file parsers. The point is to
+ * feed malformed/truncated buffers straight into the parser entry points
+ * (Sample::parse_riff_wave(void*, size_t)) and assert they fail gracefully
+ * rather than crash. Build with -DSCXT_SANITIZE=ON to turn the "didn't
+ * obviously crash" checks into real OOB/overflow assertions (ASan+UBSan).
+ *
+ * Targets the S1 / RIFF-WAV hardening batch: SMP-1 (EndStack clamp), SMP-2
+ * (RIFFReadChunk DataSize), SMP-4 (INAM bounded copy), SMP-5 (cue/strc count).
+ */
+
+#include "catch2/catch2.hpp"
+#include "sample/sample.h"
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+using namespace scxt;
+
+namespace
+{
+// Little-endian appenders + ASCII fourcc, matching what RIFFMemFile reads.
+void putTag(std::vector<uint8_t> &b, const char *t) { b.insert(b.end(), t, t + 4); }
+void putU16(std::vector<uint8_t> &b, uint16_t v)
+{
+    b.push_back(v & 0xFF);
+    b.push_back((v >> 8) & 0xFF);
+}
+void putU32(std::vector<uint8_t> &b, uint32_t v)
+{
+    b.push_back(v & 0xFF);
+    b.push_back((v >> 8) & 0xFF);
+    b.push_back((v >> 16) & 0xFF);
+    b.push_back((v >> 24) & 0xFF);
+}
+void patchU32(std::vector<uint8_t> &b, size_t at, uint32_t v)
+{
+    b[at + 0] = v & 0xFF;
+    b[at + 1] = (v >> 8) & 0xFF;
+    b[at + 2] = (v >> 16) & 0xFF;
+    b[at + 3] = (v >> 24) & 0xFF;
+}
+
+void putFmt(std::vector<uint8_t> &b, uint16_t fmt, uint16_t ch, uint32_t rate, uint16_t bits)
+{
+    putTag(b, "fmt ");
+    putU32(b, 16);
+    putU16(b, fmt);                       // wFormatTag (1 == PCM)
+    putU16(b, ch);                        // nChannels
+    putU32(b, rate);                      // nSamplesPerSec
+    putU32(b, rate * ch * bits / 8);      // nAvgBytesPerSec
+    putU16(b, (uint16_t)(ch * bits / 8)); // nBlockAlign
+    putU16(b, bits);                      // wBitsPerSample
+}
+
+// The bytes after the 8-byte "RIFF"+size header: "WAVE" + fmt + data chunks.
+// Tests append further chunks before assembleRiff().
+std::vector<uint8_t> wavBody(uint32_t nframes = 16)
+{
+    std::vector<uint8_t> body;
+    putTag(body, "WAVE");
+    putFmt(body, 1, 2, 48000, 16);
+    putTag(body, "data");
+    uint32_t dataBytes = nframes * 2 /*ch*/ * 2 /*bytes16*/;
+    putU32(body, dataBytes);
+    for (uint32_t i = 0; i < dataBytes; ++i)
+        body.push_back((uint8_t)(i & 0xFF));
+    return body;
+}
+
+// Wrap a body in the outer RIFF header. sizeOverride < 0 => correct size.
+std::vector<uint8_t> assembleRiff(const std::vector<uint8_t> &body, int64_t sizeOverride = -1)
+{
+    std::vector<uint8_t> f;
+    putTag(f, "RIFF");
+    putU32(f, sizeOverride >= 0 ? (uint32_t)sizeOverride : (uint32_t)body.size());
+    f.insert(f.end(), body.begin(), body.end());
+    return f;
+}
+} // namespace
+
+TEST_CASE("parse_riff_wave: valid baseline parses", "[sample][fuzz][wav]")
+{
+    auto f = assembleRiff(wavBody(32));
+    sample::Sample s;
+    REQUIRE(s.parse_riff_wave(f.data(), f.size()));
+    CHECK(s.channels == 2);
+    CHECK(s.sample_rate == 48000);
+    CHECK(s.getSampleLength() == 32);
+}
+
+TEST_CASE("parse_riff_wave: inflated LIST size cannot read past the buffer", "[sample][fuzz][wav]")
+{
+    // SMP-1: a LIST:INFO chunk whose declared size dwarfs the file. Without the
+    // EndStack clamp the INFO scan walks off the end of the buffer (ASan trip).
+    auto body = wavBody();
+    putTag(body, "LIST");
+    putU32(body, 0x7FFFFF00); // wildly larger than the buffer
+    putTag(body, "INFO");
+    putTag(body, "INAM");
+    putU32(body, 8);
+    const uint8_t nm[8] = {'h', 'e', 'l', 'l', 'o', '!', '!', 0};
+    body.insert(body.end(), nm, nm + 8);
+
+    auto f = assembleRiff(body); // outer RIFF size is honest; the LIST lies
+    sample::Sample s;
+    // Must terminate without reading out of bounds; success/failure both fine.
+    s.parse_riff_wave(f.data(), f.size());
+    SUCCEED();
+}
+
+TEST_CASE("parse_riff_wave: short un-terminated INAM is copied safely", "[sample][fuzz][wav]")
+{
+    // SMP-4 (+SMP-2): INAM declares 10 bytes with no NUL and sits at the very end
+    // of the buffer. The old strncpy(name, ptr, 64) read 54 bytes past EOF.
+    auto body = wavBody();
+    putTag(body, "LIST");
+    size_t listSizeAt = body.size();
+    putU32(body, 0); // patched below
+    putTag(body, "INFO");
+    putTag(body, "INAM");
+    putU32(body, 10);
+    for (int i = 0; i < 10; ++i)
+        body.push_back((uint8_t)('A' + i)); // no NUL terminator
+    // LIST payload = "INFO" + INAM header(8) + 10 bytes
+    patchU32(body, listSizeAt, (uint32_t)(4 + 8 + 10));
+
+    auto f = assembleRiff(body);
+    sample::Sample s;
+    REQUIRE(s.parse_riff_wave(f.data(), f.size()));
+    // name must be NUL-terminated within its 64-byte buffer
+    CHECK(s.name[63] == 0);
+    CHECK(strnlen(s.name, sizeof(s.name)) == 10);
+}
+
+TEST_CASE("parse_riff_wave: huge cue count does not over-allocate", "[sample][fuzz][wav]")
+{
+    // SMP-5: a 'cue ' chunk that claims 256M cue points but carries one. Old code
+    // did new int[268435456] twice. New code caps to bytesRemaining().
+    auto body = wavBody();
+    putTag(body, "cue ");
+    putU32(body, 4 + 24);     // chunk size: count(4) + one CuePoint(24)
+    putU32(body, 0x10000000); // 268,435,456 cue points (lie)
+    for (int i = 0; i < 24; ++i)
+        body.push_back(0);
+
+    auto f = assembleRiff(body);
+    sample::Sample s;
+    REQUIRE(s.parse_riff_wave(f.data(), f.size()));
+    // clamped to what the chunk can hold (1) => below the >1 threshold => no slices
+    CHECK(s.meta.n_slices == 0);
+}
+
+TEST_CASE("parse_riff_wave: truncated cue chunk leaves no garbage slices", "[sample][fuzz][wav]")
+{
+    // SMP-5: count says 5, chunk header claims 5 records, but only 2 are present
+    // before EOF. Must not read uninitialized memory; n_slices reflects reality.
+    auto body = wavBody();
+    putTag(body, "cue ");
+    putU32(body, 4 + 5 * 24); // header claims room for 5
+    putU32(body, 5);          // count: 5
+    for (int i = 0; i < 2 * 24; ++i)
+        body.push_back((uint8_t)(i & 0xFF)); // only 2 CuePoints actually present
+
+    auto f = assembleRiff(body);
+    sample::Sample s;
+    REQUIRE(s.parse_riff_wave(f.data(), f.size()));
+    CHECK(s.meta.n_slices <= 2);
+}
+
+TEST_CASE("parse_riff_wave: survives truncation at every prefix length", "[sample][fuzz][wav]")
+{
+    // The core fuzz: a feature-rich WAV (data + smpl + cue + LIST:INFO) parsed at
+    // every prefix length. Under ASan this catches OOB reads anywhere in the
+    // descent/chunk-walk for any truncation point.
+    auto body = wavBody();
+
+    // smpl chunk (root note + one loop)
+    putTag(body, "smpl");
+    putU32(body, 36 + 24); // SamplerChunk(36) + one SampleLoop(24)
+    for (int i = 0; i < 36; ++i)
+        body.push_back(0);
+    putU32(body, 0);  // SampleLoop.dwIdentifier
+    putU32(body, 0);  // dwType
+    putU32(body, 4);  // dwStart
+    putU32(body, 12); // dwEnd
+    putU32(body, 0);
+    putU32(body, 0);
+    // overwrite cSampleLoops (field index 7 of SamplerChunk) so the loop is read
+    // SamplerChunk layout: 9 int32; cSampleLoops is the 8th (offset 28 in chunk data)
+    // chunk data starts right after the 8-byte "smpl"+size header.
+    {
+        size_t smplDataStart = body.size() - (36 + 24);
+        patchU32(body, smplDataStart + 28, 1); // cSampleLoops = 1
+    }
+
+    // cue chunk (2 points)
+    putTag(body, "cue ");
+    putU32(body, 4 + 2 * 24);
+    putU32(body, 2);
+    for (int i = 0; i < 2 * 24; ++i)
+        body.push_back((uint8_t)(i & 0xFF));
+
+    // LIST:INFO with an INAM
+    putTag(body, "LIST");
+    size_t listSizeAt = body.size();
+    putU32(body, 0);
+    putTag(body, "INFO");
+    putTag(body, "INAM");
+    putU32(body, 6);
+    const uint8_t nm[6] = {'h', 'i', 't', 'h', 'r', 0};
+    body.insert(body.end(), nm, nm + 6);
+    patchU32(body, listSizeAt, (uint32_t)(4 + 8 + 6));
+
+    auto f = assembleRiff(body);
+
+    for (size_t n = 1; n <= f.size(); ++n)
+    {
+        sample::Sample s;
+        // Any return value is acceptable; the requirement is "does not crash /
+        // read out of bounds" for an arbitrarily truncated file.
+        s.parse_riff_wave(f.data(), n);
+    }
+    SUCCEED();
+}
+
+TEST_CASE("parse_riff_wave: byte-flip fuzz of size fields does not crash", "[sample][fuzz][wav]")
+{
+    auto base = assembleRiff(wavBody(64));
+    // Flip the high bit of every 4-aligned word (hits chunk-size fields among
+    // others) and parse each mutant.
+    for (size_t off = 0; off + 4 <= base.size(); off += 4)
+    {
+        auto m = base;
+        m[off + 3] ^= 0x80;
+        sample::Sample s;
+        s.parse_riff_wave(m.data(), m.size());
+    }
+    SUCCEED();
+}
+
+TEST_CASE("parse_riff_wave: 256MB+ data chunk sample count does not overflow",
+          "[.][sample][fuzz][wav][smp3]")
+{
+    // SMP-3: 8 * WaveDataSize overflowed int32 above 256MB, yielding a negative
+    // sample count. Hidden by default ([.]) because it allocates ~256MB; run
+    // explicitly with `scxt-test "[smp3]"`.
+    const uint32_t dataBytes = 256u * 1024 * 1024 + 4096; // just over the int32 cliff
+    std::vector<uint8_t> body;
+    putTag(body, "WAVE");
+    putFmt(body, 1, 1, 48000, 8); // 8-bit mono: 1 byte per sample
+    putTag(body, "data");
+    putU32(body, dataBytes);
+    body.resize(body.size() + dataBytes, 0);
+
+    auto f = assembleRiff(body, /*sizeOverride*/ (int64_t)body.size());
+    sample::Sample s;
+    REQUIRE(s.parse_riff_wave(f.data(), f.size()));
+    CHECK(s.getSampleLength() == dataBytes); // 8 * bytes / 8 == bytes, no wrap
+}


### PR DESCRIPTION
The RIFF chunk walker trusted file-supplied chunk sizes when descending into LIST/RIFF containers, so a malformed WAV with an inflated container size pushed an end-of-chunk marker past the buffer and defeated every later bounds check, letting the metadata scan read past the end of the mapped file. Container ends are now clamped to the enclosing chunk and the file size, and zero-length containers are rejected before the size math can underflow.

Several WAV reads on top of that were unsafe with odd or hostile input: the sample-count was computed in 32-bit and overflowed (negative count) for data chunks over a couple hundred MB; the INAM name copy could read past a short, un-terminated chunk and leave the name unterminated; and the cue/slice readers trusted an attacker-controlled count for the allocation and left slices uninitialized on a truncated chunk. These now use 64-bit math, copy the name bounded to the real chunk length and always terminate, and cap slice counts to what the file actually holds while zero-initializing so a short read can't leave garbage.

Also reports the correct per-chunk size from the chunk reader (it was returning the whole-file size), which the bounded name copy relies on.

Adds an in-memory fuzz harness that feeds malformed and truncated WAV buffers straight to the parser and asserts it fails gracefully; built under -DSCXT_SANITIZE=ON these turn into real out-of-bounds assertions.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>