### PR TITLE
Fix a sample-zero problem; defend against a second

### DIFF
--- a/src/scxt-core/engine/engine.cpp
+++ b/src/scxt-core/engine/engine.cpp
@@ -359,58 +359,7 @@ bool Engine::processAudio()
     messageController->isAudioRunning = true;
     auto av = (uint32_t)activeVoices;
 
-    bool tryToDrain{true};
-    while (tryToDrain && !messageController->serializationToAudioQueue.empty())
-    {
-        auto msgopt = messageController->serializationToAudioQueue.pop();
-        if (!msgopt.has_value())
-        {
-            tryToDrain = false;
-            break;
-        }
-        switch (msgopt->id)
-        {
-        case messaging::audio::s2a_dispatch_to_pointer:
-        {
-            auto cb =
-                static_cast<messaging::MessageController::AudioThreadCallback *>(msgopt->payload.p);
-            cb->exec(*this);
-
-            messaging::audio::AudioToSerialization rt;
-            rt.id = messaging::audio::a2s_pointer_complete;
-            rt.payloadType = messaging::audio::AudioToSerialization::VOID_STAR;
-            rt.payload.p = (void *)cb;
-            messageController->audioToSerializationQueue.push(rt);
-        }
-        break;
-        case messaging::audio::s2a_dispatch_to_pointer_under_structurelock:
-        {
-            // We know this will lock and potentailly allocate so for now don't add rtsan noise
-            SST_CPPUTILS_RTSAN_DISABLE;
-            std::lock_guard<std::mutex> structG(modifyStructureMutex);
-            auto cb =
-                static_cast<messaging::MessageController::AudioThreadCallback *>(msgopt->payload.p);
-            cb->exec(*this);
-
-            messaging::audio::AudioToSerialization rt;
-            rt.id = messaging::audio::a2s_pointer_complete;
-            rt.payloadType = messaging::audio::AudioToSerialization::VOID_STAR;
-            rt.payload.p = (void *)cb;
-            messageController->audioToSerializationQueue.push(rt);
-        }
-        break;
-        case messaging::audio::s2a_param_beginendedit:
-        case messaging::audio::s2a_param_set_value:
-        case messaging::audio::s2a_param_refresh:
-        {
-            if (messageController->passWrapperEventsToWrapperQueue)
-                messageController->engineToPluginWrapperQueue.push(*msgopt);
-        }
-        break;
-        case messaging::audio::s2a_none:
-            break;
-        }
-    }
+    drainSerialToEngineQueue();
 
     getPatch()->busses.clear();
 
@@ -520,6 +469,62 @@ bool Engine::processAudio()
     cpuAvg += (pct - ppct) / cpuAverageObservation;
     sharedUIMemoryState.cpuLevel = cpuAvg;
     return true;
+}
+
+void Engine::drainSerialToEngineQueue()
+{
+    bool tryToDrain{true};
+    while (tryToDrain && !messageController->serializationToAudioQueue.empty())
+    {
+        auto msgopt = messageController->serializationToAudioQueue.pop();
+        if (!msgopt.has_value())
+        {
+            tryToDrain = false;
+            break;
+        }
+        switch (msgopt->id)
+        {
+        case messaging::audio::s2a_dispatch_to_pointer:
+        {
+            auto cb =
+                static_cast<messaging::MessageController::AudioThreadCallback *>(msgopt->payload.p);
+            cb->exec(*this);
+
+            messaging::audio::AudioToSerialization rt;
+            rt.id = messaging::audio::a2s_pointer_complete;
+            rt.payloadType = messaging::audio::AudioToSerialization::VOID_STAR;
+            rt.payload.p = (void *)cb;
+            messageController->audioToSerializationQueue.push(rt);
+        }
+        break;
+        case messaging::audio::s2a_dispatch_to_pointer_under_structurelock:
+        {
+            // We know this will lock and potentailly allocate so for now don't add rtsan noise
+            SST_CPPUTILS_RTSAN_DISABLE;
+            std::lock_guard<std::mutex> structG(modifyStructureMutex);
+            auto cb =
+                static_cast<messaging::MessageController::AudioThreadCallback *>(msgopt->payload.p);
+            cb->exec(*this);
+
+            messaging::audio::AudioToSerialization rt;
+            rt.id = messaging::audio::a2s_pointer_complete;
+            rt.payloadType = messaging::audio::AudioToSerialization::VOID_STAR;
+            rt.payload.p = (void *)cb;
+            messageController->audioToSerializationQueue.push(rt);
+        }
+        break;
+        case messaging::audio::s2a_param_beginendedit:
+        case messaging::audio::s2a_param_set_value:
+        case messaging::audio::s2a_param_refresh:
+        {
+            if (messageController->passWrapperEventsToWrapperQueue)
+                messageController->engineToPluginWrapperQueue.push(*msgopt);
+        }
+        break;
+        case messaging::audio::s2a_none:
+            break;
+        }
+    }
 }
 
 void Engine::assertActiveVoiceCount()

--- a/src/scxt-core/engine/engine.h
+++ b/src/scxt-core/engine/engine.h
@@ -113,6 +113,7 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
      * Returns true if processing should continue
      */
     bool processAudio();
+    void drainSerialToEngineQueue();
 
     sst::basic_blocks::modulators::Transport transport;
     void onTransportUpdated();

--- a/src/scxt-core/engine/group.cpp
+++ b/src/scxt-core/engine/group.cpp
@@ -615,6 +615,7 @@ void Group::setupOnUnstream(engine::Engine &e)
 
     triggerConditions.setupOnUnstream(parentPart->groupTriggerInstrumentState);
     resetPolyAndPlaymode(e);
+    lastOversample = outputInfo.oversample;
 }
 
 void Group::onGroupMidiChannelSubscriptionChanged()

--- a/src/scxt-plugin/clap/scxt-plugin.cpp
+++ b/src/scxt-plugin/clap/scxt-plugin.cpp
@@ -295,6 +295,9 @@ SCXTPlugin::process_nonblock(const clap_process *process) SST_CPPUTILS_NONBLOCKI
     {
         if (blockPos == 0)
         {
+            // do this before any voice creation
+            engine->drainSerialToEngineQueue();
+
             // Only realy need to run events when we do the block process
             while (nextEvent && nextEvent->time <= s)
             {


### PR DESCRIPTION
1. If group unstreamed with oversampling off, at sapmle zero it set an all sounds off since the internal state assumed default, not unstream. Set last- to unstream in onUnstream
2. The bug here I thought was the problem was actually that voices started with a unflushed s-to-a queue. So flush that queue before handling any clap events by segmenting processAudio but retain the precautionary flush in processAudio also

Addresses #2541