### PR TITLE
One more oversapmle-restart state error

### DIFF
--- a/src/scxt-core/engine/group.cpp
+++ b/src/scxt-core/engine/group.cpp
@@ -742,6 +742,8 @@ void Group::attack()
         return;
     }
 
+    // This group is starting from scracth so don't oversapmle detect.
+    lastOversample = outputInfo.oversample;
     for (int i = 0; i < processorsPerZoneAndGroup; ++i)
     {
         const auto &ps = processorStorage[i];


### PR DESCRIPTION
The same oversample restart state error in unstream at 920bdd9 occurs in attack for unstarted groups (which meant also things like sf2 import would skip first note). Fix by setting state accordingly for non-active group attacks.