### PR TITLE
Harden the remaining sample-file parsers against malformed files

### DIFF
--- a/src/scxt-core/browser/scanner.cpp
+++ b/src/scxt-core/browser/scanner.cpp
@@ -92,7 +92,16 @@ struct ScanWorker
             }
             if (p && keepRunning)
             {
-                p->go(*this);
+                try
+                {
+                    p->go(*this);
+                }
+                catch (const std::exception &e)
+                {
+                    // backstop so no work item can ever escape and
+                    // terminate the worker thread.
+                    SCLOG_IF(warnings, "Scan work item threw: " << e.what());
+                }
                 delete p;
 
                 if (lastCount != nextCount)
@@ -121,13 +130,24 @@ struct ScanWorker
         ScanFile(const fs::path &p) : path(p) {}
         void go(ScanWorker &w) override
         {
-            if (fs::exists(path))
+            // a file removed/locked between enqueue and scan throws from
+            // the filesystem calls; let it escape and it takes the worker thread
+            // (and the process) down via std::terminate.
+            try
             {
-                auto sc = infrastructure::createMD5SumFromFile(path);
-                auto sz = fs::file_size(path);
-                auto mt = writeTimeInMinutes(path);
-                w.scanner.writer.enqueueWorkItem(
-                    new WriterWorker::EnQAddSampleInfo(path, sc, mt, sz));
+                if (fs::exists(path))
+                {
+                    auto sc = infrastructure::createMD5SumFromFile(path);
+                    auto sz = fs::file_size(path);
+                    auto mt = writeTimeInMinutes(path);
+                    w.scanner.writer.enqueueWorkItem(
+                        new WriterWorker::EnQAddSampleInfo(path, sc, mt, sz));
+                }
+            }
+            catch (const std::exception &e)
+            {
+                SCLOG_IF(warnings,
+                         "Skipping unreadable file '" << path.u8string() << "': " << e.what());
             }
         }
     };
@@ -140,25 +160,37 @@ struct ScanWorker
 
         void go(ScanWorker &w) override
         {
-            auto files = fs::directory_iterator(path);
+            // a permission-denied directory (or one deleted mid-scan)
+            // throws from directory_iterator/last_write_time. An unhandled throw
+            // out of the worker thread is std::terminate, so contain it here and
+            // skip the offending directory.
             std::vector<fs::path> toScan;
-            for (auto &dirent : files)
+            try
             {
-                if (dirent.is_regular_file())
+                auto files = fs::directory_iterator(path);
+                for (auto &dirent : files)
                 {
-                    if (browser::Browser::isLoadableFile(dirent.path()))
+                    if (dirent.is_regular_file())
                     {
-                        auto mse = writeTimeInMinutes(dirent.path());
-                        if (mse > afterMtime)
+                        if (browser::Browser::isLoadableFile(dirent.path()))
                         {
-                            toScan.push_back(dirent.path());
+                            auto mse = writeTimeInMinutes(dirent.path());
+                            if (mse > afterMtime)
+                            {
+                                toScan.push_back(dirent.path());
+                            }
                         }
                     }
+                    else if (dirent.is_directory())
+                    {
+                        w.enqueueWorkItem(new ScanDir{dirent.path(), (uint64_t)afterMtime});
+                    }
                 }
-                else if (dirent.is_directory())
-                {
-                    w.enqueueWorkItem(new ScanDir{dirent.path(), (uint64_t)afterMtime});
-                }
+            }
+            catch (const std::exception &e)
+            {
+                SCLOG_IF(warnings,
+                         "Skipping unreadable directory '" << path.u8string() << "': " << e.what());
             }
 
             for (const auto &s : toScan)

--- a/src/scxt-core/patch_io/patch_io.cpp
+++ b/src/scxt-core/patch_io/patch_io.cpp
@@ -79,7 +79,12 @@ void addSCManifest(const std::unique_ptr<RIFF::File> &f, const std::string &type
 
 std::string readSCManifestString(RIFF::File *f)
 {
+    // libgig returns null for an absent chunk; opening a RIFF that isn't
+    // an SCXT patch would deref null. Throw so the callers' RIFF::Exception
+    // handlers report an error instead of crashing.
     auto c1 = f->GetSubChunk(manifestChunk);
+    if (!c1)
+        throw RIFF::Exception("File has no SCXT manifest chunk");
     std::string s((char *)c1->LoadChunkData(), c1->GetSize());
     c1->ReleaseChunkData();
     return s;
@@ -88,6 +93,8 @@ std::string readSCManifestString(RIFF::File *f)
 std::unordered_map<std::string, std::string> readSCManifest(RIFF::File *f)
 {
     auto c1 = f->GetSubChunk(manifestChunk);
+    if (!c1)
+        throw RIFF::Exception("File has no SCXT manifest chunk");
     std::string s((char *)c1->LoadChunkData(), c1->GetSize());
     c1->ReleaseChunkData();
 
@@ -114,6 +121,8 @@ void addSCDataChunk(const std::unique_ptr<RIFF::File> &f, const std::string &msg
 std::string readSCDataChunk(const std::unique_ptr<RIFF::File> &f)
 {
     auto cp = f->GetSubChunk(dataChunk);
+    if (!cp)
+        throw RIFF::Exception("File has no SCXT data chunk");
     auto res = std::string((char *)cp->LoadChunkData(), cp->GetSize());
     cp->ReleaseChunkData();
     return res;
@@ -215,6 +224,8 @@ std::vector<fs::path> readMonolithBinaryIndex(const std::unique_ptr<RIFF::File> 
         return {};
     }
     auto c = lst->GetSubChunk(samplePathsChunk);
+    if (!c)
+        throw RIFF::Exception("Monolith sample list has no paths chunk");
     std::string s((char *)c->LoadChunkData(), c->GetSize());
     c->ReleaseChunkData();
 

--- a/src/scxt-core/sample/akai_support/akai_import.cpp
+++ b/src/scxt-core/sample/akai_support/akai_import.cpp
@@ -376,7 +376,8 @@ struct GLOBAL_MODS
 
     void load(const char *data, uint32_t size)
     {
-        if (size < 25)
+        // reads through data[25], which needs at least 26 bytes.
+        if (size < 26)
             return;
         ampMod1Src = (uint8_t)data[5];
         ampMod2Src = (uint8_t)data[7];
@@ -429,7 +430,9 @@ std::pair<std::string, uint32_t> fourCCSize(const char *c)
 
 void KEYGROUP::parse(const char *data, uint32_t size)
 {
-    uint32_t pos = 0;
+    // pos is 64-bit so `pos + 8 + sz` can't wrap a near-0xFFFFFFFF chunk
+    // size past the bounds check (and into an OOB read / infinite advance).
+    size_t pos = 0;
     while (pos + 8 <= size)
     {
         auto [id, sz] = fourCCSize(data + pos);
@@ -482,7 +485,8 @@ bool AKPFile::load(const char *data, size_t size)
     if (fourCC(data) != "RIFF" || fourCC(data + 8) != "APRG")
         return false;
 
-    uint32_t pos = 12;
+    // 64-bit pos so chunk-size arithmetic can't wrap (see KEYGROUP::parse).
+    size_t pos = 12;
     while (pos + 8 <= size)
     {
         auto [id, sz] = fourCCSize(data + pos);

--- a/src/scxt-core/sample/loaders/load_aiff.cpp
+++ b/src/scxt-core/sample/loaders/load_aiff.cpp
@@ -127,7 +127,11 @@ bool Sample::parse_aiff(void *data, size_t filesize)
     }
     aiff_CommonChunk cc;
     // read header
-    mf.Read(&cc, sizeof(cc));
+    if (!mf.Read(&cc, sizeof(cc)))
+    {
+        addError("AIFF 'COMM' chunk is truncated");
+        return false;
+    }
     channels = sst::basic_blocks::mechanics::swap_endian_16(cc.numChannels);
     if (channels > 2)
     {
@@ -136,12 +140,6 @@ bool Sample::parse_aiff(void *data, size_t filesize)
     }
     int nsamples = sst::basic_blocks::mechanics::swap_endian_32(cc.numSampleFrames);
     int bitdepth = sst::basic_blocks::mechanics::swap_endian_16(cc.sampleSize);
-
-    if (!SetMeta(channels, ConvertFromIeeeExtended(cc.sampleRate), nsamples))
-    {
-        addError("Unable to setup meta data");
-        return false;
-    }
 
     // load sample data
     mf.SeekI(wr);
@@ -158,10 +156,34 @@ bool Sample::parse_aiff(void *data, size_t filesize)
     // of padding + the actual audio data. Logic factory AIFFs use a non-zero
     // offset (e.g. 386 bytes), and ignoring it causes ReadPtr to walk past the
     // chunk end and return null → SIGSEGV in the loader.
-    unsigned char *loaddata = (unsigned char *)mf.ReadPtr(datasize - 8 - offset);
+    size_t audioBytes = (size_t)datasize - 8 - offset;
+    unsigned char *loaddata = (unsigned char *)mf.ReadPtr(audioBytes);
     if (!loaddata)
     {
         addError("AIFF 'SSND' chunk is shorter than the declared audio length");
+        return false;
+    }
+
+    // the COMM frame count is independent of the SSND payload, so a file
+    // that declares more frames than the chunk holds makes the load_data_*
+    // helpers read past the mapped buffer. Clamp to what the SSND data can
+    // actually supply before SetMeta allocates and the loaders fill it.
+    unsigned int bytesPerFrame = (unsigned int)channels * (bitdepth / 8);
+    if (bytesPerFrame > 0)
+    {
+        size_t maxFrames = audioBytes / bytesPerFrame;
+        if (nsamples < 0 || (size_t)nsamples > maxFrames)
+        {
+            SCLOG_IF(warnings, "AIFF COMM frame count " << nsamples
+                                                        << " exceeds SSND payload; clamping to "
+                                                        << maxFrames);
+            nsamples = (int)maxFrames;
+        }
+    }
+
+    if (!SetMeta(channels, ConvertFromIeeeExtended(cc.sampleRate), nsamples))
+    {
+        addError("Unable to setup meta data");
         return false;
     }
 
@@ -221,20 +243,34 @@ bool Sample::parse_aiff(void *data, size_t filesize)
     {
         uint16_t markercount = sst::basic_blocks::mechanics::swap_endian_16(mf.ReadWORD());
 
-        meta.slice_start = new int[markercount];
-        meta.slice_end = new int[markercount];
-        meta.n_slices = markercount;
+        // cap the count to what the chunk can physically hold (each marker
+        // is at least sizeof(aiff_marker) bytes) so a hostile count can't drive a
+        // huge allocation; zero-init the arrays so an INST loop referencing an
+        // absent marker id reads a defined 0 rather than uninitialized heap; and
+        // bail on a short read instead of consuming garbage.
+        size_t maxMarkers = mf.bytesRemaining() / sizeof(aiff_marker);
+        if (markercount > maxMarkers)
+            markercount = (uint16_t)maxMarkers;
 
-        for (int i = 0; i < markercount; i++)
+        if (markercount > 0)
         {
-            aiff_marker marker;
-            mf.Read(&marker, sizeof(marker));
-            mf.SkipPSTRING();
-            uint16_t id = sst::basic_blocks::mechanics::swap_endian_16(marker.id);
-            if (id < markercount)
+            meta.slice_start = new int[markercount]();
+            meta.slice_end = new int[markercount]();
+            meta.n_slices = markercount;
+
+            for (int i = 0; i < markercount; i++)
             {
-                meta.slice_start[id] = sst::basic_blocks::mechanics::swap_endian_32(marker.pos);
-                meta.slice_end[id] = sst::basic_blocks::mechanics::swap_endian_32(marker.pos);
+                aiff_marker marker;
+                if (!mf.Read(&marker, sizeof(marker)))
+                    break;
+                if (!mf.SkipPSTRING())
+                    break;
+                uint16_t id = sst::basic_blocks::mechanics::swap_endian_16(marker.id);
+                if (id < markercount)
+                {
+                    meta.slice_start[id] = sst::basic_blocks::mechanics::swap_endian_32(marker.pos);
+                    meta.slice_end[id] = sst::basic_blocks::mechanics::swap_endian_32(marker.pos);
+                }
             }
         }
     }

--- a/src/scxt-core/sample/loaders/load_flac.cpp
+++ b/src/scxt-core/sample/loaders/load_flac.cpp
@@ -67,17 +67,25 @@ template <class T> class SampleFLACDecoderBase : public T
             collectedSize += frame->header.blocksize;
             return FLAC__STREAM_DECODER_WRITE_STATUS_CONTINUE;
         }
+
+        // STREAMINFO can understate the total frame count; never write past
+        // the buffer that metadata_callback allocated for sampleLengthPerChannel.
+        int64_t avail = (int64_t)sample->sampleLengthPerChannel - streamPos;
+        if (avail <= 0)
+            return FLAC__STREAM_DECODER_WRITE_STATUS_CONTINUE;
+        const unsigned n = (unsigned)std::min<int64_t>(frame->header.blocksize, avail);
+
         if (bitDepth == 16 && sample->bitDepth == Sample::BD_I16)
         {
             for (int c = 0; c < sample->channels; ++c)
             {
                 auto sdata = sample->GetSamplePtrI16(c);
-                for (int i = 0; i < frame->header.blocksize; i++)
+                for (unsigned i = 0; i < n; i++)
                 {
                     sdata[i + streamPos] = (FLAC__int16)buffer[c][i];
                 }
             }
-            streamPos += frame->header.blocksize;
+            streamPos += n;
             return FLAC__STREAM_DECODER_WRITE_STATUS_CONTINUE;
         }
         else if (bitDepth == 24 && sample->bitDepth == Sample::BD_F32)
@@ -85,12 +93,12 @@ template <class T> class SampleFLACDecoderBase : public T
             for (int c = 0; c < sample->channels; ++c)
             {
                 auto sdata = sample->GetSamplePtrF32(c);
-                for (int i = 0; i < frame->header.blocksize; i++)
+                for (unsigned i = 0; i < n; i++)
                 {
                     sdata[i + streamPos] = buffer[c][i] * 1.f / (1 << 24);
                 }
             }
-            streamPos += frame->header.blocksize;
+            streamPos += n;
 
             return FLAC__STREAM_DECODER_WRITE_STATUS_CONTINUE;
         }
@@ -99,12 +107,12 @@ template <class T> class SampleFLACDecoderBase : public T
             for (int c = 0; c < sample->channels; ++c)
             {
                 auto sdata = sample->GetSamplePtrF32(c);
-                for (int i = 0; i < frame->header.blocksize; i++)
+                for (unsigned i = 0; i < n; i++)
                 {
                     sdata[i + streamPos] = (double)(buffer[c][i] * 1.0) / (1LL << 32);
                 }
             }
-            streamPos += frame->header.blocksize;
+            streamPos += n;
 
             return FLAC__STREAM_DECODER_WRITE_STATUS_CONTINUE;
         }
@@ -141,31 +149,24 @@ template <class T> class SampleFLACDecoderBase : public T
                 collectSizeOnly = true;
                 needsSecondPass = true;
             }
+            else if (channels != 1 && channels != 2)
+            {
+                // with no buffer allocated for 3+ channels, leaving
+                // isValid/bitDepth unset makes write_callback abort cleanly
+                // instead of writing through a null GetSamplePtr.
+                SCLOG_IF(warnings, "Unsupported FLAC channel count " << channels);
+            }
             else if (bps == 16)
             {
-                if (channels == 1)
-                {
-                    sample->allocateI16(0, total_samples);
-                }
-                else if (channels == 2)
-                {
-                    sample->allocateI16(0, total_samples);
-                    sample->allocateI16(1, total_samples);
-                }
+                for (unsigned c = 0; c < channels; ++c)
+                    sample->allocateI16(c, total_samples);
                 isValid = true;
                 bitDepth = 16;
             }
             else if (bps == 24 || bps == 32)
             {
-                if (channels == 1)
-                {
-                    sample->allocateF32(0, total_samples);
-                }
-                else if (channels == 2)
-                {
-                    sample->allocateF32(0, total_samples);
-                    sample->allocateF32(1, total_samples);
-                }
+                for (unsigned c = 0; c < channels; ++c)
+                    sample->allocateF32(c, total_samples);
                 isValid = true;
                 bitDepth = bps;
             }
@@ -274,55 +275,59 @@ bool Sample::parseFlac(const fs::path &p)
         {
             if (si->get_block_type() == FLAC__METADATA_TYPE_APPLICATION)
             {
+                // must not `continue` out of here — that would skip the
+                // si->next() at the loop bottom and spin on this block. Guard
+                // with positive conditions and always delete instead.
                 auto a = dynamic_cast<FLAC::Metadata::Application *>(si->get_block());
-                if (!a)
+                if (a)
                 {
-                    continue;
-                }
-                auto fourB2 = [](const auto *b) {
-                    std::string ids;
-                    for (int i = 0; i < 4; ++i)
-                        ids += (char)b[i];
-                    return ids;
-                };
-                if (fourB2(a->get_id()) != "riff")
-                {
-                    continue;
-                }
-
-                auto *d = a->get_data();
-                auto blockType = fourB2(d);
-                d += 4;
-                if (blockType == "smpl")
-                {
-                    // strip off size.
-                    d += 4;
-
-                    loaders::SamplerChunk smpl_chunk;
-                    loaders::SampleLoop smpl_loop;
-
-                    memccpy(&smpl_chunk, d, 1, sizeof(loaders::SamplerChunk));
-                    d += sizeof(loaders::SamplerChunk);
-
-                    meta.key_root = smpl_chunk.dwMIDIUnityNote & 0xFF;
-                    meta.rootkey_present = true;
-
-                    if (smpl_chunk.cSampleLoops > 0)
+                    auto fourB2 = [](const auto *b) {
+                        std::string ids;
+                        for (int i = 0; i < 4; ++i)
+                            ids += (char)b[i];
+                        return ids;
+                    };
+                    // get_length() excludes the block header but includes the
+                    // 4-byte application id; get_data() points past that id.
+                    size_t appLen = a->get_length() >= 4 ? (size_t)a->get_length() - 4 : 0;
+                    if (fourB2(a->get_id()) == "riff" && appLen >= 8)
                     {
-                        meta.loop_present = true;
-                        memccpy(&smpl_loop, d, 1, sizeof(loaders::SampleLoop));
-                        d += sizeof(loaders::SampleLoop);
+                        auto *d = a->get_data();
+                        auto blockType = fourB2(d);
+                        // consumed from get_data(): blockType(4) + chunk size(4)
+                        size_t off = 8;
+                        // bounds-check each read against the application block
+                        // length before copying the fixed-size structs.
+                        if (blockType == "smpl" && off + sizeof(loaders::SamplerChunk) <= appLen)
+                        {
+                            loaders::SamplerChunk smpl_chunk;
+                            loaders::SampleLoop smpl_loop;
 
-                        meta.loop_start = smpl_loop.dwStart;
-                        meta.loop_end =
-                            std::min((uint32_t)smpl_loop.dwEnd + 1, sampleLengthPerChannel);
-                        if (smpl_loop.dwType == 1)
-                            meta.playmode = pm_forward_loop_bidirectional;
-                        else
-                            meta.playmode = pm_forward_loop;
+                            memcpy(&smpl_chunk, d + off, sizeof(loaders::SamplerChunk));
+                            off += sizeof(loaders::SamplerChunk);
+
+                            meta.key_root = smpl_chunk.dwMIDIUnityNote & 0xFF;
+                            meta.rootkey_present = true;
+
+                            if (smpl_chunk.cSampleLoops > 0 &&
+                                off + sizeof(loaders::SampleLoop) <= appLen)
+                            {
+                                meta.loop_present = true;
+                                memcpy(&smpl_loop, d + off, sizeof(loaders::SampleLoop));
+                                off += sizeof(loaders::SampleLoop);
+
+                                meta.loop_start = smpl_loop.dwStart;
+                                meta.loop_end =
+                                    std::min((uint32_t)smpl_loop.dwEnd + 1, sampleLengthPerChannel);
+                                if (smpl_loop.dwType == 1)
+                                    meta.playmode = pm_forward_loop_bidirectional;
+                                else
+                                    meta.playmode = pm_forward_loop;
+                            }
+                        }
                     }
+                    delete a;
                 }
-                delete a;
             }
             else if (si->get_block_type() == FLAC__METADATA_TYPE_STREAMINFO)
             {
@@ -330,16 +335,14 @@ bool Sample::parseFlac(const fs::path &p)
             else if (si->get_block_type() == FLAC__METADATA_TYPE_VORBIS_COMMENT)
             {
                 auto a = dynamic_cast<FLAC::Metadata::VorbisComment *>(si->get_block());
-                if (!a)
+                if (a)
                 {
-                    continue;
+                    for (int q = 0; q < a->get_num_comments(); ++q)
+                    {
+                        auto c = a->get_comment(q);
+                    }
+                    delete a;
                 }
-
-                for (int q = 0; q < a->get_num_comments(); ++q)
-                {
-                    auto c = a->get_comment(q);
-                }
-                delete a;
             }
             else
             {

--- a/src/scxt-core/sample/loaders/load_riff_wave.cpp
+++ b/src/scxt-core/sample/loaders/load_riff_wave.cpp
@@ -98,7 +98,7 @@ bool Sample::parse_riff_wave(void *data, size_t filesize, bool skip_riffchunk)
         return false;
     }
     // 64-bit intermediate: 8 * WaveDataSize overflows int32 for a data chunk over
-    // 256MB (a few minutes of hi-res stereo). (SMP-3)
+    // 256MB (a few minutes of hi-res stereo).
     unsigned int WaveDataSamples =
         (unsigned int)((uint64_t)8 * WaveDataSize /
                        ((uint64_t)(uint16_t)wh.wBitsPerSample * (uint16_t)wh.nChannels));
@@ -274,7 +274,7 @@ bool Sample::parse_riff_wave(void *data, size_t filesize, bool skip_riffchunk)
             case 'INAM':
             {
                 // RIFFReadChunk can return null; chunk data isn't NUL-terminated
-                // and may be longer than name[], so copy bounded and terminate. (SMP-4)
+                // and may be longer than name[], so copy bounded and terminate.
                 size_t inamLen = 0;
                 auto *inam = (char *)mf.RIFFReadChunk(nullptr, &inamLen);
                 if (inam)
@@ -302,7 +302,7 @@ bool Sample::parse_riff_wave(void *data, size_t filesize, bool skip_riffchunk)
         if (cuepoints > 1)
         {
             // Don't trust the count: a hostile file can request a giant alloc.
-            // Cap to the cue points the file can actually contain. (SMP-5)
+            // Cap to the cue points the file can actually contain.
             size_t maxCue = mf.bytesRemaining() / sizeof(loaders::CuePoint);
             if ((size_t)cuepoints > maxCue)
                 cuepoints = (int32_t)maxCue;
@@ -344,7 +344,7 @@ bool Sample::parse_riff_wave(void *data, size_t filesize, bool skip_riffchunk)
 
             if (subchunks > 1)
             {
-                // Cap by what the file holds: one skipped first entry + subchunks. (SMP-5)
+                // Cap by what the file holds: one skipped first entry + subchunks.
                 size_t maxEntries = mf.bytesRemaining() / sizeof(loaders::wave_strc_entry);
                 size_t cap = (maxEntries > 0) ? (maxEntries - 1) : 0;
                 if ((size_t)subchunks > cap)

--- a/src/scxt-core/sample/loaders/riff_memfile.h
+++ b/src/scxt-core/sample/loaders/riff_memfile.h
@@ -187,7 +187,7 @@ class RIFFMemFile
     size_t bytesRemaining() const { return (loc < size) ? (size - loc) : 0; }
 
     // Never trust a file-supplied chunk size: clamp a proposed child-chunk end
-    // offset to the enclosing chunk's end and the file size. (SMP-1)
+    // offset to the enclosing chunk's end and the file size.
     size_t clampChildEnd(size_t proposedEnd) const
     {
         size_t parentEnd = EndStack.empty() ? size : EndStack.front();

--- a/src/scxt-core/sample/multisample_support/multisample_import.cpp
+++ b/src/scxt-core/sample/multisample_support/multisample_import.cpp
@@ -73,7 +73,10 @@ bool importMultisample(const fs::path &p, engine::Engine &engine)
 
     // Step two grab the multisample.xml
     if (fileToIndex.find("multisample.xml") == fileToIndex.end())
+    {
+        mz_zip_reader_end(&zip_archive); // don't leak the archive handle
         return ctx.fail("Multisample Error", "No XML file in Multisample");
+    }
 
     size_t rsize{0};
     auto data =
@@ -107,15 +110,25 @@ bool importMultisample(const fs::path &p, engine::Engine &engine)
     start="0.000" stop="317919.000"/>
     </sample>
          */
-        if (!fc->Attribute("file"))
+        auto fileAttr = fc->Attribute("file");
+        if (!fileAttr)
             return ctx.fail("Multisample Error", "Sample is not a file");
 
-        size_t ssize{0};
-        auto data = mz_zip_reader_extract_to_heap(&zip_archive, fileToIndex[fc->Attribute("file")],
-                                                  &ssize, 0);
+        // use find(), not operator[]: a name absent from the archive must be a
+        // hard error, not a default-inserted index 0.
+        auto fti = fileToIndex.find(fileAttr);
+        if (fti == fileToIndex.end())
+            return ctx.fail("Multisample Error",
+                            std::string("Referenced file not in archive: ") + fileAttr);
+        auto fileIndex = fti->second;
 
-        auto lsid = engine.getSampleManager()->setupSampleFromMultifile(
-            p, md5, fileToIndex[fc->Attribute("file")], data, ssize);
+        size_t ssize{0};
+        auto data = mz_zip_reader_extract_to_heap(&zip_archive, fileIndex, &ssize, 0);
+        if (!data)
+            return ctx.fail("Multisample Error", std::string("Unable to extract ") + fileAttr);
+
+        auto lsid =
+            engine.getSampleManager()->setupSampleFromMultifile(p, md5, fileIndex, data, ssize);
         free(data);
 
         if (!lsid.has_value())
@@ -179,7 +192,7 @@ bool importMultisample(const fs::path &p, engine::Engine &engine)
             auto group{0};
             fc->QueryIntAttribute("group", &group);
 
-            if (group < 0 || group > (int)addedGroupIndices.size())
+            if (group < 0 || group >= (int)addedGroupIndices.size())
             {
                 SCLOG_IF(sampleCompoundParsers, "Bad group : " << group);
                 return false;

--- a/src/scxt-core/sample/sample.cpp
+++ b/src/scxt-core/sample/sample.cpp
@@ -229,10 +229,12 @@ bool Sample::loadFromSF2(const fs::path &p, sf2::File *f, int sampleIndex)
     }
     else if (sfsample->GetFrameSize() == 3 && sfsample->GetChannelCount() == 1)
     {
-        bitDepth = BD_I16;
         channels = 1;
         auto buf = sfsample->LoadSampleData();
-        load_data_i24(0, (void *)(buf.pStart), buf.Size, sfsample->GetFrameSize());
+        // buf.Size is bytes; the sample count is bytes / frameSize (3).
+        // load_data_i24 calls allocateF32 which sets bitDepth = BD_F32.
+        load_data_i24(0, (void *)(buf.pStart), buf.Size / 3, sfsample->GetFrameSize());
+        sfsample->ReleaseSampleData();
         return true;
     }
 

--- a/src/scxt-core/sample/sample_manager.cpp
+++ b/src/scxt-core/sample/sample_manager.cpp
@@ -215,7 +215,7 @@ std::optional<SampleID> SampleManager::loadSampleFromSF2(const fs::path &p, cons
         sidx = region;
     }
 
-    if (sidx < 0 && sidx >= f->GetSampleCount())
+    if (sidx < 0 || sidx >= f->GetSampleCount())
     {
         return std::nullopt;
     }
@@ -252,19 +252,30 @@ std::optional<SampleID> SampleManager::loadSampleFromSF2(const fs::path &p, cons
 
 int SampleManager::findSF2SampleIndexFor(sf2::File *f, int presetNum, int instrument, int region)
 {
+    // every "not found" path must return -1: that's the caller's sentinel, and
+    // 0 is a valid sample index.
     auto *preset = f->GetPreset(presetNum);
+    if (!preset)
+        return -1;
 
     auto *presetRegion = preset->GetRegion(instrument);
+    if (!presetRegion)
+        return -1;
     sf2::Instrument *instr = presetRegion->pInstrument;
+    if (!instr)
+        return -1;
 
     if (instr->pGlobalRegion)
     {
         // TODO: Global Region
     }
 
-    auto sfsample = instr->GetRegion(region)->GetSample();
+    auto *instrRegion = instr->GetRegion(region);
+    if (!instrRegion)
+        return -1;
+    auto sfsample = instrRegion->GetSample();
     if (!sfsample)
-        return false;
+        return -1;
 
     for (int i = 0; i < f->GetSampleCount(); ++i)
     {
@@ -332,7 +343,7 @@ std::optional<SampleID> SampleManager::loadSampleFromGIG(const fs::path &p, cons
 
     auto sidx = region;
 
-    if (sidx < 0 && sidx >= f->CountSamples())
+    if (sidx < 0 || sidx >= f->CountSamples())
     {
         return std::nullopt;
     }

--- a/src/scxt-core/sample/sfz_support/sfz_export.cpp
+++ b/src/scxt-core/sample/sfz_support/sfz_export.cpp
@@ -66,13 +66,17 @@ bool exportSFZ(const fs::path &toFile, engine::Engine &e, int partNumber)
             }
             if (va == 0)
             {
+                // RAISE_ERROR_ENGINE reports but does not return; without
+                // bailing here the code emits a region referencing variants[0].
                 RAISE_ERROR_ENGINE(e, "SFZ Export Error",
                                    "Zones with no samples are not yet supported in SFZ export");
+                return false;
             }
             if (va > 1)
             {
                 RAISE_ERROR_ENGINE(e, "SFZ Export Error",
                                    "Zones multiple variants are not yet supported in SFZ export");
+                return false;
             }
             oss << "\n<region>\n";
             oss << "// zone name: " << z->getName() << "\n";
@@ -99,9 +103,11 @@ bool exportSFZ(const fs::path &toFile, engine::Engine &e, int partNumber)
             auto cmf = collectMap.find(z->variantData.variants[0].sampleID);
             if (cmf == collectMap.end())
             {
+                // bail before dereferencing the end() iterator below.
                 RAISE_ERROR_ENGINE(e, "SFZ Export Error",
                                    "Can't remap " +
                                        z->variantData.variants[0].sampleID.to_string());
+                return false;
             }
             auto pt = cmf->second;
             auto rp = pt.lexically_relative(dir.parent_path());

--- a/src/scxt-core/sample/sfz_support/sfz_parse.cpp
+++ b/src/scxt-core/sample/sfz_support/sfz_parse.cpp
@@ -106,12 +106,12 @@ SFZParser::document_t SFZParser::parse(const std::string &s)
     };
 
     auto stripTrailingAndQuotes = [](const auto &s) {
-        auto ep = s.size() - 1;
-        while (ep >= 0 && (s[ep] == ' ' || s[ep] == '\n' || s[ep] == '\r'))
+        auto ep = s.size(); // one past last kept char; size_t, so never go below 0
+        while (ep > 0 && (s[ep - 1] == ' ' || s[ep - 1] == '\n' || s[ep - 1] == '\r'))
         {
             ep--;
         }
-        auto res = s.substr(0, ep + 1);
+        auto res = s.substr(0, ep);
         if (!res.empty())
         {
             if (res.size() > 1 && res[0] == '"' && res.back() == '"')

--- a/tests/importer_tests.cpp
+++ b/tests/importer_tests.cpp
@@ -30,11 +30,14 @@
 #include <filesystem>
 #include <string>
 
+#include <fstream>
+
 #include "console_harness.h"
 #include "engine/engine.h"
 #include "engine/part.h"
 #include "engine/zone.h"
 #include "modulation/voice_matrix.h"
+#include "patch_io/patch_io.h"
 
 #ifndef SCXT_TEST_SOURCE_DIR
 #define SCXT_TEST_SOURCE_DIR ""
@@ -325,4 +328,45 @@ TEST_CASE("Import SFZ *square generator", "[importer]")
             scxt::dsp::processor::ProcessorType::proct_osc_EBWaveforms);
     CHECK(zone->processorStorage[0].intParams[0] == 2); // PULSE
     CHECK(zone->processorStorage[0].mix == Approx(1.0f));
+}
+
+TEST_CASE("Import FLAC fixture", "[importer]")
+{
+    // Smoke test for the FLAC loader: exercises the metadata-iteration loop
+    // (must not spin forever on non-"riff" application / vorbis blocks)
+    // and the smpl APPLICATION reader (memcpy, bounds-checked) end to end.
+    auto p = fixturePath("聲音不好.flac");
+    INFO("fixture=" << p.string());
+    REQUIRE(fs::exists(p));
+
+    ImporterFixture f;
+    f.loadSample(p);
+
+    auto &part = f.part0();
+    REQUIRE(part.getGroups().size() >= 1);
+    int totalZones = 0;
+    for (auto &g : part.getGroups())
+        totalZones += (int)g->getZones().size();
+    CHECK(totalZones >= 1);
+}
+
+TEST_CASE("loadMulti on a non-SCXT RIFF errors instead of crashing", "[importer][patch_io]")
+{
+    // a valid RIFF that is not an SCXT patch has no manifest subchunk; libgig
+    // returns null for it. The readers must throw a RIFF::Exception (which
+    // loadMulti catches → clean `false`) rather than dereference the null.
+    auto tmp = fs::temp_directory_path() / "scxt_not_a_patch.scm";
+    {
+        std::ofstream o(tmp, std::ios::binary);
+        // Minimal but valid RIFF: "RIFF" + size(4) + "WAVE", no subchunks.
+        const unsigned char riff[12] = {'R', 'I', 'F', 'F', 4, 0, 0, 0, 'W', 'A', 'V', 'E'};
+        o.write((const char *)riff, sizeof(riff));
+    }
+
+    ImporterFixture f;
+    bool result = scxt::patch_io::loadMulti(tmp, f.engine());
+    CHECK_FALSE(result);
+
+    std::error_code ec;
+    fs::remove(tmp, ec);
 }

--- a/tests/sample_fuzz.cpp
+++ b/tests/sample_fuzz.cpp
@@ -32,8 +32,11 @@
  * rather than crash. Build with -DSCXT_SANITIZE=ON to turn the "didn't
  * obviously crash" checks into real OOB/overflow assertions (ASan+UBSan).
  *
- * Targets the S1 / RIFF-WAV hardening batch: SMP-1 (EndStack clamp), SMP-2
- * (RIFFReadChunk DataSize), SMP-4 (INAM bounded copy), SMP-5 (cue/strc count).
+ * Covers the RIFF-WAV hardening: the EndStack/chunk-size clamp, the bounded
+ * RIFFReadChunk size, the bounded INAM copy, and the cue/strc count caps.
+ *
+ * Also covers AIFF: the COMM frame count clamped to the SSND payload, and the
+ * capped/zero-initialized MARK marker arrays.
  */
 
 #include "catch2/catch2.hpp"
@@ -118,7 +121,7 @@ TEST_CASE("parse_riff_wave: valid baseline parses", "[sample][fuzz][wav]")
 
 TEST_CASE("parse_riff_wave: inflated LIST size cannot read past the buffer", "[sample][fuzz][wav]")
 {
-    // SMP-1: a LIST:INFO chunk whose declared size dwarfs the file. Without the
+    // a LIST:INFO chunk whose declared size dwarfs the file. Without the
     // EndStack clamp the INFO scan walks off the end of the buffer (ASan trip).
     auto body = wavBody();
     putTag(body, "LIST");
@@ -138,8 +141,8 @@ TEST_CASE("parse_riff_wave: inflated LIST size cannot read past the buffer", "[s
 
 TEST_CASE("parse_riff_wave: short un-terminated INAM is copied safely", "[sample][fuzz][wav]")
 {
-    // SMP-4 (+SMP-2): INAM declares 10 bytes with no NUL and sits at the very end
-    // of the buffer. The old strncpy(name, ptr, 64) read 54 bytes past EOF.
+    // INAM declares 10 bytes with no NUL and sits at the very end of the
+    // buffer; the copy must stay within the chunk and NUL-terminate name[].
     auto body = wavBody();
     putTag(body, "LIST");
     size_t listSizeAt = body.size();
@@ -162,8 +165,8 @@ TEST_CASE("parse_riff_wave: short un-terminated INAM is copied safely", "[sample
 
 TEST_CASE("parse_riff_wave: huge cue count does not over-allocate", "[sample][fuzz][wav]")
 {
-    // SMP-5: a 'cue ' chunk that claims 256M cue points but carries one. Old code
-    // did new int[268435456] twice. New code caps to bytesRemaining().
+    // a 'cue ' chunk that claims 256M cue points but carries one. The count
+    // must be capped to what the chunk can hold, not allocated wholesale.
     auto body = wavBody();
     putTag(body, "cue ");
     putU32(body, 4 + 24);     // chunk size: count(4) + one CuePoint(24)
@@ -180,7 +183,7 @@ TEST_CASE("parse_riff_wave: huge cue count does not over-allocate", "[sample][fu
 
 TEST_CASE("parse_riff_wave: truncated cue chunk leaves no garbage slices", "[sample][fuzz][wav]")
 {
-    // SMP-5: count says 5, chunk header claims 5 records, but only 2 are present
+    // count says 5, chunk header claims 5 records, but only 2 are present
     // before EOF. Must not read uninitialized memory; n_slices reflects reality.
     auto body = wavBody();
     putTag(body, "cue ");
@@ -269,7 +272,7 @@ TEST_CASE("parse_riff_wave: byte-flip fuzz of size fields does not crash", "[sam
 TEST_CASE("parse_riff_wave: 256MB+ data chunk sample count does not overflow",
           "[.][sample][fuzz][wav][smp3]")
 {
-    // SMP-3: 8 * WaveDataSize overflowed int32 above 256MB, yielding a negative
+    // 8 * WaveDataSize overflowed int32 above 256MB, yielding a negative
     // sample count. Hidden by default ([.]) because it allocates ~256MB; run
     // explicitly with `scxt-test "[smp3]"`.
     const uint32_t dataBytes = 256u * 1024 * 1024 + 4096; // just over the int32 cliff
@@ -284,4 +287,238 @@ TEST_CASE("parse_riff_wave: 256MB+ data chunk sample count does not overflow",
     sample::Sample s;
     REQUIRE(s.parse_riff_wave(f.data(), f.size()));
     CHECK(s.getSampleLength() == dataBytes); // 8 * bytes / 8 == bytes, no wrap
+}
+
+// ---------------------------------------------------------------------------
+// AIFF (big-endian) builders + cases. parse_aiff reads everything big-endian.
+// ---------------------------------------------------------------------------
+namespace
+{
+void putU16BE(std::vector<uint8_t> &b, uint16_t v)
+{
+    b.push_back((v >> 8) & 0xFF);
+    b.push_back(v & 0xFF);
+}
+void putU32BE(std::vector<uint8_t> &b, uint32_t v)
+{
+    b.push_back((v >> 24) & 0xFF);
+    b.push_back((v >> 16) & 0xFF);
+    b.push_back((v >> 8) & 0xFF);
+    b.push_back(v & 0xFF);
+}
+
+// 80-bit IEEE-extended encoding of 44100.0, what ConvertFromIeeeExtended decodes.
+const uint8_t kRate44100[10] = {0x40, 0x0E, 0xAC, 0x44, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+// COMM chunk: numChannels, numSampleFrames, sampleSize(bits), 10-byte rate.
+void putAiffCOMM(std::vector<uint8_t> &b, uint16_t ch, uint32_t nframes, uint16_t bits)
+{
+    putTag(b, "COMM");
+    putU32BE(b, 18); // 2 + 4 + 2 + 10
+    putU16BE(b, ch);
+    putU32BE(b, nframes);
+    putU16BE(b, bits);
+    b.insert(b.end(), kRate44100, kRate44100 + 10);
+}
+
+// SSND chunk: 4-byte offset, 4-byte blockSize, `offset` pad bytes, then audio.
+void putAiffSSND(std::vector<uint8_t> &b, uint32_t offset, const std::vector<uint8_t> &audio)
+{
+    putTag(b, "SSND");
+    putU32BE(b, (uint32_t)(8 + offset + audio.size()));
+    putU32BE(b, offset);
+    putU32BE(b, 0); // blockSize
+    for (uint32_t i = 0; i < offset; ++i)
+        b.push_back(0);
+    b.insert(b.end(), audio.begin(), audio.end());
+}
+
+// Wrap chunks in the outer FORM/AIFF header (FORM size is big-endian).
+std::vector<uint8_t> assembleAiff(const std::vector<uint8_t> &chunks)
+{
+    std::vector<uint8_t> f;
+    putTag(f, "FORM");
+    putU32BE(f, (uint32_t)(4 + chunks.size())); // "AIFF" + chunks
+    putTag(f, "AIFF");
+    f.insert(f.end(), chunks.begin(), chunks.end());
+    return f;
+}
+
+std::vector<uint8_t> rampAudio(size_t bytes)
+{
+    std::vector<uint8_t> a(bytes);
+    for (size_t i = 0; i < bytes; ++i)
+        a[i] = (uint8_t)(i & 0xFF);
+    return a;
+}
+} // namespace
+
+TEST_CASE("parse_aiff: valid mono 16-bit baseline parses", "[sample][fuzz][aiff]")
+{
+    std::vector<uint8_t> chunks;
+    putAiffCOMM(chunks, 1, 32, 16);
+    putAiffSSND(chunks, 0, rampAudio(32 * 2));
+    auto f = assembleAiff(chunks);
+
+    sample::Sample s;
+    REQUIRE(s.parse_aiff(f.data(), f.size()));
+    CHECK(s.channels == 1);
+    CHECK(s.sample_rate == 44100);
+    CHECK(s.getSampleLength() == 32);
+}
+
+TEST_CASE("parse_aiff: COMM frame count exceeding SSND payload is clamped (mono)",
+          "[sample][fuzz][aiff]")
+{
+    // COMM claims 100000 frames but SSND carries 16; the frame count must be
+    // clamped to the payload or load_data_i16BE reads past the buffer (ASan).
+    std::vector<uint8_t> chunks;
+    putAiffCOMM(chunks, 1, 100000, 16);
+    putAiffSSND(chunks, 0, rampAudio(16 * 2));
+    auto f = assembleAiff(chunks);
+
+    sample::Sample s;
+    REQUIRE(s.parse_aiff(f.data(), f.size()));
+    CHECK(s.getSampleLength() <= 16);
+}
+
+TEST_CASE("parse_aiff: COMM frame count exceeding SSND payload is clamped (stereo)",
+          "[sample][fuzz][aiff]")
+{
+    // Same OOB for the stereo path: stride 4, both channels read nframes apart.
+    std::vector<uint8_t> chunks;
+    putAiffCOMM(chunks, 2, 100000, 16);
+    putAiffSSND(chunks, 0, rampAudio(8 * 4));
+    auto f = assembleAiff(chunks);
+
+    sample::Sample s;
+    REQUIRE(s.parse_aiff(f.data(), f.size()));
+    CHECK(s.channels == 2);
+    CHECK(s.getSampleLength() <= 8);
+}
+
+TEST_CASE("parse_aiff: 24-bit COMM frame count exceeding SSND payload is clamped",
+          "[sample][fuzz][aiff]")
+{
+    // Exercises the i24 stride-3 path (bytesPerFrame derived from bitdepth/8).
+    std::vector<uint8_t> chunks;
+    putAiffCOMM(chunks, 1, 100000, 24);
+    putAiffSSND(chunks, 0, rampAudio(10 * 3));
+    auto f = assembleAiff(chunks);
+
+    sample::Sample s;
+    REQUIRE(s.parse_aiff(f.data(), f.size()));
+    CHECK(s.getSampleLength() <= 10);
+}
+
+TEST_CASE("parse_aiff: huge MARK count does not over-allocate or read past the chunk",
+          "[sample][fuzz][aiff]")
+{
+    // MARK claims 65535 markers but the chunk carries one. The count is
+    // capped to what the chunk can hold; the loop bails on the short read.
+    std::vector<uint8_t> chunks;
+    putAiffCOMM(chunks, 1, 16, 16);
+    putAiffSSND(chunks, 0, rampAudio(16 * 2));
+
+    std::vector<uint8_t> mark;
+    putU16BE(mark, 0xFFFF); // lie: 65535 markers
+    putU16BE(mark, 0);      // marker id
+    putU32BE(mark, 4);      // pos
+    mark.push_back(0);      // pstring length 0
+    mark.push_back(0);      // pad to even
+    putTag(chunks, "MARK");
+    putU32BE(chunks, (uint32_t)mark.size());
+    chunks.insert(chunks.end(), mark.begin(), mark.end());
+
+    auto f = assembleAiff(chunks);
+    sample::Sample s;
+    s.parse_aiff(f.data(), f.size()); // success/failure both fine; must not OOB
+    SUCCEED();
+}
+
+TEST_CASE("parse_aiff: INST loop referencing an absent marker reads a defined value",
+          "[sample][fuzz][aiff]")
+{
+    // zero-initialized marker arrays mean an INST sustain loop pointing at
+    // a marker id that was never written resolves to 0 rather than stale heap.
+    std::vector<uint8_t> chunks;
+    putAiffCOMM(chunks, 1, 16, 16);
+    putAiffSSND(chunks, 0, rampAudio(16 * 2));
+
+    // MARK: declare 4 markers but only supply id 0.
+    std::vector<uint8_t> mark;
+    putU16BE(mark, 4);
+    putU16BE(mark, 0); // id 0 only
+    putU32BE(mark, 4); // pos
+    mark.push_back(0);
+    mark.push_back(0);
+    putTag(chunks, "MARK");
+    putU32BE(chunks, (uint32_t)mark.size());
+    chunks.insert(chunks.end(), mark.begin(), mark.end());
+
+    // INST (20 bytes): sustainLoop playmode=1, markers 2 and 3 (absent).
+    std::vector<uint8_t> inst;
+    for (int i = 0; i < 6; ++i)
+        inst.push_back(0); // baseNote..highvelocity
+    putU16BE(inst, 0);     // gain
+    putU16BE(inst, 1);     // sustainLoop.playmode (looping)
+    putU16BE(inst, 2);     // sustainLoop.marker_start (absent)
+    putU16BE(inst, 3);     // sustainLoop.marker_end   (absent)
+    putU16BE(inst, 0);     // releaseLoop.playmode
+    putU16BE(inst, 0);     // releaseLoop.marker_start
+    putU16BE(inst, 0);     // releaseLoop.marker_end
+    putTag(chunks, "INST");
+    putU32BE(chunks, (uint32_t)inst.size());
+    chunks.insert(chunks.end(), inst.begin(), inst.end());
+
+    auto f = assembleAiff(chunks);
+    sample::Sample s;
+    REQUIRE(s.parse_aiff(f.data(), f.size()));
+    CHECK(s.meta.loop_start == 0);
+    CHECK(s.meta.loop_end == 1); // absent marker → 0, code stores +1
+}
+
+TEST_CASE("parse_aiff: survives truncation at every prefix length", "[sample][fuzz][aiff]")
+{
+    // Full AIFF (COMM + SSND + MARK + INST) parsed at every prefix length. Under
+    // ASan this catches an OOB read anywhere in the chunk walk for any cut point.
+    std::vector<uint8_t> chunks;
+    putAiffCOMM(chunks, 2, 24, 16);
+    putAiffSSND(chunks, 4, rampAudio(24 * 4));
+
+    std::vector<uint8_t> mark;
+    putU16BE(mark, 2);
+    putU16BE(mark, 0);
+    putU32BE(mark, 0);
+    mark.push_back(0);
+    mark.push_back(0);
+    putU16BE(mark, 1);
+    putU32BE(mark, 12);
+    mark.push_back(0);
+    mark.push_back(0);
+    putTag(chunks, "MARK");
+    putU32BE(chunks, (uint32_t)mark.size());
+    chunks.insert(chunks.end(), mark.begin(), mark.end());
+
+    std::vector<uint8_t> inst;
+    for (int i = 0; i < 6; ++i)
+        inst.push_back(0);
+    putU16BE(inst, 0);
+    putU16BE(inst, 1);
+    putU16BE(inst, 0);
+    putU16BE(inst, 1);
+    putU16BE(inst, 0);
+    putU16BE(inst, 0);
+    putU16BE(inst, 0);
+    putTag(chunks, "INST");
+    putU32BE(chunks, (uint32_t)inst.size());
+    chunks.insert(chunks.end(), inst.begin(), inst.end());
+
+    auto f = assembleAiff(chunks);
+    for (size_t n = 1; n <= f.size(); ++n)
+    {
+        sample::Sample s;
+        s.parse_aiff(f.data(), n);
+    }
+    SUCCEED();
 }


### PR DESCRIPTION
Bounds-check untrusted fields in the AIFF, FLAC, SF2, Akai and multisample loaders so a malformed or truncated file errors out instead of reading or writing past its buffer. The AIFF reader clamps the COMM frame count to the SSND payload; FLAC stops over-reading the application metadata and rejects unsupported channel counts; the SF2 24-bit path uses the correct sample count; Akai chunk walking can no longer wrap; multisample lookups fail on a missing entry instead of grabbing the wrong one. The SFZ parser no longer reads out of bounds on an empty value.

Loading a non-SCXT RIFF as a patch now reports an error rather than dereferencing a null chunk, the browser scanner survives unreadable files and directories instead of terminating the worker thread, SFZ export aborts cleanly on unsupported zones, and the sample-manager index range checks are corrected.

Adds in-memory AIFF fuzz cases plus FLAC and patch-load regression tests, and drops stale internal review-ticket references from existing parser comments.

Assisted-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>