### PR TITLE
Fix compilation error in keyboard.h due to missing <algorithm> header on GCC

### DIFF
--- a/src/scxt-core/engine/keyboard.h
+++ b/src/scxt-core/engine/keyboard.h
@@ -29,6 +29,7 @@
 
 #include <utility>
 #include <cassert>
+#include <algorithm>
 
 namespace scxt::engine
 {


### PR DESCRIPTION
### 1. Problem
`keyboard.h` uses `std::clamp`, but does not include `<algorithm>` directly.   
This PR fixes a compilation failure in src/scxt-core/engine/keyboard.h. The file utilizes std::clamp but does not explicitly include the `<algorithm>` header. While some compilers (like AppleClang on macOS) might implicitly include it through other headers, strict compilers like GCC on Linux will fail to compile.

### 2. Development Environment
I encountered this issue when building the project in the following environment:
- OS: Ubuntu 26.04 LTS
- Compiler: gcc / g++ version 15.2.0 (x86_64-linux-gnu)
- Building System: CMake (Debug Build Variant)
- Target: scxt_clapfirst_standalone

### 3. Error Log
Here is the compilation error output before applying the fix:
```txt
[build] In file included from shortcircuit-xt/src/scxt-core/engine/zone.h:35,
[build]                       shortcircuit-xt/src/scxt-core/engine/zone.cpp:28:
[build] shortcircuit-xt/src/scxt-core/engine/keyboard.h: In member function ‘float scxt::engine::KeyboardRange::fadeAmpltiudeAt(int16_t)’:
[build] shortcircuit-xt/src/scxt-core/engine/keyboard.h:76:25: error: ‘clamp’ is not a member of ‘std’
[build]    76 |             return std::clamp(static_cast<float>(toKey - keyStart) / fadeStart, 0.f, 1.f);
[build]       |                         ^~~~~
[build] shortcircuit-xt/src/scxt-core/engine/keyboard.h:80:25: error: ‘clamp’ is not a member of ‘std’
[build]    80 |             return std::clamp(static_cast<float>(keyEnd - toKey) / fadeEnd, 0.f, 1.f);
[build]       |                         ^~~~~
```

### 4. How was it fixed
Explicitly added `#include <algorithm>` to the top of src/scxt-core/engine/keyboard.h to ensure std::clamp is properly defined across all compliant standard library implementations. Verified that the project now compiles successfully (exit code 0) on Ubuntu with GCC 15.2.