### PR TITLE
notify host of state change every time an undo item is pushed or applied

### DIFF
--- a/src/scxt-core/engine/engine.cpp
+++ b/src/scxt-core/engine/engine.cpp
@@ -516,6 +516,7 @@ void Engine::drainSerialToEngineQueue()
         case messaging::audio::s2a_param_beginendedit:
         case messaging::audio::s2a_param_set_value:
         case messaging::audio::s2a_param_refresh:
+        case messaging::audio::s2a_state_mark_dirty:
         {
             if (messageController->passWrapperEventsToWrapperQueue)
                 messageController->engineToPluginWrapperQueue.push(*msgopt);

--- a/src/scxt-core/engine/engine.cpp
+++ b/src/scxt-core/engine/engine.cpp
@@ -347,6 +347,13 @@ void Engine::immediatelyTerminateAllVoices()
     forceVoiceUpdate = true;
 }
 
+void Engine::markDirty() const
+{
+    messaging::audio::SerializationToAudio s2am;
+    s2am.id = messaging::audio::s2a_state_mark_dirty;
+    messageController->sendSerializationToAudio(s2am);
+}
+
 bool Engine::processAudio()
 {
     auto processingStartTime = std::chrono::high_resolution_clock::now();

--- a/src/scxt-core/engine/engine.h
+++ b/src/scxt-core/engine/engine.h
@@ -434,6 +434,11 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     }
 
     /**
+     * Notify the host that the serialized state has changed.
+     */
+    void markDirty() const;
+
+    /**
      * Prepare to play sets up the internal state to prepare us to play. Call it in
      * your interfaces pre-playing once.
      */

--- a/src/scxt-core/messaging/audio/audio_serial.h
+++ b/src/scxt-core/messaging/audio/audio_serial.h
@@ -114,7 +114,8 @@ enum SerializationToAudioMessageId
 
     s2a_param_beginendedit,
     s2a_param_set_value,
-    s2a_param_refresh
+    s2a_param_refresh,
+    s2a_state_mark_dirty
 };
 
 /**

--- a/src/scxt-core/messaging/client/interaction_messages.h
+++ b/src/scxt-core/messaging/client/interaction_messages.h
@@ -127,6 +127,7 @@ inline void doResetEngine(const std::string &fl, engine::Engine &e, MessageContr
 {
     e.undoManager.clear();
     scxt::patch_io::initFromResourceBundle(e, fl);
+    e.markDirty();
     e.sendFullRefreshToClient();
 }
 CLIENT_TO_SERIAL(ResetEngine, c2s_reset_engine, std::string, doResetEngine(payload, engine, cont));

--- a/src/scxt-core/messaging/client/structure_messages.h
+++ b/src/scxt-core/messaging/client/structure_messages.h
@@ -435,7 +435,7 @@ inline void moveZonesFromTo(const zoneAddressFromTo_t &payload, engine::Engine &
             undoItem->deleteGroupsAtEnd.push_back(
                 (int32_t)engine.getPatch()->getPart(tgt.part)->getGroups().size());
         }
-        engine.undoManager.storeUndoStep(std::move(undoItem));
+        engine.undoManager.storeUndoStep(engine, std::move(undoItem));
     }
 
     cont.scheduleAudioThreadCallbackUnderStructureLock(

--- a/src/scxt-core/undo_manager/payload_undoable_items.h
+++ b/src/scxt-core/undo_manager/payload_undoable_items.h
@@ -189,11 +189,7 @@ inline void pushPayloadUndoFor(engine::Engine &e, const std::vector<ZoneAddress>
     if (g == UndoGesture::Discrete && e.undoManager.gestureCovers(tag))
     {
         // skip the snapshot work, but notify the host of the state change
-
-        messaging::audio::SerializationToAudio s2am;
-        s2am.id = messaging::audio::s2a_state_mark_dirty;
-        e.getMessageController()->sendSerializationToAudio(s2am);
-
+        e.markDirty();
         return;
     }
 

--- a/src/scxt-core/undo_manager/payload_undoable_items.h
+++ b/src/scxt-core/undo_manager/payload_undoable_items.h
@@ -187,11 +187,17 @@ inline void pushPayloadUndoFor(engine::Engine &e, const std::vector<ZoneAddress>
 
     auto tag = gestureTag<Spec>(index);
     if (g == UndoGesture::Discrete && e.undoManager.gestureCovers(tag))
-        return; // skip the snapshot work too
+    {
+        // skip the snapshot work, but notify the host of the state change
 
-    auto item = std::make_unique<PayloadUndoableItem<Spec>>();
-    item->store(e, index, sel);
-    e.undoManager.storeUndoStepTagged(std::move(item), tag, g);
+        messaging::audio::SerializationToAudio s2am;
+        s2am.id = messaging::audio::s2a_state_mark_dirty;
+        e.getMessageController()->sendSerializationToAudio(s2am);
+
+        return;
+    }
+
+    undo::pushUndoTagged<PayloadUndoableItem<Spec>>(e, tag, g, index, sel);
 }
 
 // One-line undo push for handler call sites: snapshot the current selection

--- a/src/scxt-core/undo_manager/structure_undoable_items.cpp
+++ b/src/scxt-core/undo_manager/structure_undoable_items.cpp
@@ -578,11 +578,7 @@ void pushPartStreamUndo(engine::Engine &e, int16_t part, const std::string &labe
     if (g == UndoGesture::Discrete && e.undoManager.gestureCovers(tag))
     {
         // skip the snapshot work, but notify the host of the state change
-
-        messaging::audio::SerializationToAudio s2am;
-        s2am.id = messaging::audio::s2a_state_mark_dirty;
-        e.getMessageController()->sendSerializationToAudio(s2am);
-
+        e.markDirty();
         return;
     }
 

--- a/src/scxt-core/undo_manager/structure_undoable_items.cpp
+++ b/src/scxt-core/undo_manager/structure_undoable_items.cpp
@@ -118,7 +118,7 @@ void pushZoneAddUndo(engine::Engine &e, int16_t part, int32_t group)
         (group < (int)pt->getGroups().size()) ? (int32_t)pt->getGroup(group)->getZones().size() : 0;
     auto item = std::make_unique<ZonesDeleteOnUndoItem>();
     item->store(e, {{part, group, zi}});
-    e.undoManager.storeUndoStep(std::move(item));
+    e.undoManager.storeUndoStep(e, std::move(item));
 }
 
 // --- ZonesRestoreItem ---
@@ -576,11 +576,17 @@ void pushPartStreamUndo(engine::Engine &e, int16_t part, const std::string &labe
 {
     auto tag = "Part Stream/" + std::to_string(part);
     if (g == UndoGesture::Discrete && e.undoManager.gestureCovers(tag))
-        return; // skip streaming the whole part just to drop it
+    {
+        // skip the snapshot work, but notify the host of the state change
 
-    auto item = std::make_unique<PartStreamRestoreItem>();
-    item->store(e, part, label);
-    e.undoManager.storeUndoStepTagged(std::move(item), tag, g);
+        messaging::audio::SerializationToAudio s2am;
+        s2am.id = messaging::audio::s2a_state_mark_dirty;
+        e.getMessageController()->sendSerializationToAudio(s2am);
+
+        return;
+    }
+
+    undo::pushUndoTagged<PartStreamRestoreItem>(e, tag, g, part, label);
 }
 
 // --- EngineStateRestoreItem ---

--- a/src/scxt-core/undo_manager/undo.cpp
+++ b/src/scxt-core/undo_manager/undo.cpp
@@ -34,7 +34,7 @@
 namespace scxt::undo
 {
 
-void UndoManager::storeUndoStep(std::unique_ptr<UndoableItem> item)
+void UndoManager::storeUndoStep(engine::Engine &e, std::unique_ptr<UndoableItem> item)
 {
     if (coalesce == Coalesce::Captured)
     {
@@ -50,18 +50,27 @@ void UndoManager::storeUndoStep(std::unique_ptr<UndoableItem> item)
         undoStack.pop_front();
     if (coalesce == Coalesce::Armed)
         coalesce = Coalesce::Captured;
+
+    messaging::audio::SerializationToAudio s2am;
+    s2am.id = messaging::audio::s2a_state_mark_dirty;
+    e.getMessageController()->sendSerializationToAudio(s2am);
 }
 
-void UndoManager::storeUndoStepTagged(std::unique_ptr<UndoableItem> item, const std::string &tag,
-                                      UndoGesture g)
+void UndoManager::storeUndoStepTagged(engine::Engine &e, std::unique_ptr<UndoableItem> item,
+                                      const std::string &tag, UndoGesture g)
 {
     if (g == UndoGesture::Discrete && gestureCovers(tag))
     {
         SCLOG_IF(undoRedo,
                  "|== drop '" << item->describe() << "' covered by open gesture '" << tag << "'");
+
+        messaging::audio::SerializationToAudio s2am;
+        s2am.id = messaging::audio::s2a_state_mark_dirty;
+        e.getMessageController()->sendSerializationToAudio(s2am);
+
         return;
     }
-    storeUndoStep(std::move(item));
+    storeUndoStep(e, std::move(item));
     if (g == UndoGesture::Begin)
         openGesture(tag);
 }
@@ -100,6 +109,11 @@ bool UndoManager::applyUndoStep(engine::Engine &e)
     }
 
     item->restore(e);
+
+    messaging::audio::SerializationToAudio s2am;
+    s2am.id = messaging::audio::s2a_state_mark_dirty;
+    e.getMessageController()->sendSerializationToAudio(s2am);
+
     return true;
 }
 
@@ -127,6 +141,11 @@ bool UndoManager::applyRedoStep(engine::Engine &e)
     }
 
     item->restore(e);
+
+    messaging::audio::SerializationToAudio s2am;
+    s2am.id = messaging::audio::s2a_state_mark_dirty;
+    e.getMessageController()->sendSerializationToAudio(s2am);
+
     return true;
 }
 

--- a/src/scxt-core/undo_manager/undo.cpp
+++ b/src/scxt-core/undo_manager/undo.cpp
@@ -39,6 +39,7 @@ void UndoManager::storeUndoStep(engine::Engine &e, std::unique_ptr<UndoableItem>
     if (coalesce == Coalesce::Captured)
     {
         SCLOG_IF(undoRedo, "|== drop '" << item->describe() << "' coalesced into open batch");
+        e.markDirty();
         return;
     }
     SCLOG_IF(undoRedo, "|>> push '" << item->describe() << "' (stack size " << undoStack.size() + 1
@@ -50,10 +51,7 @@ void UndoManager::storeUndoStep(engine::Engine &e, std::unique_ptr<UndoableItem>
         undoStack.pop_front();
     if (coalesce == Coalesce::Armed)
         coalesce = Coalesce::Captured;
-
-    messaging::audio::SerializationToAudio s2am;
-    s2am.id = messaging::audio::s2a_state_mark_dirty;
-    e.getMessageController()->sendSerializationToAudio(s2am);
+    e.markDirty();
 }
 
 void UndoManager::storeUndoStepTagged(engine::Engine &e, std::unique_ptr<UndoableItem> item,
@@ -63,11 +61,7 @@ void UndoManager::storeUndoStepTagged(engine::Engine &e, std::unique_ptr<Undoabl
     {
         SCLOG_IF(undoRedo,
                  "|== drop '" << item->describe() << "' covered by open gesture '" << tag << "'");
-
-        messaging::audio::SerializationToAudio s2am;
-        s2am.id = messaging::audio::s2a_state_mark_dirty;
-        e.getMessageController()->sendSerializationToAudio(s2am);
-
+        e.markDirty();
         return;
     }
     storeUndoStep(e, std::move(item));
@@ -110,9 +104,7 @@ bool UndoManager::applyUndoStep(engine::Engine &e)
 
     item->restore(e);
 
-    messaging::audio::SerializationToAudio s2am;
-    s2am.id = messaging::audio::s2a_state_mark_dirty;
-    e.getMessageController()->sendSerializationToAudio(s2am);
+    e.markDirty();
 
     return true;
 }
@@ -142,9 +134,7 @@ bool UndoManager::applyRedoStep(engine::Engine &e)
 
     item->restore(e);
 
-    messaging::audio::SerializationToAudio s2am;
-    s2am.id = messaging::audio::s2a_state_mark_dirty;
-    e.getMessageController()->sendSerializationToAudio(s2am);
+    e.markDirty();
 
     return true;
 }

--- a/src/scxt-core/undo_manager/undo.h
+++ b/src/scxt-core/undo_manager/undo.h
@@ -47,11 +47,11 @@ enum struct UndoGesture
 
 struct UndoManager
 {
-    void storeUndoStep(std::unique_ptr<UndoableItem> item);
+    void storeUndoStep(engine::Engine &e, std::unique_ptr<UndoableItem> item);
     // gesture-aware push: drops the item if a gesture with this tag is
     // open; any other tag closes that gesture first. Begin opens the tag.
-    void storeUndoStepTagged(std::unique_ptr<UndoableItem> item, const std::string &tag,
-                             UndoGesture g);
+    void storeUndoStepTagged(engine::Engine &e, std::unique_ptr<UndoableItem> item,
+                             const std::string &tag, UndoGesture g);
     bool applyUndoStep(engine::Engine &e);
     bool applyRedoStep(engine::Engine &e);
     // For whole-engine replacements (load multi, load part, unstream, reset)
@@ -110,7 +110,7 @@ template <typename Item, typename E, typename... Args> void pushUndo(E &e, Args 
 {
     auto item = std::make_unique<Item>();
     item->store(e, std::forward<Args>(args)...);
-    e.undoManager.storeUndoStep(std::move(item));
+    e.undoManager.storeUndoStep(e, std::move(item));
 }
 
 // Gesture-aware variant: tag + gesture so continuous edits coalesce to one entry.
@@ -119,7 +119,7 @@ void pushUndoTagged(E &e, const std::string &tag, UndoGesture g, Args &&...args)
 {
     auto item = std::make_unique<Item>();
     item->store(e, std::forward<Args>(args)...);
-    e.undoManager.storeUndoStepTagged(std::move(item), tag, g);
+    e.undoManager.storeUndoStepTagged(e, std::move(item), tag, g);
 }
 
 } // namespace scxt::undo

--- a/src/scxt-plugin/clap/scxt-plugin.cpp
+++ b/src/scxt-plugin/clap/scxt-plugin.cpp
@@ -367,6 +367,12 @@ SCXTPlugin::process_nonblock(const clap_process *process) SST_CPPUTILS_NONBLOCKI
                     _host.requestCallback();
                 }
                 break;
+                case messaging::audio::s2a_state_mark_dirty:
+                {
+                    nextMainThreadAction |= STATE_MARK_DIRTY;
+                    _host.requestCallback();
+                }
+                break;
                 default:
                     SCLOG_IF(plugin, "Unexpected message " << msgopt->id);
                     break;
@@ -579,6 +585,13 @@ void SCXTPlugin::onMainThread() noexcept
         {
             _host.paramsRescan(CLAP_PARAM_RESCAN_INFO | CLAP_PARAM_RESCAN_VALUES |
                                CLAP_PARAM_RESCAN_TEXT);
+        }
+    }
+    if (a & STATE_MARK_DIRTY)
+    {
+        if (_host.canUseState())
+        {
+            _host.stateMarkDirty();
         }
     }
 }

--- a/src/scxt-plugin/clap/scxt-plugin.h
+++ b/src/scxt-plugin/clap/scxt-plugin.h
@@ -83,6 +83,7 @@ struct SCXTPlugin : public plugHelper_t, sst::clap_juce_shim::EditorProvider
     enum MainThreadActions : uint64_t
     {
         RESCAN_PARAM_IVT = 1 << 0,
+        STATE_MARK_DIRTY = 1 << 1,
     };
     std::atomic<uint64_t> nextMainThreadAction;
     void onMainThread() noexcept override;


### PR DESCRIPTION
I probably missed some spots where an undo item push is short-circuited (hehe), but from my testing this seems to fix #2547. Happy to take criticism given I'm a hardcore C++ noob.