### PR TITLE
Fix sample-zero waveform position at high zoom

### DIFF
--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/SampleWaveform.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/SampleWaveform.cpp
@@ -191,7 +191,12 @@ void SampleWaveform::rebuildEnvelopePaths()
             }
             for (int s = startSample; s < endSample; ++s)
             {
-                if (c + fac < s)
+                mx = std::max(data[s], mx);
+                mn = std::min(data[s], mn);
+
+                // accumulate first, then close the bucket at s so sample s isn't
+                // shoved one bucket to the right
+                if (s + 1 >= c + fac)
                 {
                     double nmx = mx * 1.0 / normFactor;
                     double nmn = mn * 1.0 / normFactor;
@@ -204,8 +209,6 @@ void SampleWaveform::rebuildEnvelopePaths()
                     mx = seedmx;
                     mn = seedmn;
                 }
-                mx = std::max(data[s], mx);
-                mn = std::min(data[s], mn);
             }
         };
 


### PR DESCRIPTION
The downsampled waveform stamped each point one bucket to the right of the audio it summarized. This only surfaced as a repaint error on sample zero at high horizontal zoom, where it painted at sample one's position.

Assisted-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>