### PR TITLE
Add a toggle mode to macros

### DIFF
--- a/src/scxt-core/engine/macros.cpp
+++ b/src/scxt-core/engine/macros.cpp
@@ -29,5 +29,27 @@
 
 namespace scxt::engine
 {
+std::string Macro::toStringMode(const Mode &m)
+{
+    switch (m)
+    {
+    case UNIPOLAR:
+        return "unipolar";
+    case BIPOLAR:
+        return "bipolar";
+    case TOGGLE:
+        return "toggle";
+    }
+    return "unipolar";
+}
 
+Macro::Mode Macro::fromStringMode(const std::string &s)
+{
+    static auto inverse = makeEnumInverse<Macro::Mode, Macro::toStringMode>(Macro::Mode::UNIPOLAR,
+                                                                            Macro::Mode::TOGGLE);
+    auto p = inverse.find(s);
+    if (p == inverse.end())
+        return UNIPOLAR;
+    return p->second;
+}
 } // namespace scxt::engine

--- a/src/scxt-core/engine/macros.h
+++ b/src/scxt-core/engine/macros.h
@@ -29,6 +29,7 @@
 #define SCXT_SRC_SCXT_CORE_ENGINE_MACROS_H
 
 #include <cassert>
+#include <cctype>
 #include <cstdint>
 #include <cstddef>
 #include <algorithm>
@@ -37,6 +38,7 @@
 
 #include "sst/basic-blocks/params/ParamMetadata.h"
 #include "configuration.h"
+#include "utils.h"
 
 namespace scxt::engine
 {
@@ -46,22 +48,35 @@ struct Macro
 
     int16_t part{-1}, index{-1};
 
-    bool isBipolar{false}; // The value is expected in range -1..1
-    bool isStepped{false}; // The value has discrete stepped value
-    size_t stepCount{1};   // how many steps between min and max.
-                           // So 1 means a 0..1 or -1..1 toggle
+    enum Mode
+    {
+        UNIPOLAR, // 0 .. 1
+        BIPOLAR,  // -1 .. 1
+        TOGGLE,   // 0 or 1 only; snapped at 0.5
+    } mode{UNIPOLAR};
+    DECLARE_ENUM_STRING(Mode);
+
     std::string name{};
 
-    void setIsBipolar(bool b)
+    bool isBipolar() const { return mode == BIPOLAR; }
+    bool isToggle() const { return mode == TOGGLE; }
+
+    void setMode(Mode m)
     {
-        isBipolar = b;
+        mode = m;
         setValueConstrained(value);
     }
-    void setValueConstrained(float f) { value = std::clamp(f, isBipolar ? -1.f : 0.f, 1.f); }
+    void setValueConstrained(float f)
+    {
+        if (mode == TOGGLE)
+            value = (f > 0.5f ? 1.f : 0.f);
+        else
+            value = std::clamp(f, isBipolar() ? -1.f : 0.f, 1.f);
+    }
     void setValue01(float f)
     {
         assert(f >= 0.f && f <= 1.f);
-        if (isBipolar)
+        if (isBipolar())
         {
             setValueConstrained(f * 2 - 1.0);
         }
@@ -73,7 +88,7 @@ struct Macro
     float getValue01For(float vv) const
     {
         float res = vv;
-        if (isBipolar)
+        if (isBipolar())
         {
             res = (res + 1) * 0.5;
         }
@@ -83,24 +98,39 @@ struct Macro
 
     float valueFromString(const std::string &s) const
     {
+        if (mode == TOGGLE)
+            return boolFromString(s) ? 1.f : 0.f;
         auto sv = std::atof(s.c_str());
-        return std::clamp((float)sv, isBipolar ? -1.f : 0.f, 1.f);
+        return std::clamp((float)sv, isBipolar() ? -1.f : 0.f, 1.f);
     }
 
     float value01FromString(const std::string &s) const
     {
         auto v = valueFromString(s);
-        if (isBipolar)
+        if (isBipolar())
             v = (v + 1) * 0.5;
         return v;
     }
 
     std::string value01ToString(float dv) const
     {
+        if (mode == TOGGLE)
+            return dv > 0.5f ? "On" : "Off";
         auto fv = dv;
-        if (isBipolar)
+        if (isBipolar())
             fv = fv * 2 - 1;
         return fmt::format("{:.4f}", fv);
+    }
+
+    static bool boolFromString(const std::string &s)
+    {
+        auto t = s;
+        std::transform(t.begin(), t.end(), t.begin(), [](auto c) { return std::tolower(c); });
+        if (t == "on" || t == "true" || t == "yes")
+            return true;
+        if (t == "off" || t == "false" || t == "no")
+            return false;
+        return std::atof(t.c_str()) > 0.5;
     }
 
     static std::string defaultNameFor(int index) { return "Macro " + std::to_string(index + 1); }

--- a/src/scxt-core/json/engine_traits.h
+++ b/src/scxt-core/json/engine_traits.h
@@ -220,12 +220,12 @@ SC_STREAMDEF(scxt::engine::Engine::PGZStructureBundle,
                  findOrSet(v, "features", 0, to.features);
              }));
 
+STREAM_ENUM(engine::Macro::Mode, engine::Macro::toStringMode, engine::Macro::fromStringMode);
+
 SC_STREAMDEF(scxt::engine::Macro, SC_FROM({
                  v = {{"p", t.part}, {"i", t.index}, {"v", t.value}};
 
-                 addUnlessDefault<val_t>(v, "bp", false, t.isBipolar);
-                 addUnlessDefault<val_t>(v, "st", false, t.isStepped);
-                 addUnlessDefault<val_t>(v, "sc", (size_t)1, t.stepCount);
+                 addUnlessDefault<val_t>(v, "md", scxt::engine::Macro::UNIPOLAR, t.mode);
                  addUnlessDefault<val_t>(v, "nm", scxt::engine::Macro::defaultNameFor(t.index),
                                          t.name);
              }),
@@ -233,9 +233,13 @@ SC_STREAMDEF(scxt::engine::Macro, SC_FROM({
                  findIf(v, "v", result.value);
                  findIf(v, "i", result.index);
                  findIf(v, "p", result.part);
-                 findOrSet(v, "bp", false, result.isBipolar);
-                 findOrSet(v, "st", false, result.isStepped);
-                 findOrSet(v, "sc", 1, result.stepCount);
+                 // "bp" is the pre-mode bipolar flag; "md" wins when present
+                 bool legacyBipolar{false};
+                 findOrSet(v, "bp", false, legacyBipolar);
+                 findOrSet(v, "md",
+                           legacyBipolar ? scxt::engine::Macro::BIPOLAR
+                                         : scxt::engine::Macro::UNIPOLAR,
+                           result.mode);
                  findOrSet(v, "nm", scxt::engine::Macro::defaultNameFor(result.index), result.name);
              }));
 

--- a/src/scxt-core/messaging/client/macro_messages.h
+++ b/src/scxt-core/messaging/client/macro_messages.h
@@ -134,7 +134,8 @@ inline void updateMacroValue(const macroValue_t &t, engine::Engine &engine, Mess
             // Set the value
             auto &partO = e.getPatch()->getPart(part); // ->macros[index];
             partO->macroLagHandler.setTargetOnMacro(index, value);
-            if (!partO->isActive())
+            // toggles switch immediately; lagging a two state value just delays it
+            if (!partO->isActive() || partO->macros[index].isToggle())
                 partO->macroLagHandler.instantlySnap();
             // macro.setValueConstrained(value);
         },

--- a/src/scxt-plugin/app/shared/SingleMacroEditor.cpp
+++ b/src/scxt-plugin/app/shared/SingleMacroEditor.cpp
@@ -64,15 +64,47 @@ struct MacroValueAttachment : HasEditor, sst::jucegui::data::Continuous
     }
     void setValueFromModel(const float &) override {}
     float getDefaultValue() const override { return 0; }
-    bool isBipolar() const override { return macro().isBipolar; }
+    bool isBipolar() const override { return macro().isBipolar(); }
     float getMin() const override
     {
-        if (macro().isBipolar)
+        if (macro().isBipolar())
             return -1;
         else
             return 0;
     }
     float getMax() const override { return 1; }
+};
+
+struct MacroToggleAttachment : HasEditor, sst::jucegui::data::Discrete
+{
+    int part{-1}, index{-1};
+    MacroToggleAttachment(SCXTEditor *e, int p, int i) : HasEditor(e), part(p), index(i) {}
+
+    const engine::Macro &macro() const
+    {
+        assert(part >= 0 && part < scxt::numParts);
+        assert(index >= 0 && index < scxt::macrosPerPart);
+        return editor->macroCache[part][index];
+    }
+
+    engine::Macro &macro()
+    {
+        assert(part >= 0 && part < scxt::numParts);
+        assert(index >= 0 && index < scxt::macrosPerPart);
+        return editor->macroCache[part][index];
+    }
+
+    std::string getLabel() const override { return macro().name; }
+    int getValue() const override { return macro().value > 0.5 ? 1 : 0; }
+    void setValueFromGUI(const int &f) override
+    {
+        macro().setValueConstrained(f ? 1.f : 0.f);
+        sendToSerialization(scxt::messaging::client::SetMacroValue({part, index, macro().value}));
+    }
+    void setValueFromModel(const int &) override {}
+    int getMin() const override { return 0; }
+    int getMax() const override { return 1; }
+    std::string getValueAsStringFor(int i) const override { return i > 0 ? "On" : "Off"; }
 };
 
 struct NarrowVerticalMenu : HasEditor, juce::Component
@@ -158,6 +190,28 @@ SingleMacroEditor::SingleMacroEditor(SCXTEditor *e, int p, int i, bool vo)
     valueAttachment = std::make_unique<MacroValueAttachment>(editor, part, index);
     knob->setSource(valueAttachment.get());
 
+    toggleButton = std::make_unique<sst::jucegui::components::ToggleButton>();
+    toggleButton->setDrawMode(sst::jucegui::components::ToggleButton::DrawMode::GLYPH_WITH_BG);
+    toggleButton->setGlyph(sst::jucegui::components::GlyphPainter::SMALL_POWER_LIGHT);
+    addChildComponent(*toggleButton);
+
+    toggleButton->onBeginEdit = [w = juce::Component::SafePointer(this)]() {
+        if (!w)
+            return;
+        w->sendToSerialization(messaging::client::MacroBeginEndEdit({true, w->part, w->index}));
+    };
+    toggleButton->onEndEdit = [w = juce::Component::SafePointer(this)]() {
+        if (!w)
+            return;
+        w->sendToSerialization(messaging::client::MacroBeginEndEdit({false, w->part, w->index}));
+    };
+
+    sst::jucegui::component_adapters::setClapParamId(toggleButton.get(),
+                                                     engine::Macro::partIndexToMacroID(p, i));
+
+    toggleAttachment = std::make_unique<MacroToggleAttachment>(editor, part, index);
+    toggleButton->setSource(toggleAttachment.get());
+
     if (valueOnly)
     {
         macroNameLabel = std::make_unique<sst::jucegui::components::Label>();
@@ -188,8 +242,11 @@ SingleMacroEditor::~SingleMacroEditor() {}
 void SingleMacroEditor::changePart(int p, int i)
 {
     valueAttachment->part = p;
+    toggleAttachment->part = p;
     part = p;
     sst::jucegui::component_adapters::setClapParamId(knob.get(),
+                                                     engine::Macro::partIndexToMacroID(p, i));
+    sst::jucegui::component_adapters::setClapParamId(toggleButton.get(),
                                                      engine::Macro::partIndexToMacroID(p, i));
     repaint();
 }
@@ -209,11 +266,13 @@ void SingleMacroEditor::resized()
             kb = kb.reduced(overShoot / 2, 0);
         }
         knob->setBounds(kb);
+        toggleButton->setBounds(kb.reduced(2));
     }
     else
     {
         auto b = getLocalBounds();
         knob->setBounds(b.withHeight(b.getWidth()).reduced(15));
+        toggleButton->setBounds(b.withHeight(b.getWidth()).reduced(13));
         menuButton->setBounds(b.withWidth(12).withHeight(24).translated(0, 10));
         macroNameEditor->setBounds(
             b.withTrimmedTop(b.getWidth() - 12 + 3).withHeight(18).reduced(3, 0));
@@ -239,15 +298,21 @@ void SingleMacroEditor::showMenu()
     juce::PopupMenu p;
     p.addSectionHeader(macro.name);
     p.addSeparator();
-    p.addItem("Bipolar", true, macro.isBipolar, [w = juce::Component::SafePointer(this)]() {
-        if (!w)
-            return;
-        auto &macro = w->editor->macroCache[w->part][w->index];
-        macro.setIsBipolar(!macro.isBipolar);
-        w->sendToSerialization(
-            scxt::messaging::client::SetMacroFullState({w->part, w->index, macro}));
-        w->repaint();
-    });
+    auto addMode = [this, &p, &macro](const std::string &label, engine::Macro::Mode mode) {
+        p.addItem(label, true, macro.mode == mode,
+                  [w = juce::Component::SafePointer(this), mode]() {
+                      if (!w)
+                          return;
+                      auto &macro = w->editor->macroCache[w->part][w->index];
+                      macro.setMode(mode);
+                      w->sendToSerialization(
+                          scxt::messaging::client::SetMacroFullState({w->part, w->index, macro}));
+                      w->updateFromEditorData();
+                  });
+    };
+    addMode("Unipolar", engine::Macro::UNIPOLAR);
+    addMode("Bipolar", engine::Macro::BIPOLAR);
+    addMode("Toggle", engine::Macro::TOGGLE);
     p.showMenuAsync(editor->defaultPopupMenuOptions(menuButton.get()));
 }
 void SingleMacroEditor::onStyleChanged()
@@ -283,6 +348,8 @@ void SingleMacroEditor::updateFromEditorData()
     {
         macroNameLabel->setText(macro.name);
     }
+    knob->setVisible(!macro.isToggle());
+    toggleButton->setVisible(macro.isToggle());
     repaint();
 }
 void SingleMacroEditor::textEditorReturnKeyPressed(juce::TextEditor &e)

--- a/src/scxt-plugin/app/shared/SingleMacroEditor.h
+++ b/src/scxt-plugin/app/shared/SingleMacroEditor.h
@@ -31,6 +31,7 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 #include "sst/jucegui/components/Knob.h"
 #include "sst/jucegui/components/Label.h"
+#include "sst/jucegui/components/ToggleButton.h"
 #include "sst/jucegui/style/StyleAndSettingsConsumer.h"
 #include "sst/jucegui/util/VisibilityParentWatcher.h"
 #include "app/HasEditor.h"
@@ -39,13 +40,16 @@
 namespace scxt::ui::app::shared
 {
 struct MacroValueAttachment;
+struct MacroToggleAttachment;
 struct SingleMacroEditor : HasEditor,
                            juce::Component,
                            juce::TextEditor::Listener,
                            sst::jucegui::style::StyleConsumer
 {
     std::unique_ptr<MacroValueAttachment> valueAttachment;
+    std::unique_ptr<MacroToggleAttachment> toggleAttachment;
     std::unique_ptr<sst::jucegui::components::Knob> knob;
+    std::unique_ptr<sst::jucegui::components::ToggleButton> toggleButton;
     std::unique_ptr<juce::Component> menuButton;
     std::unique_ptr<juce::TextEditor> macroNameEditor;
     std::unique_ptr<sst::jucegui::components::Label> macroNameLabel;

--- a/src/scxt-plugin/clap/scxt-plugin.cpp
+++ b/src/scxt-plugin/clap/scxt-plugin.cpp
@@ -507,7 +507,9 @@ bool SCXTPlugin::paramsInfo(uint32_t paramIndex, clap_param_info *info) const no
         strncpy(info->module, moduleName.c_str(), CLAP_NAME_SIZE);
         info->min_value = 0;
         info->max_value = 1;
-        info->default_value = (macro.isBipolar ? 0.5 : 0);
+        info->default_value = (macro.isBipolar() ? 0.5 : 0);
+        if (macro.isToggle())
+            info->flags |= CLAP_PARAM_IS_STEPPED;
         return true;
     }
     return false;

--- a/tests/undo_tests.cpp
+++ b/tests/undo_tests.cpp
@@ -245,25 +245,25 @@ TEST_CASE("Macro full state undo/redo", "[undo]")
     UndoFixture f;
     auto &macro = f.engine().getPatch()->getPart(0)->macros[0];
     auto originalName = macro.name;
-    auto originalBipolar = macro.isBipolar;
+    auto originalMode = macro.mode;
 
     scxt::engine::Macro newMacro = macro;
     newMacro.name = "Brightness";
-    newMacro.isBipolar = true;
+    newMacro.setMode(scxt::engine::Macro::BIPOLAR);
 
     f.send(cmsg::SetMacroFullState({(int16_t)0, (int16_t)0, newMacro}));
     REQUIRE(macro.name == "Brightness");
-    REQUIRE(macro.isBipolar == true);
+    REQUIRE(macro.mode == scxt::engine::Macro::BIPOLAR);
     REQUIRE(f.undoManager().hasUndoSteps());
 
     f.sendUndo();
     REQUIRE(macro.name == originalName);
-    REQUIRE(macro.isBipolar == originalBipolar);
+    REQUIRE(macro.mode == originalMode);
     REQUIRE(f.undoManager().hasRedoSteps());
 
     f.sendRedo();
     REQUIRE(macro.name == "Brightness");
-    REQUIRE(macro.isBipolar == true);
+    REQUIRE(macro.mode == scxt::engine::Macro::BIPOLAR);
 }
 
 TEST_CASE("Zone mapping gesture coalesces to one undo", "[undo]")


### PR DESCRIPTION
Macros now have a three way mode - unipolar, bipolar or toggle - selected from the macro menu, replacing the old bipolar flag.

A toggle macro shows a large on/off button instead of the knob, reads as On/Off to the host as a stepped parameter, and always delivers exactly 0 or 1 to the modulation matrix. Toggles also skip the macro value lag so they switch immediately.

Assisted-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>