### PR TITLE
Use the discrete draggable text value for integer parameters

### DIFF
--- a/src/scxt-core/engine/group.h
+++ b/src/scxt-core/engine/group.h
@@ -429,7 +429,7 @@ SC_DESCRIBE(
                               {scxt::engine::Zone::ProcRoutingPath::procRoute_par3, "P3"},
                               {scxt::engine::Zone::ProcRoutingPath::procRoute_bypass, "BYP"},
                           }));
-    SC_FIELD(oversample, pmd().asBool().withName("Oversample"));
+    SC_FIELD(oversample, pmd().asOnOffBool().withName("Oversample"));
     SC_FIELD(velocitySensitivity,
              pmd().asPercent().withName("Velocity Sensitivity").withDefault(0.6f));
     SC_FIELD(glideTime, pmd().as25SecondExpTime().withDefault(0.f).withName("Glide Time"));)

--- a/src/scxt-core/modulation/modulator_storage.h
+++ b/src/scxt-core/modulation/modulator_storage.h
@@ -350,7 +350,7 @@ SC_DESCRIBE(scxt::modulation::ModulatorStorage, {
                                   {modulation::ModulatorStorage::RELEASE, "RELEASE"},
                                   {modulation::ModulatorStorage::ONESHOT, "ONESHOT"},
                               }));
-    SC_FIELD(temposync, pmd().asBool().withName("Temposync"));
+    SC_FIELD(temposync, pmd().asOnOffBool().withName("Temposync"));
     SC_FIELD(rate, pmd().asLfoRate().withName("Rate"));
     SC_FIELD(amplitude,
              pmd().asPercent().withName("Amplitude").withSupportsMultiplicativeModulation());
@@ -371,7 +371,7 @@ SC_DESCRIBE(scxt::modulation::ModulatorStorage, {
                  .withDefault(16)
                  .withName("Step Count"));
     SC_FIELD(stepLfoStorage.rateIsForSingleStep, pmd()
-                                                     .asBool()
+                                                     .asOnOffBool()
                                                      .withName("Cycle")
                                                      .withCustomMinDisplay("RATE: CYCLE")
                                                      .withCustomMaxDisplay("RATE: STEP"));
@@ -381,8 +381,8 @@ SC_DESCRIBE(scxt::modulation::ModulatorStorage, {
     SC_FIELD(curveLfoStorage.delay, envTime().withDefault(0).withName("Delay"));
     SC_FIELD(curveLfoStorage.attack, envTime().withDefault(0).withName("Attack"));
     SC_FIELD(curveLfoStorage.release, envTime().withDefault(1).withName("Release"));
-    SC_FIELD(curveLfoStorage.unipolar, pmd().asBool().withName("Unipolar"));
-    SC_FIELD(curveLfoStorage.useenv, pmd().asBool().withName("Use Envelope"));
+    SC_FIELD(curveLfoStorage.unipolar, pmd().asOnOffBool().withName("Unipolar"));
+    SC_FIELD(curveLfoStorage.useenv, pmd().asOnOffBool().withName("Use Envelope"));
 
     SC_FIELD(envLfoStorage.delay, envTime().withDefault(0).withName("Delay"));
     SC_FIELD(envLfoStorage.attack, envTime().withDefault(0).withName("Attack"));
@@ -404,7 +404,7 @@ SC_DESCRIBE(scxt::modulation::ModulatorStorage, {
                                         .withFeature(pmd::Features::BELOW_ONE_IS_INVERSE_FRACTION)
                                         .withFeature(pmd::Features::ALLOW_FRACTIONAL_TYPEINS)
                                         .withName("Rate Multiplier"));
-    SC_FIELD(envLfoStorage.loop, pmd().asBool().withDefault(0.0).withName("Loop"));
+    SC_FIELD(envLfoStorage.loop, pmd().asOnOffBool().withDefault(0.0).withName("Loop"));
 });
 
 SC_DESCRIBE(scxt::modulation::modulators::PhasorStorage,
@@ -439,7 +439,7 @@ SC_DESCRIBE(scxt::modulation::AudioSourceStorage,
             SC_FIELD_ARRAY_MEMBER(followers, gain, envFollowersPerGroupOrZone,
                                   pmd().asFloat().asDecibelWithRange(-36.f, 36.f).withName("Gain"));
             SC_FIELD_ARRAY_MEMBER(followers, stereoLink, envFollowersPerGroupOrZone,
-                                  pmd().asBool().withDefault(false).withName("Stereo Link"));
+                                  pmd().asOnOffBool().withDefault(false).withName("Stereo Link"));
             SC_FIELD_ARRAY_MEMBER(
                 followers, followSource, envFollowersPerGroupOrZone,
                 pmd()

--- a/src/scxt-core/modulation/voice_matrix.cpp
+++ b/src/scxt-core/modulation/voice_matrix.cpp
@@ -95,7 +95,8 @@ const datamodel::pmd playbackRatioMetadata =
     datamodel::pmd().asFloat().withRange(0, 2).withLinearScaleFormatting("x");
 const datamodel::pmd startPosMetadata =
     datamodel::pmd().asPercentBipolar().withName("Start Pos Adjustment");
-const datamodel::pmd playSampleMetadata = datamodel::pmd().asBool().withName("Sample Playing Gate");
+const datamodel::pmd playSampleMetadata =
+    datamodel::pmd().asOnOffBool().withName("Sample Playing Gate");
 const datamodel::pmd sampleTuneMetadata =
     datamodel::pmd().asSemitoneRange().withName("Sample Tune").withDefault(0.0);
 } // namespace

--- a/src/scxt-plugin/app/edit-screen/components/GroupSettingsCard.h
+++ b/src/scxt-plugin/app/edit-screen/components/GroupSettingsCard.h
@@ -32,6 +32,7 @@
 
 #include "sst/jucegui/components/MenuButton.h"
 #include "sst/jucegui/components/DraggableTextEditableValue.h"
+#include "sst/jucegui/components/DraggableTextEditableDiscreteValue.h"
 #include "sst/jucegui/components/Label.h"
 #include "sst/jucegui/components/GlyphButton.h"
 #include "sst/jucegui/components/TextPushButton.h"
@@ -64,13 +65,14 @@ struct GroupSettingsCard : juce::Component, HasEditor
     std::unique_ptr<sst::jucegui::components::TickSeparatorLabel> pbRuleH;
     std::unique_ptr<sst::jucegui::components::TickSeparatorLabel> rightVRule01, rightVRule12,
         glideRuleH;
-    std::unique_ptr<sst::jucegui::components::DraggableTextEditableValue> pbDnVal, pbUpVal,
-        glideDrag, volDrag, panDrag, tuneDrag;
+    std::unique_ptr<sst::jucegui::components::DraggableTextEditableValue> glideDrag, volDrag,
+        panDrag, tuneDrag;
+    std::unique_ptr<sst::jucegui::components::DraggableTextEditableDiscreteValue> pbDnVal, pbUpVal;
 
     using floatMsg_t = scxt::messaging::client::UpdateGroupOutputFloatValue;
     using intMsg_t = scxt::messaging::client::UpdateGroupOutputInt16TValue;
     typedef connectors::PayloadDataAttachment<engine::Group::GroupOutputInfo> attachment_t;
-    typedef connectors::PayloadDataAttachment<engine::Group::GroupOutputInfo, int16_t>
+    typedef connectors::DiscretePayloadDataAttachment<engine::Group::GroupOutputInfo, int16_t>
         iattachment_t;
 
     std::unique_ptr<attachment_t> volAttachment, panAttachment, tuneAttachment, glideAttachment;

--- a/src/scxt-plugin/app/edit-screen/components/LFOPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/LFOPane.cpp
@@ -41,6 +41,7 @@
 #include "sst/jucegui/components/VSlider.h"
 #include "sst/jucegui/components/NamedPanelDivider.h"
 #include "sst/jucegui/components/DraggableTextEditableValue.h"
+#include "sst/jucegui/components/DraggableTextEditableDiscreteValue.h"
 
 #include "sst/jucegui/layouts/ListLayout.h"
 
@@ -402,7 +403,7 @@ struct StepLFOPane : juce::Component, app::HasEditor
     std::unique_ptr<jcmp::Label> rateL, deformL, phaseL;
 
     std::unique_ptr<LfoPane::int16Attachment_t> stepsA;
-    std::unique_ptr<jcmp::DraggableTextEditableValue> stepsEd;
+    std::unique_ptr<jcmp::DraggableTextEditableDiscreteValue> stepsEd;
     std::unique_ptr<jcmp::GlyphPainter> stepsGlyph;
 
     std::unique_ptr<LfoPane::boolBaseAttachment_t> cycleA;
@@ -885,7 +886,8 @@ struct MiscPanel : juce::Component, HasEditor
         buildComponents();
     }
 
-    using intatt_t = connectors::PayloadDataAttachment<modulation::MiscSourceStorage, int32_t>;
+    using intatt_t =
+        connectors::DiscretePayloadDataAttachment<modulation::MiscSourceStorage, int32_t>;
 
     std::unique_ptr<jcmp::Label> phasorTitle, randomTitle;
     std::array<std::unique_ptr<jcmp::Label>, scxt::phasorsPerGroupOrZone> phasorABCs;
@@ -893,7 +895,8 @@ struct MiscPanel : juce::Component, HasEditor
     std::array<std::unique_ptr<jcmp::MenuButton>, scxt::phasorsPerGroupOrZone> syncButtons;
     std::array<std::unique_ptr<jcmp::MenuButton>, scxt::phasorsPerGroupOrZone> divButtons;
 
-    std::array<std::unique_ptr<jcmp::DraggableTextEditableValue>, scxt::phasorsPerGroupOrZone>
+    std::array<std::unique_ptr<jcmp::DraggableTextEditableDiscreteValue>,
+               scxt::phasorsPerGroupOrZone>
         numText, denText;
     std::array<std::unique_ptr<intatt_t>, scxt::phasorsPerGroupOrZone> numTextA, denTextA;
 
@@ -1019,57 +1022,29 @@ struct MiscPanel : juce::Component, HasEditor
     {
         void paint(juce::Graphics &g) override
         {
-            std::string msg;
-            if (continuous())
-            {
-                msg = continuous()->getValueAsString();
-                if (!displayUnits)
-                    msg = continuous()->getValueAsStringWithoutUnits();
-            }
+            auto msg = hasSource() ? displayString() : std::string();
             auto slp = msg.find("/");
 
-            if (underlyingEditor->isVisible())
+            // while the type-in is open, or when there is no n/d split to show,
+            // this is exactly the stock draggable text value
+            if (underlyingEditor->isVisible() || slp == std::string::npos)
             {
-                g.setColour(getColour(Styles::background));
-                if (isHovered)
-                    g.setColour(getColour(Styles::background_hover));
-                g.fillRoundedRectangle(getLocalBounds().toFloat(), 3.f);
-
+                paintFor(this, g);
                 return;
             }
 
-            g.setColour(getColour(Styles::background));
-            if (isHovered)
-                g.setColour(getColour(Styles::background_hover));
+            // this matches resized below
+            auto ls = getLocalBounds().withWidth(20);
+            auto rs = getLocalBounds().withWidth(20).translated(getWidth() - 20, 0);
 
-            if (slp == std::string::npos)
-            {
-                g.fillRoundedRectangle(getLocalBounds().toFloat(), 3.f);
-                g.setFont(getFont(Styles::labelfont));
-                g.setColour(getColour(
-                    Styles::value)); // on Hover, the text colour is intensionally the same.
-                g.drawText(msg, getLocalBounds(), juce::Justification::centred);
-            }
-            else
-            {
-                // this matches resized below
-                auto ls = getLocalBounds().withWidth(20);
-                auto rs = getLocalBounds().withWidth(20).translated(getWidth() - 20, 0);
+            paintBackgroundFor(this, g, ls);
+            paintBackgroundFor(this, g, rs);
+            paintValueTextFor(this, g, msg.substr(0, slp), ls);
+            paintValueTextFor(this, g, msg.substr(slp + 1), rs);
 
-                g.fillRoundedRectangle(ls.toFloat(), 3.f);
-                g.fillRoundedRectangle(rs.toFloat(), 3.f);
-
-                g.setFont(getFont(Styles::labelfont));
-                g.setColour(getColour(
-                    Styles::value)); // on Hover, the text colour is intensionally the same.
-                auto ns = msg.substr(0, slp);
-                auto ds = msg.substr(slp + 1);
-                g.drawText(ns, ls, juce::Justification::centred);
-                g.drawText(ds, rs, juce::Justification::centred);
-                g.setColour(style()->getColour(jcmp::Label::Styles::styleClass,
-                                               jcmp::Label::Styles::labelcolor));
-                g.drawText("/", getLocalBounds(), juce::Justification::centred);
-            }
+            g.setColour(style()->getColour(jcmp::Label::Styles::styleClass,
+                                           jcmp::Label::Styles::labelcolor));
+            g.drawText("/", getLocalBounds(), juce::Justification::centred);
         }
     };
 
@@ -1130,13 +1105,21 @@ struct MiscPanel : juce::Component, HasEditor
             const auto &dd =
                 scxt::datamodel::describeValue(ms.phasors[i], ms.phasors[i].denominator);
             numTextA[i] = std::make_unique<intatt_t>(nd, onChange, ms.phasors[i].numerator);
-            numText[i] = std::make_unique<jcmp::DraggableTextEditableValue>();
+            numText[i] = std::make_unique<jcmp::DraggableTextEditableDiscreteValue>();
             numText[i]->setSource(numTextA[i].get());
+            numText[i]->onPopupMenu = [w = juce::Component::SafePointer(numText[i].get())](auto &) {
+                if (w)
+                    w->activateEditor();
+            };
             addChildComponent(*numText[i]);
 
             denTextA[i] = std::make_unique<intatt_t>(dd, onChange, ms.phasors[i].denominator);
-            denText[i] = std::make_unique<jcmp::DraggableTextEditableValue>();
+            denText[i] = std::make_unique<jcmp::DraggableTextEditableDiscreteValue>();
             denText[i]->setSource(denTextA[i].get());
+            denText[i]->onPopupMenu = [w = juce::Component::SafePointer(denText[i].get())](auto &) {
+                if (w)
+                    w->activateEditor();
+            };
             addChildComponent(*denText[i]);
 
             phasorSlashes[i] = std::make_unique<jcmp::Label>();

--- a/src/scxt-plugin/app/edit-screen/components/LFOPane.h
+++ b/src/scxt-plugin/app/edit-screen/components/LFOPane.h
@@ -71,7 +71,7 @@ struct LfoPane : sst::jucegui::components::NamedPanel, app::HasEditor
         boolBaseAttachment_t;
     typedef connectors::BooleanPayloadDataAttachment<modulation::ModulatorStorage> boolAttachment_t;
 
-    typedef connectors::PayloadDataAttachment<modulation::ModulatorStorage, int16_t>
+    typedef connectors::DiscretePayloadDataAttachment<modulation::ModulatorStorage, int16_t>
         int16Attachment_t;
 
     LfoPane(SCXTEditor *, bool forZone);

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.cpp
@@ -103,11 +103,11 @@ MappingDisplay::MappingDisplay(MacroMappingVariantPane *p)
         ffac::attachAndAdd(mappingView, v, this, a, w);
     };
 
-    iAdd(mappingView.rootKey, intAttachments.RootKey, textEds.RootKey);
+    iAdd(mappingView.rootKey, intAttachments.RootKey, discreteTextEds.RootKey);
     makeLabel(labels.RootKey, "Root Key");
 
-    iAddConstrained(mappingView.keyboardRange.keyStart, intAttachments.KeyStart, textEds.KeyStart,
-                    [w = juce::Component::SafePointer(this)](auto v) {
+    iAddConstrained(mappingView.keyboardRange.keyStart, intAttachments.KeyStart,
+                    discreteTextEds.KeyStart, [w = juce::Component::SafePointer(this)](auto v) {
                         if (!w)
                             return true;
                         return v <= w->mappingView.keyboardRange.keyEnd;
@@ -178,55 +178,59 @@ MappingDisplay::MappingDisplay(MacroMappingVariantPane *p)
             sendToSerialization(cmsg::RequestZoneMapping({editor->selectedPart}));
         };
     };
-    addDeltas(intAttachments.KeyStart, textEds.KeyStart,
+    addDeltas(intAttachments.KeyStart, discreteTextEds.KeyStart,
               engine::Zone::ChangeDimension::KEY_RANGE_START);
 
-    iAddConstrained(mappingView.keyboardRange.keyEnd, intAttachments.KeyEnd, textEds.KeyEnd,
+    iAddConstrained(mappingView.keyboardRange.keyEnd, intAttachments.KeyEnd, discreteTextEds.KeyEnd,
                     [w = juce::Component::SafePointer(this)](auto v) {
                         if (!w)
                             return true;
                         return v >= w->mappingView.keyboardRange.keyStart;
                     });
-    addDeltas(intAttachments.KeyEnd, textEds.KeyEnd, engine::Zone::ChangeDimension::KEY_RANGE_END);
+    addDeltas(intAttachments.KeyEnd, discreteTextEds.KeyEnd,
+              engine::Zone::ChangeDimension::KEY_RANGE_END);
 
     makeLabel(labels.KeyStart, "Key Range");
-    iAdd(mappingView.keyboardRange.fadeStart, intAttachments.FadeStart, textEds.FadeStart);
-    addDeltas(intAttachments.FadeStart, textEds.FadeStart,
+    iAdd(mappingView.keyboardRange.fadeStart, intAttachments.FadeStart, discreteTextEds.FadeStart);
+    addDeltas(intAttachments.FadeStart, discreteTextEds.FadeStart,
               engine::Zone::ChangeDimension::KEY_FADE_START);
 
-    iAdd(mappingView.keyboardRange.fadeEnd, intAttachments.FadeEnd, textEds.FadeEnd);
-    addDeltas(intAttachments.FadeEnd, textEds.FadeEnd, engine::Zone::ChangeDimension::KEY_FADE_END);
+    iAdd(mappingView.keyboardRange.fadeEnd, intAttachments.FadeEnd, discreteTextEds.FadeEnd);
+    addDeltas(intAttachments.FadeEnd, discreteTextEds.FadeEnd,
+              engine::Zone::ChangeDimension::KEY_FADE_END);
     makeLabel(labels.FadeStart, "Key XFade");
 
-    iAddConstrained(mappingView.velocityRange.velStart, intAttachments.VelStart, textEds.VelStart,
-                    [w = juce::Component::SafePointer(this)](auto v) {
+    iAddConstrained(mappingView.velocityRange.velStart, intAttachments.VelStart,
+                    discreteTextEds.VelStart, [w = juce::Component::SafePointer(this)](auto v) {
                         if (!w)
                             return true;
                         return v <= w->mappingView.velocityRange.velEnd;
                     });
-    addDeltas(intAttachments.VelStart, textEds.VelStart,
+    addDeltas(intAttachments.VelStart, discreteTextEds.VelStart,
               engine::Zone::ChangeDimension::VEL_RANGE_START);
-    iAddConstrained(mappingView.velocityRange.velEnd, intAttachments.VelEnd, textEds.VelEnd,
+    iAddConstrained(mappingView.velocityRange.velEnd, intAttachments.VelEnd, discreteTextEds.VelEnd,
                     [w = juce::Component::SafePointer(this)](auto v) {
                         if (!w)
                             return true;
                         return v >= w->mappingView.velocityRange.velStart;
                     });
-    addDeltas(intAttachments.VelEnd, textEds.VelEnd, engine::Zone::ChangeDimension::VEL_RANGE_END);
+    addDeltas(intAttachments.VelEnd, discreteTextEds.VelEnd,
+              engine::Zone::ChangeDimension::VEL_RANGE_END);
 
     makeLabel(labels.VelStart, "Vel Range");
 
-    iAdd(mappingView.velocityRange.fadeStart, intAttachments.VelFadeStart, textEds.VelFadeStart);
-    addDeltas(intAttachments.VelFadeStart, textEds.VelFadeStart,
+    iAdd(mappingView.velocityRange.fadeStart, intAttachments.VelFadeStart,
+         discreteTextEds.VelFadeStart);
+    addDeltas(intAttachments.VelFadeStart, discreteTextEds.VelFadeStart,
               engine::Zone::ChangeDimension::VEL_FADE_START);
-    iAdd(mappingView.velocityRange.fadeEnd, intAttachments.VelFadeEnd, textEds.VelFadeEnd);
-    addDeltas(intAttachments.VelFadeEnd, textEds.VelFadeEnd,
+    iAdd(mappingView.velocityRange.fadeEnd, intAttachments.VelFadeEnd, discreteTextEds.VelFadeEnd);
+    addDeltas(intAttachments.VelFadeEnd, discreteTextEds.VelFadeEnd,
               engine::Zone::ChangeDimension::VEL_FADE_END);
 
     makeLabel(labels.VelFadeStart, "Vel XFade");
 
-    iAdd(mappingView.pbDown, intAttachments.PBDown, textEds.PBDown);
-    iAdd(mappingView.pbUp, intAttachments.PBUp, textEds.PBUp);
+    iAdd(mappingView.pbDown, intAttachments.PBDown, discreteTextEds.PBDown);
+    iAdd(mappingView.pbUp, intAttachments.PBUp, discreteTextEds.PBUp);
     makeLabel(labels.PBDown, "Pitch Bend");
 
     fAdd(mappingView.amplitude, floatAttachments.Level, textEds.Level);
@@ -332,36 +336,36 @@ void MappingDisplay::resized()
     };
 
     labels.RootKey->setBounds(spl(0, 0, 169, 16));
-    textEds.RootKey->setBounds(sp(169, 0, 32, 16));
+    discreteTextEds.RootKey->setBounds(sp(169, 0, 32, 16));
 
     labels.KeyStart->setBounds(spl(0, 24, 129, 16));
-    textEds.KeyStart->setBounds(sp(129, 24, 32, 16));
+    discreteTextEds.KeyStart->setBounds(sp(129, 24, 32, 16));
     rules[KeyHSep]->setBounds(spr(161, 24, 8, 16));
-    textEds.KeyEnd->setBounds(sp(169, 24, 32, 16));
+    discreteTextEds.KeyEnd->setBounds(sp(169, 24, 32, 16));
 
     labels.FadeStart->setBounds(spl(0, 48, 129, 16));
-    textEds.FadeStart->setBounds(sp(129, 48, 32, 16));
-    textEds.FadeEnd->setBounds(sp(169, 48, 32, 16));
+    discreteTextEds.FadeStart->setBounds(sp(129, 48, 32, 16));
+    discreteTextEds.FadeEnd->setBounds(sp(169, 48, 32, 16));
 
     rules[KeyVSepLo]->setBounds(spr(141, 40, 8, 8));
     rules[KeyVSepHi]->setBounds(spr(181, 40, 8, 8));
 
     labels.VelStart->setBounds(spl(0, 72, 129, 16));
-    textEds.VelStart->setBounds(sp(129, 72, 32, 16));
+    discreteTextEds.VelStart->setBounds(sp(129, 72, 32, 16));
     rules[VelHSep]->setBounds(spr(161, 72, 8, 16));
-    textEds.VelEnd->setBounds(sp(169, 72, 32, 16));
+    discreteTextEds.VelEnd->setBounds(sp(169, 72, 32, 16));
 
     labels.VelFadeStart->setBounds(spl(0, 96, 129, 16));
-    textEds.VelFadeStart->setBounds(sp(129, 96, 32, 16));
-    textEds.VelFadeEnd->setBounds(sp(169, 96, 32, 16));
+    discreteTextEds.VelFadeStart->setBounds(sp(129, 96, 32, 16));
+    discreteTextEds.VelFadeEnd->setBounds(sp(169, 96, 32, 16));
 
     rules[VelVSepLo]->setBounds(spr(141, 88, 8, 8));
     rules[VelVSepHi]->setBounds(spr(181, 88, 8, 8));
 
     labels.PBDown->setBounds(spl(0, 120, 129, 16));
-    textEds.PBDown->setBounds(sp(129, 120, 32, 16));
+    discreteTextEds.PBDown->setBounds(sp(129, 120, 32, 16));
     rules[PBHSep]->setBounds(spr(161, 120, 8, 16));
-    textEds.PBUp->setBounds(sp(169, 120, 32, 16));
+    discreteTextEds.PBUp->setBounds(sp(169, 120, 32, 16));
 
     glyphs.Pitch->setBounds(sp(135, 146, 16, 16));
     textEds.Pitch->setBounds(sp(153, 146, 48, 16));

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.h
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/MappingDisplay.h
@@ -31,6 +31,7 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 #include "sst/jucegui/components/Viewport.h"
 #include "sst/jucegui/components/DraggableTextEditableValue.h"
+#include "sst/jucegui/components/DraggableTextEditableDiscreteValue.h"
 #include "sst/jucegui/components/Label.h"
 #include "sst/jucegui/components/GlyphPainter.h"
 #include "sst/jucegui/components/TextPushButton.h"
@@ -97,7 +98,7 @@ struct MappingDisplay : juce::Component,
 
 {
 
-    typedef connectors::PayloadDataAttachment<engine::Zone::ZoneMappingData, int16_t>
+    typedef connectors::DiscretePayloadDataAttachment<engine::Zone::ZoneMappingData, int16_t>
         int16Attachment_t;
     typedef connectors::PayloadDataAttachment<engine::Zone::ZoneMappingData, float>
         floatAttachment_t;
@@ -159,9 +160,21 @@ struct MappingDisplay : juce::Component,
             PBDown, PBUp, VelocitySens, Level, Pan, Pitch, Tracking;
     };
 
-    MapEls<std::unique_ptr<int16Attachment_t>> intAttachments;
+    // Same membership as MapEls; used for the integer-backed controls, which are
+    // sparse here (only the key/velocity/pitch-bend slots are populated).
+    template <typename T> struct MapDiscreteEls
+    {
+        T RootKey, KeyStart, KeyEnd, FadeStart, FadeEnd, VelStart, VelEnd, VelFadeStart, VelFadeEnd,
+            PBDown, PBUp, VelocitySens, Level, Pan, Pitch, Tracking;
+    };
+
+    MapDiscreteEls<std::unique_ptr<int16Attachment_t>> intAttachments;
     MapEls<std::unique_ptr<floatAttachment_t>> floatAttachments;
+    // continuous (float) text editors; sparse — only Level/Pan/Pitch/Tracking/VelocitySens
     MapEls<std::unique_ptr<sst::jucegui::components::DraggableTextEditableValue>> textEds;
+    // discrete (integer) text editors; sparse — the key/velocity/pitch-bend slots
+    MapDiscreteEls<std::unique_ptr<sst::jucegui::components::DraggableTextEditableDiscreteValue>>
+        discreteTextEds;
     MapEls<std::unique_ptr<sst::jucegui::components::Label>> labels;
     MapEls<std::unique_ptr<sst::jucegui::components::GlyphPainter>> glyphs;
 

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
@@ -181,16 +181,20 @@ void VariantDisplay::rebuildForSelectedVariation(size_t sel, bool rebuildTabs)
     auto attachSamplePoint = [this](Ctrl c, const std::string &aLabel, auto &v) {
         auto at = std::make_unique<connectors::SamplePointDataAttachment>(
             v, [this](const auto &) { onSamplePointChangedFromGUI(); });
-        auto sl = std::make_unique<jcmp::DraggableTextEditableValue>();
+        auto sl = std::make_unique<jcmp::DraggableTextEditableDiscreteValue>();
         sl->setSource(at.get());
-        if (sampleEditors[c])
+        sl->onPopupMenu = [w = juce::Component::SafePointer(sl.get())](auto &) {
+            if (w)
+                w->activateEditor();
+        };
+        if (discreteSampleEditors[c])
         {
-            removeChildComponent(sampleEditors[c].get());
-            sampleEditors[c].reset();
+            removeChildComponent(discreteSampleEditors[c].get());
+            discreteSampleEditors[c].reset();
             sampleAttachments[c].reset();
         }
         addAndMakeVisible(*sl);
-        sampleEditors[c] = std::move(sl);
+        discreteSampleEditors[c] = std::move(sl);
         sampleAttachments[c] = std::move(at);
     };
 
@@ -257,16 +261,16 @@ void VariantDisplay::rebuildForSelectedVariation(size_t sel, bool rebuildTabs)
         return std::min(f, this->variantView.variants[this->selectedVariation].endLoop);
     };
 
-    editor->themeApplier.applyVariantLoopTheme(sampleEditors[startL].get());
+    editor->themeApplier.applyVariantLoopTheme(discreteSampleEditors[startL].get());
     addLabel(startL, "Start");
     attachSamplePoint(endL, "EndL", variantView.variants[selectedVariation].endLoop);
     sampleAttachments[endL]->precheckGuiAdjust = [this](auto f) {
         return std::max(f, this->variantView.variants[this->selectedVariation].startLoop);
     };
-    editor->themeApplier.applyVariantLoopTheme(sampleEditors[endL].get());
+    editor->themeApplier.applyVariantLoopTheme(discreteSampleEditors[endL].get());
     addLabel(endL, "End");
     attachSamplePoint(fadeL, "fadeL", variantView.variants[selectedVariation].loopFade);
-    editor->themeApplier.applyVariantLoopTheme(sampleEditors[fadeL].get());
+    editor->themeApplier.applyVariantLoopTheme(discreteSampleEditors[fadeL].get());
     addLabel(fadeL, "XF");
 
     attachToDummy(curve, "Curve", 'vcrv');
@@ -363,8 +367,12 @@ void VariantDisplay::rebuildForSelectedVariation(size_t sel, bool rebuildTabs)
             }
         },
         variantView.variants[selectedVariation].loopCountWhenCounted);
-    loopCnt = std::make_unique<jcmp::DraggableTextEditableValue>();
+    loopCnt = std::make_unique<jcmp::DraggableTextEditableDiscreteValue>();
     loopCnt->setSource(loopCntAttachment.get());
+    loopCnt->onPopupMenu = [w = juce::Component::SafePointer(loopCnt.get())](auto &) {
+        if (w)
+            w->activateEditor();
+    };
     addAndMakeVisible(*loopCnt);
 
     if (rebuildTabs)
@@ -449,7 +457,7 @@ void VariantDisplay::resized()
     for (const auto m : {startP, endP})
     {
         ofRow(labels[m], p.getWidth() - 72 - padding);
-        ofRow(sampleEditors[m], 72);
+        ofRow(discreteSampleEditors[m], 72);
         newRow("ctrl");
     }
 
@@ -468,16 +476,16 @@ void VariantDisplay::resized()
 
     ofRow(zoomButton, 16);
     ofRow(labels[startL], p.getWidth() - 72 - 16 - 2 * padding);
-    ofRow(sampleEditors[startL], 72);
+    ofRow(discreteSampleEditors[startL], 72);
     newRow("endL");
 
     ofRow(labels[endL], p.getWidth() - 72 - padding);
-    ofRow(sampleEditors[endL], 72);
+    ofRow(discreteSampleEditors[endL], 72);
     newRow("endL");
 
     // 25 34 18 40
     ofRow(labels[fadeL], 25);
-    ofRow(sampleEditors[fadeL], 34);
+    ofRow(discreteSampleEditors[fadeL], 34);
     addPad(7);
     ofRow(glyphLabels[curve], 18);
     ofRow(sampleEditors[curve], 40);
@@ -627,10 +635,10 @@ void VariantDisplay::rebuild()
     bool hasLoop = variantView.variants[selectedVariation].loopActive;
     loopModeButton->setEnabled(hasLoop);
     loopCnt->setEnabled(hasLoop);
-    sampleEditors[startL]->setVisible(hasLoop);
-    sampleEditors[endL]->setVisible(hasLoop);
+    discreteSampleEditors[startL]->setVisible(hasLoop);
+    discreteSampleEditors[endL]->setVisible(hasLoop);
 
-    sampleEditors[fadeL]->setVisible(hasLoop);
+    discreteSampleEditors[fadeL]->setVisible(hasLoop);
     sampleEditors[curve]->setVisible(hasLoop);
     zoomButton->setVisible(hasLoop);
     labels[startL]->setVisible(hasLoop);

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.h
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.h
@@ -31,6 +31,7 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 #include "sst/jucegui/components/ZoomContainer.h"
 #include "sst/jucegui/components/DraggableTextEditableValue.h"
+#include "sst/jucegui/components/DraggableTextEditableDiscreteValue.h"
 #include "sst/jucegui/components/Label.h"
 #include "sst/jucegui/components/TabbedComponent.h"
 #include "sst/jucegui/components/ToggleButton.h"
@@ -71,17 +72,23 @@ struct VariantDisplay : juce::Component, HasEditor
 
     std::unordered_map<Ctrl, std::unique_ptr<connectors::SamplePointDataAttachment>>
         sampleAttachments;
+    // continuous (float/dummy) text editors: curve, volume, pan, tune
     std::unordered_map<Ctrl, std::unique_ptr<sst::jucegui::components::DraggableTextEditableValue>>
         sampleEditors;
+    // discrete (integer frame) text editors: the sample-point controls
+    std::unordered_map<
+        Ctrl, std::unique_ptr<sst::jucegui::components::DraggableTextEditableDiscreteValue>>
+        discreteSampleEditors;
     std::unordered_map<Ctrl, std::unique_ptr<floatAttachment_t>> sampleFloatAttachments;
 
     std::unordered_map<Ctrl, std::unique_ptr<sst::jucegui::components::Label>> labels;
     std::unordered_map<Ctrl, std::unique_ptr<sst::jucegui::components::GlyphPainter>> glyphLabels;
 
-    typedef connectors::PayloadDataAttachment<engine::Zone::Variants, int> sample_attachment_t;
+    typedef connectors::DiscretePayloadDataAttachment<engine::Zone::Variants, int>
+        sample_attachment_t;
 
     std::unique_ptr<sample_attachment_t> loopCntAttachment;
-    std::unique_ptr<sst::jucegui::components::DraggableTextEditableValue> loopCnt;
+    std::unique_ptr<sst::jucegui::components::DraggableTextEditableDiscreteValue> loopCnt;
 
     std::unique_ptr<connectors::BooleanPayloadDataAttachment<engine::Zone::Variants>>
         loopAttachment, reverseAttachment;
@@ -136,6 +143,8 @@ struct VariantDisplay : juce::Component, HasEditor
     {
         for (auto &[k, c] : sampleEditors)
             c.reset();
+        for (auto &[k, c] : discreteSampleEditors)
+            c.reset();
     }
 
     void onSamplePointChangedFromGUI();
@@ -158,6 +167,8 @@ struct VariantDisplay : juce::Component, HasEditor
         loopModeButton->setVisible(b);
         reverseActive->setVisible(b);
         for (const auto &[k, p] : sampleEditors)
+            p->setVisible(b);
+        for (const auto &[k, p] : discreteSampleEditors)
             p->setVisible(b);
         for (const auto &[k, l] : labels)
             l->setVisible(b);

--- a/src/scxt-plugin/app/shared/PartSidebarCard.cpp
+++ b/src/scxt-plugin/app/shared/PartSidebarCard.cpp
@@ -131,6 +131,13 @@ PartSidebarCard::PartSidebarCard(int p, SCXTEditor *e) : part(p), HasEditor(e)
     att(editor->partConfigurations[part].tuning, tuning, tuningAtt);
     att(editor->partConfigurations[part].transpose, transpose, transposeAtt);
 
+    // The discrete text value is not a ContinuousParamEditor, so setupFloatWidget
+    // leaves its popup at the default discrete menu; route right-click to type-in.
+    transpose->onPopupMenu = [w = juce::Component::SafePointer(transpose.get())](auto &m) {
+        if (w)
+            w->activateEditor();
+    };
+
     partBlurb = std::make_unique<jcmp::TextEditor>();
     partBlurb->setAllText("");
     partBlurb->setMultiLine(true);

--- a/src/scxt-plugin/app/shared/PartSidebarCard.h
+++ b/src/scxt-plugin/app/shared/PartSidebarCard.h
@@ -35,6 +35,7 @@
 #include "sst/jucegui/components/TextEditor.h"
 #include "sst/jucegui/components/HSliderFilled.h"
 #include "sst/jucegui/components/DraggableTextEditableValue.h"
+#include "sst/jucegui/components/DraggableTextEditableDiscreteValue.h"
 #include "app/HasEditor.h"
 #include "connectors/PayloadDataAttachment.h"
 #include "engine/part.h"
@@ -53,7 +54,8 @@ struct PartSidebarCard : juce::Component,
     using attachment_t =
         scxt::ui::connectors::PayloadDataAttachment<engine::Part::PartConfiguration>;
     using tsposeattachment_t =
-        scxt::ui::connectors::PayloadDataAttachment<engine::Part::PartConfiguration, int32_t>;
+        scxt::ui::connectors::DiscretePayloadDataAttachment<engine::Part::PartConfiguration,
+                                                            int32_t>;
 
     static constexpr int row0{2}, rowHeight{20}, rowMargin{2}, tuningTransposeSplit{38};
 
@@ -66,7 +68,8 @@ struct PartSidebarCard : juce::Component,
     std::unique_ptr<sst::jucegui::components::MenuButton> patchName;
     std::unique_ptr<sst::jucegui::components::TextPushButton> midiMode, outBus, polyCount;
     std::unique_ptr<sst::jucegui::components::HSliderFilled> level, pan;
-    std::unique_ptr<sst::jucegui::components::DraggableTextEditableValue> tuning, transpose;
+    std::unique_ptr<sst::jucegui::components::DraggableTextEditableValue> tuning;
+    std::unique_ptr<sst::jucegui::components::DraggableTextEditableDiscreteValue> transpose;
     std::unique_ptr<sst::jucegui::components::TextEditor> partBlurb;
 
     std::unique_ptr<juce::FileChooser> fileChooser;

--- a/src/scxt-plugin/connectors/PayloadDataAttachment.h
+++ b/src/scxt-plugin/connectors/PayloadDataAttachment.h
@@ -33,9 +33,13 @@
 #include <memory>
 #include <string>
 #include <type_traits>
+#include <algorithm>
+#include <limits>
+#include <cmath>
 #include "sst/jucegui/data/Continuous.h"
 #include "sst/jucegui/data/Discrete.h"
 #include "sst/jucegui/components/DraggableTextEditableValue.h"
+#include "sst/jucegui/components/DraggableTextEditableDiscreteValue.h"
 #include "datamodel/metadata.h"
 #include "sample/sample.h"
 #include "app/HasEditor.h"
@@ -400,6 +404,8 @@ struct DiscretePayloadDataAttachment : sst::jucegui::data::Discrete
     std::function<void(const onGui_t &at)> onGuiValueChanged;
     // reports a user-visible error (title, message); set by configureUpdater
     std::function<void(const std::string &, const std::string &)> onError{nullptr};
+    // when set, widget begin-edit sends the tagged undo snapshot message
+    std::function<void()> sendBeginEdit{nullptr};
 
     DiscretePayloadDataAttachment(const datamodel::pmd &cd,
                                   std::function<void(const onGui_t &at)> oGVC, ValueType &v)
@@ -439,13 +445,85 @@ struct DiscretePayloadDataAttachment : sst::jucegui::data::Discrete
 
     int getMin() const override { return (int)description.minVal; }
     int getMax() const override { return (int)description.maxVal; }
+    int getDefaultValue() const override { return (int)description.defaultVal; }
 
+    sst::basic_blocks::params::ParamMetaData::FeatureState getFeatureState() const
+    {
+        return sst::basic_blocks::params::ParamMetaData::FeatureState();
+    }
+
+    std::function<std::string(int)> valueToString{nullptr};
+
+    /*
+     * A pmd that carries display labels must declare supportsStringConversion, or
+     * it renders here as a raw integer. Note asBool() alone does NOT set it, so a
+     * labelled bool wants asOnOffBool() (custom min/max displays still win over
+     * the on/off map -- see ParamMetaData::valueToString, the BOOL branch).
+     */
     std::string getValueAsStringFor(int i) const override
     {
-        auto r = description.valueToString((float)i);
-        if (r.has_value())
-            return *r;
-        return "";
+        if (description.supportsStringConversion)
+        {
+            auto res = description.valueToString((float)i, getFeatureState());
+            if (res.has_value())
+                return *res;
+        }
+        if (valueToString)
+            return valueToString(i);
+        return sst::jucegui::data::Discrete::getValueAsStringFor(i);
+    }
+
+    std::string getValueAsStringWithoutUnitsFor(int i) const override
+    {
+        if (description.supportsStringConversion)
+        {
+            auto res = description.valueToString((float)i, getFeatureState().withNoUnits(true));
+            if (res.has_value())
+                return *res;
+        }
+        if (valueToString)
+            return valueToString(i);
+        return sst::jucegui::data::Discrete::getValueAsStringWithoutUnitsFor(i);
+    }
+
+    std::optional<std::string> getValueAlternateAsStringFor(int i) const override
+    {
+        if (description.supportsStringConversion)
+            return description.valueToAlternateString((float)i, getFeatureState());
+        return std::nullopt;
+    }
+
+    std::function<std::optional<float>(const std::string &)> stringToValue{nullptr};
+    void setValueAsString(const std::string &s) override
+    {
+        if (description.supportsStringConversion)
+        {
+            std::string em;
+            auto res = description.valueFromString(s, em);
+            if (res.has_value())
+            {
+                setValueFromGUI((int)std::round(*res));
+                return;
+            }
+            else
+            {
+                if (onError)
+                    onError(label + ": Invalid Value", em);
+                else
+                    SCLOG_IF(debug, em);
+                return;
+            }
+        }
+        if (stringToValue)
+        {
+            auto f = stringToValue(s);
+            if (f.has_value())
+            {
+                setValueFromGUI((int)std::round(*f));
+                return;
+            }
+        }
+        sst::jucegui::data::Discrete::setValueAsString(s);
     }
 
     void andThenOnGui(std::function<void(const DiscretePayloadDataAttachment &)> f)
@@ -543,7 +621,7 @@ struct DirectBooleanPayloadDataAttachment : sst::jucegui::data::Discrete
     std::string getValueAsStringFor(int i) const override { return i == 0 ? "Off" : "On"; }
 };
 
-struct SamplePointDataAttachment : sst::jucegui::data::Continuous
+struct SamplePointDataAttachment : sst::jucegui::data::Discrete
 {
     int64_t &value;
     std::string label;
@@ -551,36 +629,54 @@ struct SamplePointDataAttachment : sst::jucegui::data::Continuous
     std::function<void(const SamplePointDataAttachment &)> onGuiChanged{nullptr};
     std::function<int64_t(int64_t)> precheckGuiAdjust{nullptr};
 
+    // Frames advanced per jog. 0 => auto (sampleCount / 4096), so one wheel notch
+    // or arrow key is a useful nudge regardless of sample length. Left settable so
+    // a future waveform-zoom hook can drive it; shift-drag still gives one frame.
+    int64_t jogIncrement{0};
+
     SamplePointDataAttachment(int64_t &v,
                               std::function<void(const SamplePointDataAttachment &)> ogc)
         : value(v), onGuiChanged(ogc)
     {
+        setJogWrapsAtEnd(false);
     }
 
-    float getValue() const override { return value; }
-    std::string getValueAsStringFor(float f) const override
+    int getValue() const override { return (int)value; }
+    std::string getValueAsStringFor(int i) const override
     {
-        if (f < 0)
+        if (i < 0)
             return "";
-        return fmt::format("{}", (int64_t)f);
+        return fmt::format("{}", (int64_t)i);
     }
-    void setValueFromGUI(const float &ff) override
+    void setValueFromGUI(const int &fi) override
     {
-        auto f = ff;
+        int64_t f = fi;
         if (precheckGuiAdjust)
         {
-            f = precheckGuiAdjust(ff);
+            f = precheckGuiAdjust(f);
         }
-        value = (int64_t)f;
+        value = f;
         if (onGuiChanged)
             onGuiChanged(*this);
     }
     std::string getLabel() const override { return label; }
-    float getQuantizedStepSize() const override { return 1; }
-    float getMin() const override { return -1; }
-    float getMax() const override { return sampleCount; }
-    float getDefaultValue() const override { return 0; }
-    void setValueFromModel(const float &f) override
+    int getMin() const override { return -1; }
+    // clamp the (int64) frame count into int range rather than narrowing silently;
+    // >2^31 frames is ~12h at 48k and not a practical sample length.
+    int getMax() const override
+    {
+        return (int)std::min<int64_t>(sampleCount, std::numeric_limits<int>::max());
+    }
+    int getDefaultValue() const override { return 0; }
+
+    void jog(int dir) override
+    {
+        auto inc = jogIncrement > 0 ? jogIncrement : std::max<int64_t>(1, sampleCount / 4096);
+        auto nv = std::clamp<int64_t>(value + (int64_t)dir * inc, getMin(), getMax());
+        setValueFromGUI((int)nv);
+    }
+
+    void setValueFromModel(const int &f) override
     {
         value = (int64_t)f;
         for (auto *l : guilisteners)
@@ -604,13 +700,14 @@ template <typename A, typename Msg, typename ABase = A> struct SingleValueFactor
             typename std::remove_cv<typename std::remove_reference<decltype(val)>::type>::type,
             float>;
         constexpr bool isText =
-            std::is_same_v<W, sst::jucegui::components::DraggableTextEditableValue>;
+            std::is_same_v<W, sst::jucegui::components::DraggableTextEditableValue> ||
+            std::is_same_v<W, sst::jucegui::components::DraggableTextEditableDiscreteValue>;
 
         if constexpr (isText)
         {
-            // A draggable text value still drags like a continuous control, so
-            // wire its begin/end-edit (which drives the undo gesture) and
-            // tooltips, then override the popup to open the inline editor.
+            // A draggable text value drags/types like a plain control, so wire its
+            // begin/end-edit (which drives the undo gesture) and tooltips, then
+            // override the popup to open the inline editor instead of a menu.
             if (showTT)
                 e->setupFloatWidget(wid.get(), att.get());
             else

--- a/src/scxt-plugin/theme/ThemeApplier.cpp
+++ b/src/scxt-plugin/theme/ThemeApplier.cpp
@@ -34,6 +34,7 @@
 #include "sst/jucegui/components/MultiSwitch.h"
 #include "sst/jucegui/components/Knob.h"
 #include "sst/jucegui/components/DraggableTextEditableValue.h"
+#include "sst/jucegui/components/DraggableTextEditableDiscreteValue.h"
 #include "sst/jucegui/components/ToolTip.h"
 #include "sst/jucegui/components/ToggleButton.h"
 #include "sst/jucegui/components/JogUpDownButton.h"
@@ -270,6 +271,8 @@ void ThemeApplier::applyZoneMultiScreenModulationTheme(juce::Component *toThis)
     map.addCustomClass<jcmp::HSliderFilled>(detail::edit::zone::ModulationHSliderFilled);
     map.addCustomClass<jcmp::DraggableTextEditableValue>(
         detail::edit::zone::ModulationDraggableTextEditableValue);
+    map.addCustomClass<jcmp::DraggableTextEditableDiscreteValue>(
+        detail::edit::zone::ModulationDraggableTextEditableValue);
     populateSharedGroupZoneMultiModulation(map);
     map.applyMapTo(toThis);
 }
@@ -291,6 +294,8 @@ void ThemeApplier::applyGroupMultiScreenModulationTheme(juce::Component *toThis)
     map.addCustomClass<jcmp::Knob>(detail::edit::group::ModulationKnob);
     map.addCustomClass<jcmp::DraggableTextEditableValue>(
         detail::edit::group::ModulationDraggableTextEditableValue);
+    map.addCustomClass<jcmp::DraggableTextEditableDiscreteValue>(
+        detail::edit::group::ModulationDraggableTextEditableValue);
     map.addCustomClass<jcmp::HSliderFilled>(detail::edit::group::ModulationHSliderFilled);
     populateSharedGroupZoneMultiModulation(map);
     map.applyMapTo(toThis);
@@ -303,6 +308,8 @@ void ThemeApplier::applyGroupMultiScreenTheme(juce::Component *toThis)
     map.addCustomClass<jcmp::Knob>(detail::edit::group::Knob);
     map.addCustomClass<jcmp::DraggableTextEditableValue>(
         detail::edit::group::DraggableTextEditableValue);
+    map.addCustomClass<jcmp::DraggableTextEditableDiscreteValue>(
+        detail::edit::group::DraggableTextEditableValue);
     map.applyMapTo(toThis);
 }
 
@@ -310,6 +317,8 @@ void ThemeApplier::applyVariantLoopTheme(juce::Component *toThis)
 {
     jstl::CustomTypeMap map;
     map.addCustomClass<jcmp::DraggableTextEditableValue>(
+        detail::edit::variant::DraggableTextEditableValue);
+    map.addCustomClass<jcmp::DraggableTextEditableDiscreteValue>(
         detail::edit::variant::DraggableTextEditableValue);
     map.addCustomClass<jcmp::ToggleButton>(detail::edit::variant::ToggleButton);
     map.applyMapTo(toThis);


### PR DESCRIPTION
Integer parameters were bound to the continuous draggable text value, which truncates on write. The mouse wheel skipped values and travelled further down than up, and drag speed scaled with the parameter range, so a key range and a step count moved at wildly different rates.

The real work is in sst-jucegui, which gains a draggable text value on the discrete data model. This diff reads bigger than the change actually is: almost all of it is substituting the type of existing attachment and widget variables, plus the parallel sparse containers that follow once two widget types live where one used to.

Every integer-backed control moves across - key and velocity ranges and fades, root key, pitch bend, LFO step count and phasor numerator and denominator, part transpose, loop count, and the sample start, end, loop and crossfade points. The discrete attachment picks up the string handling and undo gesture tagging the continuous one already had, and sample points advance by a fraction of the sample rather than one frame so a wheel notch is useful on long samples.

Booleans now ask for on/off formatting, so a control that displays its value shows one rather than an integer.

Closes #2530
Closes #2553
Closes #2555

Assisted-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>