### PR TITLE
Implement LFO trigger modes

### DIFF
--- a/src/clients/console-ui/audio_thread_provider.h
+++ b/src/clients/console-ui/audio_thread_provider.h
@@ -65,6 +65,7 @@ struct AudioThreadProvider
             engine.processAudio();
             engine.transport.timeInBeats +=
                 (double)scxt::blockSize * 120 * engine.getSampleRateInv() / 60.f;
+            engine.transport.timeInSeconds += (double)scxt::blockSize * engine.getSampleRateInv();
             std::this_thread::sleep_for(std::chrono::microseconds(sleepTime));
         }
     }

--- a/src/scxt-core/engine/group.cpp
+++ b/src/scxt-core/engine/group.cpp
@@ -206,60 +206,7 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
         if (!lfosActive[i])
             continue;
 
-        bool rt = doLFORetrigger[i];
-        doLFORetrigger[i] = false;
-
-        if (lfoEvaluator[i] == STEP)
-        {
-            if (rt)
-            {
-                stepLfos[i].retrigger();
-            }
-            stepLfos[i].process(blockSize);
-            stepLfos[i].output *= *(endpoints.lfo[i].amplitudeP);
-        }
-        else if (lfoEvaluator[i] == CURVE)
-        {
-            auto &lp = endpoints.lfo[i];
-
-            if (rt)
-            {
-                curveLfos[i].attack(0, *lp.curve.delayP, modulatorStorage[i].modulatorShape);
-            }
-
-            curveLfos[i].process(*lp.rateP, *lp.curve.deformP, *lp.curve.angleP, *lp.curve.delayP,
-                                 *lp.curve.attackP, *lp.curve.releaseP,
-                                 modulatorStorage[i].curveLfoStorage.useenv,
-                                 modulatorStorage[i].curveLfoStorage.unipolar, gated);
-
-            curveLfos[i].output *= *(endpoints.lfo[i].amplitudeP);
-        }
-        else if (lfoEvaluator[i] == ENV)
-        {
-            auto &lp = endpoints.lfo[i].env;
-
-            auto eloop = modulatorStorage[i].envLfoStorage.loop;
-            auto useGate = gated;
-
-            if (eloop)
-            {
-                useGate = envLfos[i].envelope.stage <
-                          scxt::modulation::modulators::EnvLFO::env_t::s_sustain;
-            }
-            if (rt)
-            {
-                envLfos[i].attackFrom(envLfos[i].output, *lp.delayP, *lp.attackP);
-                useGate = true;
-            }
-
-            envLfos[i].process(*lp.delayP, *lp.attackP, *lp.holdP, *lp.decayP, *lp.sustainP,
-                               *lp.releaseP, *lp.aShapeP, *lp.dShapeP, *lp.rShapeP, *lp.rateMulP,
-                               useGate, modulatorStorage[i].temposync, e.transport.tempo / 120.f);
-            envLfos[i].output *= *(endpoints.lfo[i].amplitudeP);
-        }
-        else
-        {
-        }
+        processLFOBlock(i, modulatorStorage[i], gated, e.transport, e.rng, endpoints.lfo[i]);
     }
     phasorEvaluator.step(e.transport, miscSourceStorage);
 
@@ -728,6 +675,21 @@ void Group::attack()
             {
                 const auto &ms = modulatorStorage[i];
 
+                // RELEASE re-arms rather than re-attacking - it fires when the group ungates
+                if (ms.triggerMode == modulation::ModulatorStorage::RELEASE)
+                {
+                    lfoTrigger[i] = {false, true};
+                    silenceLFO(i);
+                    continue;
+                }
+
+                // ONESHOT re-fires its burst on every group attack
+                if (ms.triggerMode == modulation::ModulatorStorage::ONESHOT)
+                {
+                    startLFO(i, ms, getEngine()->transport, getEngine()->rng, endpoints.lfo[i]);
+                    continue;
+                }
+
                 // Looping envelopes are basically unipolar lfos so follow lfos
                 if (ms.isEnv() && !ms.envLfoStorage.loop)
                 {
@@ -871,16 +833,25 @@ void Group::resetLFOs(int whichLFO)
         else if (lfoEvaluator[i] == CURVE)
         {
             curveLfos[i].setSampleRate(sampleRate, sampleRateInv);
-            curveLfos[i].attack(ms.start_phase, *endpoints.lfo[i].curve.delayP, ms.modulatorShape);
         }
         else if (lfoEvaluator[i] == ENV)
         {
             envLfos[i].setSampleRate(sampleRate, sampleRateInv);
-            envLfos[i].attack(*endpoints.lfo[i].env.delayP, *endpoints.lfo[i].env.attackP);
         }
         else
         {
             SCLOG_IF(warnings, "Unimplemented modulator shape " << ms.modulatorShape);
+        }
+
+        // RELEASE holds off until the group ungates; everything else starts here.
+        if (ms.triggerMode == modulation::ModulatorStorage::RELEASE)
+        {
+            lfoTrigger[i] = {false, true};
+            silenceLFO(i);
+        }
+        else
+        {
+            startLFO(i, ms, getEngine()->transport, getEngine()->rng, endpoints.lfo[i]);
         }
     }
 

--- a/src/scxt-core/modulation/has_modulators.h
+++ b/src/scxt-core/modulation/has_modulators.h
@@ -30,6 +30,8 @@
 
 #include "configuration.h"
 
+#include <cmath>
+
 #include "sst/basic-blocks/modulators/AHDSRShapedSC.h"
 #include "modulation/modulators/steplfo.h"
 #include "modulation/modulators/curvelfo.h"
@@ -130,6 +132,219 @@ template <typename T, size_t egsPerObject> struct HasModulators
                 doLFORetrigger[i] = true;
             }
             lastLFORetrigger[i] = nrt;
+        }
+    }
+
+    /*
+     * Per-LFO trigger bookkeeping. RELEASE arms at attack and fires on the gate's
+     * falling edge; everything else starts immediately.
+     */
+    struct LFOTriggerState
+    {
+        bool started{false};
+        bool armed{false};
+    };
+    std::array<LFOTriggerState, lfosPerObject> lfoTrigger{};
+
+    /*
+     * The phase (0..1) a curve LFO should start at for this trigger mode. SONGPOS locks
+     * to song position at attack and free-runs after, so a note at bar 3 lands where the
+     * cycle would have been had it been running since the song started.
+     */
+    static float initialLFOPhase(const modulation::ModulatorStorage &ms,
+                                 const sst::basic_blocks::modulators::Transport &transport,
+                                 float rate, sst::basic_blocks::dsp::RNG &rng)
+    {
+        switch (ms.triggerMode)
+        {
+        case modulation::ModulatorStorage::RANDOM:
+            return rng.unif01();
+        case modulation::ModulatorStorage::SONGPOS:
+        {
+            // Same table SimpleLFO's own phase increment goes through, so the locked
+            // phase and the free-run frequency agree exactly rather than to table error
+            auto effRate = modulation::modulators::CurveLFO::snappedRate(ms, rate);
+            auto freqHz = (double)dsp::twoToTheXTable.twoToThe(effRate) *
+                          (ms.temposync ? transport.tempo / 120.0 : 1.0);
+            auto ph = ms.start_phase + transport.timeInSeconds * freqHz;
+            return (float)(ph - std::floor(ph));
+        }
+        default:
+            return ms.start_phase;
+        }
+    }
+
+    /*
+     * The step sequencer needs its position expressed as (step, phase within step)
+     * rather than a bare phase, so it gets its own entry point.
+     */
+    void startStepLFO(int i, const modulation::ModulatorStorage &ms,
+                      const sst::basic_blocks::modulators::Transport &transport,
+                      sst::basic_blocks::dsp::RNG &rng)
+    {
+        switch (ms.triggerMode)
+        {
+        case modulation::ModulatorStorage::SONGPOS:
+            stepLfos[i].setStartPosition(ms.start_phase, transport.timeInSeconds);
+            break;
+        case modulation::ModulatorStorage::RANDOM:
+            stepLfos[i].setStartPosition(rng.unif01());
+            break;
+        default:
+            stepLfos[i].setStartPosition(ms.start_phase);
+            break;
+        }
+    }
+
+    /*
+     * Fire LFO i: position it for its trigger mode and mark it running. The evaluator
+     * must already have been assigned and had its sample rate set.
+     */
+    template <typename LFOEndpoint>
+    void startLFO(int i, const modulation::ModulatorStorage &ms,
+                  const sst::basic_blocks::modulators::Transport &transport,
+                  sst::basic_blocks::dsp::RNG &rng, const LFOEndpoint &lp)
+    {
+        lfoTrigger[i] = {true, false};
+        switch (lfoEvaluator[i])
+        {
+        case STEP:
+            startStepLFO(i, ms, transport, rng);
+            break;
+        case CURVE:
+            curveLfos[i].attack(initialLFOPhase(ms, transport, *lp.rateP, rng), *lp.curve.delayP,
+                                ms.modulatorShape);
+            break;
+        case ENV:
+            envLfos[i].attack(*lp.env.delayP, *lp.env.attackP);
+            break;
+        default:
+            break;
+        }
+    }
+
+    void silenceLFO(int i)
+    {
+        switch (lfoEvaluator[i])
+        {
+        case STEP:
+            stepLfos[i].silence();
+            break;
+        case CURVE:
+            curveLfos[i].silence();
+            break;
+        case ENV:
+            envLfos[i].silence();
+            break;
+        default:
+            break;
+        }
+    }
+
+    /*
+     * The gate an LFO's own envelope (curve DAR / env DAHDSR) should see. ONESHOT drops
+     * the gate once the envelope is past its peak so it makes exactly one pass; RELEASE
+     * holds the gate open from the moment it fires, since the key is already up.
+     */
+    template <typename Stage>
+    static bool lfoEnvelopeGate(modulation::ModulatorStorage::TriggerMode tm, bool keyGate,
+                                Stage stage, Stage sustainStage)
+    {
+        switch (tm)
+        {
+        case modulation::ModulatorStorage::RELEASE:
+            return true;
+        case modulation::ModulatorStorage::ONESHOT:
+            return stage < sustainStage;
+        default:
+            return keyGate;
+        }
+    }
+
+    /*
+     * One LFO's per-block work: honor the trigger mode (deferred start, release-fire),
+     * then run whichever evaluator this LFO is and scale by amplitude. Shared verbatim
+     * by Voice (gate = isGated) and Group (gate = gated) so the two can't drift.
+     */
+    template <typename LFOEndpoint>
+    void processLFOBlock(int i, const modulation::ModulatorStorage &ms, bool gate,
+                         const sst::basic_blocks::modulators::Transport &transport,
+                         sst::basic_blocks::dsp::RNG &rng, const LFOEndpoint &lp)
+    {
+        bool rt = doLFORetrigger[i];
+        doLFORetrigger[i] = false;
+
+        if (!lfoTrigger[i].started)
+        {
+            // RELEASE fires on the gate falling edge; an explicit retrigger fires it too
+            if (!rt && !(lfoTrigger[i].armed && !gate))
+            {
+                silenceLFO(i);
+                return;
+            }
+            startLFO(i, ms, transport, rng, lp);
+            rt = false;
+        }
+
+        auto oneShot = (ms.triggerMode == modulation::ModulatorStorage::ONESHOT);
+        auto amp = *(lp.amplitudeP);
+
+        switch (lfoEvaluator[i])
+        {
+        case STEP:
+            if (rt)
+                stepLfos[i].retrigger();
+            stepLfos[i].process(blockSize);
+            stepLfos[i].output *= amp;
+            break;
+        case CURVE:
+        {
+            if (rt)
+                curveLfos[i].attack(0, *lp.curve.delayP, ms.modulatorShape);
+
+            // ONESHOT is the DAR envelope running exactly once, so it forces the env on
+            using senv_t = modulation::modulators::CurveLFO::senv_t;
+            auto useGate =
+                lfoEnvelopeGate(ms.triggerMode, gate, curveLfos[i].simpleEnv.stage, senv_t::s_hold);
+
+            curveLfos[i].process(*lp.rateP, *lp.curve.deformP, *lp.curve.angleP, *lp.curve.delayP,
+                                 *lp.curve.attackP, *lp.curve.releaseP,
+                                 ms.curveLfoStorage.useenv || oneShot, ms.curveLfoStorage.unipolar,
+                                 useGate);
+            curveLfos[i].output *= amp;
+            break;
+        }
+        case ENV:
+        {
+            using env_t = modulation::modulators::EnvLFO::env_t;
+            auto eloop = ms.envLfoStorage.loop && !oneShot;
+            auto useGate =
+                lfoEnvelopeGate(ms.triggerMode, gate, envLfos[i].envelope.stage, env_t::s_sustain);
+
+            if (eloop)
+            {
+                // A looping env is a unipolar LFO: gate through DAHD, drop at sustain so it
+                // releases, then re-attack once it completes so it cycles. This drives the
+                // loop for both Voice and Group (the Group path previously lacked it).
+                useGate = envLfos[i].envelope.stage < env_t::s_sustain;
+                if (envLfos[i].envelope.stage > env_t::s_release)
+                    rt = true;
+            }
+            if (rt)
+            {
+                envLfos[i].attackFrom(envLfos[i].output, *lp.env.delayP, *lp.env.attackP);
+                useGate = true;
+            }
+
+            envLfos[i].process(*lp.env.delayP, *lp.env.attackP, *lp.env.holdP, *lp.env.decayP,
+                               *lp.env.sustainP, *lp.env.releaseP, *lp.env.aShapeP, *lp.env.dShapeP,
+                               *lp.env.rShapeP, *lp.env.rateMulP, useGate, ms.temposync,
+                               transport.tempo / 120.f);
+            envLfos[i].output *= amp;
+            break;
+        }
+        default:
+            break;
         }
     }
 

--- a/src/scxt-core/modulation/modulator_storage.cpp
+++ b/src/scxt-core/modulation/modulator_storage.cpp
@@ -232,8 +232,8 @@ ModulatorStorage::toStringTriggerMode(const scxt::modulation::ModulatorStorage::
     {
     case KEYTRIGGER:
         return "kt";
-    case FREERUN:
-        return "free";
+    case SONGPOS:
+        return "song";
     case RANDOM:
         return "rnd";
     case RELEASE:

--- a/src/scxt-core/modulation/modulator_storage.h
+++ b/src/scxt-core/modulation/modulator_storage.h
@@ -181,11 +181,10 @@ struct ModulatorStorage
     DECLARE_ENUM_STRING(ModulatorShape);
 
     // These enum values are streamed. Do not change them.
-    // ...but they don't work yet anyway so maybe do? :)
     enum TriggerMode : int16_t
     {
         KEYTRIGGER,
-        FREERUN,
+        SONGPOS,
         RANDOM,
         RELEASE,
         ONESHOT
@@ -345,7 +344,7 @@ SC_DESCRIBE(scxt::modulation::ModulatorStorage, {
                                          modulation::ModulatorStorage::ONESHOT)
                               .withUnorderedMapFormatting({
                                   {modulation::ModulatorStorage::KEYTRIGGER, "KEYTRIG"},
-                                  {modulation::ModulatorStorage::FREERUN, "SONGPOS"},
+                                  {modulation::ModulatorStorage::SONGPOS, "SONGPOS"},
                                   {modulation::ModulatorStorage::RANDOM, "RANDOM"},
                                   {modulation::ModulatorStorage::RELEASE, "RELEASE"},
                                   {modulation::ModulatorStorage::ONESHOT, "ONESHOT"},

--- a/src/scxt-core/modulation/modulators/curvelfo.h
+++ b/src/scxt-core/modulation/modulators/curvelfo.h
@@ -31,6 +31,7 @@
 #include "sst/basic-blocks/modulators/SimpleLFO.h"
 #include "sst/basic-blocks/modulators/DAREnvelope.h"
 #include "sst/basic-blocks/modulators/Transport.h"
+#include "sst/basic-blocks/tables/TemposyncSupport.h"
 #include "sst/basic-blocks/dsp/RNG.h"
 
 #include "utils.h"
@@ -114,8 +115,18 @@ struct CurveLFO : SampleRateSupport
         simpleEnv.attack(delay);
     }
 
+    // The rate the SimpleLFO actually runs at - temposync-snapped when synced. Shared
+    // with the songpos phase lock so the lock and the free-run can't drift apart.
+    static float snappedRate(const ModulatorStorage &ms, float rate)
+    {
+        if (!ms.temposync)
+            return rate;
+        return -sst::basic_blocks::tables::temposync::TwoToThe::snap(-rate);
+    }
+
+    void silence() { output = 0.f; }
+
     uint32_t smp{0};
-    datamodel::pmd tsConverter{datamodel::pmd().asLfoRate()};
     void process(const float rate, const float deform, const float angle, const float delay,
                  const float attack, const float release, bool useEnv, bool unipolar, bool isGated)
     {
@@ -124,7 +135,7 @@ struct CurveLFO : SampleRateSupport
         bool isTemposync{false};
         if (settings && td && settings->temposync)
         {
-            rt = -tsConverter.snapToTemposync(-rt);
+            rt = snappedRate(*settings, rt);
             tsRatio = td->tempo / 120.0;
             isTemposync = true;
         }

--- a/src/scxt-core/modulation/modulators/envlfo.h
+++ b/src/scxt-core/modulation/modulators/envlfo.h
@@ -46,6 +46,7 @@ struct EnvLFO : SampleRateSupport
 
     env_t envelope{this};
     float output{0.f};
+    void silence() { output = 0.f; }
     void attack(float delay, float attack) { envelope.attackFromWithDelay(0.f, delay, attack); }
     void attackFrom(float level, float delay, float attack)
     {

--- a/src/scxt-core/modulation/modulators/steplfo.h
+++ b/src/scxt-core/modulation/modulators/steplfo.h
@@ -32,6 +32,8 @@
 #include <array>
 #include <vector>
 #include <utility>
+#include <algorithm>
+#include <cmath>
 #include <modulation/modulator_storage.h>
 #include "sst/basic-blocks/dsp/RNG.h"
 #include "sst/basic-blocks/modulators/Transport.h"
@@ -57,10 +59,46 @@ struct StepLFO : MoveableOnly<StepLFO>, SampleRateSupport
         this->rate = rate;
         underlyingLfo.setSampleRate(sampleRate, sampleRateInv);
         underlyingLfo.assign(&settings->stepLfoStorage, *rate, td, rng, settings->temposync);
-        underlyingLfo.phase = settings->start_phase;
+        setStartPosition(settings->start_phase);
+    }
+
+    /*
+     * phase01 is a fraction of the whole sequence. songPosSeconds, when non-zero,
+     * additionally advances the position by where the song is (SONGPOS trigger).
+     */
+    void setStartPosition(float phase01, double songPosSeconds = 0.0)
+    {
+        if (!settings || !rate)
+            return;
+
+        const auto &ss = settings->stepLfoStorage;
+        auto repeat = std::max((int)ss.repeat, 1);
+        double total = std::clamp(phase01, 0.f, 0.999999f) * repeat;
+
+        if (songPosSeconds != 0.0)
+        {
+            // Steps advance at 2^rate per second, scaled by the whole-sequence length in
+            // cycle mode and by tempo when synced. Mirrors UpdatePhaseIncrement exactly,
+            // table for table, so the lock and the free-run don't drift apart.
+            double stepsPerSec = (ss.rateIsForSingleStep ? 1.0 : repeat);
+            if (settings->temposync && td)
+            {
+                stepsPerSec *= std::pow(2.0, (double)*rate) * td->tempo / 120.0;
+            }
+            else
+            {
+                stepsPerSec *= tuning::equalTuning.note_to_pitch(12 * *rate);
+            }
+            total += songPosSeconds * stepsPerSec;
+        }
+
+        auto totalFloor = (long)std::floor(total);
+        auto step = (int)(((totalFloor % repeat) + repeat) % repeat);
+        underlyingLfo.setPhaseTo(step, (float)(total - totalFloor));
     }
 
     void retrigger() { underlyingLfo.retrigger(); }
+    void silence() { output = 0.f; }
     // void sync();
     void process(int samples)
     {

--- a/src/scxt-core/voice/voice.cpp
+++ b/src/scxt-core/voice/voice.cpp
@@ -156,16 +156,25 @@ void Voice::voiceStarted()
         {
             curveLfos[i].setSampleRate(sampleRate, sampleRateInv);
             curveLfos[i].assign(&zone->modulatorStorage[i], &engine->transport);
-            curveLfos[i].attack(ms.start_phase, *endpoints->lfo[i].curve.delayP, ms.modulatorShape);
         }
         else if (lfoEvaluator[i] == ENV)
         {
             envLfos[i].setSampleRate(sampleRate, sampleRateInv);
-            envLfos[i].attack(*endpoints->lfo[i].env.delayP, *endpoints->lfo[i].env.attackP);
         }
         else
         {
             SCLOG_IF(warnings, "Unimplemented modulator shape " << ms.modulatorShape);
+        }
+
+        // RELEASE holds off until the key comes up; everything else starts here.
+        if (ms.triggerMode == scxt::modulation::ModulatorStorage::RELEASE)
+        {
+            lfoTrigger[i] = {false, true};
+            silenceLFO(i);
+        }
+        else
+        {
+            startLFO(i, ms, engine->transport, engine->rng, endpoints->lfo[i]);
         }
     }
 
@@ -248,63 +257,8 @@ template <bool OS> bool Voice::processWithOS()
         {
             continue;
         }
-        bool rt = doLFORetrigger[i];
-        doLFORetrigger[i] = false;
-
-        if (lfoEvaluator[i] == STEP)
-        {
-            if (rt)
-            {
-                stepLfos[i].retrigger();
-            }
-            stepLfos[i].process(blockSize);
-            stepLfos[i].output *= *(endpoints->lfo[i].amplitudeP);
-        }
-        else if (lfoEvaluator[i] == CURVE)
-        {
-            auto &lp = endpoints->lfo[i];
-
-            if (rt)
-            {
-                curveLfos[i].attack(0, *lp.curve.delayP, zone->modulatorStorage[i].modulatorShape);
-            }
-
-            curveLfos[i].process(*lp.rateP, *lp.curve.deformP, *lp.curve.angleP, *lp.curve.delayP,
-                                 *lp.curve.attackP, *lp.curve.releaseP,
-                                 zone->modulatorStorage[i].curveLfoStorage.useenv,
-                                 zone->modulatorStorage[i].curveLfoStorage.unipolar, isGated);
-            curveLfos[i].output *= *(endpoints->lfo[i].amplitudeP);
-        }
-        else if (lfoEvaluator[i] == ENV)
-        {
-            auto &lp = endpoints->lfo[i].env;
-
-            auto eloop = zone->modulatorStorage[i].envLfoStorage.loop;
-            auto useGate = isGated;
-            if (envLfos[i].envelope.stage > scxt::modulation::modulators::EnvLFO::env_t::s_release)
-            {
-                rt = true;
-            }
-            if (eloop)
-            {
-                useGate = envLfos[i].envelope.stage <
-                          scxt::modulation::modulators::EnvLFO::env_t::s_sustain;
-            }
-            if (rt)
-            {
-                envLfos[i].attackFrom(envLfos[i].output, *lp.delayP, *lp.attackP);
-                useGate = true;
-            }
-
-            envLfos[i].process(*lp.delayP, *lp.attackP, *lp.holdP, *lp.decayP, *lp.sustainP,
-                               *lp.releaseP, *lp.aShapeP, *lp.dShapeP, *lp.rShapeP, *lp.rateMulP,
-                               useGate, zone->modulatorStorage[i].temposync,
-                               engine->transport.tempo / 120.f);
-            envLfos[i].output *= *(endpoints->lfo[i].amplitudeP);
-        }
-        else
-        {
-        }
+        processLFOBlock(i, zone->modulatorStorage[i], isGated, engine->transport, engine->rng,
+                        endpoints->lfo[i]);
     }
 
     if (phasorsActive)

--- a/src/scxt-plugin/app/edit-screen/components/LFOPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/LFOPane.cpp
@@ -1799,6 +1799,10 @@ void LfoPane::rebuildPanelComponents()
                                                 cmsg::UpdateZoneOrGroupModStorageInt16TValue>;
 
     tfac::attach(ms, ms.triggerMode, this, triggerModeA, triggerMode, forZone, selectedTab);
+    triggerModeA->andThenOnGui([w = juce::Component::SafePointer(this)](const auto &) {
+        if (w)
+            w->updateTriggerDependentUI();
+    });
     getContentAreaComponent()->addAndMakeVisible(*triggerMode);
 
     triggerL = std::make_unique<jcmp::Label>();
@@ -1832,6 +1836,7 @@ void LfoPane::rebuildPanelComponents()
 
     repositionContentAreaComponents();
     setSubPaneVisibility();
+    updateTriggerDependentUI();
 
     std::unique_ptr<jcmp::ToggleButton> tsb;
     using tsfac = connectors::BooleanSingleValueFactory<boolAttachment_t,
@@ -1906,6 +1911,25 @@ void LfoPane::setSubPaneVisibility()
     envLfoPane->setVisible(ms.isEnv() && con);
     consistencyLfoPane->setVisible(!con);
     modulatorShape->setVisible(con);
+}
+
+void LfoPane::updateTriggerDependentUI()
+{
+    if (!curveLfoPane || !envLfoPane)
+        return;
+
+    auto &ms = modulatorStorageData[selectedTab];
+    auto oneShot = ms.triggerMode == modulation::ModulatorStorage::ONESHOT;
+
+    // The one shot *is* the sub-envelope running once, so the engine forces it either
+    // way. Arm the toggle so the UI agrees with what you hear, and lock it while armed.
+    curveLfoPane->useenvB->setEnabled(!oneShot);
+    if (oneShot && !ms.curveLfoStorage.useenv)
+        curveLfoPane->useenvA->setValueFromGUI(1);
+
+    envLfoPane->loopB->setEnabled(!oneShot);
+    if (oneShot && ms.envLfoStorage.loop)
+        envLfoPane->loopA->setValueFromGUI(0);
 }
 
 void LfoPane::showModulatorShapeMenu()

--- a/src/scxt-plugin/app/edit-screen/components/LFOPane.h
+++ b/src/scxt-plugin/app/edit-screen/components/LFOPane.h
@@ -91,6 +91,9 @@ struct LfoPane : sst::jucegui::components::NamedPanel, app::HasEditor
 
     void setSubPaneVisibility();
 
+    // ONESHOT owns the sub-envelope, so its toggle shows armed and greys out
+    void updateTriggerDependentUI();
+
     void resized() override;
     void rebuildPanelComponents(); // entirely new components
 

--- a/src/scxt-plugin/clap/scxt-plugin.cpp
+++ b/src/scxt-plugin/clap/scxt-plugin.cpp
@@ -312,6 +312,7 @@ SCXTPlugin::process_nonblock(const clap_process *process) SST_CPPUTILS_NONBLOCKI
             engine->processAudio();
             engine->transport.timeInBeats += (double)scxt::blockSize * engine->transport.tempo *
                                              engine->getSampleRateInv() / 60.f;
+            engine->transport.timeInSeconds += (double)scxt::blockSize * engine->getSampleRateInv();
 
             bool tryToDrain{true};
             while (tryToDrain &&

--- a/tests/modulator_tests.cpp
+++ b/tests/modulator_tests.cpp
@@ -26,6 +26,7 @@
  */
 
 #include "catch2/catch2.hpp"
+#include "engine/engine.h"
 #include "engine/zone.h"
 #include "modulation/modulator_storage.h"
 #include "modulation/has_modulators.h"
@@ -116,4 +117,242 @@ TEST_CASE("GateMode serialization round-trips including SAMPLE_GATED")
 
     // Unknown string falls back to GATED
     REQUIRE(AS::fromStringGateMode("?") == GM::GATED);
+}
+
+using MS = scxt::modulation::ModulatorStorage;
+using TM = MS::TriggerMode;
+using CurveLFO = scxt::modulation::modulators::CurveLFO;
+using Transport = sst::basic_blocks::modulators::Transport;
+
+TEST_CASE("TriggerMode serialization round-trips")
+{
+    REQUIRE(MS::toStringTriggerMode(TM::KEYTRIGGER) == "kt");
+    REQUIRE(MS::toStringTriggerMode(TM::SONGPOS) == "song");
+    REQUIRE(MS::toStringTriggerMode(TM::RANDOM) == "rnd");
+    REQUIRE(MS::toStringTriggerMode(TM::RELEASE) == "rel");
+    REQUIRE(MS::toStringTriggerMode(TM::ONESHOT) == "ones");
+
+    REQUIRE(MS::fromStringTriggerMode("kt") == TM::KEYTRIGGER);
+    REQUIRE(MS::fromStringTriggerMode("song") == TM::SONGPOS);
+    REQUIRE(MS::fromStringTriggerMode("rnd") == TM::RANDOM);
+    REQUIRE(MS::fromStringTriggerMode("rel") == TM::RELEASE);
+    REQUIRE(MS::fromStringTriggerMode("ones") == TM::ONESHOT);
+
+    // Unknown falls back to KEYTRIGGER - including the retired "free" token, which
+    // never did anything but key trigger anyway
+    REQUIRE(MS::fromStringTriggerMode("free") == TM::KEYTRIGGER);
+    REQUIRE(MS::fromStringTriggerMode("?") == TM::KEYTRIGGER);
+}
+
+TEST_CASE("Non-songpos trigger modes start at the phase param")
+{
+    sst::basic_blocks::dsp::RNG rng{8675309};
+    Transport tr;
+    tr.timeInSeconds = 3.7;
+
+    MS ms;
+    ms.start_phase = 0.3f;
+    ms.rate = 0.f;
+
+    for (auto tm : {TM::KEYTRIGGER, TM::RELEASE, TM::ONESHOT})
+    {
+        ms.triggerMode = tm;
+        REQUIRE(ZoneMods::initialLFOPhase(ms, tr, ms.rate, rng) == Approx(0.3f));
+    }
+}
+
+TEST_CASE("RANDOM trigger starts at a random phase, ignoring the phase param")
+{
+    sst::basic_blocks::dsp::RNG rng{8675309};
+    Transport tr;
+
+    MS ms;
+    ms.triggerMode = TM::RANDOM;
+    ms.start_phase = 0.3f;
+
+    auto a = ZoneMods::initialLFOPhase(ms, tr, ms.rate, rng);
+    auto b = ZoneMods::initialLFOPhase(ms, tr, ms.rate, rng);
+
+    REQUIRE(a >= 0.f);
+    REQUIRE(a < 1.f);
+    REQUIRE(b >= 0.f);
+    REQUIRE(b < 1.f);
+    REQUIRE(a != b);
+}
+
+TEST_CASE("SONGPOS trigger locks phase to the seconds timeline")
+{
+    sst::basic_blocks::dsp::RNG rng{8675309};
+    Transport tr;
+
+    MS ms;
+    ms.triggerMode = TM::SONGPOS;
+    ms.start_phase = 0.f;
+    ms.temposync = false;
+
+    // rate is log2 Hz, so rate 0 is a one second cycle
+    ms.rate = 0.f;
+    tr.timeInSeconds = 0.0;
+    REQUIRE(ZoneMods::initialLFOPhase(ms, tr, ms.rate, rng) == Approx(0.f));
+
+    tr.timeInSeconds = 0.25;
+    REQUIRE(ZoneMods::initialLFOPhase(ms, tr, ms.rate, rng) == Approx(0.25f));
+
+    // A whole number of cycles later we are back where we started
+    tr.timeInSeconds = 7.0;
+    REQUIRE(ZoneMods::initialLFOPhase(ms, tr, ms.rate, rng) == Approx(0.f));
+
+    // rate 1 is 2Hz, so a quarter second is half a cycle
+    ms.rate = 1.f;
+    tr.timeInSeconds = 0.25;
+    REQUIRE(ZoneMods::initialLFOPhase(ms, tr, ms.rate, rng) == Approx(0.5f));
+
+    // The phase param offsets the song lock
+    ms.rate = 0.f;
+    ms.start_phase = 0.1f;
+    tr.timeInSeconds = 0.25;
+    REQUIRE(ZoneMods::initialLFOPhase(ms, tr, ms.rate, rng) == Approx(0.35f));
+
+    // ...and wraps
+    tr.timeInSeconds = 0.95;
+    REQUIRE(ZoneMods::initialLFOPhase(ms, tr, ms.rate, rng) == Approx(0.05f));
+}
+
+TEST_CASE("Temposynced SONGPOS lands on the same phase at the same beat, any tempo")
+{
+    sst::basic_blocks::dsp::RNG rng{8675309};
+
+    MS ms;
+    ms.triggerMode = TM::SONGPOS;
+    ms.start_phase = 0.f;
+    ms.temposync = true;
+    ms.rate = 1.f;
+
+    // Same musical position, three tempos: a temposynced LFO is a function of beats
+    auto phaseAtBeat = [&](double beats, double tempo) {
+        Transport tr;
+        tr.tempo = tempo;
+        tr.timeInSeconds = beats * 60.0 / tempo;
+        return ZoneMods::initialLFOPhase(ms, tr, ms.rate, rng);
+    };
+
+    for (auto beats : {0.0, 1.0, 2.5, 9.75})
+    {
+        REQUIRE(phaseAtBeat(beats, 90.0) == Approx(phaseAtBeat(beats, 120.0)).margin(1e-5));
+        REQUIRE(phaseAtBeat(beats, 140.0) == Approx(phaseAtBeat(beats, 120.0)).margin(1e-5));
+    }
+
+    // And it does actually move
+    REQUIRE(phaseAtBeat(0.0, 120.0) != Approx(phaseAtBeat(0.7, 120.0)));
+}
+
+TEST_CASE("lfoEnvelopeGate maps trigger mode onto the sub-envelope gate")
+{
+    // Key trigger, songpos and random just follow the key
+    for (auto tm : {TM::KEYTRIGGER, TM::SONGPOS, TM::RANDOM})
+    {
+        REQUIRE(ZoneMods::lfoEnvelopeGate(tm, true, stg_attack, stg_sustain));
+        REQUIRE(ZoneMods::lfoEnvelopeGate(tm, true, stg_sustain, stg_sustain));
+        REQUIRE_FALSE(ZoneMods::lfoEnvelopeGate(tm, false, stg_attack, stg_sustain));
+    }
+
+    // RELEASE fires with the key already up, so it holds its own gate open
+    REQUIRE(ZoneMods::lfoEnvelopeGate(TM::RELEASE, false, stg_attack, stg_sustain));
+    REQUIRE(ZoneMods::lfoEnvelopeGate(TM::RELEASE, false, stg_sustain, stg_sustain));
+
+    // ONESHOT ignores the key and drops the gate once the envelope is past its peak
+    REQUIRE(ZoneMods::lfoEnvelopeGate(TM::ONESHOT, false, stg_attack, stg_sustain));
+    REQUIRE(ZoneMods::lfoEnvelopeGate(TM::ONESHOT, false, stg_decay, stg_sustain));
+    REQUIRE_FALSE(ZoneMods::lfoEnvelopeGate(TM::ONESHOT, true, stg_sustain, stg_sustain));
+    REQUIRE_FALSE(ZoneMods::lfoEnvelopeGate(TM::ONESHOT, true, stg_release, stg_sustain));
+
+    // The curve LFO's DAR envelope hands in s_hold as its cutoff instead
+    REQUIRE(ZoneMods::lfoEnvelopeGate(TM::ONESHOT, true, stg_attack, stg_hold));
+    REQUIRE_FALSE(ZoneMods::lfoEnvelopeGate(TM::ONESHOT, true, stg_hold, stg_hold));
+}
+
+/*
+ * Drive a real Group's ENV-shaped LFO through the shared processLFOBlock with a held
+ * gate and watch its output: a looping env should cycle (climb to its peak more than
+ * once), a non-looping one should climb once and hold. Runs on the test thread with no
+ * voice, so the group stays put for as long as we keep calling it.
+ */
+namespace
+{
+constexpr double LOOP_TEST_SR = 48000.0;
+
+scxt::engine::Group *setupEnvLFOGroup(scxt::engine::Engine *e, bool loop)
+{
+    e->prepareToPlay(LOOP_TEST_SR);
+
+    auto &part = *e->getPatch()->getPart(0);
+    part.addGroup();
+    auto *g = part.getGroup(0).get();
+    g->setSampleRate(LOOP_TEST_SR);
+
+    auto z = std::make_unique<scxt::engine::Zone>();
+    z->mapping.keyboardRange = {60, 60};
+    z->mapping.velocityRange = {0, 127};
+    z->initialize();
+    g->addZone(z);
+
+    auto &ms = g->modulatorStorage[0];
+    ms.modulatorShape = MS::LFO_ENV;
+    ms.triggerMode = MS::KEYTRIGGER;
+    ms.envLfoStorage.loop = loop;
+    ms.envLfoStorage.delay = 0.f;
+    ms.envLfoStorage.attack = 0.1f;
+    ms.envLfoStorage.hold = 0.f;
+    ms.envLfoStorage.decay = 0.1f;
+    ms.envLfoStorage.sustain = 1.f;
+    ms.envLfoStorage.release = 0.1f;
+
+    // attack() binds the endpoints, sets lfoEvaluator[0]=ENV and starts the env LFO
+    g->warmup();
+    g->attack();
+    return g;
+}
+
+// How many times the env output climbs from near-zero to near-peak.
+int countEnvPeaks(scxt::engine::Engine *e, scxt::engine::Group *g, int maxBlocks)
+{
+    int peaks = 0;
+    bool armed = true; // ready to count the next rise
+    for (int b = 0; b < maxBlocks; ++b)
+    {
+        g->processLFOBlock(0, g->modulatorStorage[0], /*gate=*/true, e->transport, e->rng,
+                           g->endpoints.lfo[0]);
+        auto o = g->envLfos[0].output;
+        if (armed && o > 0.9f)
+        {
+            peaks++;
+            armed = false;
+        }
+        if (o < 0.1f)
+            armed = true;
+    }
+    return peaks;
+}
+} // namespace
+
+TEST_CASE("Group looping envelope LFO cycles while held")
+{
+    auto *e = new scxt::engine::Engine();
+    auto *g = setupEnvLFOGroup(e, /*loop=*/true);
+
+    // ~6.7s of a 0.1/0.1/0.1 env is many cycles; require it came back at least twice
+    REQUIRE(countEnvPeaks(e, g, 20000) >= 2);
+
+    delete e;
+}
+
+TEST_CASE("Group non-looping envelope LFO rises once and holds while held")
+{
+    auto *e = new scxt::engine::Engine();
+    auto *g = setupEnvLFOGroup(e, /*loop=*/false);
+
+    // Held gated with sustain 1.0, it climbs to the peak once and stays there
+    REQUIRE(countEnvPeaks(e, g, 20000) == 1);
+
+    delete e;
 }


### PR DESCRIPTION
Make the LFO Trigger switch actually work. Key-trigger, song position, random, release and one-shot each now shape when and how an LFO starts, for both zone and group LFOs across the step, curve and envelope shapes.

Song position locks an LFO's phase to the transport at attack, so notes land where the cycle would be had it been running since the song started; this adds a seconds timeline to the transport. Release starts the LFO when the gate falls, one-shot runs its envelope once and arms the envelope toggle in the UI, and random starts at a random phase.

Also fixes looping envelopes on group LFOs, which never cycled, and renames the streamed FREERUN mode to SONGPOS.

Closes #1572

Assisted-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>