### PR TITLE
Flip the sign convention for aShape

### DIFF
--- a/src/scxt-core/configuration.h
+++ b/src/scxt-core/configuration.h
@@ -33,7 +33,7 @@
 
 namespace scxt
 {
-static constexpr uint64_t currentStreamingVersion{0x2026'05'29};
+static constexpr uint64_t currentStreamingVersion{0x2026'07'24};
 
 static constexpr uint16_t blockSize{16};
 static constexpr uint16_t blockSizeQuad{16 >> 2};

--- a/src/scxt-core/json/modulation_traits.h
+++ b/src/scxt-core/json/modulation_traits.h
@@ -98,6 +98,10 @@ SC_STREAMDEF(scxt::modulation::modulators::EnvLFOStorage, SC_FROM({
                  findOrSet(v, "release", 0.f, result.release);
 
                  findOrSet(v, "aShape", 0.f, result.aShape);
+                 // aShapePositive template flag flipped to true on 2026-07-24; older streams
+                 // used the opposite attack-shape sign convention, so negate to preserve sound.
+                 if (SC_UNSTREAMING_FROM_PRIOR_TO(0x2026'07'24))
+                     result.aShape = -result.aShape;
                  findOrSet(v, "dShape", 0.f, result.dShape);
                  findOrSet(v, "rShape", 0.f, result.rShape);
                  findOrSet(v, "rateMul", 0.f, result.rateMul);
@@ -134,6 +138,10 @@ SC_STREAMDEF(modulation::modulators::AdsrStorage, SC_FROM({
                  findOrSet(v, "s", 1.f, result.s);
                  findOrSet(v, "r", 0.5f, result.r);
                  findOrSet(v, "aShape", 0.f, result.aShape);
+                 // aShapePositive template flag flipped to true on 2026-07-24; older streams
+                 // used the opposite attack-shape sign convention, so negate to preserve sound.
+                 if (SC_UNSTREAMING_FROM_PRIOR_TO(0x2026'07'24))
+                     result.aShape = -result.aShape;
                  findOrSet(v, "dShape", 0.f, result.dShape);
                  findOrSet(v, "rShape", 0.f, result.rShape);
                  findOrSet(v, "groupGate", false, result.gateGroupEGOnAnyPlaying);

--- a/src/scxt-core/modulation/has_modulators.h
+++ b/src/scxt-core/modulation/has_modulators.h
@@ -90,11 +90,11 @@ template <typename T, size_t egsPerObject> struct HasModulators
         envelopeFollowers{};
 
     typedef sst::basic_blocks::modulators::AHDSRShapedSC<
-        T, blockSize, sst::basic_blocks::modulators::TwentyFiveSecondExp>
+        T, blockSize, sst::basic_blocks::modulators::TwentyFiveSecondExp, true>
         ahdsrenv_t;
 
     typedef sst::basic_blocks::modulators::AHDSRShapedSC<
-        DoubleRate, (blockSize << 1), sst::basic_blocks::modulators::TwentyFiveSecondExp>
+        DoubleRate, (blockSize << 1), sst::basic_blocks::modulators::TwentyFiveSecondExp, true>
         ahdsrenvOS_t;
 
     std::array<ahdsrenv_t, egsPerObject> eg;

--- a/src/scxt-core/modulation/modulators/envlfo.h
+++ b/src/scxt-core/modulation/modulators/envlfo.h
@@ -37,7 +37,7 @@ namespace scxt::modulation::modulators
 struct EnvLFO : SampleRateSupport
 {
     using env_t = sst::basic_blocks::modulators::AHDSRShapedSC<
-        EnvLFO, blockSize, sst::basic_blocks::modulators::TwentyFiveSecondExp>;
+        EnvLFO, blockSize, sst::basic_blocks::modulators::TwentyFiveSecondExp, true>;
 
     float envelope_rate_linear_nowrap(float f)
     {


### PR DESCRIPTION
The envelope shape convention was "100% pushes you towards the end of the period" which meant increasing phase curves had a be convex and d be concave. Fix this downstream with an optional flag then turn that optional flag on here, unstream aShape as -aShape for old patches.

Will have a small break for patches which modulate attack shape.

Assisted-By: Claude Opus 4.8