### PR TITLE
Refine what an LFO one shot does per shape

### DIFF
--- a/src/scxt-core/modulation/has_modulators.h
+++ b/src/scxt-core/modulation/has_modulators.h
@@ -294,24 +294,47 @@ template <typename T, size_t egsPerObject> struct HasModulators
         case STEP:
             if (rt)
                 stepLfos[i].retrigger();
+
+            // A one shot plays the sequence out and then goes quiet
+            if (oneShot && stepLfos[i].sequenceComplete())
+            {
+                stepLfos[i].silence();
+                break;
+            }
             stepLfos[i].process(blockSize);
-            stepLfos[i].output *= amp;
+            if (oneShot && stepLfos[i].sequenceComplete())
+                stepLfos[i].silence();
+            else
+                stepLfos[i].output *= amp;
             break;
         case CURVE:
         {
             if (rt)
                 curveLfos[i].attack(0, *lp.curve.delayP, ms.modulatorShape);
 
-            // ONESHOT is the DAR envelope running exactly once, so it forces the env on
+            // With the sub-envelope off, a one shot is one cycle of the curve and then
+            // silence; with it on, it is the DAR envelope making a single pass instead
+            auto useEnv = ms.curveLfoStorage.useenv;
+            auto oneCycle = oneShot && !useEnv;
+
+            if (oneCycle && curveLfos[i].cycleComplete())
+            {
+                curveLfos[i].silence();
+                break;
+            }
+
             using senv_t = modulation::modulators::CurveLFO::senv_t;
             auto useGate =
                 lfoEnvelopeGate(ms.triggerMode, gate, curveLfos[i].simpleEnv.stage, senv_t::s_hold);
 
             curveLfos[i].process(*lp.rateP, *lp.curve.deformP, *lp.curve.angleP, *lp.curve.delayP,
-                                 *lp.curve.attackP, *lp.curve.releaseP,
-                                 ms.curveLfoStorage.useenv || oneShot, ms.curveLfoStorage.unipolar,
-                                 useGate);
-            curveLfos[i].output *= amp;
+                                 *lp.curve.attackP, *lp.curve.releaseP, useEnv,
+                                 ms.curveLfoStorage.unipolar, useGate);
+            // Silence the block the cycle ends on rather than show the next one starting
+            if (oneCycle && curveLfos[i].cycleComplete())
+                curveLfos[i].silence();
+            else
+                curveLfos[i].output *= amp;
             break;
         }
         case ENV:

--- a/src/scxt-core/modulation/modulator_storage.h
+++ b/src/scxt-core/modulation/modulator_storage.h
@@ -187,6 +187,9 @@ struct ModulatorStorage
         SONGPOS,
         RANDOM,
         RELEASE,
+        // Runs once and then goes silent. What "once" means depends on the shape: one
+        // pass of the env, one pass of the curve's DAR or - with that off - one cycle
+        // of the curve itself, or one play through of the step sequence.
         ONESHOT
     } triggerMode{TriggerMode::KEYTRIGGER};
     DECLARE_ENUM_STRING(TriggerMode);

--- a/src/scxt-core/modulation/modulators/curvelfo.h
+++ b/src/scxt-core/modulation/modulators/curvelfo.h
@@ -113,6 +113,9 @@ struct CurveLFO : SampleRateSupport
         }
         simpleLfo.applyPhaseOffset(initPhase);
         simpleEnv.attack(delay);
+
+        cyclesElapsed = 0.0;
+        lastPhase = wrappedPhase();
     }
 
     // The rate the SimpleLFO actually runs at - temposync-snapped when synced. Shared
@@ -125,6 +128,21 @@ struct CurveLFO : SampleRateSupport
     }
 
     void silence() { output = 0.f; }
+
+    /*
+     * How far the LFO has run since attack, in cycles. The underlying phase wraps, so
+     * accumulate the per-block deltas; ONESHOT uses this to stop after exactly one pass.
+     * The noise shapes park above 1 until their first block, hence the wrap here.
+     */
+    float wrappedPhase() const
+    {
+        auto p = simpleLfo.phase;
+        return p >= 1.f ? p - 1.f : p;
+    }
+    bool cycleComplete() const { return cyclesElapsed >= 1.0; }
+
+    double cyclesElapsed{0.0};
+    float lastPhase{0.f};
 
     uint32_t smp{0};
     void process(const float rate, const float deform, const float angle, const float delay,
@@ -140,6 +158,14 @@ struct CurveLFO : SampleRateSupport
             isTemposync = true;
         }
         simpleLfo.process_block(rt, deform, curveShape, false, tsRatio, angle);
+
+        auto ph = wrappedPhase();
+        auto dp = ph - lastPhase;
+        if (dp < 0)
+            dp += 1.f;
+        cyclesElapsed += dp;
+        lastPhase = ph;
+
         auto lfov = simpleLfo.lastTarget;
         if (unipolar)
             lfov = (lfov + 1) * 0.5;

--- a/src/scxt-core/modulation/modulators/steplfo.h
+++ b/src/scxt-core/modulation/modulators/steplfo.h
@@ -95,21 +95,50 @@ struct StepLFO : MoveableOnly<StepLFO>, SampleRateSupport
         auto totalFloor = (long)std::floor(total);
         auto step = (int)(((totalFloor % repeat) + repeat) % repeat);
         underlyingLfo.setPhaseTo(step, (float)(total - totalFloor));
+
+        startStep = step;
+        stepsAdvanced = 0;
+        lastPhase = underlyingLfo.phase;
     }
 
-    void retrigger() { underlyingLfo.retrigger(); }
+    void retrigger()
+    {
+        underlyingLfo.retrigger();
+        startStep = 0;
+        stepsAdvanced = 0;
+        lastPhase = underlyingLfo.phase;
+    }
     void silence() { output = 0.f; }
+
+    /*
+     * Has the sequence played all of its steps? A one shot pins the underlying LFO at
+     * the last step rather than wrapping, so count the phase wraps instead of the steps.
+     */
+    bool sequenceComplete() const
+    {
+        if (!settings)
+            return false;
+        return startStep + stepsAdvanced >= std::max((int)settings->stepLfoStorage.repeat, 1);
+    }
+
     // void sync();
     void process(int samples)
     {
         underlyingLfo.process(*rate, settings->triggerMode, settings->temposync,
                               settings->triggerMode == ModulatorStorage::ONESHOT, samples);
         output = underlyingLfo.output;
+
+        if (underlyingLfo.phase < lastPhase)
+            stepsAdvanced++;
+        lastPhase = underlyingLfo.phase;
     }
 
     float output{0.f};
 
   private:
+    int startStep{0}, stepsAdvanced{0};
+    double lastPhase{0.0};
+
     const float *rate{nullptr};
     sst::basic_blocks::modulators::Transport *td{nullptr};
     modulation::ModulatorStorage *settings{nullptr};

--- a/src/scxt-plugin/app/edit-screen/components/LFOPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/LFOPane.cpp
@@ -1921,11 +1921,18 @@ void LfoPane::updateTriggerDependentUI()
     auto &ms = modulatorStorageData[selectedTab];
     auto oneShot = ms.triggerMode == modulation::ModulatorStorage::ONESHOT;
 
-    // The one shot *is* the sub-envelope running once, so the engine forces it either
-    // way. Arm the toggle so the UI agrees with what you hear, and lock it while armed.
-    curveLfoPane->useenvB->setEnabled(!oneShot);
-    if (oneShot && !ms.curveLfoStorage.useenv)
-        curveLfoPane->useenvA->setValueFromGUI(1);
+    // A one shot ignores the gate, so the env breaks at its sustain level rather than
+    // holding there - DAHDSR reads DAHDBR - and the curve's DAR release is really a decay
+    std::optional<std::string> breakName{}, decayName{};
+    if (oneShot)
+    {
+        breakName = "Breakpoint";
+        decayName = "Decay";
+    }
+    envLfoPane->sustainA->labelOverride = breakName;
+    envLfoPane->sustainL->setText(oneShot ? "B" : "S");
+    curveLfoPane->envA[2]->labelOverride = decayName;
+    curveLfoPane->envL[2]->setText(oneShot ? "D" : "R");
 
     envLfoPane->loopB->setEnabled(!oneShot);
     if (oneShot && ms.envLfoStorage.loop)

--- a/src/scxt-plugin/app/edit-screen/components/LFOPane.h
+++ b/src/scxt-plugin/app/edit-screen/components/LFOPane.h
@@ -91,7 +91,7 @@ struct LfoPane : sst::jucegui::components::NamedPanel, app::HasEditor
 
     void setSubPaneVisibility();
 
-    // ONESHOT owns the sub-envelope, so its toggle shows armed and greys out
+    // ONESHOT relabels the gate-dependent env stages and locks out env looping
     void updateTriggerDependentUI();
 
     void resized() override;

--- a/tests/modulator_tests.cpp
+++ b/tests/modulator_tests.cpp
@@ -280,8 +280,10 @@ TEST_CASE("lfoEnvelopeGate maps trigger mode onto the sub-envelope gate")
 namespace
 {
 constexpr double LOOP_TEST_SR = 48000.0;
+constexpr int blocksPerSecond{(int)(LOOP_TEST_SR / scxt::blockSize)};
 
-scxt::engine::Group *setupEnvLFOGroup(scxt::engine::Engine *e, bool loop)
+// A part with a single group holding a single zone, ready for LFO 0 to be set up
+scxt::engine::Group *makeLFOGroup(scxt::engine::Engine *e)
 {
     e->prepareToPlay(LOOP_TEST_SR);
 
@@ -295,6 +297,13 @@ scxt::engine::Group *setupEnvLFOGroup(scxt::engine::Engine *e, bool loop)
     z->mapping.velocityRange = {0, 127};
     z->initialize();
     g->addZone(z);
+
+    return g;
+}
+
+scxt::engine::Group *setupEnvLFOGroup(scxt::engine::Engine *e, bool loop)
+{
+    auto *g = makeLFOGroup(e);
 
     auto &ms = g->modulatorStorage[0];
     ms.modulatorShape = MS::LFO_ENV;
@@ -355,4 +364,150 @@ TEST_CASE("Group non-looping envelope LFO rises once and holds while held")
     REQUIRE(countEnvPeaks(e, g, 20000) == 1);
 
     delete e;
+}
+
+/*
+ * ONESHOT means "run once and stop", which each shape spells differently: a curve with
+ * no sub-envelope is one cycle of the waveform, a curve with one is its DAR making a
+ * single pass, and a step sequence is its steps played out. Drive real group LFOs with
+ * the gate held and check where the output actually stops.
+ */
+namespace
+{
+// Run LFO 0 with the gate held, collecting a block by block copy of its output
+std::vector<float> runLFOBlocks(scxt::engine::Engine *e, scxt::engine::Group *g, const float &out,
+                                int nBlocks)
+{
+    std::vector<float> res;
+    res.reserve(nBlocks);
+    for (int b = 0; b < nBlocks; ++b)
+    {
+        g->processLFOBlock(0, g->modulatorStorage[0], /*gate=*/true, e->transport, e->rng,
+                           g->endpoints.lfo[0]);
+        res.push_back(out);
+    }
+    return res;
+}
+
+int lastNonZeroBlock(const std::vector<float> &v)
+{
+    int res{-1};
+    for (int i = 0; i < (int)v.size(); ++i)
+        if (v[i] != 0.f)
+            res = i;
+    return res;
+}
+
+float maxAbsOver(const std::vector<float> &v, int from, int to)
+{
+    float res{0.f};
+    for (int i = from; i < std::min(to, (int)v.size()); ++i)
+        res = std::max(res, std::fabs(v[i]));
+    return res;
+}
+
+// A ramp at rate 0 is one cycle per second, and is nonzero for all of it but the midpoint
+scxt::engine::Group *setupCurveLFOGroup(scxt::engine::Engine *e, MS::TriggerMode tm, bool useEnv)
+{
+    auto *g = makeLFOGroup(e);
+
+    auto &ms = g->modulatorStorage[0];
+    ms.modulatorShape = MS::LFO_RAMP;
+    ms.triggerMode = tm;
+    ms.rate = 0.f;
+    ms.start_phase = 0.f;
+    ms.curveLfoStorage.useenv = useEnv;
+    ms.curveLfoStorage.delay = 0.f;
+    ms.curveLfoStorage.attack = 0.f;
+    ms.curveLfoStorage.release = 1.f; // the top of the env time scale, so 25s
+
+    g->warmup();
+    g->attack();
+    return g;
+}
+
+// Four alternating steps, the whole sequence in a second, no smoothing between them
+scxt::engine::Group *setupStepLFOGroup(scxt::engine::Engine *e, MS::TriggerMode tm)
+{
+    auto *g = makeLFOGroup(e);
+
+    auto &ms = g->modulatorStorage[0];
+    ms.modulatorShape = MS::STEP;
+    ms.triggerMode = tm;
+    ms.rate = 0.f;
+    ms.start_phase = 0.f;
+    ms.stepLfoStorage.repeat = 4;
+    ms.stepLfoStorage.smooth = 0.f;
+    ms.stepLfoStorage.rateIsForSingleStep = false;
+    for (int i = 0; i < 4; ++i)
+        ms.stepLfoStorage.data[i] = (i % 2 == 0) ? 1.f : -1.f;
+
+    g->warmup();
+    g->attack();
+    return g;
+}
+} // namespace
+
+TEST_CASE("ONESHOT curve LFO without an envelope runs one cycle then silence")
+{
+    auto e = std::make_unique<scxt::engine::Engine>();
+    auto *g = setupCurveLFOGroup(e.get(), MS::ONESHOT, /*useEnv=*/false);
+
+    auto out = runLFOBlocks(e.get(), g, g->curveLfos[0].output, 3 * blocksPerSecond);
+
+    // The cycle itself runs full scale...
+    REQUIRE(maxAbsOver(out, 0, blocksPerSecond - 10) > 0.9f);
+    // ...and then it stops, at the cycle boundary rather than anywhere else
+    REQUIRE(std::abs(lastNonZeroBlock(out) - blocksPerSecond) <= 2);
+}
+
+TEST_CASE("ONESHOT curve LFO with an envelope keeps cycling under its envelope")
+{
+    auto e = std::make_unique<scxt::engine::Engine>();
+    auto *g = setupCurveLFOGroup(e.get(), MS::ONESHOT, /*useEnv=*/true);
+
+    auto out = runLFOBlocks(e.get(), g, g->curveLfos[0].output, 3 * blocksPerSecond);
+
+    // The 25 second release is nowhere near done, so the LFO is still going well past
+    // the one cycle mark the envelope-free one shot stops at
+    REQUIRE(maxAbsOver(out, 2 * blocksPerSecond, 3 * blocksPerSecond) > 0.5f);
+}
+
+TEST_CASE("Non-ONESHOT curve LFO free runs past its first cycle")
+{
+    auto e = std::make_unique<scxt::engine::Engine>();
+    auto *g = setupCurveLFOGroup(e.get(), MS::KEYTRIGGER, /*useEnv=*/false);
+
+    auto out = runLFOBlocks(e.get(), g, g->curveLfos[0].output, 3 * blocksPerSecond);
+
+    REQUIRE(maxAbsOver(out, 2 * blocksPerSecond, 3 * blocksPerSecond) > 0.9f);
+}
+
+TEST_CASE("ONESHOT step LFO plays every step once then silence")
+{
+    auto e = std::make_unique<scxt::engine::Engine>();
+    auto *g = setupStepLFOGroup(e.get(), MS::ONESHOT);
+
+    auto out = runLFOBlocks(e.get(), g, g->stepLfos[0].output, 3 * blocksPerSecond);
+
+    // All four steps play, including the last one
+    auto blocksPerStep = blocksPerSecond / 4;
+    for (int s = 0; s < 4; ++s)
+    {
+        auto at = out[s * blocksPerStep + blocksPerStep / 2];
+        REQUIRE(at == Approx(s % 2 == 0 ? 1.f : -1.f));
+    }
+
+    // Then the sequence goes quiet rather than parking on the last step
+    REQUIRE(std::abs(lastNonZeroBlock(out) - blocksPerSecond) <= 2);
+}
+
+TEST_CASE("Non-ONESHOT step LFO loops the sequence")
+{
+    auto e = std::make_unique<scxt::engine::Engine>();
+    auto *g = setupStepLFOGroup(e.get(), MS::KEYTRIGGER);
+
+    auto out = runLFOBlocks(e.get(), g, g->stepLfos[0].output, 3 * blocksPerSecond);
+
+    REQUIRE(maxAbsOver(out, 2 * blocksPerSecond, 3 * blocksPerSecond) > 0.9f);
 }


### PR DESCRIPTION
A curve one shot no longer forces its sub-envelope on. With the envelope on it still makes a single DAR pass; with it off the curve now runs for exactly one cycle and then outputs silence.

A step sequence one shot goes quiet once it has played every step rather than holding its last value forever.

While one shot is selected the stages which ignore the gate are relabelled to say so: the env reads DAHDBR and the curve's DAR reads DAD, with Breakpoint and Decay tooltips to match.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>