### PR TITLE
Hold the last step when a step LFO one shot finishes

### DIFF
--- a/src/scxt-core/modulation/has_modulators.h
+++ b/src/scxt-core/modulation/has_modulators.h
@@ -294,18 +294,8 @@ template <typename T, size_t egsPerObject> struct HasModulators
         case STEP:
             if (rt)
                 stepLfos[i].retrigger();
-
-            // A one shot plays the sequence out and then goes quiet
-            if (oneShot && stepLfos[i].sequenceComplete())
-            {
-                stepLfos[i].silence();
-                break;
-            }
             stepLfos[i].process(blockSize);
-            if (oneShot && stepLfos[i].sequenceComplete())
-                stepLfos[i].silence();
-            else
-                stepLfos[i].output *= amp;
+            stepLfos[i].output *= amp;
             break;
         case CURVE:
         {

--- a/src/scxt-core/modulation/modulator_storage.h
+++ b/src/scxt-core/modulation/modulator_storage.h
@@ -187,9 +187,9 @@ struct ModulatorStorage
         SONGPOS,
         RANDOM,
         RELEASE,
-        // Runs once and then goes silent. What "once" means depends on the shape: one
-        // pass of the env, one pass of the curve's DAR or - with that off - one cycle
-        // of the curve itself, or one play through of the step sequence.
+        // Runs once rather than looping. For the env that is one pass, for the curve one
+        // pass of its DAR or - with that off - one cycle and then silence, and for the
+        // step sequence one play through which then holds on the last step.
         ONESHOT
     } triggerMode{TriggerMode::KEYTRIGGER};
     DECLARE_ENUM_STRING(TriggerMode);

--- a/src/scxt-core/modulation/modulators/steplfo.h
+++ b/src/scxt-core/modulation/modulators/steplfo.h
@@ -95,31 +95,10 @@ struct StepLFO : MoveableOnly<StepLFO>, SampleRateSupport
         auto totalFloor = (long)std::floor(total);
         auto step = (int)(((totalFloor % repeat) + repeat) % repeat);
         underlyingLfo.setPhaseTo(step, (float)(total - totalFloor));
-
-        startStep = step;
-        stepsAdvanced = 0;
-        lastPhase = underlyingLfo.phase;
     }
 
-    void retrigger()
-    {
-        underlyingLfo.retrigger();
-        startStep = 0;
-        stepsAdvanced = 0;
-        lastPhase = underlyingLfo.phase;
-    }
+    void retrigger() { underlyingLfo.retrigger(); }
     void silence() { output = 0.f; }
-
-    /*
-     * Has the sequence played all of its steps? A one shot pins the underlying LFO at
-     * the last step rather than wrapping, so count the phase wraps instead of the steps.
-     */
-    bool sequenceComplete() const
-    {
-        if (!settings)
-            return false;
-        return startStep + stepsAdvanced >= std::max((int)settings->stepLfoStorage.repeat, 1);
-    }
 
     // void sync();
     void process(int samples)
@@ -127,18 +106,11 @@ struct StepLFO : MoveableOnly<StepLFO>, SampleRateSupport
         underlyingLfo.process(*rate, settings->triggerMode, settings->temposync,
                               settings->triggerMode == ModulatorStorage::ONESHOT, samples);
         output = underlyingLfo.output;
-
-        if (underlyingLfo.phase < lastPhase)
-            stepsAdvanced++;
-        lastPhase = underlyingLfo.phase;
     }
 
     float output{0.f};
 
   private:
-    int startStep{0}, stepsAdvanced{0};
-    double lastPhase{0.0};
-
     const float *rate{nullptr};
     sst::basic_blocks::modulators::Transport *td{nullptr};
     modulation::ModulatorStorage *settings{nullptr};

--- a/tests/modulator_tests.cpp
+++ b/tests/modulator_tests.cpp
@@ -483,7 +483,7 @@ TEST_CASE("Non-ONESHOT curve LFO free runs past its first cycle")
     REQUIRE(maxAbsOver(out, 2 * blocksPerSecond, 3 * blocksPerSecond) > 0.9f);
 }
 
-TEST_CASE("ONESHOT step LFO plays every step once then silence")
+TEST_CASE("ONESHOT step LFO plays every step once then holds the last one")
 {
     auto e = std::make_unique<scxt::engine::Engine>();
     auto *g = setupStepLFOGroup(e.get(), MS::ONESHOT);
@@ -498,8 +498,9 @@ TEST_CASE("ONESHOT step LFO plays every step once then silence")
         REQUIRE(at == Approx(s % 2 == 0 ? 1.f : -1.f));
     }
 
-    // Then the sequence goes quiet rather than parking on the last step
-    REQUIRE(std::abs(lastNonZeroBlock(out) - blocksPerSecond) <= 2);
+    // Then it parks on the last step rather than looping or dropping out
+    for (int b = blocksPerSecond + 2; b < 3 * blocksPerSecond; ++b)
+        REQUIRE(out[b] == Approx(-1.f));
 }
 
 TEST_CASE("Non-ONESHOT step LFO loops the sequence")


### PR DESCRIPTION
A one shot step sequence stays on its final step once it has played through rather than dropping to silence. Curve and envelope one shots still go quiet as before.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>