### PR TITLE
Let a played-out zone in a legato group sound again

### DIFF
--- a/src/scxt-core/engine/engine.cpp
+++ b/src/scxt-core/engine/engine.cpp
@@ -275,7 +275,9 @@ voice::Voice *Engine::initiateVoice(const pathToZone_t &path)
     SCLOG_IF(voiceResponder, "Fallthrough - looking for early termination voices");
     for (const auto &[idx, v] : sst::cpputils::enumerate(voices))
     {
-        if (v && v->terminationSequence > 0)
+        // Parked voices are silent and only held in case a legato move wants them back, so
+        // under pool exhaustion they go the same way as voices already fading out.
+        if (v && (v->terminationSequence > 0 || v->isParked))
         {
             voices[idx]->cleanupVoice();
             std::unique_ptr<voice::modulation::MatrixEndpoints> mp;
@@ -437,7 +439,7 @@ bool Engine::processAudio()
         {
             auto &itm = sharedUIMemoryState.voiceDisplayItems[i];
 
-            if (v && (v->isVoiceAssigned && v->isVoicePlaying))
+            if (v && v->isVoiceAssigned && v->isSounding())
             {
                 itm.active = true;
                 itm.part = v->zonePath.part;

--- a/src/scxt-core/engine/engine_voice_responder.cpp
+++ b/src/scxt-core/engine/engine_voice_responder.cpp
@@ -141,64 +141,7 @@ int32_t Engine::VoiceManagerResponder::initializeMultipleVoices(
         {
             assert(variantIndex == -1);
             SCLOG_IF(voiceResponder, "-- Launching zone and using its RR tactic");
-            int nextAvail{0};
-            if (nbSampleLoadedInZone == 1 || z->variantData.variantPlaybackMode == Zone::UNISON)
-            {
-                z->sampleIndex = 0;
-            }
-            else if (nbSampleLoadedInZone == 2 &&
-                     z->variantData.variantPlaybackMode != Zone::TRUE_RANDOM)
-            {
-                z->sampleIndex = (z->sampleIndex + 1) % 2;
-            }
-            else
-            {
-                if (z->variantData.variantPlaybackMode == Zone::FORWARD_RR)
-                {
-                    z->sampleIndex = (z->sampleIndex + 1) % nbSampleLoadedInZone;
-                }
-                else if (z->variantData.variantPlaybackMode == Zone::TRUE_RANDOM)
-                {
-                    z->sampleIndex = engine.rng.unifInt(0, nbSampleLoadedInZone);
-                }
-                else if (z->variantData.variantPlaybackMode == Zone::RANDOM_NOREPEAT)
-                {
-                    auto previdx = z->sampleIndex;
-                    auto newidx = previdx;
-                    while (newidx == previdx)
-                        newidx = engine.rng.unifInt(0, nbSampleLoadedInZone);
-                    z->sampleIndex = newidx;
-                }
-                else if (z->variantData.variantPlaybackMode == Zone::RANDOM_CYCLE)
-                {
-                    if (z->numAvail == 0 || z->setupFor != nbSampleLoadedInZone)
-                    {
-                        for (auto i = 0; i < nbSampleLoadedInZone; ++i)
-                        {
-                            z->rrs[i] = i;
-                        }
-                        z->numAvail = nbSampleLoadedInZone;
-                        z->setupFor = nbSampleLoadedInZone;
-
-                        nextAvail = engine.rng.unifInt(0, z->numAvail);
-                        if (z->rrs[nextAvail] == z->lastPlayed)
-                        {
-                            // the -1 here makes sure we don't re-reach ourselves
-                            nextAvail = (nextAvail + (engine.rng.unifInt(0, z->numAvail - 1))) %
-                                        z->numAvail;
-                        }
-                    }
-                    else
-                    {
-                        nextAvail = z->numAvail == 1 ? 0 : (engine.rng.unifInt(0, z->numAvail));
-                    }
-                    auto voice = z->rrs[nextAvail];              // we've used it so its a gap
-                    z->rrs[nextAvail] = z->rrs[z->numAvail - 1]; // fill the gap with the end point
-                    z->numAvail--; // and move the endpoint back by one
-                    z->lastPlayed = voice;
-                    z->sampleIndex = voice;
-                }
-            }
+            z->advanceVariantIndex();
 
             if (!z->samplePointers[z->sampleIndex])
             {
@@ -408,8 +351,10 @@ void Engine::VoiceManagerResponder::moveAndRetriggerVoice(VMConfig::voice_t *v, 
     v->initiateGlide(key);
     v->key = key;
     v->originalMidiKey = key - dkey;
+    v->keyChangedInLegatoModeTrigger = 1.f;
     v->calculateVoicePitch();
     v->setIsGated(true);
+    // aeg/aegOS are eg[0]/egOS[0], so this re-attacks the amp envelope too
     for (auto &eg : v->eg)
     {
         eg.attackFrom(eg.outBlock0);
@@ -417,6 +362,24 @@ void Engine::VoiceManagerResponder::moveAndRetriggerVoice(VMConfig::voice_t *v, 
     for (auto &eg : v->egOS)
     {
         eg.attackFrom(eg.outBlock0);
+    }
+
+    if (v->isParked)
+    {
+        /*
+         * The parked voice's generators have stopped, so unlike a releasing voice it needs its
+         * samples rewound. Modulators are deliberately left running - see Voice::isParked. The
+         * generator init reads the voice pitch, so it has to follow the key update above.
+         */
+        SCLOG_IF(voiceResponder, "unparking voice " << v << " to " << (int)key);
+
+        v->isParked = false;
+        v->firstSamplePlayback = true;
+        if (v->zone->getNumSampleLoaded() > 0)
+        {
+            v->setSampleIndex(v->zone->advanceVariantIndex());
+        }
+        v->initializeGenerator();
     }
 }
 

--- a/src/scxt-core/engine/group.cpp
+++ b/src/scxt-core/engine/group.cpp
@@ -174,7 +174,8 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
         assert(z->isActive());
         gated = gated || (z->gatedVoiceCount > 0);
         fGatedCount += z->gatedVoiceCount;
-        fVoiceCount += z->activeVoices;
+        // parked voices are assigned but silent, so they don't count as sounding
+        fVoiceCount += (int)z->activeVoices - z->parkedVoiceCount;
     }
 
     fAnyGated = (fGatedCount > 0) * 1.f;
@@ -265,6 +266,28 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
                 blk::accumulate_from_to<blockSize>(z->output[0], lOut);
                 blk::accumulate_from_to<blockSize>(z->output[1], rOut);
             }
+        }
+    }
+
+    /*
+     * Legato parking: a voice which ran out of sound in a LEGATO group stays alive so a later
+     * legato move can re-attack that same voice (see Voice::isParked). Once nothing in the
+     * group is sounding there is nothing left to come back to, so let them all go - as is also
+     * true the moment the group stops being LEGATO. These counts were refreshed by the zone
+     * pass just above, so this sees the current block.
+     */
+    int parked{0}, sounding{0};
+    for (int i = 0; i < activeZones; ++i)
+    {
+        parked += activeZoneWeakRefs[i]->parkedVoiceCount;
+        sounding += activeZoneWeakRefs[i]->soundingVoiceCount;
+    }
+
+    if (parked > 0 && (sounding == 0 || outputInfo.playMode != PlayMode::LEGATO))
+    {
+        for (int i = 0; i < activeZones; ++i)
+        {
+            activeZoneWeakRefs[i]->endParkedVoices();
         }
     }
 

--- a/src/scxt-core/engine/zone.cpp
+++ b/src/scxt-core/engine/zone.cpp
@@ -71,6 +71,8 @@ template <bool OS> void Zone::processWithOS(scxt::engine::Engine &onto)
     std::array<voice::Voice *, maxVoices> toCleanUp;
     size_t cleanupIdx{0};
     gatedVoiceCount = 0;
+    soundingVoiceCount = 0;
+    parkedVoiceCount = 0;
     for (int i = 0; i < activeVoices; ++i)
     {
         auto &v = voiceWeakPointers[i];
@@ -103,6 +105,15 @@ template <bool OS> void Zone::processWithOS(scxt::engine::Engine &onto)
         {
             gatedVoiceCount++;
         }
+
+        if (v->isParked)
+        {
+            parkedVoiceCount++;
+        }
+        else if (v->isVoicePlaying)
+        {
+            soundingVoiceCount++;
+        }
     }
 
     for (int i = 0; i < cleanupIdx; ++i)
@@ -131,6 +142,20 @@ void Zone::addVoice(voice::Voice *v)
 
     assert(false);
 }
+void Zone::endParkedVoices()
+{
+    for (int i = 0; i < activeVoices; ++i)
+    {
+        auto v = voiceWeakPointers[i];
+        if (v && v->isParked)
+        {
+            SCLOG_IF(voiceLifecycle, "Ending parked voice at " << SCD((int)v->key));
+            v->isParked = false;
+            v->isVoicePlaying = false;
+        }
+    }
+}
+
 void Zone::removeVoice(voice::Voice *v)
 {
     for (auto &nv : voiceWeakPointers)
@@ -393,6 +418,74 @@ Zone::LoopDirection Zone::fromStringLoopDirection(const std::string &s)
     if (p == inverse.end())
         return FORWARD_ONLY;
     return p->second;
+}
+
+int8_t Zone::advanceVariantIndex()
+{
+    auto nbSampleLoadedInZone = getNumSampleLoaded();
+    if (nbSampleLoadedInZone == 0)
+    {
+        sampleIndex = -1;
+        return sampleIndex;
+    }
+
+    auto &rng = getEngine()->rng;
+    int nextAvail{0};
+
+    if (nbSampleLoadedInZone == 1 || variantData.variantPlaybackMode == UNISON)
+    {
+        sampleIndex = 0;
+    }
+    else if (nbSampleLoadedInZone == 2 && variantData.variantPlaybackMode != TRUE_RANDOM)
+    {
+        sampleIndex = (sampleIndex + 1) % 2;
+    }
+    else if (variantData.variantPlaybackMode == FORWARD_RR)
+    {
+        sampleIndex = (sampleIndex + 1) % nbSampleLoadedInZone;
+    }
+    else if (variantData.variantPlaybackMode == TRUE_RANDOM)
+    {
+        sampleIndex = rng.unifInt(0, nbSampleLoadedInZone);
+    }
+    else if (variantData.variantPlaybackMode == RANDOM_NOREPEAT)
+    {
+        auto previdx = sampleIndex;
+        auto newidx = previdx;
+        while (newidx == previdx)
+            newidx = rng.unifInt(0, nbSampleLoadedInZone);
+        sampleIndex = newidx;
+    }
+    else if (variantData.variantPlaybackMode == RANDOM_CYCLE)
+    {
+        if (numAvail == 0 || setupFor != nbSampleLoadedInZone)
+        {
+            for (auto i = 0; i < nbSampleLoadedInZone; ++i)
+            {
+                rrs[i] = i;
+            }
+            numAvail = nbSampleLoadedInZone;
+            setupFor = nbSampleLoadedInZone;
+
+            nextAvail = rng.unifInt(0, numAvail);
+            if (rrs[nextAvail] == lastPlayed)
+            {
+                // the -1 here makes sure we don't re-reach ourselves
+                nextAvail = (nextAvail + (rng.unifInt(0, numAvail - 1))) % numAvail;
+            }
+        }
+        else
+        {
+            nextAvail = numAvail == 1 ? 0 : (rng.unifInt(0, numAvail));
+        }
+        auto voice = rrs[nextAvail];        // we've used it so its a gap
+        rrs[nextAvail] = rrs[numAvail - 1]; // fill the gap with the end point
+        numAvail--;                         // and move the endpoint back by one
+        lastPlayed = voice;
+        sampleIndex = voice;
+    }
+
+    return sampleIndex;
 }
 
 void Zone::onSampleRateChanged() { mUILag.setRate(120, blockSize, sampleRate); }

--- a/src/scxt-core/engine/zone.h
+++ b/src/scxt-core/engine/zone.h
@@ -152,6 +152,10 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
     int lastPlayed{-1};
     std::array<int, maxVariantsPerZone> rrs{};
 
+    // Pick the variant the next voice off this zone should play, per variantPlaybackMode,
+    // and store it in sampleIndex. Advances the round-robin/random-cycle state.
+    int8_t advanceVariantIndex();
+
     auto getNumSampleLoaded() const
     {
         return std::distance(variantData.variants.begin(),
@@ -243,6 +247,9 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
     uint32_t activeVoices{0};
     std::array<voice::Voice *, maxVoices> voiceWeakPointers;
     int gatedVoiceCount{0};
+    // Recomputed every process block; see Voice::isParked
+    int soundingVoiceCount{0};
+    int parkedVoiceCount{0};
     void terminateAllVoices();
     bool terminateOnNextProcess{false};
 
@@ -250,6 +257,8 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
     // Just a weak ref - don't take ownership. engine manages lifetime
     void addVoice(voice::Voice *);
     void removeVoice(voice::Voice *);
+    // End any parked voices; they are reaped on the next process block
+    void endParkedVoices();
 
     voice::modulation::Matrix::RoutingTable routingTable;
     void onRoutingChanged();

--- a/src/scxt-core/voice/voice.cpp
+++ b/src/scxt-core/voice/voice.cpp
@@ -44,15 +44,7 @@ Voice::Voice(engine::Engine *e, engine::Zone *z)
 {
     assert(zone);
 
-    sampleIndexF = sampleIndex;
-    if (zone->getNumSampleLoaded() <= 1)
-    {
-        sampleIndexFraction = 0;
-    }
-    else
-    {
-        sampleIndexFraction = sampleIndexF / (zone->getNumSampleLoaded() - 1);
-    }
+    setSampleIndex(sampleIndex);
 
     inLoopF = 0.f;
     loopCountF = 0.f;
@@ -78,6 +70,20 @@ Voice::~Voice()
     {
         dsp::processor::unspawnProcessor(processors[i]);
         processors[i] = nullptr;
+    }
+}
+
+void Voice::setSampleIndex(int8_t idx)
+{
+    sampleIndex = idx;
+    sampleIndexF = sampleIndex;
+    if (zone->getNumSampleLoaded() <= 1)
+    {
+        sampleIndexFraction = 0;
+    }
+    else
+    {
+        sampleIndexFraction = sampleIndexF / (zone->getNumSampleLoaded() - 1);
     }
 }
 
@@ -264,6 +270,24 @@ template <bool OS> bool Voice::processWithOS()
     if (phasorsActive)
     {
         phasorEvaluator.step(engine->transport, zone->miscSourceStorage);
+    }
+
+    /*
+     * A parked voice runs its modulators and nothing else. Keeping the LFOs turning means a
+     * zone retriggered by a later legato move comes back in phase with the siblings that kept
+     * sounding, and stays locked to song position. Whether it restarts instead is decided the
+     * same way as for any other legato key change - by routing keyChangedLeg to its retrigger.
+     *
+     * Note this returns before the isVoicePlaying update at the end of the block, which would
+     * otherwise unpark the voice immediately.
+     */
+    if (isParked)
+    {
+        updateTransportPhasors();
+        modMatrix->process();
+        memset(output, 0, sizeof(output));
+        keyChangedInLegatoModeTrigger = 0;
+        return true;
     }
 
     bool envGate{isGated};
@@ -889,6 +913,19 @@ template <bool OS> bool Voice::processWithOS()
     if (isAEGRunning && (hasProcs || isAnyGeneratorRunning))
     {
         isVoicePlaying = true;
+    }
+    else if (zone->parentGroup->outputInfo.playMode == engine::Group::PlayMode::LEGATO &&
+             terminationSequence < 0)
+    {
+        /*
+         * Park rather than die, so a later legato move can re-attack this same voice. We park
+         * unconditionally - if nothing else in the group is sounding, Group::process reaps it
+         * on this very block, which costs one block of silence and saves us maintaining a
+         * sibling count that could drift.
+         */
+        SCLOG_IF(voiceLifecycle, "Voice parking for legato at " << SCD(key));
+
+        isParked = true;
     }
     else
     {

--- a/src/scxt-core/voice/voice.h
+++ b/src/scxt-core/voice/voice.h
@@ -59,6 +59,9 @@ struct alignas(16) Voice : MoveableOnly<Voice>,
     float sampleIndexF{0.f};
     float sampleIndexFraction{0};
 
+    // sampleIndex plus its two derived modulation sources
+    void setSampleIndex(int8_t idx);
+
     float inLoopF{0.f}, currentLoopPercentageF{0.f}, currentSamplePercentageF{0.f}, loopCountF{0.0};
 
     bool forceOversample{true};
@@ -297,6 +300,17 @@ struct alignas(16) Voice : MoveableOnly<Voice>,
     bool isVoicePlaying{false};
     bool isVoiceAssigned{false};
 
+    /*
+     * A voice in a LEGATO group which runs out of sound doesn't die - it parks. It stays
+     * assigned and registered with the voice manager, runs its modulators but none of its
+     * audio chain, and can be re-attacked in place by a subsequent legato move. That keeps
+     * a short zone layered under a long one retriggerable instead of gone for good.
+     *
+     * Parked voices are reaped by Group::process once nothing in the group is sounding.
+     */
+    bool isParked{false};
+    bool isSounding() const { return isVoicePlaying && !isParked; }
+
     int16_t terminationSequence{-1};
     // how many blocks is the early-terminate/steal fade
     static constexpr int blocksToTerminateAt48k{8};
@@ -327,6 +341,17 @@ struct alignas(16) Voice : MoveableOnly<Voice>,
     void release() { setIsGated(false); }
     void beginTerminationSequence()
     {
+        /*
+         * A parked voice is already silent and runs none of its audio chain, so it would never
+         * tick a termination fade down to zero. Nothing to fade - end it here instead.
+         */
+        if (isParked)
+        {
+            isParked = false;
+            isVoicePlaying = false;
+            return;
+        }
+
         // 8 block fade at 48k
         blocksToTerminate =
             (int)std::ceil(std::max(sampleRate, 44100.) * blocksToTerminateAt48k / 48000);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(scxt-test
 		mod_matrix_operations_tests.cpp
 		exclusive_group_tests.cpp
 		glide_tests.cpp
+		legato_tests.cpp
 		undo_tests.cpp
 		importer_tests.cpp
 		midi_channel_tests.cpp

--- a/tests/exclusive_group_tests.cpp
+++ b/tests/exclusive_group_tests.cpp
@@ -33,13 +33,13 @@
 #include "voice/voice.h"
 #include "json/engine_traits.h"
 
+#include "test_utils.h"
+
 /*
  * These tests drive the engine directly on the test thread (no ConsoleHarness,
  * no background audio thread) so we avoid the threading complexity of the full
  * harness while still exercising real voice-creation logic.
  */
-
-static constexpr double TEST_SAMPLE_RATE = 48000.0;
 
 /*
  * Build a minimal two-group engine in part 0:

--- a/tests/glide_tests.cpp
+++ b/tests/glide_tests.cpp
@@ -37,9 +37,7 @@
 #include "messaging/messaging.h"
 #include "voice/voice.h"
 
-#ifndef SCXT_TEST_SOURCE_DIR
-#define SCXT_TEST_SOURCE_DIR ""
-#endif
+#include "test_utils.h"
 
 /*
  * Glide (portamento) in MONO mode does not move the playing voice the way LEGATO
@@ -56,15 +54,8 @@ namespace fs = std::filesystem;
 
 namespace
 {
-constexpr double TEST_SAMPLE_RATE = 48000.0;
-
 // 0..1 on the 25-second exp scale; ~32ms, so a glide resolves in ~100 blocks.
 constexpr float SLOW_GLIDE = 0.3f;
-
-fs::path samplePath(const std::string &relative)
-{
-    return fs::path(SCXT_TEST_SOURCE_DIR) / "resources" / "test_samples" / relative;
-}
 
 /*
  * One part / one group / one zone spanning the keys we play, driven directly on the

--- a/tests/legato_tests.cpp
+++ b/tests/legato_tests.cpp
@@ -1,0 +1,330 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "catch2/catch2.hpp"
+
+#include <filesystem>
+#include <memory>
+#include <string>
+
+#include "engine/engine.h"
+#include "engine/part.h"
+#include "engine/zone.h"
+#include "messaging/messaging.h"
+#include "voice/voice.h"
+
+#ifndef SCXT_TEST_SOURCE_DIR
+#define SCXT_TEST_SOURCE_DIR ""
+#endif
+
+/*
+ * A LEGATO group layers two zones on one key. If one of them runs out of sound while the key
+ * is still down - a short one-shot under a long pad, say - it used to be gone for good: the
+ * voice terminated and unregistered, and every later legato move found only its surviving
+ * sibling and skipped creating anything.
+ *
+ * Such a voice now parks instead of ending, so the *same* voice is still there to be
+ * re-attacked in place, and the group reaps the parked voices once nothing in it is sounding.
+ *
+ * Revival is deliberately limited to the release tail - the voice manager's
+ * moveAndRetriggerVoice path, taken when no key is down. A legato move made while a key is
+ * still held goes through moveVoice, and a played-out zone stays silent through it rather than
+ * restarting its sample under the held note. These tests fence both sides of that line, and
+ * the reap. GH #1895.
+ */
+
+namespace fs = std::filesystem;
+
+namespace
+{
+constexpr double TEST_SAMPLE_RATE = 48000.0;
+
+// The sample is ~14s long. Truncating one zone's playback to a few hundred samples makes its
+// generator run out - and so its voice end - a handful of blocks into a held note.
+constexpr int64_t SHORT_ZONE_END_SAMPLE = 512;
+
+// 0..1 on the exp time scale; long enough that the release tail is still sounding a few
+// blocks after the key comes up.
+constexpr float SLOW_RELEASE = 0.5f;
+
+fs::path samplePath(const std::string &relative)
+{
+    return fs::path(SCXT_TEST_SOURCE_DIR) / "resources" / "test_samples" / relative;
+}
+
+/*
+ * One part / one group, driven directly on the test thread (no ConsoleHarness, no audio
+ * thread) exactly like glide_tests. The group is LEGATO with a long zone and - unless
+ * shortZoneOnly is set - a short one layered on the same keys.
+ */
+struct LegatoFixture
+{
+    std::unique_ptr<scxt::engine::Engine> eng;
+    scxt::engine::Group *group{nullptr};
+    scxt::engine::Zone *longZone{nullptr};
+    scxt::engine::Zone *shortZone{nullptr};
+
+    /*
+     * longRelease is on the 0..1 exp time scale. The default is instant, which keeps the "let
+     * everything fall silent" tests short; the release-tail test needs an audible tail to move
+     * into and asks for a slow one.
+     */
+    explicit LegatoFixture(bool shortZoneOnly = false, float longRelease = 0.f)
+    {
+        eng = std::make_unique<scxt::engine::Engine>();
+        eng->prepareToPlay(TEST_SAMPLE_RATE);
+        // Pin to 12-TET so an MTS-ESP master on the dev box can't retune the keys.
+        eng->midikeyRetuner.setTuningMode(scxt::tuning::MidikeyRetuner::TWELVE_TET);
+
+        auto &part = *eng->getPatch()->getPart(0);
+        part.addGroup();
+        group = part.getGroup(0).get();
+
+        if (!shortZoneOnly)
+        {
+            longZone = addZone(-1);
+            longZone->egStorage[0].r = longRelease;
+        }
+        shortZone = addZone(SHORT_ZONE_END_SAMPLE);
+
+        group->outputInfo.playMode = scxt::engine::Group::PlayMode::LEGATO;
+        group->outputInfo.notePriority = scxt::engine::Group::NotePriority::LATEST;
+        group->resetPolyAndPlaymode(*eng);
+    }
+
+    // endSample < 0 plays the whole sample
+    scxt::engine::Zone *addZone(int64_t endSample)
+    {
+        auto z = std::make_unique<scxt::engine::Zone>();
+        z->mapping.keyboardRange = {48, 84};
+        z->mapping.velocityRange = {0, 127};
+        z->mapping.rootKey = 60;
+        z->initialize();
+        group->addZone(z);
+        auto *zp = group->getZone(group->getZones().size() - 1).get();
+
+        auto p = samplePath("WavStereo48k.wav");
+        REQUIRE(fs::exists(p));
+
+        // loadSampleByPath asserts it is on the serial thread; we are the only thread.
+        auto bypass = eng->getMessageController()->threadingChecker.bypassChecksInScope();
+        auto sid = eng->getSampleManager()->loadSampleByPath(p);
+        REQUIRE(sid.has_value());
+
+        zp->variantData.variants[0].sampleID = *sid;
+        zp->variantData.variants[0].active = true;
+        // ENDPOINTS only - MAPPING would let the wav's chunks overwrite our key range.
+        REQUIRE(zp->attachToSample(*eng->getSampleManager(), 0,
+                                   scxt::engine::Zone::SampleInformationRead::ENDPOINTS));
+        REQUIRE(zp->getNumSampleLoaded() == 1);
+
+        if (endSample >= 0)
+        {
+            zp->variantData.variants[0].startSample = 0;
+            zp->variantData.variants[0].endSample = endSample;
+        }
+        return zp;
+    }
+
+    void noteOn(int key) { eng->processNoteOnEvent(0, 0, key, -1, 1.f, 0.f); }
+    void noteOff(int key) { eng->processNoteOffEvent(0, 0, key, -1, 0.f); }
+
+    void runBlocks(int n)
+    {
+        for (int i = 0; i < n; ++i)
+            eng->processAudio();
+    }
+
+    // The group is monophonic, so a zone has at most one voice on it.
+    scxt::voice::Voice *voiceIn(const scxt::engine::Zone *z) const
+    {
+        for (int i = 0; i < (int)scxt::maxVoices; ++i)
+        {
+            auto *v = z->voiceWeakPointers[i];
+            if (v && v->isVoiceAssigned)
+                return v;
+        }
+        return nullptr;
+    }
+};
+
+// Hold a note until the short zone has played itself out and parked.
+scxt::voice::Voice *holdUntilShortZoneParks(LegatoFixture &f, int key)
+{
+    f.noteOn(key);
+    f.runBlocks(80);
+
+    auto *sv = f.voiceIn(f.shortZone);
+    REQUIRE(sv != nullptr);
+    REQUIRE(sv->isParked);
+    return sv;
+}
+} // namespace
+
+TEST_CASE("Legato into a release tail revives a zone which ran out of sound", "[legato]")
+{
+    // A slow release on the long zone gives us a tail to play legato into.
+    LegatoFixture f{false, SLOW_RELEASE};
+
+    auto *shortVoice = holdUntilShortZoneParks(f, 60);
+    auto creationId = shortVoice->voiceCreationId;
+
+    // Lift the key. The long zone starts releasing, which keeps the group sounding and so
+    // keeps the parked voice around; both voices are now ungated.
+    f.noteOff(60);
+    f.runBlocks(4);
+
+    auto *longVoice = f.voiceIn(f.longZone);
+    REQUIRE(longVoice != nullptr);
+    REQUIRE(longVoice->isSounding());
+    REQUIRE_FALSE(longVoice->isGated);
+    REQUIRE(f.voiceIn(f.shortZone) == shortVoice);
+
+    f.noteOn(64);
+    f.runBlocks(1);
+
+    auto *revived = f.voiceIn(f.shortZone);
+    REQUIRE(revived != nullptr);
+
+    // The whole point: it is the *same* voice, not a replacement.
+    CHECK(revived == shortVoice);
+    CHECK(revived->voiceCreationId == creationId);
+
+    CHECK_FALSE(revived->isParked);
+    CHECK(revived->isSounding());
+    CHECK(revived->isGated);
+    CHECK((int)revived->key == 64);
+
+    // ...and its sample was rewound rather than left at the end point.
+    CHECK(revived->GD[0].samplePos < SHORT_ZONE_END_SAMPLE);
+
+    // The sibling was retriggered onto the new key rather than replaced.
+    CHECK(f.voiceIn(f.longZone) == longVoice);
+    CHECK((int)longVoice->key == 64);
+}
+
+TEST_CASE("A held-key legato move leaves a played-out zone parked", "[legato]")
+{
+    /*
+     * The other side of the line. With 60 still down the voice manager takes moveVoice, which
+     * glides without retriggering - a zone which has already played out stays silent rather
+     * than restarting its sample underneath the held note. It is still parked, though, so it
+     * is available to the release-tail path later.
+     */
+    LegatoFixture f;
+
+    auto *shortVoice = holdUntilShortZoneParks(f, 60);
+
+    f.noteOn(64);
+    f.runBlocks(1);
+
+    auto *sv = f.voiceIn(f.shortZone);
+    REQUIRE(sv == shortVoice);
+    CHECK(sv->isParked);
+    CHECK_FALSE(sv->isSounding());
+    // It still tracks the move, so a later revival lands on the right key.
+    CHECK((int)sv->key == 64);
+
+    // The sibling glided across as usual.
+    auto *longVoice = f.voiceIn(f.longZone);
+    REQUIRE(longVoice != nullptr);
+    CHECK(longVoice->isSounding());
+    CHECK((int)longVoice->key == 64);
+}
+
+TEST_CASE("Legato release back to a held key does not revive a parked zone", "[legato]")
+{
+    /*
+     * Releasing 64 while 60 is still held goes through the voice manager's doMonoRetrigger.
+     * 60 is down, so this is a moveVoice too - no revival.
+     */
+    LegatoFixture f;
+
+    holdUntilShortZoneParks(f, 60);
+
+    f.noteOn(64);
+    f.runBlocks(20);
+
+    auto *sv = f.voiceIn(f.shortZone);
+    REQUIRE(sv != nullptr);
+    REQUIRE(sv->isParked);
+
+    f.noteOff(64);
+    f.runBlocks(1);
+
+    REQUIRE(f.voiceIn(f.shortZone) == sv);
+    CHECK(sv->isParked);
+    CHECK((int)sv->key == 60);
+}
+
+TEST_CASE("A parked voice is reaped once its group falls silent", "[legato]")
+{
+    LegatoFixture f;
+
+    holdUntilShortZoneParks(f, 60);
+    REQUIRE(f.eng->activeVoices == 2);
+
+    f.noteOff(60);
+    f.runBlocks(200);
+
+    // The long zone releases, and with nothing left sounding the parked voice goes too.
+    CHECK(f.eng->activeVoices == 0);
+    CHECK(f.voiceIn(f.shortZone) == nullptr);
+    CHECK(f.voiceIn(f.longZone) == nullptr);
+    CHECK_FALSE(f.group->isActive());
+}
+
+TEST_CASE("A lone zone in a legato group does not park forever", "[legato]")
+{
+    /*
+     * With nothing else sounding there is nothing to come back to, so the park lasts a single
+     * block. This is the case that would leak a silent voice if the group reap were missing.
+     */
+    LegatoFixture f{true};
+
+    f.noteOn(60);
+    f.runBlocks(80);
+
+    CHECK(f.eng->activeVoices == 0);
+    CHECK(f.voiceIn(f.shortZone) == nullptr);
+    CHECK_FALSE(f.group->isActive());
+}
+
+TEST_CASE("Parking is legato only - a mono group still ends its voices", "[legato]")
+{
+    LegatoFixture f;
+    f.group->outputInfo.playMode = scxt::engine::Group::PlayMode::MONO;
+    f.group->resetPolyAndPlaymode(*f.eng);
+
+    f.noteOn(60);
+    f.runBlocks(80);
+
+    auto *sv = f.voiceIn(f.shortZone);
+    CHECK(sv == nullptr); // ended outright, never parked
+    CHECK(f.voiceIn(f.longZone) != nullptr);
+    CHECK(f.eng->activeVoices == 1);
+}

--- a/tests/legato_tests.cpp
+++ b/tests/legato_tests.cpp
@@ -37,9 +37,7 @@
 #include "messaging/messaging.h"
 #include "voice/voice.h"
 
-#ifndef SCXT_TEST_SOURCE_DIR
-#define SCXT_TEST_SOURCE_DIR ""
-#endif
+#include "test_utils.h"
 
 /*
  * A LEGATO group layers two zones on one key. If one of them runs out of sound while the key
@@ -61,8 +59,6 @@ namespace fs = std::filesystem;
 
 namespace
 {
-constexpr double TEST_SAMPLE_RATE = 48000.0;
-
 // The sample is ~14s long. Truncating one zone's playback to a few hundred samples makes its
 // generator run out - and so its voice end - a handful of blocks into a held note.
 constexpr int64_t SHORT_ZONE_END_SAMPLE = 512;
@@ -70,11 +66,6 @@ constexpr int64_t SHORT_ZONE_END_SAMPLE = 512;
 // 0..1 on the exp time scale; long enough that the release tail is still sounding a few
 // blocks after the key comes up.
 constexpr float SLOW_RELEASE = 0.5f;
-
-fs::path samplePath(const std::string &relative)
-{
-    return fs::path(SCXT_TEST_SOURCE_DIR) / "resources" / "test_samples" / relative;
-}
 
 /*
  * One part / one group, driven directly on the test thread (no ConsoleHarness, no audio

--- a/tests/sample_load.cpp
+++ b/tests/sample_load.cpp
@@ -33,17 +33,10 @@
 #include <cmath>
 #include <algorithm>
 
-#ifndef SCXT_TEST_SOURCE_DIR
-#define SCXT_TEST_SOURCE_DIR ""
-#endif
+#include "test_utils.h"
 
 using namespace scxt;
 namespace fs = std::filesystem;
-
-static fs::path samplePath(const std::string &relative)
-{
-    return fs::path(SCXT_TEST_SOURCE_DIR) / "resources" / "test_samples" / relative;
-}
 
 TEST_CASE("Load Opus sample", "[sample][opus]")
 {

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -1,0 +1,51 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_TESTS_TEST_UTILS_H
+#define SCXT_TESTS_TEST_UTILS_H
+
+/*
+ * Small helpers shared by more than one test file. They live in a header rather than being
+ * repeated per .cpp because a unity build folds every test into one translation unit, where
+ * duplicate definitions collide.
+ */
+
+#include <filesystem>
+#include <string>
+
+#ifndef SCXT_TEST_SOURCE_DIR
+#define SCXT_TEST_SOURCE_DIR ""
+#endif
+
+constexpr double TEST_SAMPLE_RATE = 48000.0;
+
+inline std::filesystem::path samplePath(const std::string &relative)
+{
+    return std::filesystem::path(SCXT_TEST_SOURCE_DIR) / "resources" / "test_samples" / relative;
+}
+
+#endif // SCXT_TESTS_TEST_UTILS_H


### PR DESCRIPTION
A zone which ran out of sound while a sibling in the same legato group was still playing used to terminate for good, so it stayed silent for the rest of the phrase no matter how it was played. Such a voice now parks instead: silent and running only its modulators, but still there to be re-attacked as the same voice when a legato move arrives in the release tail. A held-key legato move still glides without restarting it. The group ends its parked voices once nothing in it is sounding.

Closes #1895

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>