### PR TITLE
Let a note played the instant a legato group falls silent sound

### DIFF
--- a/src/scxt-core/engine/zone.cpp
+++ b/src/scxt-core/engine/zone.cpp
@@ -144,6 +144,14 @@ void Zone::addVoice(voice::Voice *v)
 }
 void Zone::endParkedVoices()
 {
+    /*
+     * These have to be reaped here rather than left for the next process block to notice.
+     * Until cleanupVoice runs the voice manager still holds them, and a note arriving in
+     * that gap would legato-move onto a voice which is already dead - silently, since
+     * finding one also suppresses creating a replacement.
+     */
+    std::array<voice::Voice *, maxVoices> toCleanUp;
+    size_t cleanupIdx{0};
     for (int i = 0; i < activeVoices; ++i)
     {
         auto v = voiceWeakPointers[i];
@@ -152,7 +160,13 @@ void Zone::endParkedVoices()
             SCLOG_IF(voiceLifecycle, "Ending parked voice at " << SCD((int)v->key));
             v->isParked = false;
             v->isVoicePlaying = false;
+            toCleanUp[cleanupIdx++] = v;
         }
+    }
+
+    for (size_t i = 0; i < cleanupIdx; ++i)
+    {
+        toCleanUp[i]->cleanupVoice();
     }
 }
 

--- a/tests/legato_tests.cpp
+++ b/tests/legato_tests.cpp
@@ -150,6 +150,18 @@ struct LegatoFixture
             eng->processAudio();
     }
 
+    int soundingVoices() const
+    {
+        int n{0};
+        for (const auto &z : group->getZones())
+        {
+            auto *v = voiceIn(z.get());
+            if (v && v->isSounding())
+                n++;
+        }
+        return n;
+    }
+
     // The group is monophonic, so a zone has at most one voice on it.
     scxt::voice::Voice *voiceIn(const scxt::engine::Zone *z) const
     {
@@ -318,4 +330,41 @@ TEST_CASE("Parking is legato only - a mono group still ends its voices", "[legat
     CHECK(sv == nullptr); // ended outright, never parked
     CHECK(f.voiceIn(f.longZone) != nullptr);
     CHECK(f.eng->activeVoices == 1);
+}
+
+TEST_CASE("A note landing on the reap block still sounds", "[legato]")
+{
+    /*
+     * The reap is what a parked voice dies of, and it used to only mark the voice as no longer
+     * playing, leaving the actual cleanup to the next process block. For that one block the
+     * voice manager still held a dead voice, so a note arriving right then was legato-moved
+     * onto it - and finding a voice to move is also what suppresses creating a replacement, so
+     * the note made no sound at all. Zones which run out together, which is the common case for
+     * a layered patch, all reap on the same block and take the whole note down with them.
+     */
+    auto nZones = GENERATE(1, 2, 3);
+
+    LegatoFixture f{true};
+    for (int i = 1; i < nZones; ++i)
+    {
+        // identical zones, so they all run out of sound on the same block
+        f.addZone(SHORT_ZONE_END_SAMPLE);
+    }
+
+    f.noteOn(60);
+
+    // Step to the exact block on which the group stops making sound
+    bool silent{false};
+    for (int i = 0; i < 300 && !silent; ++i)
+    {
+        f.runBlocks(1);
+        silent = f.soundingVoices() == 0;
+    }
+    REQUIRE(silent);
+    REQUIRE(f.eng->activeVoices == 0);
+
+    f.noteOn(64);
+    f.runBlocks(2);
+
+    CHECK(f.soundingVoices() == nZones);
 }


### PR DESCRIPTION
A parked voice was only marked as no longer playing when its group reaped it, leaving the cleanup to the next process block. For that one block the voice manager still held a voice which was already dead, so a note arriving right then was legato-moved onto it - and finding a voice to move is also what suppresses creating a replacement, so the note made no sound at all. Zones which run out together, which is what a layered patch does, all reap on the same block and take the whole note down.

Also picks up the voice manager fix for a legato note left gated forever when the sustain pedal is lifted onto a still held key.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>