### PR TITLE
Add program change and pitch bend group trigger conditions

### DIFF
--- a/src/scxt-core/engine/engine.cpp
+++ b/src/scxt-core/engine/engine.cpp
@@ -1689,7 +1689,24 @@ void Engine::setMacro01ValueFromPlugin(int part, int index, float value01)
 
 void Engine::processMIDI1Event(uint16_t idx, const uint8_t data[3])
 {
+    // The voice manager has no notion of program change, so peel it off here
+    if ((data[0] & 0xf0) == 0xc0)
+    {
+        processProgramChangeEvent(idx, data[0] & 0x0f, data[1] & 0x7f);
+        return;
+    }
     sst::voicemanager::applyMidi1Message(voiceManager, idx, data);
+}
+
+void Engine::processProgramChangeEvent(int16_t port, int16_t channel, int16_t program)
+{
+    for (const auto &p : getPatch()->getParts())
+    {
+        if (p->configuration.active && p->respondsToMIDIChannel(channel))
+        {
+            p->lastProgramChange = program;
+        }
+    }
 }
 
 void Engine::processNoteOnEvent(int16_t port, int16_t channel, int16_t key, int32_t note_id,

--- a/src/scxt-core/engine/engine.h
+++ b/src/scxt-core/engine/engine.h
@@ -123,6 +123,7 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
      * blockSize sample block
      */
     void processMIDI1Event(uint16_t midiPort, const uint8_t data[3]);
+    void processProgramChangeEvent(int16_t port, int16_t channel, int16_t program);
     void processNoteOnEvent(int16_t port, int16_t channel, int16_t key, int32_t note_id,
                             double velocity, float retune);
     void processNoteOffEvent(int16_t port, int16_t channel, int16_t key, int32_t note_id,

--- a/src/scxt-core/engine/engine_voice_responder.cpp
+++ b/src/scxt-core/engine/engine_voice_responder.cpp
@@ -390,6 +390,7 @@ void Engine::MonoVoiceManagerResponder::setMIDIPitchBend(int16_t channel, int16_
     {
         if (p->configuration.active && p->respondsToMIDIChannel(channel))
         {
+            p->pitchBend14Bit = pb14bit - 8192;
             p->externalSignalLag.setTarget(Part::LagIndexes::pitchBend, fv, &p->pitchBendValue);
         }
     }

--- a/src/scxt-core/engine/group_triggers.cpp
+++ b/src/scxt-core/engine/group_triggers.cpp
@@ -55,6 +55,10 @@ std::string toStringGroupTriggerID(const GroupTriggerID &p)
         return "ksL";
     case GroupTriggerID::KEYSWITCH_MOMENTARY:
         return "ksM";
+    case GroupTriggerID::PROGRAM_CHANGE:
+        return "pgm";
+    case GroupTriggerID::PITCH_BEND:
+        return "pbnd";
     case GroupTriggerID::MACRO:
     case GroupTriggerID::MIDICC:
     case GroupTriggerID::LAST_MIDICC:
@@ -158,6 +162,58 @@ struct GTMIDI1CC : GroupTrigger
     }
 };
 
+struct GTProgramChange : GroupTrigger
+{
+    int lb{0}, ub{0};
+    GTProgramChange(GroupTriggerID id, GroupTriggerInstrumentState &onState,
+                    GroupTriggerStorage &onStorage)
+        : GroupTrigger(id, onState, onStorage)
+    {
+    }
+
+    // The last program change the part saw, which is 0 until one arrives
+    bool conditionHolds(const Engine &, const Group &g, int16_t, int16_t) const override
+    {
+        assert(g.parentPart);
+        auto pc = g.parentPart->lastProgramChange;
+        return pc >= lb && pc <= ub;
+    }
+
+    void storageAdjusted() override
+    {
+        lb = (int)std::round(storage.args[0]);
+        ub = (int)std::round(storage.args[1]);
+        if (lb > ub)
+            std::swap(lb, ub);
+    }
+};
+
+struct GTPitchBend : GroupTrigger
+{
+    // Signed 14 bit, matching the part - not the -1..1 float the DSP uses
+    int lb{0}, ub{0};
+    GTPitchBend(GroupTriggerID id, GroupTriggerInstrumentState &onState,
+                GroupTriggerStorage &onStorage)
+        : GroupTrigger(id, onState, onStorage)
+    {
+    }
+
+    bool conditionHolds(const Engine &, const Group &g, int16_t, int16_t) const override
+    {
+        assert(g.parentPart);
+        auto pb = g.parentPart->pitchBend14Bit;
+        return pb >= lb && pb <= ub;
+    }
+
+    void storageAdjusted() override
+    {
+        lb = (int)std::round(storage.args[0]);
+        ub = (int)std::round(storage.args[1]);
+        if (lb > ub)
+            std::swap(lb, ub);
+    }
+};
+
 struct GTKeyswitchLatch : GroupTrigger
 {
     GTKeyswitchLatch(GroupTriggerID id, GroupTriggerInstrumentState &onState,
@@ -224,6 +280,8 @@ GroupTrigger *makeGroupTrigger(GroupTriggerID id, GroupTriggerInstrumentState &g
     {
         CS(GroupTriggerID::KEYSWITCH_LATCH, GTKeyswitchLatch);
         CS(GroupTriggerID::KEYSWITCH_MOMENTARY, GTKeyswitchMomentary);
+        CS(GroupTriggerID::PROGRAM_CHANGE, GTProgramChange);
+        CS(GroupTriggerID::PITCH_BEND, GTPitchBend);
     default:
         return nullptr;
     }
@@ -250,6 +308,10 @@ std::string getGroupTriggerDisplayName(GroupTriggerID id)
         return "KSWITCH";
     case GroupTriggerID::KEYSWITCH_MOMENTARY:
         return "KSW/MOM";
+    case GroupTriggerID::PROGRAM_CHANGE:
+        return "PROGRAM";
+    case GroupTriggerID::PITCH_BEND:
+        return "PBEND";
     default:
     {
         SCLOG_IF(groupTrigggers, "Un-named group trigger id=" << (int)id);

--- a/src/scxt-core/engine/group_triggers.h
+++ b/src/scxt-core/engine/group_triggers.h
@@ -58,6 +58,9 @@ enum struct GroupTriggerID : int32_t
     KEYSWITCH_LATCH,
     KEYSWITCH_MOMENTARY,
 
+    PROGRAM_CHANGE,
+    PITCH_BEND,
+
     // Leave these at the end please
     MACRO,
     MIDICC = MACRO + scxt::macrosPerPart,

--- a/src/scxt-core/engine/part.h
+++ b/src/scxt-core/engine/part.h
@@ -186,6 +186,17 @@ struct Part : MoveableOnly<Part>, SampleRateSupport
     float channelAT{0.f};
     float pitchBendValue{0.f}; // -1..1 so the 8192 taken out
 
+    /*
+     * The bend the MIDI stream last sent, kept in the signed 14 bit space MIDI delivers it in:
+     * -8192 .. 8191, centered at 0. pitchBendValue lags toward the float form and only advances
+     * while the part is processing, so a silent part would report a stale bend. Trigger
+     * conditions ask a question about the gesture, not the DSP, so they read this instead.
+     */
+    int16_t pitchBend14Bit{0};
+
+    // Last program change seen on a channel we respond to. Runtime state, not streamed.
+    int16_t lastProgramChange{0};
+
     struct MacroUILagHandler : sst::basic_blocks::dsp::UIComponentLagHandlerBase<MacroUILagHandler>
     {
         Part &part;

--- a/src/scxt-plugin/app/edit-screen/components/GroupTriggersCard.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/GroupTriggersCard.cpp
@@ -26,6 +26,10 @@
  */
 
 #include "GroupTriggersCard.h"
+
+#include <array>
+#include <optional>
+
 #include "sst/jucegui/components/ToggleButton.h"
 #include "sst/jucegui/components/TextPushButton.h"
 #include "sst/jucegui/components/MenuButton.h"
@@ -38,6 +42,54 @@
 namespace scxt::ui::app::edit_screen
 {
 namespace jcmp = sst::jucegui::components;
+
+/*
+ * The two args mean something different for every trigger type, so their metadata lives here
+ * rather than on the trigger (see the note in group_triggers.h). nullopt means the type doesn't
+ * use that arg. Most types read the pair as a range, so the defaults span the whole scale: a
+ * freshly picked type holds rather than silently muting the group until you widen it.
+ */
+using argMetadata_t =
+    std::array<std::optional<datamodel::pmd>, engine::GroupTriggerStorage::numArgs>;
+
+static argMetadata_t argMetadataFor(engine::GroupTriggerID id)
+{
+    auto arg = [](float lo, float hi, int decimals, float def) {
+        return datamodel::pmd()
+            .asFloat()
+            .withRange(lo, hi)
+            .withLinearScaleFormatting("")
+            .withDecimalPlaces(decimals)
+            .withDefault(def);
+    };
+    auto range = [&arg](float lo, float hi, int decimals) -> argMetadata_t {
+        return {arg(lo, hi, decimals, lo), arg(lo, hi, decimals, hi)};
+    };
+
+    if ((int)id >= (int)engine::GroupTriggerID::MACRO &&
+        (int)id < (int)engine::GroupTriggerID::MACRO + scxt::macrosPerPart)
+        return range(0, 1, 2);
+
+    if ((int)id >= (int)engine::GroupTriggerID::MIDICC &&
+        (int)id <= (int)engine::GroupTriggerID::LAST_MIDICC)
+        return range(0, 127, 0);
+
+    switch (id)
+    {
+    case engine::GroupTriggerID::PROGRAM_CHANGE:
+        return range(0, 127, 0);
+    case engine::GroupTriggerID::PITCH_BEND:
+        return range(-8192, 8191, 0); // signed 14 bit, as the part carries it
+    case engine::GroupTriggerID::KEYSWITCH_LATCH:
+    case engine::GroupTriggerID::KEYSWITCH_MOMENTARY:
+        return {arg(0, 127, 0, 60), std::nullopt}; // a key, not a range
+    case engine::GroupTriggerID::NONE:
+        return {std::nullopt, std::nullopt};
+    default:
+        SCLOG_IF(debug, "No group trigger args for type " << (int)id);
+        return {std::nullopt, std::nullopt};
+    }
+}
 
 struct GroupTriggersCard::ConditionRow : juce::Component, HasEditor
 {
@@ -97,72 +149,27 @@ struct GroupTriggersCard::ConditionRow : juce::Component, HasEditor
 
             auto onArgChanged = [this](const auto &a) { parent->pushUpdate(); };
 
-            if (sr.id == engine::GroupTriggerID::NONE)
-            {
-                a1A.reset();
-                a2A.reset();
-                a1M.reset();
-                a2M.reset();
-            }
-            else if ((int)sr.id >= (int)engine::GroupTriggerID::MACRO &&
-                     (int)sr.id < (int)engine::GroupTriggerID::MACRO + scxt::macrosPerPart)
-            {
-                auto dm = datamodel::pmd()
-                              .asFloat()
-                              .withRange(0, 1)
-                              .withLinearScaleFormatting("")
-                              .withDecimalPlaces(2)
-                              .withDefault(0.5);
-                a1A = std::make_unique<floatAttachment_t>(dm, onArgChanged, sr.args[0]);
-                a2A = std::make_unique<floatAttachment_t>(dm, onArgChanged, sr.args[1]);
+            a1A.reset();
+            a2A.reset();
+            a1M.reset();
+            a2M.reset();
 
+            auto md = argMetadataFor(sr.id);
+            if (md[0].has_value())
+            {
+                a1A = std::make_unique<floatAttachment_t>(*md[0], onArgChanged, sr.args[0]);
                 a1M = std::make_unique<jcmp::DraggableTextEditableValue>();
                 a1M->setSource(a1A.get());
                 addAndMakeVisible(*a1M);
-
+            }
+            if (md[1].has_value())
+            {
+                a2A = std::make_unique<floatAttachment_t>(*md[1], onArgChanged, sr.args[1]);
                 a2M = std::make_unique<jcmp::DraggableTextEditableValue>();
                 a2M->setSource(a2A.get());
                 addAndMakeVisible(*a2M);
             }
-            else if ((int)sr.id >= (int)engine::GroupTriggerID::MIDICC &&
-                     (int)sr.id <= (int)engine::GroupTriggerID::LAST_MIDICC)
-            {
-                auto dm = datamodel::pmd()
-                              .asFloat()
-                              .withRange(0, 127)
-                              .withLinearScaleFormatting("")
-                              .withDecimalPlaces(0)
-                              .withDefault(64);
-                a1A = std::make_unique<floatAttachment_t>(dm, onArgChanged, sr.args[0]);
-                a2A = std::make_unique<floatAttachment_t>(dm, onArgChanged, sr.args[1]);
 
-                a1M = std::make_unique<jcmp::DraggableTextEditableValue>();
-                a1M->setSource(a1A.get());
-                addAndMakeVisible(*a1M);
-
-                a2M = std::make_unique<jcmp::DraggableTextEditableValue>();
-                a2M->setSource(a2A.get());
-                addAndMakeVisible(*a2M);
-            }
-            else if (sr.id == engine::GroupTriggerID::KEYSWITCH_LATCH ||
-                     sr.id == engine::GroupTriggerID::KEYSWITCH_MOMENTARY)
-            {
-                auto dm = datamodel::pmd()
-                              .asFloat()
-                              .withRange(0, 127)
-                              .withLinearScaleFormatting("")
-                              .withDecimalPlaces(0)
-                              .withDefault(64);
-                a1A = std::make_unique<floatAttachment_t>(dm, onArgChanged, sr.args[0]);
-
-                a1M = std::make_unique<jcmp::DraggableTextEditableValue>();
-                a1M->setSource(a1A.get());
-                addAndMakeVisible(*a1M);
-            }
-            else
-            {
-                SCLOG_IF(debug, "No group trigger for type " << (int)sr.id);
-            }
             resized();
         }
 
@@ -198,7 +205,17 @@ struct GroupTriggersCard::ConditionRow : juce::Component, HasEditor
             return [w = juce::Component::SafePointer(that), v]() {
                 if (!w)
                     return;
-                w->parent->cond.storage[w->index].id = (engine::GroupTriggerID)v;
+                auto &sr = w->parent->cond.storage[w->index];
+                auto id = (engine::GroupTriggerID)v;
+                if (sr.id != id)
+                {
+                    // the args mean something else now, so a CC range left in a bend
+                    // control would be nonsense. Start the new type at its own defaults.
+                    sr.id = id;
+                    auto md = argMetadataFor(id);
+                    for (int i = 0; i < engine::GroupTriggerStorage::numArgs; ++i)
+                        sr.args[i] = md[i].has_value() ? md[i]->defaultVal : 0.f;
+                }
                 w->parent->pushUpdate();
                 w->setupValuesFromData();
             };
@@ -208,6 +225,9 @@ struct GroupTriggersCard::ConditionRow : juce::Component, HasEditor
 
         p.addItem("KeySwitch", mkv((int)engine::GroupTriggerID::KEYSWITCH_LATCH));
         p.addItem("KeySwitch (Momentary)", mkv((int)engine::GroupTriggerID::KEYSWITCH_MOMENTARY));
+
+        p.addItem("Program Change", mkv((int)engine::GroupTriggerID::PROGRAM_CHANGE));
+        p.addItem("Pitch Bend", mkv((int)engine::GroupTriggerID::PITCH_BEND));
 
         auto mcc = juce::PopupMenu();
         for (int i = 0; i < 128; ++i)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(scxt-test
 		mod_matrix_operations_tests.cpp
 		exclusive_group_tests.cpp
 		keyswitch_tests.cpp
+		group_trigger_tests.cpp
 		glide_tests.cpp
 		legato_tests.cpp
 		undo_tests.cpp

--- a/tests/group_trigger_tests.cpp
+++ b/tests/group_trigger_tests.cpp
@@ -1,0 +1,226 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "catch2/catch2.hpp"
+
+#include "engine/engine.h"
+#include "engine/group_triggers.h"
+
+#include "test_utils.h"
+
+/*
+ * Group trigger conditions which watch a continuous performance controller rather than a key:
+ * program change and pitch bend. Like the keyswitch tests these drive the engine on the test
+ * thread so real findZone logic decides who sounds.
+ */
+
+// Named, not anonymous: unity builds paste these test files into one TU, where an anonymous
+// namespace would still collide with the identically named helpers in keyswitch_tests.cpp
+namespace grouptrigger_test
+{
+
+static constexpr int PLAY_KEY{60};
+
+// One group covering 48-72 with a single range condition on it
+static scxt::engine::Part &setupOneConditionGroup(scxt::engine::Engine &eng,
+                                                  scxt::engine::GroupTriggerID id, float lo,
+                                                  float hi)
+{
+    auto &part = *eng.getPatch()->getPart(0);
+    part.addGroup();
+    addBlankZoneToGroup(part, 0, 48, 72);
+
+    auto &tc = part.getGroup(0)->triggerConditions;
+    tc.storage[0].id = id;
+    tc.storage[0].args[0] = lo;
+    tc.storage[0].args[1] = hi;
+    tc.active[0] = true;
+    tc.setupOnUnstream(part.groupTriggerInstrumentState);
+    return part;
+}
+
+static void sendProgramChange(scxt::engine::Engine &eng, int channel, int program)
+{
+    uint8_t data[3]{(uint8_t)(0xc0 | channel), (uint8_t)program, 0};
+    eng.processMIDI1Event(0, data);
+}
+
+// bend is signed 14 bit, -8192 .. 8191, centered at 0
+static void sendPitchBend(scxt::engine::Engine &eng, int channel, int bend)
+{
+    auto bv = std::clamp(bend + 8192, 0, 16383);
+    uint8_t data[3]{(uint8_t)(0xe0 | channel), (uint8_t)(bv & 0x7f), (uint8_t)((bv >> 7) & 0x7f)};
+    eng.processMIDI1Event(0, data);
+}
+
+/*
+ * Play PLAY_KEY, report how many voices it made, then let go. These tests never run audio, so
+ * the released voices of earlier presses stay assigned and ringing forever - counting only the
+ * gated ones is what keeps one press from being seen by the next.
+ */
+static int playAndCount(scxt::engine::Engine &eng, int channel = 0)
+{
+    eng.processNoteOnEvent(0, channel, PLAY_KEY, -1, 1.f, 0.f);
+
+    int n{0};
+    for (const auto &zone : eng.getPatch()->getPart(0)->getGroup(0)->getZones())
+        for (int i = 0; i < (int)scxt::maxVoices; ++i)
+        {
+            const auto *v = zone->voiceWeakPointers[i];
+            if (v && v->isVoiceAssigned && v->isGated && v->key == PLAY_KEY)
+                n++;
+        }
+
+    eng.processNoteOffEvent(0, channel, PLAY_KEY, -1, 0.f);
+    return n;
+}
+
+TEST_CASE("Program change trigger - the default program is zero", "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = setupOneConditionGroup(*eng, scxt::engine::GroupTriggerID::PROGRAM_CHANGE, 0, 0);
+
+    // No program change has ever arrived, so a group watching for program 0 sounds
+    REQUIRE(part.lastProgramChange == 0);
+    REQUIRE(playAndCount(*eng) >= 1);
+}
+
+TEST_CASE("Program change trigger - sounds only inside the range", "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    setupOneConditionGroup(*eng, scxt::engine::GroupTriggerID::PROGRAM_CHANGE, 3, 5);
+
+    // Program 0 is outside 3..5
+    REQUIRE(playAndCount(*eng) == 0);
+
+    sendProgramChange(*eng, 0, 4);
+    REQUIRE(playAndCount(*eng) >= 1);
+
+    // Both endpoints are in
+    sendProgramChange(*eng, 0, 3);
+    REQUIRE(playAndCount(*eng) >= 1);
+    sendProgramChange(*eng, 0, 5);
+    REQUIRE(playAndCount(*eng) >= 1);
+
+    sendProgramChange(*eng, 0, 6);
+    REQUIRE(playAndCount(*eng) == 0);
+}
+
+TEST_CASE("Program change trigger - bounds given backwards still describe a range",
+          "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    setupOneConditionGroup(*eng, scxt::engine::GroupTriggerID::PROGRAM_CHANGE, 5, 3);
+
+    sendProgramChange(*eng, 0, 4);
+    REQUIRE(playAndCount(*eng) >= 1);
+    sendProgramChange(*eng, 0, 7);
+    REQUIRE(playAndCount(*eng) == 0);
+}
+
+TEST_CASE("Program change trigger - a part ignores other channels", "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = setupOneConditionGroup(*eng, scxt::engine::GroupTriggerID::PROGRAM_CHANGE, 3, 5);
+    part.configuration.channel = 2;
+
+    sendProgramChange(*eng, 7, 4);
+    REQUIRE(part.lastProgramChange == 0);
+
+    sendProgramChange(*eng, 2, 4);
+    REQUIRE(part.lastProgramChange == 4);
+    REQUIRE(playAndCount(*eng, 2) >= 1);
+}
+
+TEST_CASE("Pitch bend trigger - sounds only inside the range", "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    setupOneConditionGroup(*eng, scxt::engine::GroupTriggerID::PITCH_BEND, 4000, 8191);
+
+    // Wheel centered
+    REQUIRE(playAndCount(*eng) == 0);
+
+    sendPitchBend(*eng, 0, 6000);
+    REQUIRE(playAndCount(*eng) >= 1);
+
+    // The endpoints are in, including the top of the 14 bit range
+    sendPitchBend(*eng, 0, 4000);
+    REQUIRE(playAndCount(*eng) >= 1);
+    sendPitchBend(*eng, 0, 8191);
+    REQUIRE(playAndCount(*eng) >= 1);
+
+    sendPitchBend(*eng, 0, 3999);
+    REQUIRE(playAndCount(*eng) == 0);
+
+    sendPitchBend(*eng, 0, -6000);
+    REQUIRE(playAndCount(*eng) == 0);
+}
+
+TEST_CASE("Pitch bend trigger - a negative range works", "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    setupOneConditionGroup(*eng, scxt::engine::GroupTriggerID::PITCH_BEND, -8192, -4000);
+
+    REQUIRE(playAndCount(*eng) == 0);
+    sendPitchBend(*eng, 0, -6500);
+    REQUIRE(playAndCount(*eng) >= 1);
+
+    // Wheel all the way down is -8192, not -8191
+    sendPitchBend(*eng, 0, -8192);
+    REQUIRE(eng->getPatch()->getPart(0)->pitchBend14Bit == -8192);
+    REQUIRE(playAndCount(*eng) >= 1);
+}
+
+TEST_CASE("Pitch bend trigger - reads the gesture, not the smoothed DSP value", "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = setupOneConditionGroup(*eng, scxt::engine::GroupTriggerID::PITCH_BEND, 4000, 8191);
+
+    /*
+     * A part with nothing sounding never runs its lag, so pitchBendValue is still centered here.
+     * The first note after a bend has to see the bend anyway.
+     */
+    sendPitchBend(*eng, 0, 6000);
+    REQUIRE(part.pitchBendValue == Approx(0.f).margin(1e-6));
+    REQUIRE(part.pitchBend14Bit == 6000);
+    REQUIRE(playAndCount(*eng) >= 1);
+}
+
+TEST_CASE("Group trigger ids for program change and pitch bend round trip as strings",
+          "[grouptrigger]")
+{
+    for (auto id :
+         {scxt::engine::GroupTriggerID::PROGRAM_CHANGE, scxt::engine::GroupTriggerID::PITCH_BEND})
+    {
+        auto s = scxt::engine::toStringGroupTriggerID(id);
+        REQUIRE(s != "n");
+        REQUIRE(scxt::engine::fromStringGroupTriggerID(s) == id);
+        REQUIRE(scxt::engine::getGroupTriggerDisplayName(id) != "ERROR");
+    }
+}
+
+} // namespace grouptrigger_test

--- a/tests/undo_tests.cpp
+++ b/tests/undo_tests.cpp
@@ -480,6 +480,43 @@ TEST_CASE("Group output values undo/redo", "[undo]")
     }
 }
 
+TEST_CASE("Group trigger condition type change undo/redo", "[undo]")
+{
+    using scxt::engine::GroupTriggerID;
+
+    UndoFixture f;
+    f.send(cmsg::AddBlankZone({0, 0, 48, 60, 0, 127}));
+
+    auto &group = f.engine().getPatch()->getPart(0)->getGroup(0);
+
+    scxt::engine::GroupTriggerConditions cond;
+    cond.storage[0].id = GroupTriggerID::PITCH_BEND;
+    cond.storage[0].args[0] = 3999;
+    cond.storage[0].args[1] = 8000;
+    f.send(cmsg::UpdateGroupTriggerConditions(cond));
+    REQUIRE(group->triggerConditions.storage[0].id == GroupTriggerID::PITCH_BEND);
+
+    /*
+     * Picking a new type resets the args along with it - the client sends both in one message,
+     * so one undo has to put the whole old condition back, not just the type.
+     */
+    cond.storage[0].id = GroupTriggerID::PROGRAM_CHANGE;
+    cond.storage[0].args[0] = 0;
+    cond.storage[0].args[1] = 127;
+    f.send(cmsg::UpdateGroupTriggerConditions(cond));
+    REQUIRE(group->triggerConditions.storage[0].id == GroupTriggerID::PROGRAM_CHANGE);
+    REQUIRE(group->triggerConditions.storage[0].args[1] == 127);
+
+    f.sendUndo();
+    REQUIRE(group->triggerConditions.storage[0].id == GroupTriggerID::PITCH_BEND);
+    REQUIRE(group->triggerConditions.storage[0].args[0] == 3999);
+    REQUIRE(group->triggerConditions.storage[0].args[1] == 8000);
+
+    f.sendRedo();
+    REQUIRE(group->triggerConditions.storage[0].id == GroupTriggerID::PROGRAM_CHANGE);
+    REQUIRE(group->triggerConditions.storage[0].args[1] == 127);
+}
+
 TEST_CASE("Mute solo group undo/redo", "[undo]")
 {
     UndoFixture f;


### PR DESCRIPTION
Reset trigger args to the new type's defaults when the condition type changes.

Addresses #780

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>