### PR TITLE
Add round robin group trigger conditions

### DIFF
--- a/src/scxt-core/configuration.h
+++ b/src/scxt-core/configuration.h
@@ -80,6 +80,14 @@ static constexpr uint16_t envFollowersPerGroupOrZone{2};
 
 static constexpr uint16_t triggerConditionsPerGroup{4};
 
+/*
+ * Round robin group triggers. 32 sets so a set mask is a uint32_t, and a shuffle set is capped at
+ * the same count since its "already drawn this pass" bag is one too.
+ */
+static constexpr uint16_t maxRoundRobinSets{32};
+static constexpr uint16_t maxRoundRobinGroupsPerSet{32};
+static constexpr uint16_t maxRoundRobinOrdinal{100};
+
 static constexpr uint16_t maxGeneratorsPerVoice{64};
 
 static constexpr size_t modMatrixRowsPerZone{18};

--- a/src/scxt-core/engine/engine.h
+++ b/src/scxt-core/engine/engine.h
@@ -165,6 +165,15 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
                 auto prex = part->respondsToMIDIChannelExcludingGroupMask(channel);
                 auto kt =
                     part->configuration.transpose + part->getChannelBasedTransposition(channel);
+
+                /*
+                 * Round robin is a question about a whole set of groups at once, so the part
+                 * settles which slot is live before any group's conditions get asked.
+                 */
+                part->advanceRoundRobinSets(*this, part->roundRobinSetsForNote(*this, channel, key,
+                                                                               midiKey, velocity,
+                                                                               (int16_t)kt));
+
                 for (const auto &[gidx, group] : sst::cpputils::enumerate(*part))
                 {
                     if (hasFeature::hasGroupMIDIChannel)

--- a/src/scxt-core/engine/group_triggers.cpp
+++ b/src/scxt-core/engine/group_triggers.cpp
@@ -59,6 +59,12 @@ std::string toStringGroupTriggerID(const GroupTriggerID &p)
         return "pgm";
     case GroupTriggerID::PITCH_BEND:
         return "pbnd";
+    case GroupTriggerID::ROUND_ROBIN_CYCLE:
+        return "rr";
+    case GroupTriggerID::ROUND_ROBIN_RANDOM:
+        return "rrR";
+    case GroupTriggerID::ROUND_ROBIN_SHUFFLE:
+        return "rrS";
     case GroupTriggerID::MACRO:
     case GroupTriggerID::MIDICC:
     case GroupTriggerID::LAST_MIDICC:
@@ -258,6 +264,39 @@ struct GTKeyswitchMomentary : GroupTrigger
     void storageAdjusted() override {}
 };
 
+/*
+ * The round robin trigger does no work at all. Which slot of a set is live is a question about all
+ * of the set's groups at once, so the part answers it once per note in advanceRoundRobinSets and
+ * this just reads the answer - which keeps it const, branch free and allocation free.
+ *
+ * All three kinds share a class; the kind only picks which space of sets to look in and which
+ * field of the answer to read.
+ */
+struct GTRoundRobin : GroupTrigger
+{
+    int kind{0}, set{0}, ordinal{1};
+    bool isCycle{true};
+    GTRoundRobin(GroupTriggerID id, GroupTriggerInstrumentState &onState,
+                 GroupTriggerStorage &onStorage)
+        : GroupTrigger(id, onState, onStorage)
+    {
+    }
+
+    bool conditionHolds(const Engine &, const Group &g, int16_t, int16_t) const override
+    {
+        const auto &st = state.roundRobin[kind][set];
+        return isCycle ? (st.ordinal == ordinal) : (st.winner == g.id);
+    }
+
+    void storageAdjusted() override
+    {
+        kind = std::max(roundRobinKindIndex(id), 0);
+        isCycle = (id == GroupTriggerID::ROUND_ROBIN_CYCLE);
+        set = std::clamp((int)std::round(storage.args[0]), 0, (int)maxRoundRobinSets - 1);
+        ordinal = std::clamp((int)std::round(storage.args[1]), 1, (int)maxRoundRobinOrdinal);
+    }
+};
+
 GroupTrigger *makeGroupTrigger(GroupTriggerID id, GroupTriggerInstrumentState &gis,
                                GroupTriggerStorage &st, GroupTriggerBuffer &bf)
 {
@@ -282,6 +321,9 @@ GroupTrigger *makeGroupTrigger(GroupTriggerID id, GroupTriggerInstrumentState &g
         CS(GroupTriggerID::KEYSWITCH_MOMENTARY, GTKeyswitchMomentary);
         CS(GroupTriggerID::PROGRAM_CHANGE, GTProgramChange);
         CS(GroupTriggerID::PITCH_BEND, GTPitchBend);
+        CS(GroupTriggerID::ROUND_ROBIN_CYCLE, GTRoundRobin);
+        CS(GroupTriggerID::ROUND_ROBIN_RANDOM, GTRoundRobin);
+        CS(GroupTriggerID::ROUND_ROBIN_SHUFFLE, GTRoundRobin);
     default:
         return nullptr;
     }
@@ -312,6 +354,12 @@ std::string getGroupTriggerDisplayName(GroupTriggerID id)
         return "PROGRAM";
     case GroupTriggerID::PITCH_BEND:
         return "PBEND";
+    case GroupTriggerID::ROUND_ROBIN_CYCLE:
+        return "RR/CYC";
+    case GroupTriggerID::ROUND_ROBIN_RANDOM:
+        return "RR/RND";
+    case GroupTriggerID::ROUND_ROBIN_SHUFFLE:
+        return "RR/SHF";
     default:
     {
         SCLOG_IF(groupTrigggers, "Un-named group trigger id=" << (int)id);
@@ -325,6 +373,9 @@ void GroupTriggerConditions::setupOnUnstream(GroupTriggerInstrumentState &gis)
 {
     bool allNone{true};
     containsKeySwitchLatch = false;
+    roundRobinKind = GroupTriggerID::NONE;
+    roundRobinSet = 0;
+    roundRobinOrdinal = 1;
     for (int i = 0; i < triggerConditionsPerGroup; ++i)
     {
         auto &s = storage[i];
@@ -340,6 +391,16 @@ void GroupTriggerConditions::setupOnUnstream(GroupTriggerInstrumentState &gis)
             if (s.id == GroupTriggerID::KEYSWITCH_LATCH)
                 containsKeySwitchLatch = true;
 
+            // First active round robin row wins; a group in two cycles at once means nothing
+            if (active[i] && isRoundRobinTriggerID(s.id) && !inRoundRobin())
+            {
+                roundRobinKind = s.id;
+                roundRobinSet =
+                    (int16_t)std::clamp((int)std::round(s.args[0]), 0, (int)maxRoundRobinSets - 1);
+                roundRobinOrdinal =
+                    (int16_t)std::clamp((int)std::round(s.args[1]), 1, (int)maxRoundRobinOrdinal);
+            }
+
             if (!conditions[i] || conditions[i]->getID() != s.id)
             {
                 conditions[i] = makeGroupTrigger(s.id, gis, s, conditionBuffers[i]);
@@ -352,8 +413,8 @@ void GroupTriggerConditions::setupOnUnstream(GroupTriggerInstrumentState &gis)
     alwaysReturnsTrue = allNone;
 }
 
-bool GroupTriggerConditions::groupShouldPlay(const Engine &e, const Group &g, int16_t channel,
-                                             int16_t midiKey) const
+bool GroupTriggerConditions::evaluate(const Engine &e, const Group &g, int16_t channel,
+                                      int16_t midiKey, bool skipRoundRobin) const
 {
     if (alwaysReturnsTrue)
         return true;
@@ -363,9 +424,26 @@ bool GroupTriggerConditions::groupShouldPlay(const Engine &e, const Group &g, in
     {
         // FIXME - conjunctions
         if (active[i] && conditions[i])
+        {
+            if (skipRoundRobin && isRoundRobinTriggerID(conditions[i]->getID()))
+                continue;
             v = v & conditions[i]->groupShouldPlay(e, g, channel, midiKey);
+        }
     }
     return v;
+}
+
+bool GroupTriggerConditions::groupShouldPlay(const Engine &e, const Group &g, int16_t channel,
+                                             int16_t midiKey) const
+{
+    return evaluate(e, g, channel, midiKey, false);
+}
+
+bool GroupTriggerConditions::groupShouldPlayIgnoringRoundRobin(const Engine &e, const Group &g,
+                                                               int16_t channel,
+                                                               int16_t midiKey) const
+{
+    return evaluate(e, g, channel, midiKey, true);
 }
 
 bool GroupTriggerConditions::isKeySwitchKey(int16_t midiKey) const
@@ -376,6 +454,20 @@ bool GroupTriggerConditions::isKeySwitchKey(int16_t midiKey) const
         if (active[i] &&
             (s.id == GroupTriggerID::KEYSWITCH_LATCH ||
              s.id == GroupTriggerID::KEYSWITCH_MOMENTARY) &&
+            (int)std::round(s.args[0]) == midiKey)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool GroupTriggerConditions::isKeySwitchLatchKey(int16_t midiKey) const
+{
+    for (int i = 0; i < triggerConditionsPerGroup; ++i)
+    {
+        const auto &s = storage[i];
+        if (active[i] && s.id == GroupTriggerID::KEYSWITCH_LATCH &&
             (int)std::round(s.args[0]) == midiKey)
         {
             return true;

--- a/src/scxt-core/engine/group_triggers.h
+++ b/src/scxt-core/engine/group_triggers.h
@@ -44,13 +44,6 @@ struct Engine;
 struct Part;
 struct Group;
 
-/**
- * Maintain the state of keys ccs etc... for a particular instrument
- */
-struct GroupTriggerInstrumentState
-{
-};
-
 enum struct GroupTriggerID : int32_t
 {
     NONE,
@@ -61,14 +54,73 @@ enum struct GroupTriggerID : int32_t
     PROGRAM_CHANGE,
     PITCH_BEND,
 
+    ROUND_ROBIN_CYCLE,
+    ROUND_ROBIN_RANDOM,
+    ROUND_ROBIN_SHUFFLE,
+
     // Leave these at the end please
     MACRO,
     MIDICC = MACRO + scxt::macrosPerPart,
     LAST_MIDICC = MIDICC + 128 // Leave this at the end please
 };
 
+inline bool isRoundRobinTriggerID(GroupTriggerID id)
+{
+    return id == GroupTriggerID::ROUND_ROBIN_CYCLE || id == GroupTriggerID::ROUND_ROBIN_RANDOM ||
+           id == GroupTriggerID::ROUND_ROBIN_SHUFFLE;
+}
+
+/*
+ * Each kind gets its own space of sets - cycle 1 (RR1), random 1 (RN1) and shuffle 1 (SH1) are
+ * three unrelated round robins, not one set three groups disagree about. -1 for anything else.
+ */
+static constexpr int numRoundRobinKinds{3};
+inline int roundRobinKindIndex(GroupTriggerID id)
+{
+    switch (id)
+    {
+    case GroupTriggerID::ROUND_ROBIN_CYCLE:
+        return 0;
+    case GroupTriggerID::ROUND_ROBIN_RANDOM:
+        return 1;
+    case GroupTriggerID::ROUND_ROBIN_SHUFFLE:
+        return 2;
+    default:
+        return -1;
+    }
+}
+
+// Which sets a note lands in: one bit per set, one mask per kind
+using roundRobinMask_t = std::array<uint32_t, numRoundRobinKinds>;
+
 std::string toStringGroupTriggerID(const GroupTriggerID &p);
 GroupTriggerID fromStringGroupTriggerID(const std::string &p);
+
+/**
+ * Maintain the state of keys ccs etc... for a particular instrument
+ */
+struct GroupTriggerInstrumentState
+{
+    /*
+     * Where each round robin set has got to, indexed [kind][set]. Runtime state, deliberately not
+     * streamed - which press of the cycle a performance happens to be on is not part of the
+     * instrument.
+     */
+    struct RoundRobinSetState
+    {
+        int32_t ordinal{0}; // CYCLE: the live ordinal. Ordinals start at 1, so 0 is "not yet"
+        GroupID winner{};   // RANDOM / SHUFFLE: who won this note. The default id is -1, nobody
+        uint32_t drawn{0};  // SHUFFLE: which member slots this pass has already used
+    };
+    std::array<std::array<RoundRobinSetState, scxt::maxRoundRobinSets>, numRoundRobinKinds>
+        roundRobin{};
+
+    void resetRoundRobin()
+    {
+        for (auto &k : roundRobin)
+            k.fill(RoundRobinSetState());
+    }
+};
 
 /*
  * How a client should draw a key: not a switch at all, a switch that isn't the selected
@@ -156,6 +208,16 @@ struct GroupTriggerConditions
     bool alwaysReturnsTrue{true};
     bool containsKeySwitchLatch{false};
 
+    /*
+     * The round robin row, cached from storage. A group belongs to at most one set - the UI stops
+     * you adding a second and this keeps the first - since being in two cycles at once is
+     * meaningless. NONE means this group is in no round robin at all.
+     */
+    GroupTriggerID roundRobinKind{GroupTriggerID::NONE};
+    int16_t roundRobinSet{0};
+    int16_t roundRobinOrdinal{1};
+    bool inRoundRobin() const { return roundRobinKind != GroupTriggerID::NONE; }
+
     enum struct Conjunction : int32_t
     {
         AND,
@@ -179,13 +241,25 @@ struct GroupTriggerConditions
     bool keySwitchLatchHolds(const Engine &, const Group &, int16_t channel, int16_t midiKey) const;
 
     /*
+     * Everything except the round robin. The round robin has to know whether a note would have
+     * played this group before it decides whether to spend a slot on it, and that question has to
+     * be answered before the round robin itself is evaluated.
+     */
+    bool groupShouldPlayIgnoringRoundRobin(const Engine &, const Group &, int16_t channel,
+                                           int16_t midiKey) const;
+
+    /*
      * Storage-only queries. The client keeps a copy of this struct whose conditions are never
      * built, so anything the UI asks has to be answerable from storage and active alone.
      */
     bool isKeySwitchKey(int16_t midiKey) const;
+    bool isKeySwitchLatchKey(int16_t midiKey) const;
     int16_t firstKeySwitchLatchKey() const; // -1 if this group has no latch
 
   protected:
+    bool evaluate(const Engine &, const Group &, int16_t channel, int16_t midiKey,
+                  bool skipRoundRobin) const;
+
     std::array<GroupTriggerBuffer, scxt::triggerConditionsPerGroup> conditionBuffers;
     std::array<GroupTrigger *, scxt::triggerConditionsPerGroup> conditions{};
 };

--- a/src/scxt-core/engine/part.cpp
+++ b/src/scxt-core/engine/part.cpp
@@ -26,6 +26,8 @@
  */
 
 #include <ranges>
+#include <bit>
+#include <limits>
 #include "part.h"
 #include "bus.h"
 #include "patch.h"
@@ -324,6 +326,7 @@ void Part::setupOnUnstream(Engine &e)
     }
     rebuildGroupChannelMask();
     guaranteeKeyswitchLatchCoherence(e);
+    groupTriggerInstrumentState.resetRoundRobin();
 }
 
 void Part::guaranteeKeyswitchLatchCoherence(Engine &e)
@@ -364,6 +367,173 @@ void Part::guaranteeKeyswitchLatchCoherence(Engine &e)
         g->mutedByLatch = (k >= 0 && k != selectedKey);
         SCLOG_IF(groupTrigggers, "Coherence " << g->id.to_string() << SCD(k) << SCD(selectedKey)
                                               << SCD(g->mutedByLatch));
+    }
+}
+
+roundRobinMask_t Part::roundRobinSetsForNote(const Engine &e, int16_t channel, int16_t key,
+                                             int16_t midiKey, int16_t velocity,
+                                             int16_t keyTranspose)
+{
+    roundRobinMask_t res{};
+    auto prex = respondsToMIDIChannelExcludingGroupMask(channel);
+    bool any{false};
+
+    for (const auto &g : groups)
+    {
+        const auto &tc = g->triggerConditions;
+        if (!tc.inRoundRobin())
+            continue;
+
+        auto kind = roundRobinKindIndex(tc.roundRobinKind);
+        auto bit = 1u << tc.roundRobinSet;
+        if (res[kind] & bit) // a note landing in two groups of a set still only spends one slot
+            continue;
+
+        if (g->mutedByLatch)
+            continue;
+
+        if (hasFeature::hasGroupMIDIChannel)
+        {
+            if (!g->respondsToChannelOrUsesPartChannel(channel, prex))
+                continue;
+        }
+
+        // A note the keyswitch has already ruled out shouldn't burn a slot on its way past
+        if (!tc.groupShouldPlayIgnoringRoundRobin(e, *g, channel, midiKey))
+            continue;
+
+        for (const auto &z : *g)
+        {
+            if (z->mapping.keyboardRange.includes(key + keyTranspose) &&
+                z->mapping.velocityRange.includes(velocity))
+            {
+                res[kind] |= bit;
+                any = true;
+                break;
+            }
+        }
+    }
+
+    if (!any)
+        return {};
+
+    /*
+     * A keyswitch latch press is consumed by the switch and sounds nothing, so it must not
+     * advance anything. Only worth the scan once we know a round robin is actually in play.
+     */
+    for (const auto &g : groups)
+    {
+        if (g->triggerConditions.isKeySwitchLatchKey(midiKey))
+            return {};
+    }
+
+    return res;
+}
+
+void Part::advanceRoundRobinSets(Engine &e, const roundRobinMask_t &setMask)
+{
+    for (int k = 0; k < numRoundRobinKinds; ++k)
+    {
+        for (int s = 0; s < maxRoundRobinSets; ++s)
+        {
+            if (!(setMask[k] & (1u << s)))
+                continue;
+
+            // Members of one set always agree on the kind, since the kind is half of the set's name
+            auto isMember = [k, s](const auto &g) {
+                const auto &tc = g->triggerConditions;
+                return tc.inRoundRobin() && tc.roundRobinSet == s &&
+                       roundRobinKindIndex(tc.roundRobinKind) == k;
+            };
+
+            int memberCount{0};
+            for (const auto &g : groups)
+                memberCount += isMember(g) ? 1 : 0;
+            if (memberCount == 0)
+                continue;
+
+            auto &st = groupTriggerInstrumentState.roundRobin[k][s];
+
+            if (k == roundRobinKindIndex(GroupTriggerID::ROUND_ROBIN_CYCLE))
+            {
+                /*
+                 * The sequence is the ordinals actually in use, ascending - an unassigned number
+                 * is not a silent step. So: the smallest ordinal above the live one, or the
+                 * smallest of all when there is none. Groups sharing an ordinal share a step, and
+                 * an ordinal that just got edited away hands the next press to the one above it.
+                 */
+                constexpr auto none{std::numeric_limits<int32_t>::max()};
+                int32_t lowest{none}, next{none};
+                for (const auto &g : groups)
+                {
+                    if (!isMember(g))
+                        continue;
+                    auto o = (int32_t)g->triggerConditions.roundRobinOrdinal;
+                    lowest = std::min(lowest, o);
+                    if (o > st.ordinal)
+                        next = std::min(next, o);
+                }
+                st.ordinal = (next == none ? lowest : next);
+            }
+            else
+            {
+                // RANDOM and SHUFFLE pick one member group; slots are member index in group order
+                int slot{0};
+                if (k == roundRobinKindIndex(GroupTriggerID::ROUND_ROBIN_SHUFFLE))
+                {
+                    if (memberCount > maxRoundRobinGroupsPerSet)
+                    {
+                        SCLOG_IF(warnings, "Round robin shuffle set "
+                                               << s << " has more than "
+                                               << maxRoundRobinGroupsPerSet
+                                               << " groups; shuffling the first ones only");
+                    }
+                    auto bagCount = std::min(memberCount, (int)maxRoundRobinGroupsPerSet);
+                    uint32_t all = (bagCount >= 32 ? ~0u : ((1u << bagCount) - 1));
+                    auto avail = all & ~st.drawn;
+                    if (!avail)
+                    {
+                        // Every member has had its turn, so start a fresh pass
+                        st.drawn = 0;
+                        avail = all;
+                    }
+                    auto nth = (int)(e.rng.unifU32() % (uint32_t)std::popcount(avail));
+                    for (int i = 0; i < bagCount; ++i)
+                    {
+                        if (!(avail & (1u << i)))
+                            continue;
+                        if (nth == 0)
+                        {
+                            slot = i;
+                            break;
+                        }
+                        nth--;
+                    }
+                    st.drawn |= (1u << slot);
+                }
+                else
+                {
+                    slot = (int)(e.rng.unifU32() % (uint32_t)memberCount);
+                }
+
+                int i{0};
+                for (const auto &g : groups)
+                {
+                    if (!isMember(g))
+                        continue;
+                    if (i == slot)
+                    {
+                        st.winner = g->id;
+                        break;
+                    }
+                    i++;
+                }
+            }
+
+            SCLOG_IF(groupTrigggers, "Round robin kind " << k << " set " << s
+                                                         << " advanced to ordinal " << st.ordinal
+                                                         << " winner " << st.winner.to_string());
+        }
     }
 }
 

--- a/src/scxt-core/engine/part.h
+++ b/src/scxt-core/engine/part.h
@@ -286,6 +286,18 @@ struct Part : MoveableOnly<Part>, SampleRateSupport
     void setupOnUnstream(Engine &e);
     void guaranteeKeyswitchLatchCoherence(Engine &e);
 
+    /*
+     * Round robin. Which slot of a set is live is a question about every group in the set at once,
+     * and a group's conditions can only see themselves, so findZone asks the part first: which
+     * sets does this note land in (a bitmask over set index), then advance exactly those once.
+     * Only then do the group conditions get evaluated, against the position just chosen.
+     *
+     * key is post-retune as findZone uses it for zone matching; midiKey is what MIDI sent.
+     */
+    roundRobinMask_t roundRobinSetsForNote(const Engine &e, int16_t channel, int16_t key,
+                                           int16_t midiKey, int16_t velocity, int16_t keyTranspose);
+    void advanceRoundRobinSets(Engine &e, const roundRobinMask_t &setMask);
+
     // Every keyswitch key across this part's groups, for clients that draw a keyboard
     partKeySwitchDisplay_t keySwitchDisplay() const;
     void sendAllBusEffectInfoToClient(const Engine &e)

--- a/src/scxt-plugin/app/edit-screen/components/GroupTriggersCard.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/GroupTriggersCard.cpp
@@ -34,6 +34,7 @@
 #include "sst/jucegui/components/TextPushButton.h"
 #include "sst/jucegui/components/MenuButton.h"
 #include "sst/jucegui/components/DraggableTextEditableValue.h"
+#include "sst/jucegui/components/DraggableTextEditableDiscreteValue.h"
 
 #include "app/SCXTEditor.h"
 #include "messaging/client/client_messages.h"
@@ -83,6 +84,45 @@ static argMetadata_t argMetadataFor(engine::GroupTriggerID id)
     case engine::GroupTriggerID::KEYSWITCH_LATCH:
     case engine::GroupTriggerID::KEYSWITCH_MOMENTARY:
         return {arg(0, 127, 0, 60), std::nullopt}; // a key, not a range
+    case engine::GroupTriggerID::ROUND_ROBIN_CYCLE:
+    case engine::GroupTriggerID::ROUND_ROBIN_RANDOM:
+    case engine::GroupTriggerID::ROUND_ROBIN_SHUFFLE:
+    {
+        /*
+         * Which set this group belongs to. Each kind has its own space of sets - RR1, RN1 and SH1
+         * are three unrelated round robins - so the prefix names the kind as well as the number.
+         * There is no prefixed-integer display scale, but at this size a map is fine, and it makes
+         * the pmd an INT, which is what picks the discrete widget below.
+         */
+        auto namesFor = [](const char *prefix) {
+            std::unordered_map<int, std::string> res;
+            for (int i = 0; i < scxt::maxRoundRobinSets; ++i)
+                res[i] = fmt::format("{}{}", prefix, i + 1);
+            return res;
+        };
+        static const auto cycleNames = namesFor("RR");
+        static const auto randomNames = namesFor("RN");
+        static const auto shuffleNames = namesFor("SH");
+
+        const auto &names = (id == engine::GroupTriggerID::ROUND_ROBIN_CYCLE    ? cycleNames
+                             : id == engine::GroupTriggerID::ROUND_ROBIN_RANDOM ? randomNames
+                                                                                : shuffleNames);
+        auto set = datamodel::pmd()
+                       .asInt()
+                       .withRange(0, scxt::maxRoundRobinSets - 1)
+                       .withDefault(0)
+                       .withUnorderedMapFormatting(names);
+
+        // Random and shuffle take their order from the set, so they show no second arg at all
+        if (id != engine::GroupTriggerID::ROUND_ROBIN_CYCLE)
+            return {set, std::nullopt};
+
+        return {set, datamodel::pmd()
+                         .asInt()
+                         .withRange(1, scxt::maxRoundRobinOrdinal)
+                         .withDefault(1)
+                         .withLinearScaleFormatting("")};
+    }
     case engine::GroupTriggerID::NONE:
         return {std::nullopt, std::nullopt};
     default:
@@ -98,6 +138,13 @@ struct GroupTriggersCard::ConditionRow : juce::Component, HasEditor
 
     using floatAttachment_t =
         connectors::PayloadDataAttachment<scxt::engine::GroupTriggerConditions>;
+
+    /*
+     * The args are floats in storage whatever they mean, so an arg whose metadata is an INT binds
+     * a discrete attachment over that same float rather than dragging in fractions of a set.
+     */
+    using discreteAttachment_t =
+        connectors::DiscretePayloadDataAttachment<scxt::engine::GroupTriggerConditions, float>;
 
     GroupTriggersCard *parent{nullptr};
     engine::GroupTriggerID lastID{engine::GroupTriggerID::NONE};
@@ -149,25 +196,35 @@ struct GroupTriggersCard::ConditionRow : juce::Component, HasEditor
 
             auto onArgChanged = [this](const auto &a) { parent->pushUpdate(); };
 
-            a1A.reset();
-            a2A.reset();
-            a1M.reset();
-            a2M.reset();
-
             auto md = argMetadataFor(sr.id);
-            if (md[0].has_value())
+            for (int i = 0; i < engine::GroupTriggerStorage::numArgs; ++i)
             {
-                a1A = std::make_unique<floatAttachment_t>(*md[0], onArgChanged, sr.args[0]);
-                a1M = std::make_unique<jcmp::DraggableTextEditableValue>();
-                a1M->setSource(a1A.get());
-                addAndMakeVisible(*a1M);
-            }
-            if (md[1].has_value())
-            {
-                a2A = std::make_unique<floatAttachment_t>(*md[1], onArgChanged, sr.args[1]);
-                a2M = std::make_unique<jcmp::DraggableTextEditableValue>();
-                a2M->setSource(a2A.get());
-                addAndMakeVisible(*a2M);
+                argFA[i].reset();
+                argDA[i].reset();
+                argFM[i].reset();
+                argDM[i].reset();
+                argM[i] = nullptr;
+
+                if (!md[i].has_value())
+                    continue;
+
+                if (md[i]->type == datamodel::pmd::INT)
+                {
+                    argDA[i] =
+                        std::make_unique<discreteAttachment_t>(*md[i], onArgChanged, sr.args[i]);
+                    argDM[i] = std::make_unique<jcmp::DraggableTextEditableDiscreteValue>();
+                    argDM[i]->setSource(argDA[i].get());
+                    argM[i] = argDM[i].get();
+                }
+                else
+                {
+                    argFA[i] =
+                        std::make_unique<floatAttachment_t>(*md[i], onArgChanged, sr.args[i]);
+                    argFM[i] = std::make_unique<jcmp::DraggableTextEditableValue>();
+                    argFM[i]->setSource(argFA[i].get());
+                    argM[i] = argFM[i].get();
+                }
+                addAndMakeVisible(*argM[i]);
             }
 
             resized();
@@ -175,21 +232,21 @@ struct GroupTriggersCard::ConditionRow : juce::Component, HasEditor
 
         typeM->setLabel(engine::getGroupTriggerDisplayName(sr.id));
         auto showRest = (sr.id != engine::GroupTriggerID::NONE);
-        if (a1M)
-            a1M->setVisible(showRest);
-        if (a2M)
-            a2M->setVisible(showRest);
-        if (cM)
-            cM->setVisible(showRest);
-
         auto ac = parent->cond.active[index];
-        typeM->setEnabled(ac);
-        if (a1M)
-            a1M->setEnabled(ac);
-        if (a2M)
-            a2M->setEnabled(ac);
+        for (auto *m : argM)
+        {
+            if (m)
+            {
+                m->setVisible(showRest);
+                m->setEnabled(ac);
+            }
+        }
         if (cM)
+        {
+            cM->setVisible(showRest);
             cM->setEnabled(ac);
+        }
+        typeM->setEnabled(ac);
 
         repaint();
     }
@@ -210,11 +267,20 @@ struct GroupTriggersCard::ConditionRow : juce::Component, HasEditor
                 if (sr.id != id)
                 {
                     // the args mean something else now, so a CC range left in a bend
-                    // control would be nonsense. Start the new type at its own defaults.
+                    // control would be nonsense. Start the new type at its own defaults -
+                    // except that arg 1 still means "which set" across the round robin
+                    // kinds, so switching cycle to shuffle shouldn't move the group to S1.
+                    auto keepSet =
+                        engine::isRoundRobinTriggerID(id) && engine::isRoundRobinTriggerID(sr.id);
+                    auto set = sr.args[0];
+
                     sr.id = id;
                     auto md = argMetadataFor(id);
                     for (int i = 0; i < engine::GroupTriggerStorage::numArgs; ++i)
                         sr.args[i] = md[i].has_value() ? md[i]->defaultVal : 0.f;
+
+                    if (keepSet)
+                        sr.args[0] = set;
                 }
                 w->parent->pushUpdate();
                 w->setupValuesFromData();
@@ -228,6 +294,27 @@ struct GroupTriggersCard::ConditionRow : juce::Component, HasEditor
 
         p.addItem("Program Change", mkv((int)engine::GroupTriggerID::PROGRAM_CHANGE));
         p.addItem("Pitch Bend", mkv((int)engine::GroupTriggerID::PITCH_BEND));
+
+        /*
+         * A group can only be in one round robin - being in two cycles at once means nothing -
+         * so if another row here already holds one, offer the choices greyed rather than
+         * silently letting the engine pick a winner.
+         */
+        auto rrElsewhere{false};
+        for (int i = 0; i < scxt::triggerConditionsPerGroup; ++i)
+        {
+            if (i != index && parent->cond.active[i] &&
+                engine::isRoundRobinTriggerID(parent->cond.storage[i].id))
+                rrElsewhere = true;
+        }
+        auto mrr = juce::PopupMenu();
+        mrr.addItem("Cycle", !rrElsewhere, false,
+                    mkv((int)engine::GroupTriggerID::ROUND_ROBIN_CYCLE));
+        mrr.addItem("Random", !rrElsewhere, false,
+                    mkv((int)engine::GroupTriggerID::ROUND_ROBIN_RANDOM));
+        mrr.addItem("Shuffle", !rrElsewhere, false,
+                    mkv((int)engine::GroupTriggerID::ROUND_ROBIN_SHUFFLE));
+        p.addSubMenu("Round Robin", mrr);
 
         auto mcc = juce::PopupMenu();
         for (int i = 0; i < 128; ++i)
@@ -254,12 +341,12 @@ struct GroupTriggersCard::ConditionRow : juce::Component, HasEditor
         activeB->setBounds(tb);
         tb = tb.translated(tb.getWidth() + 2, 0).withWidth(72);
         typeM->setBounds(tb);
-        tb = tb.translated(tb.getWidth() + 2, 0).withWidth(32);
-        if (a1M)
-            a1M->setBounds(tb);
-        tb = tb.translated(tb.getWidth() + 2, 0).withWidth(32);
-        if (a2M)
-            a2M->setBounds(tb);
+        for (auto *m : argM)
+        {
+            tb = tb.translated(tb.getWidth() + 2, 0).withWidth(32);
+            if (m)
+                m->setBounds(tb);
+        }
 
         if (cM)
         {
@@ -268,11 +355,18 @@ struct GroupTriggersCard::ConditionRow : juce::Component, HasEditor
         }
     }
 
+    static constexpr int numArgs{engine::GroupTriggerStorage::numArgs};
+
     std::unique_ptr<booleanAttachment_t> activeA;
-    std::unique_ptr<floatAttachment_t> a1A, a2A;
     std::unique_ptr<jcmp::ToggleButton> activeB;
     std::unique_ptr<jcmp::TextPushButton> typeM, cM;
-    std::unique_ptr<jcmp::DraggableTextEditableValue> a1M, a2M;
+
+    // Exactly one of the float or discrete pair exists per arg; argM points at whichever it is
+    std::array<std::unique_ptr<floatAttachment_t>, numArgs> argFA;
+    std::array<std::unique_ptr<discreteAttachment_t>, numArgs> argDA;
+    std::array<std::unique_ptr<jcmp::DraggableTextEditableValue>, numArgs> argFM;
+    std::array<std::unique_ptr<jcmp::DraggableTextEditableDiscreteValue>, numArgs> argDM;
+    std::array<juce::Component *, numArgs> argM{};
 };
 GroupTriggersCard::GroupTriggersCard(SCXTEditor *e) : HasEditor(e)
 {

--- a/tests/group_trigger_tests.cpp
+++ b/tests/group_trigger_tests.cpp
@@ -223,4 +223,387 @@ TEST_CASE("Group trigger ids for program change and pitch bend round trip as str
     }
 }
 
+/*
+ * Round robin. These need per-group answers rather than a voice count, so they play a key and
+ * report which groups sounded as a bitmask over group index - bit 0 is group 0.
+ */
+static uint32_t addRoundRobinGroup(scxt::engine::Part &part, scxt::engine::GroupTriggerID kind,
+                                   int set, int ordinal, int keyLo = 48, int keyHi = 72)
+{
+    auto gidx = (int)part.addGroup() - 1;
+    addBlankZoneToGroup(part, gidx, keyLo, keyHi);
+
+    auto &tc = part.getGroup(gidx)->triggerConditions;
+    tc.storage[0].id = kind;
+    tc.storage[0].args[0] = (float)set;
+    tc.storage[0].args[1] = (float)ordinal;
+    tc.active[0] = true;
+    tc.setupOnUnstream(part.groupTriggerInstrumentState);
+    return 1u << gidx;
+}
+
+// Same "count only gated voices" trick as playAndCount - see the note there
+static uint32_t playAndSoundingGroups(scxt::engine::Engine &eng, int key = PLAY_KEY,
+                                      int channel = 0)
+{
+    eng.processNoteOnEvent(0, channel, key, -1, 1.f, 0.f);
+
+    uint32_t res{0};
+    auto &part = *eng.getPatch()->getPart(0);
+    for (int g = 0; g < (int)part.getGroups().size(); ++g)
+        for (const auto &zone : part.getGroup(g)->getZones())
+            for (int i = 0; i < (int)scxt::maxVoices; ++i)
+            {
+                const auto *v = zone->voiceWeakPointers[i];
+                if (v && v->isVoiceAssigned && v->isGated && v->key == key)
+                    res |= (1u << g);
+            }
+
+    eng.processNoteOffEvent(0, channel, key, -1, 0.f);
+    return res;
+}
+
+TEST_CASE("Round robin cycle - two groups alternate", "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = *eng->getPatch()->getPart(0);
+
+    auto g0 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 1);
+    auto g1 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 2);
+
+    // Both groups cover the key, so this also shows one note spends exactly one slot
+    REQUIRE(playAndSoundingGroups(*eng) == g0);
+    REQUIRE(playAndSoundingGroups(*eng) == g1);
+    REQUIRE(playAndSoundingGroups(*eng) == g0);
+    REQUIRE(playAndSoundingGroups(*eng) == g1);
+}
+
+TEST_CASE("Round robin cycle - a split keyboard alternates with silence", "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = *eng->getPatch()->getPart(0);
+
+    auto g0 =
+        addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 1, 48, 60);
+    auto g1 =
+        addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 2, 61, 72);
+
+    /*
+     * The spec's case. Key 65 is only in the second group, but the counter belongs to the set
+     * rather than to the note, so it still advances and the press lands on group 0's turn.
+     */
+    REQUIRE(playAndSoundingGroups(*eng, 65) == 0);
+    REQUIRE(playAndSoundingGroups(*eng, 65) == g1);
+    REQUIRE(playAndSoundingGroups(*eng, 65) == 0);
+    REQUIRE(playAndSoundingGroups(*eng, 65) == g1);
+
+    // And the same the other way up the keyboard
+    REQUIRE(playAndSoundingGroups(*eng, 55) == g0);
+    REQUIRE(playAndSoundingGroups(*eng, 55) == 0);
+}
+
+TEST_CASE("Round robin cycle - the first press plays the lowest ordinal", "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = *eng->getPatch()->getPart(0);
+
+    auto g0 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 7);
+    auto g1 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 3);
+
+    REQUIRE(playAndSoundingGroups(*eng) == g1);
+    REQUIRE(playAndSoundingGroups(*eng) == g0);
+    REQUIRE(playAndSoundingGroups(*eng) == g1);
+}
+
+TEST_CASE("Round robin cycle - unassigned ordinals are not gaps", "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = *eng->getPatch()->getPart(0);
+
+    // 1, 2, 4, 9 is a four press cycle, not a nine press one with silence at 3, 5, 6, 7, 8
+    std::vector<uint32_t> gs;
+    for (auto ord : {1, 2, 4, 9})
+        gs.push_back(
+            addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, ord));
+
+    for (int pass = 0; pass < 3; ++pass)
+        for (auto g : gs)
+            REQUIRE(playAndSoundingGroups(*eng) == g);
+}
+
+TEST_CASE("Round robin cycle - groups sharing an ordinal stack", "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = *eng->getPatch()->getPart(0);
+
+    auto g0 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 1);
+    auto g1 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 1);
+    auto g2 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 2);
+
+    REQUIRE(playAndSoundingGroups(*eng) == (g0 | g1));
+    REQUIRE(playAndSoundingGroups(*eng) == g2);
+    REQUIRE(playAndSoundingGroups(*eng) == (g0 | g1));
+}
+
+TEST_CASE("Round robin cycle - a note outside the set does not advance it", "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = *eng->getPatch()->getPart(0);
+
+    auto g0 =
+        addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 1, 48, 60);
+    addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 2, 48, 60);
+
+    // Nothing maps key 30, so these presses must not eat the first slot of the cycle
+    REQUIRE(playAndSoundingGroups(*eng, 30) == 0);
+    REQUIRE(playAndSoundingGroups(*eng, 30) == 0);
+    REQUIRE(playAndSoundingGroups(*eng, 55) == g0);
+}
+
+TEST_CASE("Round robin cycle - two sets run independently", "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = *eng->getPatch()->getPart(0);
+
+    auto a0 =
+        addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 1, 48, 60);
+    auto a1 =
+        addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 2, 48, 60);
+    auto b0 =
+        addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 1, 1, 61, 72);
+    auto b1 =
+        addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 1, 2, 61, 72);
+
+    // Working set 0 leaves set 1 sitting at its start
+    REQUIRE(playAndSoundingGroups(*eng, 55) == a0);
+    REQUIRE(playAndSoundingGroups(*eng, 55) == a1);
+    REQUIRE(playAndSoundingGroups(*eng, 55) == a0);
+
+    REQUIRE(playAndSoundingGroups(*eng, 65) == b0);
+    REQUIRE(playAndSoundingGroups(*eng, 65) == b1);
+
+    // ... and set 0 carries on from where it was
+    REQUIRE(playAndSoundingGroups(*eng, 55) == a1);
+}
+
+TEST_CASE("Round robin cycle - a note in two sets advances both once", "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = *eng->getPatch()->getPart(0);
+
+    auto a0 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 1);
+    auto a1 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 2);
+    auto b0 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 1, 1);
+    auto b1 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 1, 2);
+
+    REQUIRE(playAndSoundingGroups(*eng) == (a0 | b0));
+    REQUIRE(playAndSoundingGroups(*eng) == (a1 | b1));
+    REQUIRE(playAndSoundingGroups(*eng) == (a0 | b0));
+}
+
+TEST_CASE("Round robin cycle - a condition that fails spends no slot", "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = *eng->getPatch()->getPart(0);
+
+    auto g0 =
+        addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 1, 48, 60);
+    addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 2, 61, 72);
+
+    // Gate the first group behind CC 20, which starts at zero
+    auto &tc = part.getGroup(0)->triggerConditions;
+    tc.storage[1].id =
+        (scxt::engine::GroupTriggerID)((int)scxt::engine::GroupTriggerID::MIDICC + 20);
+    tc.storage[1].args[0] = 64;
+    tc.storage[1].args[1] = 127;
+    tc.active[1] = true;
+    tc.setupOnUnstream(part.groupTriggerInstrumentState);
+
+    // Key 55 only reaches the gated group, so a press while it is shut changes nothing
+    REQUIRE(playAndSoundingGroups(*eng, 55) == 0);
+    REQUIRE(playAndSoundingGroups(*eng, 55) == 0);
+
+    uint8_t cc[3]{0xb0, 20, 100};
+    eng->processMIDI1Event(0, cc);
+    REQUIRE(playAndSoundingGroups(*eng, 55) == g0);
+}
+
+TEST_CASE("Round robin cycle - a keyswitch press spends no slot", "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = *eng->getPatch()->getPart(0);
+
+    // An articulation latched to key 50, which is inside the round robin groups' own range
+    part.addGroup();
+    addBlankZoneToGroup(part, 0, 48, 72);
+    auto &ktc = part.getGroup(0)->triggerConditions;
+    ktc.storage[0].id = scxt::engine::GroupTriggerID::KEYSWITCH_LATCH;
+    ktc.storage[0].args[0] = 50;
+    ktc.active[0] = true;
+    ktc.setupOnUnstream(part.groupTriggerInstrumentState);
+    part.guaranteeKeyswitchLatchCoherence(*eng);
+
+    auto g1 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 1);
+    auto g2 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 2);
+
+    // The switch key is consumed by the switch, so it must not turn the cycle over
+    REQUIRE(playAndSoundingGroups(*eng, 50) == 0);
+    REQUIRE(playAndSoundingGroups(*eng, 50) == 0);
+
+    REQUIRE((playAndSoundingGroups(*eng, 60) & (g1 | g2)) == g1);
+    REQUIRE((playAndSoundingGroups(*eng, 60) & (g1 | g2)) == g2);
+}
+
+TEST_CASE("Round robin cycle - editing the live ordinal away hands on to the next",
+          "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = *eng->getPatch()->getPart(0);
+
+    auto g0 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 1);
+    auto g1 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 2);
+    auto g2 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 3);
+
+    REQUIRE(playAndSoundingGroups(*eng) == g0); // sitting on ordinal 1
+
+    // Move ordinal 1 out from under the live position. The next press moves up, it does not stall
+    part.getGroup(0)->triggerConditions.storage[0].args[1] = 5;
+    part.getGroup(0)->triggerConditions.setupOnUnstream(part.groupTriggerInstrumentState);
+
+    REQUIRE(playAndSoundingGroups(*eng) == g1); // 2
+    REQUIRE(playAndSoundingGroups(*eng) == g2); // 3
+    REQUIRE(playAndSoundingGroups(*eng) == g0); // 5, the new top of the cycle
+    REQUIRE(playAndSoundingGroups(*eng) == g1); // wraps back to 2
+}
+
+TEST_CASE("Round robin random - draws from the whole set", "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = *eng->getPatch()->getPart(0);
+    eng->rng.reseed(8675309);
+
+    std::vector<uint32_t> gs;
+    for (int i = 0; i < 4; ++i)
+        gs.push_back(
+            addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_RANDOM, 0, 0));
+
+    uint32_t everSounded{0};
+    for (int i = 0; i < 200; ++i)
+    {
+        auto s = playAndSoundingGroups(*eng);
+        // Exactly one group at a time - random and shuffle never stack
+        REQUIRE(std::popcount(s) == 1);
+        everSounded |= s;
+    }
+
+    for (auto g : gs)
+        REQUIRE((everSounded & g) == g);
+}
+
+TEST_CASE("Round robin random - repeats, unlike shuffle", "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = *eng->getPatch()->getPart(0);
+    eng->rng.reseed(24601);
+
+    for (int i = 0; i < 3; ++i)
+        addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_RANDOM, 0, 0);
+
+    bool sawRepeat{false};
+    uint32_t prev{0};
+    for (int i = 0; i < 100 && !sawRepeat; ++i)
+    {
+        auto s = playAndSoundingGroups(*eng);
+        sawRepeat = (s == prev);
+        prev = s;
+    }
+    REQUIRE(sawRepeat);
+}
+
+TEST_CASE("Round robin shuffle - every pass is a permutation of the set", "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = *eng->getPatch()->getPart(0);
+    eng->rng.reseed(112358);
+
+    constexpr int members{4};
+    uint32_t all{0};
+    for (int i = 0; i < members; ++i)
+        all |= addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_SHUFFLE, 0, 0);
+
+    // Each member wins exactly once per pass, and the passes keep coming
+    bool sawADifferentOrder{false};
+    uint32_t firstPass{0};
+    for (int pass = 0; pass < 8; ++pass)
+    {
+        uint32_t seen{0};
+        uint32_t order{0};
+        for (int i = 0; i < members; ++i)
+        {
+            auto s = playAndSoundingGroups(*eng);
+            REQUIRE(std::popcount(s) == 1);
+            REQUIRE((seen & s) == 0); // nobody twice in a pass
+            seen |= s;
+            order = order * 16 + (uint32_t)std::countr_zero(s);
+        }
+        REQUIRE(seen == all);
+
+        if (pass == 0)
+            firstPass = order;
+        else if (order != firstPass)
+            sawADifferentOrder = true;
+    }
+    REQUIRE(sawADifferentOrder);
+}
+
+TEST_CASE("Round robin - the same number in different kinds is a different set", "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = *eng->getPatch()->getPart(0);
+
+    // RR1 and RN1 are two unrelated round robins that happen to share a number
+    auto c0 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 1);
+    auto c1 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 2);
+    auto r0 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_RANDOM, 0, 0);
+    auto r1 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_RANDOM, 0, 0);
+
+    // The cycle keeps its own count while the random pair picks one of themselves each press
+    for (int i = 0; i < 6; ++i)
+    {
+        auto s = playAndSoundingGroups(*eng);
+        REQUIRE((s & (c0 | c1)) == (i % 2 == 0 ? c0 : c1));
+        REQUIRE(std::popcount(s & (r0 | r1)) == 1);
+    }
+}
+
+TEST_CASE("Round robin - the live position is not part of the instrument", "[grouptrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = *eng->getPatch()->getPart(0);
+
+    auto g0 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 1);
+    auto g1 = addRoundRobinGroup(part, scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE, 0, 2);
+
+    REQUIRE(playAndSoundingGroups(*eng) == g0);
+
+    // Whatever a performance was in the middle of, a load starts the cycle over
+    part.setupOnUnstream(*eng);
+    REQUIRE(playAndSoundingGroups(*eng) == g0);
+    REQUIRE(playAndSoundingGroups(*eng) == g1);
+}
+
+TEST_CASE("Round robin group trigger ids round trip as strings", "[grouptrigger]")
+{
+    for (auto id : {scxt::engine::GroupTriggerID::ROUND_ROBIN_CYCLE,
+                    scxt::engine::GroupTriggerID::ROUND_ROBIN_RANDOM,
+                    scxt::engine::GroupTriggerID::ROUND_ROBIN_SHUFFLE})
+    {
+        auto s = scxt::engine::toStringGroupTriggerID(id);
+        REQUIRE(s != "n");
+        REQUIRE(scxt::engine::fromStringGroupTriggerID(s) == id);
+        REQUIRE(scxt::engine::getGroupTriggerDisplayName(id) != "ERROR");
+        REQUIRE(scxt::engine::isRoundRobinTriggerID(id));
+    }
+}
+
 } // namespace grouptrigger_test


### PR DESCRIPTION
A group can be assigned to a round robin set, which advances once per note that lands in any of its groups. Cycle steps through the ordinals in use in ascending order, random picks a member per note, and shuffle picks without replacement until the set is exhausted. Groups sharing a cycle ordinal stack.

Each kind keeps its own space of sets, so RR1, RN1 and SH1 are three unrelated round robins.

Addresses #780

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>