### PR TITLE
Add SCL/KBM as a tuning source

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -81,3 +81,6 @@
 [submodule "libs/xiph/opusfile"]
 	path = libs/xiph/opusfile
 	url = https://github.com/xiph/opusfile.git
+[submodule "libs/sst/tuning-library"]
+	path = libs/sst/tuning-library
+	url = https://github.com/surge-synthesizer/tuning-library

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -57,6 +57,7 @@ add_subdirectory(sst/sst-waveshapers)
 add_subdirectory(sst/sst-effects)
 add_subdirectory(sst/sst-jucegui)
 add_subdirectory(sst/sst-voicemanager)
+add_subdirectory(sst/tuning-library)
 add_subdirectory(sst/libgig-modified)
 
 # Add a catch2 target

--- a/src/clients/console-ui/console_ui.h
+++ b/src/clients/console-ui/console_ui.h
@@ -237,6 +237,7 @@ struct ConsoleUI
     void onMpeTuningAwarenessFromEngine(bool b) ON_STUB;
     void onPitchBendTuningAwarenessFromEngine(bool b) ON_STUB;
     void onTuningStatus(const scxt::messaging::client::tuningStatusPayload_t &) ON_STUB;
+    void onSclKbm(const scxt::messaging::client::sclKbmPayload_t &) ON_STUB;
     void onOmniFlavorFromEngine(int f) ON_STUB;
     void stepUI();
 

--- a/src/scxt-core/CMakeLists.txt
+++ b/src/scxt-core/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(${PROJECT_NAME} STATIC
 
         tuning/equal.cpp
         tuning/midikey_retuner.cpp
+        tuning/scl_kbm.cpp
 
         infrastructure/file_map_view.cpp
 
@@ -110,6 +111,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
         sst-plugininfra::miniz
         sst-plugininfra::version_information
         sst-voicemanager
+        tuning-library
 
         libgig libakai
         mts-esp-client

--- a/src/scxt-core/engine/engine.cpp
+++ b/src/scxt-core/engine/engine.cpp
@@ -39,6 +39,7 @@
 #include "voice/voice.h"
 #include "dsp/data_tables.h"
 #include "tuning/equal.h"
+#include "tuning/scl_kbm.h"
 #include "messaging/messaging.h"
 #include "messaging/client/detail/client_serial_impl.h"
 #include "messaging/client/enginestatus_messages.h"
@@ -1643,6 +1644,11 @@ void Engine::sendFullRefreshToClient() const
     // to its user-prefs baseline (discard any overlay it may currently show).
     serializationSendToClient(messaging::client::s2c_set_colormap, dawExtraState.editedColormap,
                               *(getMessageController()));
+
+    serializationSendToClient(
+        messaging::client::s2c_send_scl_kbm,
+        messaging::client::sclKbmPayload_t{dawExtraState.sclContents, dawExtraState.kbmContents},
+        *(getMessageController()));
 }
 
 void Engine::clearAll(bool alsoPurge)
@@ -1781,6 +1787,30 @@ void Engine::onDawExtraStateLoaded()
     // to its user-prefs baseline (discard any overlay it may currently show).
     serializationSendToClient(messaging::client::s2c_set_colormap, dawExtraState.editedColormap,
                               *(getMessageController()));
+
+    /*
+     * The engine trait resets the tuning before it reads daw extra state, so the scale
+     * arrives after the mode has already been resolved. Rebuild and resolve again.
+     */
+    std::string err;
+    if (!applySclKbmFromDawExtraState(err))
+    {
+        midikeyRetuner.clearSCLKBM();
+        RAISE_ERROR_ENGINE(*this, "Tuning Error",
+                           "The scale stored in this session did not parse, so tuning has "
+                           "reverted to 12-TET. " +
+                               err);
+    }
+    resetTuningFromRuntimeConfig();
+
+    serializationSendToClient(
+        messaging::client::s2c_send_scl_kbm,
+        messaging::client::sclKbmPayload_t{dawExtraState.sclContents, dawExtraState.kbmContents},
+        *(getMessageController()));
+    serializationSendToClient(messaging::client::s2c_send_tuning_status,
+                              messaging::client::tuningStatusPayload_t{
+                                  runtimeConfig.tuningMode, runtimeConfig.tuningZoneResolution},
+                              *(getMessageController()));
 }
 
 std::string Engine::toStringTuningMode(const TuningMode &m)
@@ -1793,13 +1823,15 @@ std::string Engine::toStringTuningMode(const TuningMode &m)
         return "mts";
     case TuningMode::MTS_NOTE_ON:
         return "mtsno";
+    case TuningMode::SCL_KBM:
+        return "sclkbm";
     }
     return "err";
 }
 Engine::TuningMode Engine::fromStringTuningMode(const std::string &s)
 {
     static auto inverse = makeEnumInverse<Engine::TuningMode, Engine::toStringTuningMode>(
-        Engine::TuningMode::TWELVE_TET, Engine::TuningMode::MTS_NOTE_ON);
+        Engine::TuningMode::TWELVE_TET, Engine::TuningMode::SCL_KBM);
     auto p = inverse.find(s);
     if (p == inverse.end())
         return TuningMode::MTS_CONTINOUS;
@@ -1832,6 +1864,15 @@ Engine::TuningZoneResolution Engine::fromStringTuningZoneResolution(const std::s
 
 void Engine::resetTuningFromRuntimeConfig()
 {
+    /*
+     * The scale itself lives in daw extra state, but the mode streams with a multi too,
+     * so a multi can ask for SCL_KBM with no scale behind it. Demote rather than sound
+     * untuned, and do it here so every path into the mode is covered.
+     */
+    // No logging here - this runs on the audio thread from the SetTuningMode callback
+    if (runtimeConfig.tuningMode == TuningMode::SCL_KBM && !midikeyRetuner.hasSCLKBM())
+        runtimeConfig.tuningMode = TuningMode::TWELVE_TET;
+
     switch (runtimeConfig.tuningMode)
     {
     case TuningMode::TWELVE_TET:
@@ -1841,7 +1882,29 @@ void Engine::resetTuningFromRuntimeConfig()
     case TuningMode::MTS_NOTE_ON:
         midikeyRetuner.setTuningMode(tuning::MidikeyRetuner::MTS_ESP);
         break;
+    case TuningMode::SCL_KBM:
+        midikeyRetuner.setTuningMode(tuning::MidikeyRetuner::SCL_KBM);
+        break;
     }
+}
+
+bool Engine::applySclKbmFromDawExtraState(std::string &errorOut)
+{
+    assert(getMessageController()->threadingChecker.isSerialThread());
+
+    if (dawExtraState.sclContents.empty())
+    {
+        midikeyRetuner.clearSCLKBM();
+        return true;
+    }
+
+    tuning::MidikeyRetuner::RetuneTable table;
+    if (!tuning::buildRetuneTable(dawExtraState.sclContents, dawExtraState.kbmContents, table,
+                                  errorOut))
+        return false;
+
+    midikeyRetuner.setSCLKBMTable(table);
+    return true;
 }
 
 void Engine::setMpeTuningAwareness(bool a) { this->runtimeConfig.tuningAwareMPEGlides = a; }

--- a/src/scxt-core/engine/engine.h
+++ b/src/scxt-core/engine/engine.h
@@ -265,7 +265,8 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     {
         TWELVE_TET,
         MTS_CONTINOUS, // if MTS is present, else 12-tet obvs
-        MTS_NOTE_ON
+        MTS_NOTE_ON,
+        SCL_KBM // scala scale, optional keyboard mapping; else 12-tet
     };
     DECLARE_ENUM_STRING(TuningMode);
 
@@ -304,7 +305,16 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     struct DawExtraState
     {
         std::string editedColormap{};
+        std::string sclContents{};
+        std::string kbmContents{};
     } dawExtraState;
+
+    /*
+     * Rebuild the SCL/KBM retuning table from dawExtraState. Serialization thread
+     * only (it parses and allocates). Returns false and fills errorOut on a bad
+     * scale, leaving the prior tuning in place. Empty SCL contents clear the tuning.
+     */
+    bool applySclKbmFromDawExtraState(std::string &errorOut);
 
     void resetTuningFromRuntimeConfig();
     void setMpeTuningAwareness(bool a);

--- a/src/scxt-core/json/engine_traits.h
+++ b/src/scxt-core/json/engine_traits.h
@@ -152,20 +152,29 @@ SC_STREAMDEF(scxt::engine::Engine, SC_FROM({
                  to.getPatch()->setupPatchOnUnstream(to);
                  to.onPartConfigurationUpdated();
 
-                 // and reset the tuning
-                 to.resetTuningFromRuntimeConfig();
-
                  // and finally set the sample rate
                  to.getPatch()->setSampleRate(to.getSampleRate());
 
-                 // DAW-only: restore per-instance extra state if present
+                 // DAW-only: restore per-instance extra state if present. This carries the
+                 // SCL/KBM scale, so it has to land before the tuning is resolved - otherwise
+                 // SCL_KBM sees an empty retuner and demotes itself to 12-TET.
                  if (findIf(v, "dawExtraState", to.dawExtraState))
                      to.onDawExtraStateLoaded();
+
+                 // and reset the tuning
+                 to.resetTuningFromRuntimeConfig();
              }))
 
-SC_STREAMDEF(scxt::engine::Engine::DawExtraState,
-             SC_FROM({ v = {{"editedColormap", from.editedColormap}}; }),
-             SC_TO({ findIf(v, "editedColormap", to.editedColormap); }))
+SC_STREAMDEF(scxt::engine::Engine::DawExtraState, SC_FROM({
+                 v = {{"editedColormap", from.editedColormap},
+                      {"sclContents", from.sclContents},
+                      {"kbmContents", from.kbmContents}};
+             }),
+             SC_TO({
+                 findIf(v, "editedColormap", to.editedColormap);
+                 findIf(v, "sclContents", to.sclContents);
+                 findIf(v, "kbmContents", to.kbmContents);
+             }))
 
 SC_STREAMDEF(scxt::engine::Engine::RuntimeConfig, SC_FROM({
                  if (SC_STREAMING_FOR_DAW)

--- a/src/scxt-core/messaging/client/client_serial.h
+++ b/src/scxt-core/messaging/client/client_serial.h
@@ -166,6 +166,7 @@ enum ClientToSerializationMessagesIds
     c2s_mute_solo_group,
 
     c2s_set_tuning_mode,
+    c2s_set_scl_kbm,
 
     c2s_noteonoff,
 
@@ -269,6 +270,7 @@ enum SerializationToClientMessageIds
     s2c_compound_import_complete,
 
     s2c_send_tuning_status,
+    s2c_send_scl_kbm,
     s2c_update_mpe_tuning_awareness,
     s2c_update_pitchbend_tuning_awareness,
 

--- a/src/scxt-core/messaging/client/enginestatus_messages.h
+++ b/src/scxt-core/messaging/client/enginestatus_messages.h
@@ -34,6 +34,7 @@
 #include "json/engine_traits.h"
 #include "json/datamodel_traits.h"
 #include "selection/selection_manager.h"
+#include "tuning/scl_kbm.h"
 #include "client_macros.h"
 
 namespace scxt::messaging::client
@@ -129,6 +130,73 @@ inline void applyTuningStatusPayload(const tuningStatusPayload_t &payload,
 }
 CLIENT_TO_SERIAL(SetTuningMode, c2s_set_tuning_mode, tuningStatusPayload_t,
                  applyTuningStatusPayload(payload, cont));
+
+// The SCL text, then the KBM text. An empty KBM means the scale's default mapping.
+using sclKbmPayload_t = std::pair<std::string, std::string>;
+SERIAL_TO_CLIENT(SendSclKbm, s2c_send_scl_kbm, sclKbmPayload_t, onSclKbm);
+
+/*
+ * Parsing happens here, on the serialization thread, because the tuning library
+ * allocates and throws. Only the flattened table crosses to audio. A scale which
+ * fails to parse leaves the live tuning alone and reports; we deliberately do not
+ * echo the text back, so the user keeps their half-edited scale to fix.
+ */
+inline void applySclKbmPayload(const sclKbmPayload_t &payload, engine::Engine &engine,
+                               messaging::MessageController &cont)
+{
+    /*
+     * A mapping on its own is a reasonable ask - "put A4 at 432" needs no custom
+     * scale - so a bare KBM means plain 12-TET rather than no tuning at all.
+     * Both empty still clears the tuning.
+     */
+    auto scl = payload.first;
+    if (scl.empty() && !payload.second.empty())
+        scl = tuning::twelveTETSclText();
+
+    tuning::MidikeyRetuner::RetuneTable table;
+    auto haveScale = !scl.empty();
+
+    if (haveScale)
+    {
+        std::string err;
+        if (!tuning::buildRetuneTable(scl, payload.second, table, err))
+        {
+            RAISE_ERROR_CONT(cont, "Tuning Error", err);
+            return;
+        }
+    }
+
+    engine.dawExtraState.sclContents = haveScale ? scl : "";
+    engine.dawExtraState.kbmContents = haveScale ? payload.second : "";
+
+    cont.scheduleAudioThreadCallback(
+        [t = table, haveScale](scxt::engine::Engine &e) {
+            if (haveScale)
+            {
+                e.midikeyRetuner.setSCLKBMTable(t);
+                e.runtimeConfig.tuningMode = engine::Engine::TuningMode::SCL_KBM;
+            }
+            else
+            {
+                e.midikeyRetuner.clearSCLKBM();
+            }
+            // Resolves the mode, and demotes to 12-TET if we just cleared the scale
+            e.resetTuningFromRuntimeConfig();
+        },
+        [](const auto &e) {
+            serializationSendToClient(messaging::client::s2c_send_scl_kbm,
+                                      messaging::client::sclKbmPayload_t{
+                                          e.dawExtraState.sclContents, e.dawExtraState.kbmContents},
+                                      *(e.getMessageController()));
+            serializationSendToClient(
+                messaging::client::s2c_send_tuning_status,
+                messaging::client::tuningStatusPayload_t{e.runtimeConfig.tuningMode,
+                                                         e.runtimeConfig.tuningZoneResolution},
+                *(e.getMessageController()));
+        });
+}
+CLIENT_TO_SERIAL(SetSclKbm, c2s_set_scl_kbm, sclKbmPayload_t,
+                 applySclKbmPayload(payload, engine, cont));
 
 inline void applyMPETuningAwarenessPayload(const bool &payload, messaging::MessageController &cont)
 {

--- a/src/scxt-core/tuning/midikey_retuner.cpp
+++ b/src/scxt-core/tuning/midikey_retuner.cpp
@@ -27,6 +27,7 @@
 
 #include "midikey_retuner.h"
 #include "libMTSClient.h"
+#include <algorithm>
 #include <cmath>
 #include "utils.h"
 
@@ -61,6 +62,13 @@ float MidikeyRetuner::offsetKeyBy(int channel, int key)
             return 0.f;
         return MTS_RetuningInSemitones(mtsClient, key, channel);
     }
+    case SCL_KBM:
+    {
+        if (!sclKbmValid)
+            return 0.f;
+        auto idx = std::clamp(key + RetuneTable::midiOffset, 0, RetuneTable::tableSize - 1);
+        return sclKbmTable.semitones[idx];
+    }
     }
     return 0.f;
 }
@@ -81,11 +89,25 @@ int MidikeyRetuner::getRepetitionInterval() const
         else
             return tmp;
     }
+    case SCL_KBM:
+        return sclKbmValid ? sclKbmTable.repetitionInterval : 12;
     }
     return 12;
 }
 
 void MidikeyRetuner::setTuningMode(TuningMode tm) { tuningMode = tm; }
+
+void MidikeyRetuner::setSCLKBMTable(const RetuneTable &t)
+{
+    sclKbmTable = t;
+    sclKbmValid = true;
+}
+
+void MidikeyRetuner::clearSCLKBM()
+{
+    sclKbmTable = RetuneTable();
+    sclKbmValid = false;
+}
 
 int MidikeyRetuner::remapKeyTo(int channel, int key)
 {

--- a/src/scxt-core/tuning/midikey_retuner.h
+++ b/src/scxt-core/tuning/midikey_retuner.h
@@ -28,6 +28,8 @@
 #ifndef SCXT_SRC_SCXT_CORE_TUNING_MIDIKEY_RETUNER_H
 #define SCXT_SRC_SCXT_CORE_TUNING_MIDIKEY_RETUNER_H
 
+#include <array>
+
 struct MTSClient;
 
 namespace scxt::tuning
@@ -37,13 +39,35 @@ struct MidikeyRetuner
     enum TuningMode
     {
         TWELVE_TET,
-        MTS_ESP
+        MTS_ESP,
+        SCL_KBM
     } tuningMode{TWELVE_TET};
+
+    /*
+     * A flattened tuning, precomputed off the audio thread. Deliberately the same
+     * size and indexing as Tunings::Tuning::N so out of range keys clamp identically.
+     * See tuning/scl_kbm.h for the builder.
+     */
+    struct RetuneTable
+    {
+        static constexpr int tableSize{512};
+        static constexpr int midiOffset{256};
+
+        std::array<float, tableSize> semitones{}; // index is midi note + midiOffset
+        int repetitionInterval{12};
+    };
 
     MidikeyRetuner();
     ~MidikeyRetuner();
 
     void setTuningMode(TuningMode);
+
+    /*
+     * Audio thread. Copies by value; the caller owns the parse.
+     */
+    void setSCLKBMTable(const RetuneTable &);
+    void clearSCLKBM();
+    bool hasSCLKBM() const { return sclKbmValid; }
 
     int getRepetitionInterval() const;
 
@@ -64,6 +88,9 @@ struct MidikeyRetuner
 
   private:
     MTSClient *mtsClient{nullptr};
+
+    RetuneTable sclKbmTable;
+    bool sclKbmValid{false};
 };
 } // namespace scxt::tuning
 

--- a/src/scxt-core/tuning/scl_kbm.cpp
+++ b/src/scxt-core/tuning/scl_kbm.cpp
@@ -1,0 +1,131 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "scl_kbm.h"
+
+#include <cmath>
+#include "Tunings.h"
+
+namespace scxt::tuning
+{
+
+bool buildRetuneTable(const std::string &sclText, const std::string &kbmText,
+                      MidikeyRetuner::RetuneTable &out, std::string &errorOut)
+{
+    if (sclText.empty())
+    {
+        errorOut = "No scale (SCL) provided.";
+        return false;
+    }
+
+    try
+    {
+        auto scale = Tunings::parseSCLData(sclText);
+
+        Tunings::KeyboardMapping kbm;
+        auto haveKbm = !kbmText.empty();
+        if (haveKbm)
+            kbm = Tunings::parseKBMData(kbmText);
+
+        /*
+         * A KBM which skips keys leaves nonsense in the unmapped slots. Since we
+         * interpolate between adjacent keys for continuous retuning, take the
+         * interpolated variant so a skipped key never poisons its neighbours.
+         */
+        auto tuning = (haveKbm ? Tunings::Tuning(scale, kbm) : Tunings::Tuning(scale))
+                          .withSkippedNotesInterpolated();
+
+        MidikeyRetuner::RetuneTable res;
+        for (int i = 0; i < MidikeyRetuner::RetuneTable::tableSize; ++i)
+        {
+            auto mn = i - MidikeyRetuner::RetuneTable::midiOffset;
+            auto v = tuning.retuningFromEqualInSemitonesForMidiNote(mn);
+            if (!std::isfinite(v))
+            {
+                errorOut = "Scale produced a non-finite pitch at midi note " + std::to_string(mn);
+                return false;
+            }
+            res.semitones[i] = (float)v;
+        }
+
+        // A KBM count of zero means a linear mapping, so the keyboard repeats on the scale
+        auto ri = (haveKbm && kbm.count > 0) ? kbm.count : scale.count;
+        res.repetitionInterval = ri > 0 ? ri : 12;
+
+        out = res;
+        return true;
+    }
+    catch (const Tunings::TuningError &e)
+    {
+        errorOut = e.what();
+        return false;
+    }
+    catch (const std::exception &e)
+    {
+        errorOut = e.what();
+        return false;
+    }
+}
+
+std::string twelveTETSclText()
+{
+    try
+    {
+        return Tunings::evenTemperament12NoteScale().rawText;
+    }
+    catch (const std::exception &)
+    {
+        return {};
+    }
+}
+
+/*
+ * Spelled out rather than taken from Tunings::KeyboardMapping().rawText, which
+ * writes the reference frequency at six significant figures (261.626) and so is
+ * a few thousandths of a cent shy of a true no-op. The comments make it a usable
+ * starting point for hand editing too.
+ */
+std::string defaultKbmText()
+{
+    return R"KBM(! Default keyboard mapping
+!
+! Size of map. 0 is a linear map of the scale onto the keyboard
+0
+! First and last MIDI note to map
+0
+127
+! Middle note, where the scale begins
+60
+! Reference note and its frequency
+60
+261.6255653
+! Scale degree for the formal octave. 0 means the size of the scale
+0
+)KBM";
+}
+
+} // namespace scxt::tuning

--- a/src/scxt-core/tuning/scl_kbm.h
+++ b/src/scxt-core/tuning/scl_kbm.h
@@ -1,0 +1,67 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_SCXT_CORE_TUNING_SCL_KBM_H
+#define SCXT_SRC_SCXT_CORE_TUNING_SCL_KBM_H
+
+#include <string>
+#include "midikey_retuner.h"
+
+namespace scxt::tuning
+{
+/*
+ * Flatten a Scala SCL scale, and an optional KBM keyboard mapping, into the POD
+ * table the retuner reads on the audio thread.
+ *
+ * Serialization thread only: this allocates and the tuning library reports errors
+ * by exception, all of which are caught here so none escape into engine code.
+ *
+ * On failure returns false, sets errorOut, and leaves out untouched.
+ */
+bool buildRetuneTable(const std::string &sclText, const std::string &kbmText,
+                      MidikeyRetuner::RetuneTable &out, std::string &errorOut);
+
+/*
+ * The SCL text for plain 12-TET, used to seed the editor so it always shows a
+ * well formed example rather than an empty box.
+ */
+std::string twelveTETSclText();
+
+/*
+ * The default KBM - linear map, scale starting on 60, note 60 at 261.6255653Hz -
+ * used to seed the editor with something well formed to edit.
+ *
+ * This is the mapping that means "whatever the scale already does", so applying an
+ * untouched seed is a no-op against any scale. A 69-at-440 mapping would not be:
+ * it only coincides with this in 12-TET, and shifts a non-12 scale by however far
+ * 69 sits from 60 in that scale.
+ */
+std::string defaultKbmText();
+
+} // namespace scxt::tuning
+
+#endif // SCXT_SRC_SCXT_CORE_TUNING_SCL_KBM_H

--- a/src/scxt-plugin/CMakeLists.txt
+++ b/src/scxt-plugin/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(${PROJECT_NAME} STATIC
 
         app/other-screens/AboutScreen.cpp
         app/other-screens/LogScreen.cpp
+        app/other-screens/TuningScreen.cpp
         app/other-screens/ThemeEditor.cpp
         app/other-screens/WelcomeScreen.cpp
         app/play-screen/PlayScreen.cpp

--- a/src/scxt-plugin/app/SCXTEditor.h
+++ b/src/scxt-plugin/app/SCXTEditor.h
@@ -94,6 +94,7 @@ namespace other_screens
 struct WelcomeScreen;
 struct AboutScreen;
 struct LogScreen;
+struct TuningScreen;
 struct ThemeEditorWindow;
 } // namespace other_screens
 
@@ -179,6 +180,7 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel,
     std::unique_ptr<other_screens::AboutScreen> aboutScreen;
     std::unique_ptr<other_screens::WelcomeScreen> welcomeScreen;
     std::unique_ptr<other_screens::LogScreen> logScreen;
+    std::unique_ptr<other_screens::TuningScreen> tuningScreen;
     std::unique_ptr<other_screens::ThemeEditorWindow> themeEditorWindow;
     std::unique_ptr<missing_resolution::MissingResolutionScreen> missingResolutionScreen;
     bool hasMissingSamples{false};
@@ -206,6 +208,7 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel,
     void setActiveScreen(ActiveScreen s);
     void showAboutOverlay();
     void showLogOverlay();
+    void showTuningOverlay();
     void showWelcomeOverlay();
     void showThemeEditorWindow();
     int32_t checkWelcomeCountdown{20};
@@ -260,6 +263,9 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel,
     // tuningStatusPayload_t == std::pair<TuningMode, TuningZoneResolution>;
     // inlined here to avoid pulling enginestatus_messages.h.
     std::pair<engine::Engine::TuningMode, engine::Engine::TuningZoneResolution> tuningStatus;
+
+    // Last applied scale and mapping. Empty scl means SCL/KBM tuning is unavailable.
+    std::string sclText, kbmText;
 
     std::array<std::array<scxt::engine::Macro, scxt::macrosPerPart>, scxt::numParts> macroCache;
 
@@ -342,6 +348,11 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel,
     void promptForSaveTheme();
     void promptForLoadTheme();
     void applyThemeFromFile(const fs::path &);
+
+    void promptForLoadSCL();
+    void promptForLoadKBM();
+    // Single point where the "no scale means 12-TET" rule lives
+    void applySclKbmText(const std::string &scl, const std::string &kbm);
 
     void processorBypassToggled(int which);
 

--- a/src/scxt-plugin/app/SCXTEditorReceiver.h
+++ b/src/scxt-plugin/app/SCXTEditorReceiver.h
@@ -121,6 +121,7 @@ struct SCXTEditorReceiver
     void onActivityNotification(const scxt::messaging::client::activityNotificationPayload_t &);
 
     void onTuningStatus(const scxt::messaging::client::tuningStatusPayload_t &);
+    void onSclKbm(const scxt::messaging::client::sclKbmPayload_t &);
 
     void onMacroFullState(const scxt::messaging::client::macroFullState_t &);
     void onMacroValue(const scxt::messaging::client::macroValue_t &);

--- a/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
@@ -46,6 +46,7 @@
 #include "app/mixer-screen/MixerScreen.h"
 #include "app/other-screens/AboutScreen.h"
 #include "app/other-screens/LogScreen.h"
+#include "app/other-screens/TuningScreen.h"
 #include "app/other-screens/ThemeEditor.h"
 #include "app/other-screens/WelcomeScreen.h"
 #include "app/edit-screen/components/RoutingPane.h"
@@ -116,6 +117,9 @@ SCXTEditor::SCXTEditor(messaging::MessageController &e, infrastructure::Defaults
 
     logScreen = std::make_unique<other_screens::LogScreen>(this);
     addChildComponent(*logScreen);
+
+    tuningScreen = std::make_unique<other_screens::TuningScreen>(this);
+    addChildComponent(*tuningScreen);
 
     missingResolutionScreen = std::make_unique<missing_resolution::MissingResolutionScreen>(this);
     addChildComponent(*missingResolutionScreen);
@@ -213,6 +217,16 @@ void SCXTEditor::showLogOverlay()
     resized();
 }
 
+void SCXTEditor::showTuningOverlay()
+{
+    tuningScreen->toFront(true);
+    tuningScreen->setVisible(true);
+    aboutScreen->setVisible(false);
+    logScreen->setVisible(false);
+    welcomeScreen->setVisible(false);
+    resized();
+}
+
 void SCXTEditor::showWelcomeOverlay()
 {
     welcomeScreen->toFront(true);
@@ -246,6 +260,8 @@ void SCXTEditor::resized()
         aboutScreen->setBounds(0, headerHeight, edWidth, edHeight - headerHeight);
     if (logScreen->isVisible())
         logScreen->setBounds(0, headerHeight, edWidth, edHeight - headerHeight);
+    if (tuningScreen->isVisible())
+        tuningScreen->setBounds(0, headerHeight, edWidth, edHeight - headerHeight);
     if (welcomeScreen->isVisible())
         welcomeScreen->setBounds(0, 0, edWidth, edHeight);
 }

--- a/src/scxt-plugin/app/editor-impl/SCXTEditorMenus.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditorMenus.cpp
@@ -53,6 +53,7 @@
 #include "app/other-screens/ThemeEditor.h"
 #include "app/shared/MenuValueTypein.h"
 #include "app/shared/UIHelpers.h"
+#include "tuning/scl_kbm.h"
 
 namespace scxt::ui::app
 {
@@ -306,17 +307,55 @@ void SCXTEditor::addTuningMenu(juce::PopupMenu &p, bool addTitle)
                       w->sendToSerialization(cmsg::SetTuningMode(s));
                   }
               });
+    // Available only once a scale has been loaded from the SCL/KBM submenu below
+    p.addItem("SCL/KBM Scale", !sclText.empty(), st.first == engine::Engine::TuningMode::SCL_KBM,
+              [st, w = juce::Component::SafePointer(this)]() {
+                  if (w)
+                  {
+                      auto s = st;
+                      s.first = engine::Engine::TuningMode::SCL_KBM;
+                      w->sendToSerialization(cmsg::SetTuningMode(s));
+                  }
+              });
+
     p.addSeparator();
-    p.addItem("Tuning-Aware Pitch Bend", st.first == engine::Engine::TuningMode::MTS_CONTINOUS,
-              tuningAwareMPE, [w = juce::Component::SafePointer(this)]() {
+
+    juce::PopupMenu sclKbm;
+    sclKbm.addItem("Load SCL...", [w = juce::Component::SafePointer(this)]() {
+        if (w)
+            w->promptForLoadSCL();
+    });
+    sclKbm.addItem("Load KBM...", [w = juce::Component::SafePointer(this)]() {
+        if (w)
+            w->promptForLoadKBM();
+    });
+    sclKbm.addItem("Edit SCL/KBM...", [w = juce::Component::SafePointer(this)]() {
+        if (w)
+            w->showTuningOverlay();
+    });
+    sclKbm.addSeparator();
+    // Back to a session which never had a scale: no SCL, no KBM, mode off SCL/KBM
+    sclKbm.addItem("Reset to No SCL/KBM", !sclText.empty() || !kbmText.empty(), false,
+                   [w = juce::Component::SafePointer(this)]() {
+                       if (w)
+                           w->applySclKbmText("", "");
+                   });
+    p.addSubMenu("SCL/KBM", sclKbm);
+
+    // Both MTS continuous and SCL/KBM retune per block, so the tuning-aware paths apply
+    auto continuousTuning = st.first == engine::Engine::TuningMode::MTS_CONTINOUS ||
+                            st.first == engine::Engine::TuningMode::SCL_KBM;
+
+    p.addSeparator();
+    p.addItem("Tuning-Aware Pitch Bend", continuousTuning, tuningAwareMPE,
+              [w = juce::Component::SafePointer(this)]() {
                   if (w)
                   {
                       w->tuningAwareMPE = !w->tuningAwareMPE;
                       w->sendToSerialization(cmsg::SetMpeTuningAwareness(w->tuningAwareMPE));
                   }
               });
-    p.addItem("Tuning-Aware MPE/Note Expression glides",
-              st.first == engine::Engine::TuningMode::MTS_CONTINOUS, tuningAwarePitchBends,
+    p.addItem("Tuning-Aware MPE/Note Expression glides", continuousTuning, tuningAwarePitchBends,
               [w = juce::Component::SafePointer(this)]() {
                   if (w)
                   {
@@ -692,6 +731,55 @@ void SCXTEditor::promptForLoadTheme()
                                      return;
                                  w->applyThemeFromFile(shared::juceFileToFSPath(result[0]));
                              });
+}
+
+void SCXTEditor::applySclKbmText(const std::string &scl, const std::string &kbm)
+{
+    // The serialization side parses, reports any error, and fills in 12-TET for a bare KBM
+    sendToSerialization(cmsg::SetSclKbm({scl, kbm}));
+}
+
+void SCXTEditor::promptForLoadSCL()
+{
+    fileChooser = std::make_unique<juce::FileChooser>("Load Scale (SCL)", juce::File(), "*.scl");
+    fileChooser->launchAsync(
+        juce::FileBrowserComponent::canSelectFiles | juce::FileBrowserComponent::openMode,
+        [w = juce::Component::SafePointer(this)](const juce::FileChooser &c) {
+            if (!w)
+                return;
+            auto result = c.getResults();
+            if (result.size() != 1)
+                return;
+            auto txt = shared::fileToString(shared::juceFileToFSPath(result[0]));
+            if (!txt.has_value())
+            {
+                w->displayError("Tuning Error", "Unable to open that scale for reading.");
+                return;
+            }
+            w->applySclKbmText(*txt, w->kbmText);
+        });
+}
+
+void SCXTEditor::promptForLoadKBM()
+{
+    fileChooser =
+        std::make_unique<juce::FileChooser>("Load Keyboard Mapping (KBM)", juce::File(), "*.kbm");
+    fileChooser->launchAsync(
+        juce::FileBrowserComponent::canSelectFiles | juce::FileBrowserComponent::openMode,
+        [w = juce::Component::SafePointer(this)](const juce::FileChooser &c) {
+            if (!w)
+                return;
+            auto result = c.getResults();
+            if (result.size() != 1)
+                return;
+            auto txt = shared::fileToString(shared::juceFileToFSPath(result[0]));
+            if (!txt.has_value())
+            {
+                w->displayError("Tuning Error", "Unable to open that mapping for reading.");
+                return;
+            }
+            w->applySclKbmText(w->sclText, *txt);
+        });
 }
 
 } // namespace scxt::ui::app

--- a/src/scxt-plugin/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -40,6 +40,7 @@
 #include "app/edit-screen/components/MacroMappingVariantPane.h"
 #include "app/other-screens/AboutScreen.h"
 #include "app/other-screens/ThemeEditor.h"
+#include "app/other-screens/TuningScreen.h"
 #include "app/browser-ui/BrowserPane.h"
 #include "app/play-screen/PlayScreen.h"
 #include "app/missing-resolution/MissingResolutionScreen.h"
@@ -602,6 +603,14 @@ void SCXTEditorReceiver::onPartKeySwitchDisplay(
 void SCXTEditorReceiver::onTuningStatus(const scxt::messaging::client::tuningStatusPayload_t &t)
 {
     editor.tuningStatus = t;
+}
+
+void SCXTEditorReceiver::onSclKbm(const scxt::messaging::client::sclKbmPayload_t &p)
+{
+    editor.sclText = p.first;
+    editor.kbmText = p.second;
+    if (editor.tuningScreen && editor.tuningScreen->isVisible())
+        editor.tuningScreen->setSclKbmFromEngine(p.first, p.second);
 }
 
 void SCXTEditorReceiver::onMpeTuningAwarenessFromEngine(bool a) { editor.tuningAwareMPE = a; }

--- a/src/scxt-plugin/app/other-screens/TuningScreen.cpp
+++ b/src/scxt-plugin/app/other-screens/TuningScreen.cpp
@@ -1,0 +1,235 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "TuningScreen.h"
+
+#include "app/SCXTEditor.h"
+#include "app/shared/UIHelpers.h"
+#include "connectors/SCXTResources.h"
+#include "messaging/client/enginestatus_messages.h"
+#include "tuning/scl_kbm.h"
+
+#include "sst/jucegui/components/TextPushButton.h"
+
+namespace scxt::ui::app::other_screens
+{
+namespace jcmp = sst::jucegui::components;
+namespace cmsg = scxt::messaging::client;
+
+struct TuningScreenContents : juce::Component, HasEditor
+{
+    TuningScreen *parent{nullptr};
+
+    std::unique_ptr<juce::TextEditor> sclEditor, kbmEditor;
+    std::unique_ptr<jcmp::TextPushButton> loadButton, applyButton, revertButton, closeButton;
+
+#if JUCE_VERSION >= 0x080000
+    juce::Font displayFont{juce::FontOptions(1)};
+#else
+    juce::Font displayFont{};
+#endif
+
+    TuningScreenContents(TuningScreen *p, SCXTEditor *e) : parent(p), HasEditor(e)
+    {
+        auto anonPro =
+            connectors::resources::loadTypeface("fonts/Anonymous_Pro/AnonymousPro-Regular.ttf");
+        displayFont = editor->themeApplier.anonmyousProRegularFor(11);
+
+        sclEditor = makeEditor();
+        addAndMakeVisible(*sclEditor);
+        kbmEditor = makeEditor();
+        addChildComponent(*kbmEditor);
+
+        loadButton = makeButton("Load...", [](auto *w) { w->doLoad(); });
+        applyButton = makeButton("Apply", [](auto *w) { w->doApply(); });
+        revertButton = makeButton("Revert", [](auto *w) { w->doRevert(); });
+        closeButton = makeButton("Close", [](auto *w) { w->setVisible(false); });
+    }
+
+    std::unique_ptr<juce::TextEditor> makeEditor()
+    {
+        auto res = std::make_unique<juce::TextEditor>();
+        res->setMultiLine(true);
+        res->setReturnKeyStartsNewLine(true);
+        res->setTabKeyUsedAsCharacter(true);
+        res->setFont(displayFont);
+        res->setColour(juce::TextEditor::backgroundColourId,
+                       editor->themeColor(theme::ColorMap::bg_2));
+        res->setColour(juce::TextEditor::textColourId,
+                       editor->themeColor(theme::ColorMap::generic_content_high));
+        res->setColour(juce::TextEditor::outlineColourId,
+                       editor->themeColor(theme::ColorMap::grid_primary));
+        res->setColour(juce::TextEditor::highlightColourId,
+                       editor->themeColor(theme::ColorMap::accent_1a).withAlpha(0.4f));
+        return res;
+    }
+
+    template <typename Fn> std::unique_ptr<jcmp::TextPushButton> makeButton(const char *l, Fn &&fn)
+    {
+        auto res = std::make_unique<jcmp::TextPushButton>();
+        res->setLabel(l);
+        res->setOnCallback([w = juce::Component::SafePointer(parent), fn]() {
+            if (w)
+                fn(w.getComponent());
+        });
+        addAndMakeVisible(*res);
+        return res;
+    }
+
+    void setActiveTab(int t)
+    {
+        sclEditor->setVisible(t == 0);
+        kbmEditor->setVisible(t == 1);
+        resized();
+    }
+
+    void resized() override
+    {
+        auto bh = 26;
+        auto b = getLocalBounds();
+        auto tb = b.withTrimmedBottom(bh + 6);
+        auto bb = b.withTop(b.getBottom() - bh);
+
+        sclEditor->setBounds(tb);
+        kbmEditor->setBounds(tb);
+
+        auto bw = 90;
+        loadButton->setBounds(bb.withWidth(bw));
+        closeButton->setBounds(bb.withLeft(bb.getRight() - bw));
+        applyButton->setBounds(bb.withLeft(bb.getRight() - 2 * bw - 4).withWidth(bw));
+        revertButton->setBounds(bb.withLeft(bb.getRight() - 3 * bw - 8).withWidth(bw));
+    }
+};
+
+TuningScreen::TuningScreen(SCXTEditor *e) : HasEditor(e)
+{
+    auto ct = std::make_unique<jcmp::NamedPanel>("SCL/KBM Tuning");
+    ct->isTabbed = true;
+    ct->tabNames = {"SCL", "KBM"};
+    ct->selectTab(0);
+    ct->onTabSelected = [w = juce::Component::SafePointer(this)](int i) {
+        if (w)
+            w->setActiveTab(i);
+    };
+    addAndMakeVisible(*ct);
+
+    ct->setContentAreaComponent(std::make_unique<TuningScreenContents>(this, e));
+    ct->resetTabState();
+    contentsArea = std::move(ct);
+}
+
+TuningScreen::~TuningScreen() {}
+
+TuningScreenContents *TuningScreen::contents()
+{
+    return dynamic_cast<TuningScreenContents *>(contentsArea->getContentAreaComponent().get());
+}
+
+void TuningScreen::setActiveTab(int t)
+{
+    activeTab = t;
+    if (auto c = contents())
+        c->setActiveTab(t);
+}
+
+void TuningScreen::setSclKbmFromEngine(const std::string &scl, const std::string &kbm)
+{
+    auto c = contents();
+    if (!c)
+        return;
+
+    /*
+     * Seed empty boxes with well formed examples rather than a blank page. Both
+     * seeds are no-ops against what is showing, so Apply on an untouched box
+     * cannot move the pitch.
+     */
+    auto sclShown = scl.empty() ? scxt::tuning::twelveTETSclText() : scl;
+    auto kbmShown = kbm.empty() ? scxt::tuning::defaultKbmText() : kbm;
+    c->sclEditor->setText(sclShown, juce::dontSendNotification);
+    c->kbmEditor->setText(kbmShown, juce::dontSendNotification);
+}
+
+void TuningScreen::doApply()
+{
+    auto c = contents();
+    if (!c)
+        return;
+    editor->applySclKbmText(c->sclEditor->getText().toStdString(),
+                            c->kbmEditor->getText().toStdString());
+}
+
+void TuningScreen::doRevert() { setSclKbmFromEngine(editor->sclText, editor->kbmText); }
+
+void TuningScreen::doLoad()
+{
+    auto isScl = activeTab == 0;
+    fileChooser = std::make_unique<juce::FileChooser>(isScl ? "Load Scale (SCL)"
+                                                            : "Load Keyboard Mapping (KBM)",
+                                                      juce::File(), isScl ? "*.scl" : "*.kbm");
+    fileChooser->launchAsync(
+        juce::FileBrowserComponent::canSelectFiles | juce::FileBrowserComponent::openMode,
+        [w = juce::Component::SafePointer(this), isScl](const juce::FileChooser &fc) {
+            if (!w)
+                return;
+            auto result = fc.getResults();
+            if (result.size() != 1)
+                return;
+
+            auto txt = shared::fileToString(shared::juceFileToFSPath(result[0]));
+            if (!txt.has_value())
+            {
+                w->editor->displayError("Tuning Error", "Unable to open that file for reading.");
+                return;
+            }
+
+            auto c = w->contents();
+            if (!c)
+                return;
+            // Load only fills the box; the user presses Apply to make it live
+            (isScl ? c->sclEditor : c->kbmEditor)->setText(*txt, juce::dontSendNotification);
+        });
+}
+
+void TuningScreen::visibilityChanged()
+{
+    if (isVisible())
+        doRevert();
+}
+
+void TuningScreen::resized() { contentsArea->setBounds(getLocalBounds().reduced(80, 40)); }
+
+bool TuningScreen::keyPressed(const juce::KeyPress &key)
+{
+    if (key.getKeyCode() == juce::KeyPress::escapeKey)
+    {
+        setVisible(false);
+        return true;
+    }
+    return false;
+}
+
+} // namespace scxt::ui::app::other_screens

--- a/src/scxt-plugin/app/other-screens/TuningScreen.h
+++ b/src/scxt-plugin/app/other-screens/TuningScreen.h
@@ -1,0 +1,77 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_SCXT_PLUGIN_APP_OTHER_SCREENS_TUNINGSCREEN_H
+#define SCXT_SRC_SCXT_PLUGIN_APP_OTHER_SCREENS_TUNINGSCREEN_H
+
+#include "app/HasEditor.h"
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <memory>
+#include <string>
+#include "sst/jucegui/components/NamedPanel.h"
+
+namespace scxt::ui::app::other_screens
+{
+struct TuningScreenContents;
+
+/*
+ * Shows the SCL scale and KBM mapping as editable monospace text. Deliberately
+ * a plain text box for now; a structured scale editor can come later.
+ */
+struct TuningScreen : juce::Component, HasEditor
+{
+    TuningScreen(SCXTEditor *e);
+    ~TuningScreen();
+
+    // Called from the s2c handler with whatever the engine currently holds
+    void setSclKbmFromEngine(const std::string &scl, const std::string &kbm);
+
+    void doLoad();
+    void doApply();
+    void doRevert();
+    void setActiveTab(int);
+
+    void paint(juce::Graphics &g) override
+    {
+        g.fillAll(juce::Colour(0x90, 0x90, 0x90).withAlpha(0.3f));
+    }
+    void resized() override;
+    void visibilityChanged() override;
+    bool keyPressed(const juce::KeyPress &key) override;
+
+    std::unique_ptr<sst::jucegui::components::NamedPanel> contentsArea;
+    std::unique_ptr<juce::FileChooser> fileChooser;
+    int activeTab{0};
+
+  private:
+    TuningScreenContents *contents();
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TuningScreen);
+};
+} // namespace scxt::ui::app::other_screens
+
+#endif // SCXT_SRC_SCXT_PLUGIN_APP_OTHER_SCREENS_TUNINGSCREEN_H

--- a/src/scxt-plugin/app/shared/UIHelpers.h
+++ b/src/scxt-plugin/app/shared/UIHelpers.h
@@ -29,6 +29,10 @@
 #define SCXT_SRC_SCXT_PLUGIN_APP_SHARED_UIHELPERS_H
 
 #include <juce_core/juce_core.h>
+#include <fstream>
+#include <optional>
+#include <sstream>
+#include <string>
 #include "filesystem/import.h"
 
 namespace scxt::ui::app::shared
@@ -66,6 +70,17 @@ inline juce::File fsPathToJuceFile(const fs::path &p)
 #else
     return juce::File(p.u8string());
 #endif
+}
+
+// Slurp a text file, or nullopt if it won't open
+inline std::optional<std::string> fileToString(const fs::path &p)
+{
+    std::ifstream t(p);
+    if (!t)
+        return std::nullopt;
+    std::stringstream buffer;
+    buffer << t.rdbuf();
+    return buffer.str();
 }
 
 } // namespace scxt::ui::app::shared

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,11 @@ target_compile_definitions(scxt-test PRIVATE
 		SCXT_TEST_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
 )
 
+# Tests don't unity build. Concatenating them makes each file's file scope
+# visible to the next, which turns a helper or an include in one test into a
+# collision in an unrelated one.
+set_target_properties(scxt-test PROPERTIES UNITY_BUILD OFF)
+
 target_link_libraries(scxt-test
 		fmt
         scxt-core

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(scxt-test
 		importer_tests.cpp
 		midi_channel_tests.cpp
 		macro_id_tests.cpp
+		tuning_tests.cpp
 )
 
 target_compile_definitions(scxt-test PRIVATE

--- a/tests/exclusive_group_tests.cpp
+++ b/tests/exclusive_group_tests.cpp
@@ -165,15 +165,13 @@ TEST_CASE("Exclusive Group - different IDs do not choke each other", "[exclusive
 
 TEST_CASE("Exclusive Group - streaming round-trip", "[exclusive_group]")
 {
-    using namespace scxt;
-
-    engine::Group::GroupOutputInfo info;
+    scxt::engine::Group::GroupOutputInfo info;
     info.exclusiveGroup = 3;
 
     auto s = tao::json::to_string(scxt::json::scxt_value(info));
     REQUIRE(s.find("excg") != std::string::npos);
 
-    engine::Group::GroupOutputInfo info2;
+    scxt::engine::Group::GroupOutputInfo info2;
     {
         tao::json::events::transformer<tao::json::events::to_basic_value<scxt::json::scxt_traits>>
             consumer;
@@ -275,7 +273,6 @@ TEST_CASE("Exclusive Group - old ZoneMappingData JSON loads without crash", "[ex
 {
     // Patches saved before this change had "exclusiveGroup" under ZoneMappingData.
     // The field no longer exists there; it should be silently ignored on load.
-    using namespace scxt;
 
     std::string oldJson =
         R"({"rootKey":60,"keyR":{"keyStart":0,"keyEnd":127,"fadeStart":0,"fadeEnd":0},)"
@@ -283,7 +280,7 @@ TEST_CASE("Exclusive Group - old ZoneMappingData JSON loads without crash", "[ex
         R"("pbDown":-1,"pbUp":-1,"exclusiveGroup":2,"velocitySens":1.0,)"
         R"("amplitude":0.0,"pan":0.0,"pitchOffset":0.0,"tracking":1.0})";
 
-    engine::Zone::ZoneMappingData zmd;
+    scxt::engine::Zone::ZoneMappingData zmd;
     {
         tao::json::events::transformer<tao::json::events::to_basic_value<scxt::json::scxt_traits>>
             consumer;

--- a/tests/midi_channel_tests.cpp
+++ b/tests/midi_channel_tests.cpp
@@ -43,8 +43,6 @@
  * verify the migration in Engine::SC_TO.
  */
 
-using namespace scxt;
-
 namespace
 {
 

--- a/tests/sample_analytics.cpp
+++ b/tests/sample_analytics.cpp
@@ -30,8 +30,6 @@
 #include <limits>
 #include <cmath>
 
-using namespace scxt;
-
 TEST_CASE("Sample Analytics", "[sample]")
 {
     float _scratch; // Create a scratch double for modf
@@ -41,7 +39,7 @@ TEST_CASE("Sample Analytics", "[sample]")
     std::array<float, 1024> sineBuffer{};
     constexpr float sine_amp = 0.6f;
     const float sine_rms = sine_amp / sqrt(2.0f);
-    const auto sineSample = std::make_shared<sample::Sample>();
+    const auto sineSample = std::make_shared<scxt::sample::Sample>();
     sineSample->allocateF32(0, sineBuffer.size());
     for (int i = 0; i < sineBuffer.size(); i++)
     {
@@ -58,7 +56,7 @@ TEST_CASE("Sample Analytics", "[sample]")
     std::array<float, 1024> squareBuffer{};
     constexpr float square_amp = 0.8f;
     constexpr float square_rms = square_amp;
-    const auto squareSample = std::make_shared<sample::Sample>();
+    const auto squareSample = std::make_shared<scxt::sample::Sample>();
     squareSample->allocateF32(0, squareBuffer.size());
     for (int i = 0; i < squareBuffer.size(); i++)
     {
@@ -75,7 +73,7 @@ TEST_CASE("Sample Analytics", "[sample]")
     std::array<int16_t, 1024> sawBuffer{};
     constexpr float saw_amp = 0.3f;
     const float saw_rms = saw_amp / sqrt(3.0f);
-    const auto sawSample = std::make_shared<sample::Sample>();
+    const auto sawSample = std::make_shared<scxt::sample::Sample>();
     sawSample->allocateI16(0, sawBuffer.size());
     sawSample->allocateI16(1, sawBuffer.size());
     for (int i = 0; i < sawBuffer.size(); i++)
@@ -96,21 +94,21 @@ TEST_CASE("Sample Analytics", "[sample]")
 
     SECTION("Peak Analysis")
     {
-        REQUIRE_THAT(dsp::sample_analytics::computePeak(sineSample),
+        REQUIRE_THAT(scxt::dsp::sample_analytics::computePeak(sineSample),
                      Catch::WithinRel(sine_amp, tolerance));
-        REQUIRE_THAT(dsp::sample_analytics::computePeak(squareSample),
+        REQUIRE_THAT(scxt::dsp::sample_analytics::computePeak(squareSample),
                      Catch::WithinRel(square_amp, tolerance));
-        REQUIRE_THAT(dsp::sample_analytics::computePeak(sawSample),
+        REQUIRE_THAT(scxt::dsp::sample_analytics::computePeak(sawSample),
                      Catch::WithinRel(saw_amp, tolerance));
     }
 
     SECTION("RMS Analysis")
     {
-        REQUIRE_THAT(dsp::sample_analytics::computeRMS(sineSample),
+        REQUIRE_THAT(scxt::dsp::sample_analytics::computeRMS(sineSample),
                      Catch::WithinRel(sine_rms, tolerance));
-        REQUIRE_THAT(dsp::sample_analytics::computeRMS(squareSample),
+        REQUIRE_THAT(scxt::dsp::sample_analytics::computeRMS(squareSample),
                      Catch::WithinRel(square_rms, tolerance));
-        REQUIRE_THAT(dsp::sample_analytics::computeRMS(sawSample),
+        REQUIRE_THAT(scxt::dsp::sample_analytics::computeRMS(sawSample),
                      Catch::WithinRel(saw_rms, tolerance));
     }
 }

--- a/tests/sample_fuzz.cpp
+++ b/tests/sample_fuzz.cpp
@@ -45,8 +45,6 @@
 #include <cstring>
 #include <vector>
 
-using namespace scxt;
-
 namespace
 {
 // Little-endian appenders + ASCII fourcc, matching what RIFFMemFile reads.
@@ -112,7 +110,7 @@ std::vector<uint8_t> assembleRiff(const std::vector<uint8_t> &body, int64_t size
 TEST_CASE("parse_riff_wave: valid baseline parses", "[sample][fuzz][wav]")
 {
     auto f = assembleRiff(wavBody(32));
-    sample::Sample s;
+    scxt::sample::Sample s;
     REQUIRE(s.parse_riff_wave(f.data(), f.size()));
     CHECK(s.channels == 2);
     CHECK(s.sample_rate == 48000);
@@ -133,7 +131,7 @@ TEST_CASE("parse_riff_wave: inflated LIST size cannot read past the buffer", "[s
     body.insert(body.end(), nm, nm + 8);
 
     auto f = assembleRiff(body); // outer RIFF size is honest; the LIST lies
-    sample::Sample s;
+    scxt::sample::Sample s;
     // Must terminate without reading out of bounds; success/failure both fine.
     s.parse_riff_wave(f.data(), f.size());
     SUCCEED();
@@ -156,7 +154,7 @@ TEST_CASE("parse_riff_wave: short un-terminated INAM is copied safely", "[sample
     patchU32(body, listSizeAt, (uint32_t)(4 + 8 + 10));
 
     auto f = assembleRiff(body);
-    sample::Sample s;
+    scxt::sample::Sample s;
     REQUIRE(s.parse_riff_wave(f.data(), f.size()));
     // name must be NUL-terminated within its 64-byte buffer
     CHECK(s.name[63] == 0);
@@ -175,7 +173,7 @@ TEST_CASE("parse_riff_wave: huge cue count does not over-allocate", "[sample][fu
         body.push_back(0);
 
     auto f = assembleRiff(body);
-    sample::Sample s;
+    scxt::sample::Sample s;
     REQUIRE(s.parse_riff_wave(f.data(), f.size()));
     // clamped to what the chunk can hold (1) => below the >1 threshold => no slices
     CHECK(s.meta.n_slices == 0);
@@ -193,7 +191,7 @@ TEST_CASE("parse_riff_wave: truncated cue chunk leaves no garbage slices", "[sam
         body.push_back((uint8_t)(i & 0xFF)); // only 2 CuePoints actually present
 
     auto f = assembleRiff(body);
-    sample::Sample s;
+    scxt::sample::Sample s;
     REQUIRE(s.parse_riff_wave(f.data(), f.size()));
     CHECK(s.meta.n_slices <= 2);
 }
@@ -246,7 +244,7 @@ TEST_CASE("parse_riff_wave: survives truncation at every prefix length", "[sampl
 
     for (size_t n = 1; n <= f.size(); ++n)
     {
-        sample::Sample s;
+        scxt::sample::Sample s;
         // Any return value is acceptable; the requirement is "does not crash /
         // read out of bounds" for an arbitrarily truncated file.
         s.parse_riff_wave(f.data(), n);
@@ -263,7 +261,7 @@ TEST_CASE("parse_riff_wave: byte-flip fuzz of size fields does not crash", "[sam
     {
         auto m = base;
         m[off + 3] ^= 0x80;
-        sample::Sample s;
+        scxt::sample::Sample s;
         s.parse_riff_wave(m.data(), m.size());
     }
     SUCCEED();
@@ -284,7 +282,7 @@ TEST_CASE("parse_riff_wave: 256MB+ data chunk sample count does not overflow",
     body.resize(body.size() + dataBytes, 0);
 
     auto f = assembleRiff(body, /*sizeOverride*/ (int64_t)body.size());
-    sample::Sample s;
+    scxt::sample::Sample s;
     REQUIRE(s.parse_riff_wave(f.data(), f.size()));
     CHECK(s.getSampleLength() == dataBytes); // 8 * bytes / 8 == bytes, no wrap
 }
@@ -360,7 +358,7 @@ TEST_CASE("parse_aiff: valid mono 16-bit baseline parses", "[sample][fuzz][aiff]
     putAiffSSND(chunks, 0, rampAudio(32 * 2));
     auto f = assembleAiff(chunks);
 
-    sample::Sample s;
+    scxt::sample::Sample s;
     REQUIRE(s.parse_aiff(f.data(), f.size()));
     CHECK(s.channels == 1);
     CHECK(s.sample_rate == 44100);
@@ -377,7 +375,7 @@ TEST_CASE("parse_aiff: COMM frame count exceeding SSND payload is clamped (mono)
     putAiffSSND(chunks, 0, rampAudio(16 * 2));
     auto f = assembleAiff(chunks);
 
-    sample::Sample s;
+    scxt::sample::Sample s;
     REQUIRE(s.parse_aiff(f.data(), f.size()));
     CHECK(s.getSampleLength() <= 16);
 }
@@ -391,7 +389,7 @@ TEST_CASE("parse_aiff: COMM frame count exceeding SSND payload is clamped (stere
     putAiffSSND(chunks, 0, rampAudio(8 * 4));
     auto f = assembleAiff(chunks);
 
-    sample::Sample s;
+    scxt::sample::Sample s;
     REQUIRE(s.parse_aiff(f.data(), f.size()));
     CHECK(s.channels == 2);
     CHECK(s.getSampleLength() <= 8);
@@ -406,7 +404,7 @@ TEST_CASE("parse_aiff: 24-bit COMM frame count exceeding SSND payload is clamped
     putAiffSSND(chunks, 0, rampAudio(10 * 3));
     auto f = assembleAiff(chunks);
 
-    sample::Sample s;
+    scxt::sample::Sample s;
     REQUIRE(s.parse_aiff(f.data(), f.size()));
     CHECK(s.getSampleLength() <= 10);
 }
@@ -431,7 +429,7 @@ TEST_CASE("parse_aiff: huge MARK count does not over-allocate or read past the c
     chunks.insert(chunks.end(), mark.begin(), mark.end());
 
     auto f = assembleAiff(chunks);
-    sample::Sample s;
+    scxt::sample::Sample s;
     s.parse_aiff(f.data(), f.size()); // success/failure both fine; must not OOB
     SUCCEED();
 }
@@ -472,7 +470,7 @@ TEST_CASE("parse_aiff: INST loop referencing an absent marker reads a defined va
     chunks.insert(chunks.end(), inst.begin(), inst.end());
 
     auto f = assembleAiff(chunks);
-    sample::Sample s;
+    scxt::sample::Sample s;
     REQUIRE(s.parse_aiff(f.data(), f.size()));
     CHECK(s.meta.loop_start == 0);
     CHECK(s.meta.loop_end == 1); // absent marker → 0, code stores +1
@@ -517,7 +515,7 @@ TEST_CASE("parse_aiff: survives truncation at every prefix length", "[sample][fu
     auto f = assembleAiff(chunks);
     for (size_t n = 1; n <= f.size(); ++n)
     {
-        sample::Sample s;
+        scxt::sample::Sample s;
         s.parse_aiff(f.data(), n);
     }
     SUCCEED();

--- a/tests/sample_load.cpp
+++ b/tests/sample_load.cpp
@@ -35,7 +35,6 @@
 
 #include "test_utils.h"
 
-using namespace scxt;
 namespace fs = std::filesystem;
 
 TEST_CASE("Load Opus sample", "[sample][opus]")
@@ -46,13 +45,13 @@ TEST_CASE("Load Opus sample", "[sample][opus]")
     INFO("fixture=" << p.u8string());
     REQUIRE(fs::exists(p));
 
-    sample::Sample s;
+    scxt::sample::Sample s;
     REQUIRE(s.load(p));
 
-    CHECK(s.type == sample::Sample::OPUS_FILE);
+    CHECK(s.type == scxt::sample::Sample::OPUS_FILE);
     CHECK(s.sample_loaded);
     CHECK(s.sample_rate == 48000);
-    CHECK(s.bitDepth == sample::Sample::BD_F32);
+    CHECK(s.bitDepth == scxt::sample::Sample::BD_F32);
     CHECK(s.channels == 2);
     CHECK(s.getSampleLength() > 0);
 
@@ -81,7 +80,7 @@ TEST_CASE("Opus parses from in-memory bytes", "[sample][opus]")
                                std::istreambuf_iterator<char>());
     REQUIRE(!bytes.empty());
 
-    sample::Sample s;
+    scxt::sample::Sample s;
     REQUIRE(s.parseOpus(bytes.data(), bytes.size()));
     CHECK(s.sample_rate == 48000);
     CHECK(s.channels == 2);
@@ -95,13 +94,13 @@ TEST_CASE("Load extensible wav sample", "[sample][wav]")
     INFO("fixture=" << p.u8string());
     REQUIRE(fs::exists(p));
 
-    sample::Sample s;
+    scxt::sample::Sample s;
     REQUIRE(s.load(p));
 
-    CHECK(s.type == sample::Sample::WAV_FILE);
+    CHECK(s.type == scxt::sample::Sample::WAV_FILE);
     CHECK(s.sample_loaded);
     CHECK(s.sample_rate == 48000);
-    CHECK(s.bitDepth == sample::Sample::BD_F32);
+    CHECK(s.bitDepth == scxt::sample::Sample::BD_F32);
     CHECK(s.channels == 2);
     CHECK(s.getSampleLength() > 0);
 

--- a/tests/streaming.cpp
+++ b/tests/streaming.cpp
@@ -32,8 +32,6 @@
 #include "json/dsp_traits.h"
 #include "json/modulation_traits.h"
 
-using namespace scxt;
-
 template <typename T> std::string testStream(const T &in)
 {
     return tao::json::to_string(scxt::json::scxt_value(in));
@@ -49,18 +47,18 @@ template <typename T> void testUnstream(const std::string &s, T &in)
     val.to(in);
 }
 
-TEST_CASE("Stream a engine::KeyboardRange")
+TEST_CASE("Stream a scxt::engine::KeyboardRange")
 {
     SECTION("Compiles")
     {
-        engine::KeyboardRange k1, k2;
+        scxt::engine::KeyboardRange k1, k2;
         auto s = testStream(k1);
         testUnstream(s, k2);
     }
 
     SECTION("Values")
     {
-        engine::KeyboardRange k1, k2;
+        scxt::engine::KeyboardRange k1, k2;
         k1.keyStart = 13;
         k1.keyEnd = 19;
         k1.fadeStart = 2;
@@ -73,19 +71,19 @@ TEST_CASE("Stream a engine::KeyboardRange")
     }
 }
 
-TEST_CASE("Stream a dsp::filter::ProcessorStorage")
+TEST_CASE("Stream a scxt::dsp::filter::ProcessorStorage")
 {
     SECTION("Compiles")
     {
-        dsp::processor::ProcessorStorage k1, k2;
+        scxt::dsp::processor::ProcessorStorage k1, k2;
         auto s = testStream(k1);
         testUnstream(s, k2);
     }
 
     SECTION("Type Streams")
     {
-        dsp::processor::ProcessorStorage k1, k2;
-        k1.type = dsp::processor::proct_osc_EBWaveforms;
+        scxt::dsp::processor::ProcessorStorage k1, k2;
+        k1.type = scxt::dsp::processor::proct_osc_EBWaveforms;
         REQUIRE(k1 != k2);
         auto s = testStream(k1);
         testUnstream(s, k2);
@@ -94,8 +92,8 @@ TEST_CASE("Stream a dsp::filter::ProcessorStorage")
 
     SECTION("Expanded Values Stream")
     {
-        dsp::processor::ProcessorStorage k1, k2;
-        k1.type = dsp::processor::proct_osc_EBWaveforms;
+        scxt::dsp::processor::ProcessorStorage k1, k2;
+        k1.type = scxt::dsp::processor::proct_osc_EBWaveforms;
         k1.mix = 0.23;
         for (auto &fv : k1.floatParams)
             fv = 1.0 * (rand() % 10000) / 7842.2;
@@ -108,21 +106,21 @@ TEST_CASE("Stream a dsp::filter::ProcessorStorage")
     }
 }
 
-TEST_CASE("Stream modulation::modulators::StepLFOStorage")
+TEST_CASE("Stream scxt::modulation::modulators::StepLFOStorage")
 {
     SECTION("Compiles")
     {
-        modulation::modulators::StepLFOStorage k1, k2;
+        scxt::modulation::modulators::StepLFOStorage k1, k2;
         auto s = testStream(k1);
         testUnstream(s, k2);
     }
 }
 
-TEST_CASE("Stream engine::Zone")
+TEST_CASE("Stream scxt::engine::Zone")
 {
     SECTION("Compiles")
     {
-        engine::Zone k1, k2;
+        scxt::engine::Zone k1, k2;
         auto s = testStream(k1);
         testUnstream(s, k2);
     }
@@ -130,7 +128,7 @@ TEST_CASE("Stream engine::Zone")
     SECTION("Sends a Mod")
     {
 #if BADBAD
-        engine::Zone k1, k2;
+        scxt::engine::Zone k1, k2;
         k1.routingTable[3].src = scxt::modulation::vms_LFO2;
         k1.routingTable[3].dst = {scxt::modulation::vmd_Processor_Mix, 0};
         k1.routingTable[3].depth = 0.24;
@@ -144,7 +142,7 @@ TEST_CASE("Stream engine::Zone")
     SECTION("Overwrites a Mod")
     {
 #if BADBAD
-        engine::Zone k1, k2;
+        scxt::engine::Zone k1, k2;
         k1.routingTable[3].src = scxt::modulation::vms_LFO2;
         k1.routingTable[3].dst = {scxt::modulation::vmd_Processor_Mix, 0};
         k1.routingTable[3].depth = 0.24;

--- a/tests/tuning_tests.cpp
+++ b/tests/tuning_tests.cpp
@@ -1,0 +1,419 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "catch2/catch2.hpp"
+
+#include <cmath>
+
+#include "engine/engine.h"
+#include "tuning/midikey_retuner.h"
+#include "tuning/scl_kbm.h"
+#include "json/engine_traits.h"
+#include "json/stream.h"
+#include "messaging/client/enginestatus_messages.h"
+
+#include "Tunings.h"
+
+#include "console_harness.h"
+#include "test_utils.h"
+
+/*
+ * SCL/KBM tuning. The retuner contract is "semitones to offset a 12-TET key by", so
+ * every expectation here is expressed that way rather than in Hz.
+ */
+
+using RetuneTable = scxt::tuning::MidikeyRetuner::RetuneTable;
+
+static float offsetAt(const RetuneTable &t, int midiNote)
+{
+    return t.semitones[midiNote + RetuneTable::midiOffset];
+}
+
+TEST_CASE("SCL/KBM - twelve tone equal temperament is a no-op", "[tuning]")
+{
+    RetuneTable table;
+    std::string err;
+    REQUIRE(scxt::tuning::buildRetuneTable(scxt::tuning::twelveTETSclText(), "", table, err));
+    REQUIRE(err.empty());
+
+    for (int k = 0; k < 128; ++k)
+        REQUIRE(offsetAt(table, k) == Approx(0.f).margin(1e-4));
+
+    REQUIRE(table.repetitionInterval == 12);
+}
+
+TEST_CASE("SCL/KBM - 19 EDO steps are 12/19 of a semitone", "[tuning]")
+{
+    RetuneTable table;
+    std::string err;
+    REQUIRE(scxt::tuning::buildRetuneTable(Tunings::evenDivisionOfSpanByM(2, 19).rawText, "", table,
+                                           err));
+
+    // The default mapping pins the scale to midi 60, so 60 is untouched
+    REQUIRE(offsetAt(table, 60) == Approx(0.f).margin(1e-4));
+
+    // and each key above it moves by one 19-EDO step rather than one semitone
+    for (int i = 1; i < 12; ++i)
+        REQUIRE(offsetAt(table, 60 + i) == Approx(i * 12.0 / 19.0 - i).margin(1e-4));
+
+    REQUIRE(table.repetitionInterval == 19);
+}
+
+TEST_CASE("SCL/KBM - a KBM reference frequency shifts the whole keyboard", "[tuning]")
+{
+    RetuneTable table;
+    std::string err;
+    REQUIRE(scxt::tuning::buildRetuneTable(scxt::tuning::twelveTETSclText(),
+                                           Tunings::tuneA69To(432.0).rawText, table, err));
+
+    auto expected = 12.0 * std::log2(432.0 / 440.0);
+    for (auto k : {24, 60, 69, 100})
+        REQUIRE(offsetAt(table, k) == Approx(expected).margin(1e-4));
+
+    // A KBM map size of zero is a linear mapping, so the keyboard still repeats on the scale
+    REQUIRE(table.repetitionInterval == 12);
+}
+
+TEST_CASE("SCL/KBM - an explicit KBM size sets the repetition interval", "[tuning]")
+{
+    // Seven keys per repeat over a seven note scale, with one key deliberately unmapped.
+    // Note the KBM grammar rejects trailing comments on value lines and spells an
+    // unmapped key 'x'.
+    std::string kbm = R"KBM(! Seven key mapping with a gap
+7
+0
+127
+60
+60
+261.6255653
+7
+0
+1
+2
+x
+3
+4
+5
+)KBM";
+
+    RetuneTable table;
+    std::string err;
+    REQUIRE(scxt::tuning::buildRetuneTable(Tunings::evenDivisionOfSpanByM(2, 7).rawText, kbm, table,
+                                           err));
+
+    REQUIRE(table.repetitionInterval == 7);
+
+    // withSkippedNotesInterpolated means the unmapped key must still hold a sane
+    // value; without it the retuner would smear nonsense across its neighbours.
+    for (int k = 0; k < 128; ++k)
+    {
+        auto o = offsetAt(table, k);
+        REQUIRE(std::isfinite(o));
+        REQUIRE(std::fabs(o) < 128.f);
+    }
+}
+
+TEST_CASE("SCL/KBM - a bad scale reports and changes nothing", "[tuning]")
+{
+    RetuneTable table;
+    std::string err;
+    REQUIRE(scxt::tuning::buildRetuneTable(Tunings::evenDivisionOfSpanByM(2, 6).rawText, "", table,
+                                           err));
+    auto before = table;
+
+    REQUIRE(!scxt::tuning::buildRetuneTable("this is definitely not a scale", "", table, err));
+    REQUIRE(!err.empty());
+    REQUIRE(table.semitones == before.semitones);
+    REQUIRE(table.repetitionInterval == before.repetitionInterval);
+
+    // An empty scale is an error too, not a silent 12-TET
+    err.clear();
+    REQUIRE(!scxt::tuning::buildRetuneTable("", "", table, err));
+    REQUIRE(!err.empty());
+}
+
+TEST_CASE("SCL/KBM - the retuner clamps out of range keys", "[tuning]")
+{
+    RetuneTable table;
+    std::string err;
+    REQUIRE(scxt::tuning::buildRetuneTable(Tunings::evenDivisionOfSpanByM(2, 6).rawText, "", table,
+                                           err));
+
+    scxt::tuning::MidikeyRetuner retuner;
+    retuner.setSCLKBMTable(table);
+    retuner.setTuningMode(scxt::tuning::MidikeyRetuner::SCL_KBM);
+
+    // retuningForRemappedKeyWithInterpolation reaches for ik+1 with pitch bend applied,
+    // so the table has to answer well outside 0..127
+    for (auto k : {-4000, -300, -1, 0, 127, 128, 400, 4000})
+        REQUIRE(std::isfinite(retuner.offsetKeyBy(0, k)));
+
+    REQUIRE(retuner.getRepetitionInterval() == 6);
+}
+
+TEST_CASE("SCL/KBM - with no table loaded the retuner is transparent", "[tuning]")
+{
+    scxt::tuning::MidikeyRetuner retuner;
+    retuner.setTuningMode(scxt::tuning::MidikeyRetuner::SCL_KBM);
+
+    REQUIRE(!retuner.hasSCLKBM());
+    REQUIRE(retuner.offsetKeyBy(0, 60) == Approx(0.f));
+    REQUIRE(retuner.getRepetitionInterval() == 12);
+}
+
+TEST_CASE("SCL/KBM - a stretched scale remaps the key used for zone lookup", "[tuning]")
+{
+    // 6-EDO: every scale step is two semitones, so the sixth key above middle C
+    // lands a full octave up.
+    RetuneTable table;
+    std::string err;
+    REQUIRE(scxt::tuning::buildRetuneTable(Tunings::evenDivisionOfSpanByM(2, 6).rawText, "", table,
+                                           err));
+
+    scxt::tuning::MidikeyRetuner retuner;
+    retuner.setSCLKBMTable(table);
+    retuner.setTuningMode(scxt::tuning::MidikeyRetuner::SCL_KBM);
+
+    REQUIRE(retuner.remapKeyTo(0, 60) == 60);
+    REQUIRE(retuner.remapKeyTo(0, 61) == 62);
+    REQUIRE(retuner.remapKeyTo(0, 66) == 72);
+
+    // Clearing drops us straight back to an identity map
+    retuner.clearSCLKBM();
+    REQUIRE(retuner.remapKeyTo(0, 66) == 66);
+}
+
+TEST_CASE("SCL/KBM - the mode demotes to 12-TET with no scale behind it", "[tuning]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+
+    eng->runtimeConfig.tuningMode = scxt::engine::Engine::TuningMode::SCL_KBM;
+    eng->resetTuningFromRuntimeConfig();
+
+    REQUIRE(eng->runtimeConfig.tuningMode == scxt::engine::Engine::TuningMode::TWELVE_TET);
+    REQUIRE(eng->midikeyRetuner.tuningMode == scxt::tuning::MidikeyRetuner::TWELVE_TET);
+}
+
+TEST_CASE("SCL/KBM - a loaded scale keeps the mode", "[tuning]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto bg = eng->getMessageController()->threadingChecker.bypassChecksInScope();
+
+    eng->dawExtraState.sclContents = Tunings::evenDivisionOfSpanByM(2, 6).rawText;
+    std::string err;
+    REQUIRE(eng->applySclKbmFromDawExtraState(err));
+
+    eng->runtimeConfig.tuningMode = scxt::engine::Engine::TuningMode::SCL_KBM;
+    eng->resetTuningFromRuntimeConfig();
+
+    REQUIRE(eng->runtimeConfig.tuningMode == scxt::engine::Engine::TuningMode::SCL_KBM);
+    REQUIRE(eng->midikeyRetuner.remapKeyTo(0, 66) == 72);
+
+    // Clearing the scale text takes the mode with it
+    eng->dawExtraState.sclContents = "";
+    REQUIRE(eng->applySclKbmFromDawExtraState(err));
+    eng->resetTuningFromRuntimeConfig();
+    REQUIRE(eng->runtimeConfig.tuningMode == scxt::engine::Engine::TuningMode::TWELVE_TET);
+}
+
+TEST_CASE("SCL/KBM - the scale round-trips through daw extra state", "[tuning]")
+{
+    auto scl = Tunings::evenDivisionOfSpanByM(2, 6).rawText;
+    auto kbm = Tunings::tuneA69To(432.0).rawText;
+
+    std::string saved;
+    {
+        std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+        auto bg = eng->getMessageController()->threadingChecker.bypassChecksInScope();
+
+        eng->dawExtraState.sclContents = scl;
+        eng->dawExtraState.kbmContents = kbm;
+        std::string err;
+        REQUIRE(eng->applySclKbmFromDawExtraState(err));
+        eng->runtimeConfig.tuningMode = scxt::engine::Engine::TuningMode::SCL_KBM;
+        eng->resetTuningFromRuntimeConfig();
+
+        auto sg = scxt::engine::Engine::StreamGuard(scxt::engine::Engine::FOR_DAW);
+        saved = scxt::json::streamEngineState(*eng);
+    }
+
+    std::unique_ptr<scxt::engine::Engine> reloaded(makeEngine());
+    {
+        auto bg = reloaded->getMessageController()->threadingChecker.bypassChecksInScope();
+        scxt::json::unstreamEngineState(*reloaded, saved);
+    }
+
+    REQUIRE(reloaded->dawExtraState.sclContents == scl);
+    REQUIRE(reloaded->dawExtraState.kbmContents == kbm);
+    REQUIRE(reloaded->runtimeConfig.tuningMode == scxt::engine::Engine::TuningMode::SCL_KBM);
+    REQUIRE(reloaded->midikeyRetuner.hasSCLKBM());
+
+    // and it retunes identically to a table built straight from the same text
+    RetuneTable expected;
+    std::string err;
+    REQUIRE(scxt::tuning::buildRetuneTable(scl, kbm, expected, err));
+    for (int k = 0; k < 128; ++k)
+        REQUIRE(reloaded->midikeyRetuner.offsetKeyBy(0, k) == Approx(offsetAt(expected, k)));
+}
+
+TEST_CASE("SCL/KBM - a multi without the scale falls back rather than sounding untuned", "[tuning]")
+{
+    // The mode streams with a multi but the scale does not, so a multi saved in
+    // SCL/KBM has to land on 12-TET rather than in a mode with nothing behind it.
+    std::string saved;
+    {
+        std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+        auto bg = eng->getMessageController()->threadingChecker.bypassChecksInScope();
+
+        eng->dawExtraState.sclContents = Tunings::evenDivisionOfSpanByM(2, 6).rawText;
+        std::string err;
+        REQUIRE(eng->applySclKbmFromDawExtraState(err));
+        eng->runtimeConfig.tuningMode = scxt::engine::Engine::TuningMode::SCL_KBM;
+        eng->resetTuningFromRuntimeConfig();
+
+        auto sg = scxt::engine::Engine::StreamGuard(scxt::engine::Engine::FOR_MULTI);
+        saved = scxt::json::streamEngineState(*eng);
+    }
+
+    std::unique_ptr<scxt::engine::Engine> reloaded(makeEngine());
+    {
+        auto bg = reloaded->getMessageController()->threadingChecker.bypassChecksInScope();
+        scxt::json::unstreamEngineState(*reloaded, saved);
+    }
+
+    REQUIRE(reloaded->dawExtraState.sclContents.empty());
+    REQUIRE(!reloaded->midikeyRetuner.hasSCLKBM());
+    REQUIRE(reloaded->runtimeConfig.tuningMode == scxt::engine::Engine::TuningMode::TWELVE_TET);
+}
+
+TEST_CASE("SCL/KBM - SetSclKbm applies through the real message pipe", "[tuning]")
+{
+    // The engine-level tests poke the retuner directly; this one goes over the wire so
+    // the payload serialization and the audio-thread handoff are covered too.
+    scxt::clients::console_ui::ConsoleHarness th;
+    REQUIRE(th.start());
+    REQUIRE(th.engine);
+
+    auto scl = Tunings::evenDivisionOfSpanByM(2, 6).rawText;
+    th.sendToSerialization(scxt::messaging::client::SetSclKbm({scl, ""}));
+    th.stepUI(20);
+
+    REQUIRE(th.engine->dawExtraState.sclContents == scl);
+    REQUIRE(th.engine->midikeyRetuner.hasSCLKBM());
+    REQUIRE(th.engine->runtimeConfig.tuningMode == scxt::engine::Engine::TuningMode::SCL_KBM);
+    REQUIRE(th.engine->midikeyRetuner.remapKeyTo(0, 66) == 72);
+
+    // A scale which does not parse leaves the live tuning exactly as it was
+    th.sendToSerialization(scxt::messaging::client::SetSclKbm({"not a scale at all", ""}));
+    th.stepUI(20);
+
+    REQUIRE(th.engine->dawExtraState.sclContents == scl);
+    REQUIRE(th.engine->runtimeConfig.tuningMode == scxt::engine::Engine::TuningMode::SCL_KBM);
+    REQUIRE(th.engine->midikeyRetuner.remapKeyTo(0, 66) == 72);
+
+    // and clearing it takes the mode back to 12-TET
+    th.sendToSerialization(scxt::messaging::client::SetSclKbm({"", ""}));
+    th.stepUI(20);
+
+    REQUIRE(th.engine->dawExtraState.sclContents.empty());
+    REQUIRE(!th.engine->midikeyRetuner.hasSCLKBM());
+    REQUIRE(th.engine->runtimeConfig.tuningMode == scxt::engine::Engine::TuningMode::TWELVE_TET);
+    REQUIRE(th.engine->midikeyRetuner.remapKeyTo(0, 66) == 66);
+}
+
+TEST_CASE("SCL/KBM - a mapping with no scale means 12-TET, not no tuning", "[tuning]")
+{
+    // "Put A4 at 432" needs a KBM but no custom scale, so the scale gets filled in
+    scxt::clients::console_ui::ConsoleHarness th;
+    REQUIRE(th.start());
+    REQUIRE(th.engine);
+
+    th.sendToSerialization(
+        scxt::messaging::client::SetSclKbm({"", Tunings::tuneA69To(432.0).rawText}));
+    th.stepUI(20);
+
+    REQUIRE(th.engine->dawExtraState.sclContents == scxt::tuning::twelveTETSclText());
+    REQUIRE(th.engine->midikeyRetuner.hasSCLKBM());
+    REQUIRE(th.engine->runtimeConfig.tuningMode == scxt::engine::Engine::TuningMode::SCL_KBM);
+
+    auto expected = 12.0 * std::log2(432.0 / 440.0);
+    REQUIRE(th.engine->midikeyRetuner.offsetKeyBy(0, 69) == Approx(expected).margin(1e-4));
+}
+
+TEST_CASE("SCL/KBM - the editor's seed mapping never moves the pitch", "[tuning]")
+{
+    /*
+     * The editor fills an empty KBM box so there is something to edit. Applying an
+     * untouched seed must be inaudible against ANY scale, or opening the editor and
+     * pressing Apply becomes destructive. A 69-at-440 seed would fail this for
+     * anything but 12-TET.
+     */
+    auto seed = scxt::tuning::defaultKbmText();
+
+    for (const auto &scl :
+         {scxt::tuning::twelveTETSclText(), Tunings::evenDivisionOfSpanByM(2, 19).rawText,
+          Tunings::evenDivisionOfSpanByM(3, 13).rawText})
+    {
+        RetuneTable seeded, bare;
+        std::string err;
+        REQUIRE(scxt::tuning::buildRetuneTable(scl, seed, seeded, err));
+        REQUIRE(scxt::tuning::buildRetuneTable(scl, "", bare, err));
+        for (int k = 0; k < 128; ++k)
+            REQUIRE(offsetAt(seeded, k) == Approx(offsetAt(bare, k)).margin(1e-4));
+    }
+}
+
+TEST_CASE("SCL/KBM - resetting to no scale clears the mapping too", "[tuning]")
+{
+    // "Reset to No SCL/KBM" has to leave the engine as if the session never had one
+    scxt::clients::console_ui::ConsoleHarness th;
+    REQUIRE(th.start());
+    REQUIRE(th.engine);
+
+    th.sendToSerialization(scxt::messaging::client::SetSclKbm(
+        {Tunings::evenDivisionOfSpanByM(2, 6).rawText, Tunings::tuneA69To(432.0).rawText}));
+    th.stepUI(20);
+    REQUIRE(!th.engine->dawExtraState.sclContents.empty());
+    REQUIRE(!th.engine->dawExtraState.kbmContents.empty());
+
+    th.sendToSerialization(scxt::messaging::client::SetSclKbm({"", ""}));
+    th.stepUI(20);
+
+    REQUIRE(th.engine->dawExtraState.sclContents.empty());
+    REQUIRE(th.engine->dawExtraState.kbmContents.empty());
+    REQUIRE(!th.engine->midikeyRetuner.hasSCLKBM());
+    REQUIRE(th.engine->runtimeConfig.tuningMode == scxt::engine::Engine::TuningMode::TWELVE_TET);
+    REQUIRE(th.engine->midikeyRetuner.offsetKeyBy(0, 60) == Approx(0.f));
+}
+
+TEST_CASE("SCL/KBM - the tuning mode round-trips as a string", "[tuning]")
+{
+    auto s = scxt::engine::Engine::toStringTuningMode(scxt::engine::Engine::TuningMode::SCL_KBM);
+    REQUIRE(s != "err");
+    REQUIRE(scxt::engine::Engine::fromStringTuningMode(s) ==
+            scxt::engine::Engine::TuningMode::SCL_KBM);
+}


### PR DESCRIPTION
Scala scale files, with an optional keyboard mapping, now sit alongside 12-TET and MTS-ESP as a way to tune the engine. The scale and mapping text saves with the DAW session, and a tabbed overlay shows both as editable monospace text.

The Tuning menu grows an SCL/KBM submenu to load, edit, or clear the scale and mapping, and the mode itself becomes selectable once a scale is present. Tuning-aware pitch bend and MPE glides now apply under SCL/KBM as well as MTS-ESP continuous.

A multi carries the tuning mode but not the scale, so one saved in SCL/KBM reverts to 12-TET rather than sounding untuned.

Closes #469

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>