### PR TITLE
Land on a loaded variant when restoring the sample tab

### DIFF
--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
@@ -124,9 +124,8 @@ VariantDisplay::VariantDisplay(scxt::ui::app::edit_screen::MacroMappingVariantPa
     rebuildForSelectedVariation(selectedVariation, true);
 }
 
-void VariantDisplay::rebuildForSelectedVariation(size_t sel, bool rebuildTabs)
+void VariantDisplay::rebuildForSelectedVariation(size_t sel, bool rebuildTabs, EmptySlot es)
 {
-    selectedVariation = sel;
     // assume we are full unless otherwise known
     size_t emptySlot = maxVariantsPerZone;
     for (int i = 0; i < maxVariantsPerZone; ++i)
@@ -137,7 +136,14 @@ void VariantDisplay::rebuildForSelectedVariation(size_t sel, bool rebuildTabs)
             break;
         }
     }
-    selectedVariation = std::min(emptySlot, sel);
+
+    // the highest tab we may land on. Restoring a remembered index stops at the last
+    // loaded variant, so carrying a selection onto a zone with fewer variants shows a
+    // sample rather than the "+" slot. A zone with none has only "+" to offer.
+    auto maxSel = emptySlot;
+    if (es == EmptySlot::Clamp && emptySlot > 0)
+        maxSel = emptySlot - 1;
+    selectedVariation = std::min(maxSel, sel);
 
     // This wierd pattern is because for some reason we rebuild the components
     // when we select a new variant but not the header.
@@ -720,7 +726,8 @@ void VariantDisplay::MyTabbedComponent::currentTabChanged(int newCurrentTabIndex
     // called with -1 when clearing tabs
     if (newCurrentTabIndex >= 0)
     {
-        display->rebuildForSelectedVariation(newCurrentTabIndex, false);
+        // an explicit click may be on "+", which is how a variant gets added
+        display->rebuildForSelectedVariation(newCurrentTabIndex, false, EmptySlot::Allow);
         display->repaint();
     }
 

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.h
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.h
@@ -135,7 +135,19 @@ struct VariantDisplay : juce::Component, HasEditor
 
     VariantDisplay(MacroMappingVariantPane *p);
 
-    void rebuildForSelectedVariation(size_t sel, bool rebuildTabs = true);
+    /*
+     * selectedVariation outlives the zone it was chosen in - the pane is not rebuilt when
+     * the selection changes - so a remembered index can point past the variants the new
+     * zone actually has. Restoring lands on the last loaded variant; only clicking the "+"
+     * tab selects the empty slot.
+     */
+    enum struct EmptySlot
+    {
+        Clamp,
+        Allow
+    };
+    void rebuildForSelectedVariation(size_t sel, bool rebuildTabs = true,
+                                     EmptySlot es = EmptySlot::Clamp);
 
     ~VariantDisplay() { reset(); }
 


### PR DESCRIPTION
The selected variant index outlives the zone it was picked in, so carrying it onto a zone with fewer variants clamped it to the first empty slot and opened the sample view on the "+" tab. Selecting variant 3, deleting the zone and dragging in a new sample showed "+" rather than the sample just loaded.

Restoring now stops at the last loaded variant. Clicking "+" still selects the empty slot, which is how a variant gets added.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>