### PR TITLE
Add edit all to the sample variant display

### DIFF
--- a/src/scxt-core/configuration.h
+++ b/src/scxt-core/configuration.h
@@ -69,6 +69,8 @@ static constexpr size_t maxProcessorIntParams{5};
 static constexpr uint16_t lfosPerZone{4};
 static constexpr uint16_t egsPerZone{5};
 static constexpr uint16_t maxVariantsPerZone{16};
+// smallest region edit-all will collapse a variant to when the lead's points overrun it
+static constexpr int64_t minimumVariantRegionInSamples{16};
 
 static constexpr uint16_t lfosPerGroup{4};
 static constexpr uint16_t egsPerGroup{2};

--- a/src/scxt-core/engine/zone.h
+++ b/src/scxt-core/engine/zone.h
@@ -28,6 +28,11 @@
 #define SCXT_SRC_SCXT_CORE_ENGINE_ZONE_H
 
 #include <array>
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstring>
+#include <type_traits>
 
 #include "configuration.h"
 #include "utils.h"
@@ -143,6 +148,60 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
         std::array<SingleVariant, maxVariantsPerZone> variants;
         VariantPlaybackMode variantPlaybackMode{FORWARD_RR};
     } variantData;
+
+    /*
+     * Edit-all addresses the field an edit touched by its offset in SingleVariant, the same
+     * way the int and float update messages address theirs. Nothing enumerates the fields,
+     * so a setting added later is shared without being listed anywhere.
+     *
+     * The exceptions are listed instead, and they are the short list: absolute frame
+     * positions, which mean different things on samples of different lengths and get their
+     * own copy-endpoints-and-fade-zones gesture later, plus identity and the level derived
+     * from a sample's own peak. A field added here is shared by default, so a new *position*
+     * does need adding to this list.
+     */
+    static constexpr std::array<size_t, 8> variantLeadOnlyOffsets{
+        offsetof(SingleVariant, startSample), offsetof(SingleVariant, endSample),
+        offsetof(SingleVariant, startLoop),   offsetof(SingleVariant, endLoop),
+        offsetof(SingleVariant, loopFade),    offsetof(SingleVariant, active),
+        offsetof(SingleVariant, sampleID),    offsetof(SingleVariant, normalizationAmplitude)};
+
+    static bool variantFieldCrossesVariants(ptrdiff_t off)
+    {
+        return std::find(variantLeadOnlyOffsets.begin(), variantLeadOnlyOffsets.end(),
+                         (size_t)off) == variantLeadOnlyOffsets.end();
+    }
+
+    // Copy the sz-byte field at off from lead onto t, if edit-all may share that field.
+    static void applyVariantEdit(SingleVariant &t, const SingleVariant &lead, ptrdiff_t off,
+                                 size_t sz)
+    {
+        static_assert(std::is_standard_layout_v<SingleVariant>);
+        static_assert(std::is_trivially_copyable_v<SingleVariant>);
+        assert(off >= 0 && off + (ptrdiff_t)sz <= (ptrdiff_t)sizeof(SingleVariant));
+        if (!variantFieldCrossesVariants(off))
+            return;
+        memcpy((uint8_t *)&t + off, (const uint8_t *)&lead + off, sz);
+    }
+
+    /*
+     * Force a variant's [s,e] frame region to be valid on a sample of len frames: an endpoint
+     * carried over from a longer sample can land past its end or above its own other endpoint.
+     * If the result is inverted or too short, slide the start back from the end to leave a
+     * usable window. Not used by edit-all, which leaves frame positions alone - this is here
+     * for the copy-endpoints-and-fade-zones gesture described above.
+     */
+    static void clampVariantRegionToLength(int64_t &s, int64_t &e, int64_t len)
+    {
+        s = std::clamp(s, (int64_t)0, len);
+        e = std::clamp(e, (int64_t)0, len);
+        if (e - s < minimumVariantRegionInSamples)
+        {
+            s = std::max((int64_t)0, e - minimumVariantRegionInSamples);
+            if (e - s < minimumVariantRegionInSamples) // sample shorter than the minimum
+                e = std::min(len, s + minimumVariantRegionInSamples);
+        }
+    }
 
     std::array<std::shared_ptr<sample::Sample>, maxVariantsPerZone> samplePointers;
     int8_t sampleIndex{-1};

--- a/src/scxt-core/messaging/client/client_serial.h
+++ b/src/scxt-core/messaging/client/client_serial.h
@@ -95,6 +95,7 @@ enum ClientToSerializationMessagesIds
     c2s_update_zone_mapping_float,
     c2s_update_zone_mapping_int16_t,
     c2s_update_lead_zone_single_variant,
+    c2s_update_lead_zone_all_variants,
     c2s_update_zone_variants_int16_t,
     c2s_apply_all_zone_delta,
     c2s_request_zone_mapping,

--- a/src/scxt-core/messaging/client/selection_messages.h
+++ b/src/scxt-core/messaging/client/selection_messages.h
@@ -77,11 +77,12 @@ CLIENT_TO_SERIAL(UpdateOtherTabSelection, c2s_set_othertab_selection, updateOthe
  */
 enum struct EditSubtree : int32_t
 {
-    none = 0,     // gesture has no undo subtree (yet); begin is a no-op
-    zone_mapping, // forZone implicit
-    output_info,  // zone or group by forZone
-    eg,           // index = which envelope
-    mod_storage,  // index = which modulator
+    none = 0,      // gesture has no undo subtree (yet); begin is a no-op
+    zone_mapping,  // forZone implicit
+    zone_variants, // forZone implicit; sample/loop point drags in the sample tab
+    output_info,   // zone or group by forZone
+    eg,            // index = which envelope
+    mod_storage,   // index = which modulator
     misc_mod,
     audio_mod,
     processor,      // index = slot
@@ -111,6 +112,9 @@ inline void doBeginEdit(const editGestureBegin_t &payload, engine::Engine &engin
         break;
     case EditSubtree::zone_mapping:
         undo::pushPayloadUndo<undo::ZoneMappingSpec>(engine, -1, B);
+        break;
+    case EditSubtree::zone_variants:
+        undo::pushPayloadUndo<undo::ZoneVariantsSpec>(engine, -1, B);
         break;
     case EditSubtree::output_info:
         undo::pushZoneOrGroupPayloadUndo<undo::ZoneOutputInfoSpec, undo::GroupOutputInfoSpec>(

--- a/src/scxt-core/messaging/client/zone_messages.h
+++ b/src/scxt-core/messaging/client/zone_messages.h
@@ -212,6 +212,43 @@ CLIENT_TO_SERIAL(UpdateLeadZoneSingleVariant, c2s_update_lead_zone_single_varian
                  updateLeadZoneSingleVariantPayload_t,
                  doUpdateLeadZoneSingleVariant(payload, engine, cont));
 
+/*
+ * Edit-all: the client has already fanned the lead variant's edit out across the other
+ * variants (clamping frame positions to each sample's length) so this is one message and
+ * one undo entry for the whole gesture.
+ */
+using updateLeadZoneAllVariantsPayload_t =
+    std::array<engine::Zone::SingleVariant, maxVariantsPerZone>;
+inline void doUpdateLeadZoneAllVariants(const updateLeadZoneAllVariantsPayload_t &payload,
+                                        engine::Engine &engine, MessageController &cont)
+{
+    auto sz = engine.getSelectionManager()->currentLeadZone(engine);
+    if (sz.has_value())
+    {
+        undo::pushPayloadUndo<undo::ZoneVariantsSpec>(engine);
+        auto [ps, gs, zs] = *sz;
+        cont.scheduleAudioThreadCallback([p = ps, g = gs, z = zs, sampv = payload](auto &eng) {
+            auto &vd = eng.getPatch()->getPart(p)->getGroup(g)->getZone(z)->variantData;
+            for (auto i = 0U; i < maxVariantsPerZone; ++i)
+            {
+                auto &dest = vd.variants[i];
+                if (!dest.active)
+                    continue;
+                // identity and normalization belong to the engine's copy, not the edit
+                auto id = dest.sampleID;
+                auto norm = dest.normalizationAmplitude;
+                dest = sampv[i];
+                dest.active = true;
+                dest.sampleID = id;
+                dest.normalizationAmplitude = norm;
+            }
+        });
+    }
+}
+CLIENT_TO_SERIAL(UpdateLeadZoneAllVariants, c2s_update_lead_zone_all_variants,
+                 updateLeadZoneAllVariantsPayload_t,
+                 doUpdateLeadZoneAllVariants(payload, engine, cont));
+
 using normalizeVariantAmplitudePayload_t = std::tuple<size_t, bool>;
 inline void doNormalizeVariantAmplitude(const normalizeVariantAmplitudePayload_t &payload,
                                         engine::Engine &engine, MessageController &cont)

--- a/src/scxt-plugin/app/edit-screen/components/MacroMappingVariantPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/MacroMappingVariantPane.cpp
@@ -168,6 +168,11 @@ void MacroMappingVariantPane::setMappingLockFromModel(bool b)
     mappingDisplay->zoneHeader->lockButton->setValueFromModel(b);
 }
 
+void MacroMappingVariantPane::setEditAllFromModel(bool b)
+{
+    sampleDisplay->editAllButton->setValueFromModel(b);
+}
+
 void MacroMappingVariantPane::editorSelectionChanged()
 {
     if (editor->currentLeadZoneSelection.has_value())

--- a/src/scxt-plugin/app/edit-screen/components/MacroMappingVariantPane.h
+++ b/src/scxt-plugin/app/edit-screen/components/MacroMappingVariantPane.h
@@ -58,6 +58,7 @@ struct MacroMappingVariantPane : sst::jucegui::components::NamedPanel, HasEditor
 
     // Restore the mapping-grid lock toggle from the persisted tab selection
     void setMappingLockFromModel(bool b);
+    void setEditAllFromModel(bool b);
 
     std::unique_ptr<MappingDisplay> mappingDisplay;
     std::unique_ptr<VariantDisplay> sampleDisplay;

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/SampleWaveform.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/SampleWaveform.cpp
@@ -329,7 +329,30 @@ void SampleWaveform::mouseDown(const juce::MouseEvent &e)
     else
         mouseState = MouseState::NONE;
 
+    // one undo entry for the whole drag, not one per mouse move
+    if (mouseState != MouseState::NONE)
+        display->beginVariantGesture();
+
     // TODO cursor change and so on
+}
+
+int64_t *SampleWaveform::draggedPoint()
+{
+    auto &v = display->variantView.variants[display->selectedVariation];
+    switch (mouseState)
+    {
+    case MouseState::HZ_DRAG_SAMPSTART:
+        return &v.startSample;
+    case MouseState::HZ_DRAG_SAMPEND:
+        return &v.endSample;
+    case MouseState::HZ_DRAG_LOOPSTART:
+        return &v.startLoop;
+    case MouseState::HZ_DRAG_LOOPEND:
+        return &v.endLoop;
+    case MouseState::NONE:
+        break;
+    }
+    return nullptr;
 }
 
 void SampleWaveform::mouseDrag(const juce::MouseEvent &e)
@@ -370,17 +393,26 @@ void SampleWaveform::mouseDrag(const juce::MouseEvent &e)
     default:
         break;
     }
-    display->onSamplePointChangedFromGUI();
+    if (auto *f = draggedPoint())
+        display->onVariantFieldChanged(*f);
 }
 
 void SampleWaveform::mouseUp(const juce::MouseEvent &e)
 {
+    // close an open drag first: leaving the gesture open would swallow later
+    // edits into this undo entry
+    if (mouseState != MouseState::NONE)
+    {
+        if (auto *f = draggedPoint())
+            display->onVariantFieldChanged(*f);
+        display->endVariantGesture();
+        mouseState = MouseState::NONE;
+        return;
+    }
     if (e.mods.isPopupMenu() && onPopupMenu)
     {
         return;
     }
-    if (mouseState != MouseState::NONE)
-        display->onSamplePointChangedFromGUI();
 }
 
 void SampleWaveform::mouseMove(const juce::MouseEvent &e)

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/SampleWaveform.h
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/SampleWaveform.h
@@ -72,6 +72,9 @@ struct SampleWaveform : juce::Component, HasEditor, sst::jucegui::components::Zo
         HZ_DRAG_LOOPEND,
     } mouseState{MouseState::NONE};
 
+    // the sample point the in-flight drag is editing, or nullptr when not dragging
+    int64_t *draggedPoint();
+
     std::set<int64_t> playbackPositions;
     void addSamplePlaybackPosition(int64_t samplePos);
     void clearSamplePlaybackPositions();

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
@@ -85,10 +85,15 @@ VariantDisplay::VariantDisplay(scxt::ui::app::edit_screen::MacroMappingVariantPa
     variantPlaymodeButton->setOnCallback([this]() { showVariantPlaymodeMenu(); });
     addAndMakeVisible(*variantPlaymodeButton);
 
-    editAllButton = std::make_unique<jcmp::TextPushButton>();
-    editAllButton->setLabel("EDIT ALL");
-    editAllButton->setOnCallback(editor->makeComingSoon("Edit All"));
-    addAndMakeVisible(*editAllButton);
+    auto ea = std::make_unique<jcmp::ToggleButton>();
+    ea->setLabel("EDIT ALL");
+    addAndMakeVisible(*ea);
+    auto eab = std::make_unique<boolToggle_t>(ea, editAll);
+    eab->onValueChanged = [w = juce::Component::SafePointer(this)](auto v) {
+        if (w)
+            w->editor->setTabSelection(editAllTabKey, v ? "1" : "0");
+    };
+    editAllButton = std::move(eab);
 
     fileLabel = std::make_unique<jcmp::Label>();
     fileLabel->setText("File");
@@ -180,9 +185,10 @@ void VariantDisplay::rebuildForSelectedVariation(size_t sel, bool rebuildTabs)
 
     auto attachSamplePoint = [this](Ctrl c, const std::string &aLabel, auto &v) {
         auto at = std::make_unique<connectors::SamplePointDataAttachment>(
-            v, [this](const auto &) { onSamplePointChangedFromGUI(); });
+            v, [this](const auto &a) { onVariantFieldChanged(a.value); });
         auto sl = std::make_unique<jcmp::DraggableTextEditableDiscreteValue>();
         sl->setSource(at.get());
+        bracketGesture(*sl);
         sl->onPopupMenu = [w = juce::Component::SafePointer(sl.get())](auto &) {
             if (w)
                 w->activateEditor();
@@ -202,9 +208,10 @@ void VariantDisplay::rebuildForSelectedVariation(size_t sel, bool rebuildTabs)
         auto pmd = scxt::datamodel::describeValue(variantView.variants[selectedVariation], v);
 
         auto at = std::make_unique<floatAttachment_t>(
-            pmd, [this](const auto &) { onSamplePointChangedFromGUI(); }, v);
+            pmd, [this](const auto &a) { onVariantFieldChanged(a.value); }, v);
         auto sl = std::make_unique<jcmp::DraggableTextEditableValue>();
         sl->setSource(at.get());
+        bracketGesture(*sl);
         if (sampleEditors[c])
         {
             removeChildComponent(sampleEditors[c].get());
@@ -311,7 +318,7 @@ void VariantDisplay::rebuildForSelectedVariation(size_t sel, bool rebuildTabs)
             [w = juce::Component::SafePointer(this)](const auto &a) {
                 if (w)
                 {
-                    w->onSamplePointChangedFromGUI();
+                    w->onVariantFieldChanged(a.value);
                     w->rebuild();
                 }
             },
@@ -335,7 +342,7 @@ void VariantDisplay::rebuildForSelectedVariation(size_t sel, bool rebuildTabs)
             [w = juce::Component::SafePointer(this)](const auto &a) {
                 if (w)
                 {
-                    w->onSamplePointChangedFromGUI();
+                    w->onVariantFieldChanged(a.value);
                 }
             },
             variantView.variants[selectedVariation].playReverse);
@@ -363,12 +370,13 @@ void VariantDisplay::rebuildForSelectedVariation(size_t sel, bool rebuildTabs)
         [w = juce::Component::SafePointer(this)](const auto &a) {
             if (w)
             {
-                w->onSamplePointChangedFromGUI();
+                w->onVariantFieldChanged(a.value);
             }
         },
         variantView.variants[selectedVariation].loopCountWhenCounted);
     loopCnt = std::make_unique<jcmp::DraggableTextEditableDiscreteValue>();
     loopCnt->setSource(loopCntAttachment.get());
+    bracketGesture(*loopCnt);
     loopCnt->onPopupMenu = [w = juce::Component::SafePointer(loopCnt.get())](auto &) {
         if (w)
             w->activateEditor();
@@ -527,7 +535,7 @@ void VariantDisplay::resized()
 
     variantPlayModeLabel->setBounds(hP(42));
     variantPlaymodeButton->setBounds(hP(100));
-    editAllButton->setBounds(hP(55));
+    editAllButton->widget->setBounds(hP(55));
     fileInfoButton->widget->setBounds(hP(hl.getHeight()));
     fileLabel->setBounds(hP(20));
     fileButton->setBounds(hP(-14));
@@ -769,11 +777,56 @@ void VariantDisplay::showFileBrowser()
         nullptr);
 }
 
-void VariantDisplay::onSamplePointChangedFromGUI()
+void VariantDisplay::beginVariantGesture()
 {
-    sendToSerialization(cmsg::UpdateLeadZoneSingleVariant{
-        {selectedVariation, variantView.variants[selectedVariation]}});
-    waveforms[selectedVariation].waveform->rebuildHotZones();
+    sendToSerialization(
+        cmsg::BeginEdit({(int32_t)cmsg::EditSubtree::zone_variants, true, (int32_t)-1}));
+}
+
+void VariantDisplay::endVariantGesture() { sendToSerialization(cmsg::EndEdit(true)); }
+
+void VariantDisplay::propagateEditAll(ptrdiff_t off, size_t sz)
+{
+    const auto lead = variantView.variants[selectedVariation];
+    for (auto i = 0U; i < maxVariantsPerZone; ++i)
+    {
+        if (i == selectedVariation || !variantView.variants[i].active)
+            continue;
+        engine::Zone::applyVariantEdit(variantView.variants[i], lead, off, sz);
+    }
+}
+
+bool VariantDisplay::anyVariantNormalized() const
+{
+    for (const auto &v : variantView.variants)
+    {
+        if (v.active && v.normalizationAmplitude != 1.0)
+            return true;
+    }
+    return false;
+}
+
+void VariantDisplay::onSamplePointChangedFromGUI(ptrdiff_t off, size_t sz)
+{
+    // sample and loop positions are lead-only, so an edit that touches one falls through
+    // to the single-variant send even with edit-all on
+    if (editAll && engine::Zone::variantFieldCrossesVariants(off) &&
+        variantView.variants[selectedVariation].active)
+    {
+        propagateEditAll(off, sz);
+        sendToSerialization(cmsg::UpdateLeadZoneAllVariants{variantView.variants});
+        for (auto i = 0U; i < maxVariantsPerZone; ++i)
+        {
+            if (variantView.variants[i].active)
+                waveforms[i].waveform->rebuildHotZones();
+        }
+    }
+    else
+    {
+        sendToSerialization(cmsg::UpdateLeadZoneSingleVariant{
+            {selectedVariation, variantView.variants[selectedVariation]}});
+        waveforms[selectedVariation].waveform->rebuildHotZones();
+    }
     waveforms[selectedVariation].waveform->repaint();
     repaint();
 }
@@ -796,7 +849,7 @@ void VariantDisplay::showPlayModeMenu()
     auto add = [&p, this](auto e, auto n) {
         p.addItem(n, true, variantView.variants[selectedVariation].playMode == e, [this, e]() {
             variantView.variants[selectedVariation].playMode = e;
-            onSamplePointChangedFromGUI();
+            onVariantFieldChanged(variantView.variants[selectedVariation].playMode);
             rebuild();
         });
     };
@@ -823,11 +876,16 @@ void VariantDisplay::showLoopModeMenu()
                   [w = juce::Component::SafePointer(that), e, alt]() {
                       if (!w)
                           return;
-                      w->variantView.variants[w->selectedVariation].loopMode = e;
-                      w->variantView.variants[w->selectedVariation].loopDirection =
-                          (alt ? engine::Zone::LoopDirection::ALTERNATE_DIRECTIONS
-                               : engine::Zone::LoopDirection::FORWARD_ONLY);
-                      w->onSamplePointChangedFromGUI();
+                      auto &v = w->variantView.variants[w->selectedVariation];
+                      v.loopMode = e;
+                      v.loopDirection = (alt ? engine::Zone::LoopDirection::ALTERNATE_DIRECTIONS
+                                             : engine::Zone::LoopDirection::FORWARD_ONLY);
+                      // two fields, so two sends; bracket them to keep the menu pick one
+                      // undo entry
+                      w->beginVariantGesture();
+                      w->onVariantFieldChanged(v.loopMode);
+                      w->onVariantFieldChanged(v.loopDirection);
+                      w->endVariantGesture();
                       w->rebuild();
                   });
     };
@@ -850,8 +908,8 @@ void VariantDisplay::showSRCMenu()
         p.addItem(
             n, true, variantView.variants[selectedVariation].interpolationType == e, [this, e]() {
                 variantView.variants[selectedVariation].interpolationType = e;
-                connectors::updateSingleValue<cmsg::UpdateZoneVariantsInt16TValue>(
-                    variantView, variantView.variants[selectedVariation].interpolationType, this);
+                // TODO restore applying across a multi-zone selection when that lands
+                onVariantFieldChanged(variantView.variants[selectedVariation].interpolationType);
                 rebuild();
             });
     };
@@ -1141,26 +1199,36 @@ void VariantDisplay::showVariantTabMenu(int variantIdx)
             w->sendToSerialization(cmsg::DeleteVariant(variantIdx));
         });
         p.addSeparator();
-        p.addItem("Normalize Variant " + std::to_string(variantIdx + 1),
-                  [variantIdx, w = juce::Component::SafePointer(this)]() {
-                      if (!w)
-                          return;
-                      w->sendToSerialization(cmsg::NormalizeVariantAmplitude({variantIdx, true}));
-                  });
+        // under edit-all each variant normalizes against its own sample, so only offer the
+        // all-variants form
+        if (!editAll)
+        {
+            p.addItem("Normalize Variant " + std::to_string(variantIdx + 1),
+                      [variantIdx, w = juce::Component::SafePointer(this)]() {
+                          if (!w)
+                              return;
+                          w->sendToSerialization(
+                              cmsg::NormalizeVariantAmplitude({variantIdx, true}));
+                      });
+        }
         p.addItem("Normalize All Variants", [variantIdx, w = juce::Component::SafePointer(this)]() {
             if (!w)
                 return;
             w->sendToSerialization(cmsg::NormalizeVariantAmplitude({-1, true}));
         });
 
-        p.addItem("Clear Variant " + std::to_string(variantIdx + 1) + " Normalization",
-                  var.normalizationAmplitude != 1.0, false,
-                  [variantIdx, w = juce::Component::SafePointer(this)]() {
-                      if (!w)
-                          return;
-                      w->sendToSerialization(cmsg::ClearVariantAmplitudeNormalization(variantIdx));
-                  });
-        p.addItem("Clear All Variant Normalization",
+        if (!editAll)
+        {
+            p.addItem("Clear Variant " + std::to_string(variantIdx + 1) + " Normalization",
+                      var.normalizationAmplitude != 1.0, false,
+                      [variantIdx, w = juce::Component::SafePointer(this)]() {
+                          if (!w)
+                              return;
+                          w->sendToSerialization(
+                              cmsg::ClearVariantAmplitudeNormalization(variantIdx));
+                      });
+        }
+        p.addItem("Clear All Variant Normalization", anyVariantNormalized(), false,
                   [variantIdx, w = juce::Component::SafePointer(this)]() {
                       if (!w)
                           return;

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.h
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.h
@@ -35,7 +35,6 @@
 #include "sst/jucegui/components/Label.h"
 #include "sst/jucegui/components/TabbedComponent.h"
 #include "sst/jucegui/components/ToggleButton.h"
-#include "sst/jucegui/components/TextPushButton.h"
 #include "sst/jucegui/components/MenuButton.h"
 #include "sst/jucegui/components/GlyphButton.h"
 #include "sst/jucegui/components/NamedPanelDivider.h"
@@ -147,7 +146,41 @@ struct VariantDisplay : juce::Component, HasEditor
             c.reset();
     }
 
-    void onSamplePointChangedFromGUI();
+    /*
+     * Send an edit, naming the field by the reference that was just written. The offset
+     * into SingleVariant is what edit-all propagates by, the same way the int and float
+     * update messages address their targets, so nothing here enumerates the field set.
+     */
+    template <typename T> void onVariantFieldChanged(const T &field)
+    {
+        auto &v = variantView.variants[selectedVariation];
+        auto off = (const uint8_t *)&field - (const uint8_t *)&v;
+        onSamplePointChangedFromGUI(off, sizeof(T));
+    }
+    void onSamplePointChangedFromGUI(ptrdiff_t off, size_t sz);
+
+    /*
+     * Continuous edits (a waveform hot-zone drag, a draggable value) bracket
+     * themselves so the whole gesture is one undo entry rather than one per
+     * mouse move. The begin snapshot covers everything until the end.
+     */
+    void beginVariantGesture();
+    void endVariantGesture();
+
+    // wire a draggable widget's edit gesture to the bracket above
+    template <typename W> void bracketGesture(W &w)
+    {
+        w.onBeginEdit = [this]() { beginVariantGesture(); };
+        w.onEndEdit = [this]() { endVariantGesture(); };
+    }
+
+    // key into SCXTEditor::otherTabSelection, so edit-all outlives zone changes and sessions
+    static constexpr const char *editAllTabKey{"variant.editall"};
+    bool editAll{false};
+    // push just the edited field of the selected variant onto every other active one
+    void propagateEditAll(ptrdiff_t off, size_t sz);
+    // is any active variant normalized, for the edit-all clear menu item
+    bool anyVariantNormalized() const;
 
     juce::Rectangle<int> sampleDisplayRegion()
     {
@@ -203,7 +236,7 @@ struct VariantDisplay : juce::Component, HasEditor
     std::unique_ptr<sst::jucegui::components::MenuButton> variantPlaymodeButton, fileButton;
     std::unique_ptr<sst::jucegui::components::Label> variantPlayModeLabel, fileLabel;
     std::unique_ptr<boolToggle_t> fileInfoButton;
-    std::unique_ptr<sst::jucegui::components::TextPushButton> editAllButton;
+    std::unique_ptr<boolToggle_t> editAllButton;
     std::unique_ptr<sst::jucegui::components::GlyphButton> nextFileButton, prevFileButton;
 
     // sidebar section

--- a/src/scxt-plugin/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -38,6 +38,7 @@
 #include "app/mixer-screen/MixerScreen.h"
 #include "app/shared/HeaderRegion.h"
 #include "app/edit-screen/components/MacroMappingVariantPane.h"
+#include "app/edit-screen/components/mapping-pane/VariantDisplay.h"
 #include "app/other-screens/AboutScreen.h"
 #include "app/other-screens/ThemeEditor.h"
 #include "app/other-screens/TuningScreen.h"
@@ -529,6 +530,12 @@ void SCXTEditorReceiver::onOtherTabSelection(
     if (!ml.empty() && editor.editScreen && editor.editScreen->mappingPane)
     {
         editor.editScreen->mappingPane->setMappingLockFromModel(std::atoi(ml.c_str()) != 0);
+    }
+
+    auto ea = editor.queryTabSelection(edit_screen::VariantDisplay::editAllTabKey);
+    if (!ea.empty() && editor.editScreen && editor.editScreen->mappingPane)
+    {
+        editor.editScreen->mappingPane->setEditAllFromModel(std::atoi(ea.c_str()) != 0);
     }
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(scxt-test
 		midi_channel_tests.cpp
 		macro_id_tests.cpp
 		tuning_tests.cpp
+		variant_edit_all_tests.cpp
 )
 
 target_compile_definitions(scxt-test PRIVATE

--- a/tests/selection_tests.cpp
+++ b/tests/selection_tests.cpp
@@ -417,7 +417,7 @@ TEST_CASE("Fold: swap groups remaps fold state")
 
     INFO("Swap group 2 and group 4 (tgt.zone == -1 path)");
     th.sendToSerialization(cmsg::MoveGroupTo({zad{0, 2, -1}, zad{0, 4, -1}}));
-    th.stepUI();
+    th.stepUI(30); // the move and its fold remap hop the audio thread
 
     REQUIRE(!sm->isGroupCollapsed(0, 2));
     REQUIRE(sm->isGroupCollapsed(0, 4));
@@ -428,7 +428,7 @@ TEST_CASE("Fold: swap groups remaps fold state")
     REQUIRE(sm->isGroupCollapsed(0, 1));
     REQUIRE(sm->isGroupCollapsed(0, 4));
     th.sendToSerialization(cmsg::MoveGroupTo({zad{0, 1, -1}, zad{0, 4, -1}}));
-    th.stepUI();
+    th.stepUI(30); // the move and its fold remap hop the audio thread
     REQUIRE(sm->isGroupCollapsed(0, 1));
     REQUIRE(sm->isGroupCollapsed(0, 4));
 }
@@ -455,7 +455,7 @@ TEST_CASE("Fold: moveGroupToAfter remaps fold state (src<tgt)")
     // Layout: 0 1 2 3 4 -> 0 1 3 4 2. Original-2 (collapsed) now sits at index 4.
     // Originals at 3 and 4 shift down to 2 and 3.
     th.sendToSerialization(cmsg::MoveGroupTo({zad{0, 2, -1}, zad{0, 4, 0}}));
-    th.stepUI();
+    th.stepUI(30); // the move and its fold remap hop the audio thread
 
     REQUIRE(!sm->isGroupCollapsed(0, 2));
     REQUIRE(!sm->isGroupCollapsed(0, 3));
@@ -485,7 +485,7 @@ TEST_CASE("Fold: moveGroupToAfter remaps fold state (src>tgt)")
     // Layout: 0 1 2 3 4 -> 0 1 4 2 3. Original-4 (collapsed) sits at index 2.
     // Originals at 2,3 shift up to 3,4.
     th.sendToSerialization(cmsg::MoveGroupTo({zad{0, 4, -1}, zad{0, 1, 0}}));
-    th.stepUI();
+    th.stepUI(30); // the move and its fold remap hop the audio thread
 
     REQUIRE(sm->isGroupCollapsed(0, 2));
     REQUIRE(!sm->isGroupCollapsed(0, 3));
@@ -514,7 +514,7 @@ TEST_CASE("Fold: moveGroupToAfter preserves fold state outside the affected wind
 
     // Move 2 to after 4. Affected window [2, 4] — group 6 must NOT be lost.
     th.sendToSerialization(cmsg::MoveGroupTo({zad{0, 2, -1}, zad{0, 4, 0}}));
-    th.stepUI();
+    th.stepUI(30); // the move and its fold remap hop the audio thread
 
     REQUIRE(sm->isGroupCollapsed(0, 1));
     REQUIRE(!sm->isGroupCollapsed(0, 2));

--- a/tests/variant_edit_all_tests.cpp
+++ b/tests/variant_edit_all_tests.cpp
@@ -1,0 +1,536 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "catch2/catch2.hpp"
+
+#include <filesystem>
+#include <string>
+
+#include "configuration.h"
+#include "console_harness.h"
+#include "engine/engine.h"
+#include "engine/part.h"
+#include "engine/zone.h"
+#include "selection/selection_manager.h"
+#include "undo_manager/undo.h"
+
+#ifndef SCXT_TEST_SOURCE_DIR
+#define SCXT_TEST_SOURCE_DIR ""
+#endif
+
+namespace cmsg = scxt::messaging::client;
+using scxt::maxVariantsPerZone;
+using scxt::minimumVariantRegionInSamples;
+using Zone = scxt::engine::Zone;
+
+namespace
+{
+// convenience wrapper so the cases below read like the spec
+struct Region
+{
+    int64_t s, e;
+};
+Region clampTo(int64_t s, int64_t e, int64_t len)
+{
+    Zone::clampVariantRegionToLength(s, e, len);
+    return {s, e};
+}
+} // namespace
+
+TEST_CASE("Edit all clamps a region onto a shorter sample", "[variants]")
+{
+    SECTION("region that already fits is untouched")
+    {
+        auto r = clampTo(2000, 3000, 10000);
+        REQUIRE(r.s == 2000);
+        REQUIRE(r.e == 3000);
+    }
+
+    SECTION("region overhanging the end truncates at the sample length")
+    {
+        auto r = clampTo(5000, 15000, 10000);
+        REQUIRE(r.s == 5000);
+        REQUIRE(r.e == 10000);
+    }
+
+    SECTION("region entirely past the end falls back to the minimum at the sample end")
+    {
+        auto r = clampTo(12000, 15000, 10000);
+        REQUIRE(r.e == 10000);
+        REQUIRE(r.s == 10000 - minimumVariantRegionInSamples);
+    }
+
+    SECTION("start exactly at the end still yields the minimum region")
+    {
+        auto r = clampTo(10000, 12000, 10000);
+        REQUIRE(r.e == 10000);
+        REQUIRE(r.s == 10000 - minimumVariantRegionInSamples);
+    }
+
+    SECTION("start pushed above the target's own end backs off from that end")
+    {
+        // only the start propagated; the target keeps its own end of 8000
+        auto r = clampTo(9000, 8000, 10000);
+        REQUIRE(r.e == 8000);
+        REQUIRE(r.s == 8000 - minimumVariantRegionInSamples);
+    }
+
+    SECTION("end pulled below the target's own start backs off from the new end")
+    {
+        auto r = clampTo(5000, 2000, 10000);
+        REQUIRE(r.e == 2000);
+        REQUIRE(r.s == 2000 - minimumVariantRegionInSamples);
+    }
+
+    SECTION("a sample shorter than the minimum clamps to the whole sample")
+    {
+        auto r = clampTo(100, 200, 8);
+        REQUIRE(r.s == 0);
+        REQUIRE(r.e == 8);
+    }
+
+    SECTION("a longer sample does not get the region stretched")
+    {
+        auto r = clampTo(1000, 2000, 100000);
+        REQUIRE(r.s == 1000);
+        REQUIRE(r.e == 2000);
+    }
+
+    SECTION("a region backing off the front is pushed forward instead")
+    {
+        auto r = clampTo(0, 4, 10000);
+        REQUIRE(r.s == 0);
+        REQUIRE(r.e == minimumVariantRegionInSamples);
+    }
+}
+
+namespace
+{
+struct EditAllFixture
+{
+    scxt::clients::console_ui::ConsoleHarness th;
+
+    EditAllFixture()
+    {
+        th.start();
+        th.stepUI();
+    }
+
+    scxt::engine::Engine &engine() { return *th.engine; }
+
+    template <typename T> void send(const T &msg, size_t drainSteps = 30)
+    {
+        th.sendToSerialization(msg);
+        th.stepUI(drainSteps);
+    }
+
+    void sendUndo(size_t drainSteps = 30) { send(cmsg::Undo(true), drainSteps); }
+};
+
+std::string testSample(const std::string &n)
+{
+    namespace fs = std::filesystem;
+    auto p = fs::path(SCXT_TEST_SOURCE_DIR) / "resources" / "test_samples" / "next" / n;
+    REQUIRE(fs::exists(p));
+    return p.u8string();
+}
+
+/*
+ * The real fan-out: the same core call VariantDisplay::propagateEditAll makes, so a test
+ * exercises the shipped policy rather than a copy of it. Fields are addressed by offset,
+ * exactly as the UI addresses the control the user just moved.
+ */
+#define VAR_FIELD_OFF(f) offsetof(Zone::SingleVariant, f)
+#define VAR_FIELD(f) VAR_FIELD_OFF(f), sizeof(Zone::SingleVariant::f)
+
+std::array<Zone::SingleVariant, maxVariantsPerZone> fanOut(const Zone &zone, size_t lead,
+                                                           ptrdiff_t off, size_t sz)
+{
+    auto out = zone.variantData.variants;
+    const auto leadVar = out[lead];
+    for (auto i = 0U; i < maxVariantsPerZone; ++i)
+    {
+        if (i == lead || !out[i].active)
+            continue;
+        Zone::applyVariantEdit(out[i], leadVar, off, sz);
+    }
+    return out;
+}
+} // namespace
+
+TEST_CASE("Edit all never crosses positions or identity", "[variants]")
+{
+    using SV = Zone::SingleVariant;
+
+    SECTION("the lead-only offsets really are the per-sample fields")
+    {
+        // named here so a field rename or reorder cannot silently drop one
+        std::array<size_t, 8> expect{
+            VAR_FIELD_OFF(startSample), VAR_FIELD_OFF(endSample),
+            VAR_FIELD_OFF(startLoop),   VAR_FIELD_OFF(endLoop),
+            VAR_FIELD_OFF(loopFade),    VAR_FIELD_OFF(active),
+            VAR_FIELD_OFF(sampleID),    VAR_FIELD_OFF(normalizationAmplitude)};
+        for (auto o : expect)
+        {
+            INFO("offset " << o);
+            REQUIRE(!Zone::variantFieldCrossesVariants((ptrdiff_t)o));
+        }
+    }
+
+    SECTION("the settings edit-all exists for do cross")
+    {
+        for (auto o :
+             {VAR_FIELD_OFF(pan), VAR_FIELD_OFF(pitchOffset), VAR_FIELD_OFF(amplitude),
+              VAR_FIELD_OFF(playMode), VAR_FIELD_OFF(loopActive), VAR_FIELD_OFF(playReverse),
+              VAR_FIELD_OFF(loopMode), VAR_FIELD_OFF(loopDirection),
+              VAR_FIELD_OFF(loopCountWhenCounted), VAR_FIELD_OFF(interpolationType)})
+        {
+            INFO("offset " << o);
+            REQUIRE(Zone::variantFieldCrossesVariants((ptrdiff_t)o));
+        }
+    }
+
+    SECTION("applying a lead-only field is a no-op")
+    {
+        SV lead, t;
+        lead.startSample = 111;
+        lead.endSample = 222;
+        lead.startLoop = 333;
+        lead.endLoop = 444;
+        lead.loopFade = 55;
+        lead.normalizationAmplitude = 0.25f;
+        lead.active = true;
+
+        t.startSample = 10;
+        t.endSample = 20;
+        t.startLoop = 30;
+        t.endLoop = 40;
+        t.loopFade = 5;
+        t.normalizationAmplitude = 0.9f;
+        const auto before = t;
+
+        Zone::applyVariantEdit(t, lead, VAR_FIELD(startSample));
+        Zone::applyVariantEdit(t, lead, VAR_FIELD(endSample));
+        Zone::applyVariantEdit(t, lead, VAR_FIELD(startLoop));
+        Zone::applyVariantEdit(t, lead, VAR_FIELD(endLoop));
+        Zone::applyVariantEdit(t, lead, VAR_FIELD(loopFade));
+        Zone::applyVariantEdit(t, lead, VAR_FIELD(normalizationAmplitude));
+        Zone::applyVariantEdit(t, lead, VAR_FIELD(active));
+        Zone::applyVariantEdit(t, lead, VAR_FIELD(sampleID));
+
+        REQUIRE(t.startSample == before.startSample);
+        REQUIRE(t.endSample == before.endSample);
+        REQUIRE(t.startLoop == before.startLoop);
+        REQUIRE(t.endLoop == before.endLoop);
+        REQUIRE(t.loopFade == before.loopFade);
+        REQUIRE(t.normalizationAmplitude == Approx(before.normalizationAmplitude));
+        REQUIRE(t.active == before.active);
+        REQUIRE(t.sampleID == before.sampleID);
+    }
+
+    SECTION("applying a shared field copies exactly that field")
+    {
+        SV lead, t;
+        lead.pan = 0.5f;
+        lead.pitchOffset = 3.f;
+        lead.playMode = Zone::PlayMode::ONE_SHOT;
+        const auto before = t;
+
+        Zone::applyVariantEdit(t, lead, VAR_FIELD(pan));
+        REQUIRE(t.pan == Approx(0.5f));
+        // its neighbours were not dragged along
+        REQUIRE(t.pitchOffset == Approx(before.pitchOffset));
+        REQUIRE(t.playMode == before.playMode);
+
+        Zone::applyVariantEdit(t, lead, VAR_FIELD(playMode));
+        REQUIRE(t.playMode == Zone::PlayMode::ONE_SHOT);
+        REQUIRE(t.pitchOffset == Approx(before.pitchOffset));
+    }
+}
+
+TEST_CASE("Edit all applies one field without disturbing the rest", "[variants]")
+{
+    EditAllFixture f;
+
+    // seven variants, each trimmed differently, as a user would have left them
+    f.send(cmsg::AddSampleWithRange({testSample("Beep.wav"), 60, 48, 72, 0, 127}));
+    auto &zone = f.engine().getPatch()->getPart(0)->getGroup(0)->getZone(0);
+    for (int i = 1; i < 7; ++i)
+        f.send(cmsg::AddSampleInZone({testSample("Beep.wav"), 0, 0, 0, i}));
+    f.send(cmsg::ApplySelectActions({{0, 0, 0, true, true, true}}));
+
+    std::array<int64_t, 7> starts{}, ends{}, loopStarts{};
+    for (int i = 0; i < 7; ++i)
+    {
+        REQUIRE(zone->variantData.variants[i].active);
+        auto &v = zone->variantData.variants[i];
+        v.startSample = 100 * (i + 1);
+        v.endSample = 5000 - 200 * i;
+        v.startLoop = 50 * (i + 1);
+        starts[i] = v.startSample;
+        ends[i] = v.endSample;
+        loopStarts[i] = v.startLoop;
+    }
+
+    zone->variantData.variants[0].pan = 0.6f;
+    f.send(cmsg::UpdateLeadZoneAllVariants(fanOut(*zone, 0, VAR_FIELD(pan))));
+
+    for (int i = 0; i < 7; ++i)
+    {
+        INFO("variant " << i);
+        REQUIRE(zone->variantData.variants[i].pan == Approx(0.6f));
+        // a pan edit must not drag the lead's trim across
+        REQUIRE(zone->variantData.variants[i].startSample == starts[i]);
+        REQUIRE(zone->variantData.variants[i].endSample == ends[i]);
+        REQUIRE(zone->variantData.variants[i].startLoop == loopStarts[i]);
+    }
+}
+
+TEST_CASE("Edit all leaves sample and loop positions on the lead", "[variants]")
+{
+    EditAllFixture f;
+
+    f.send(cmsg::AddSampleWithRange({testSample("Beep.wav"), 60, 48, 72, 0, 127}));
+    auto &zone = f.engine().getPatch()->getPart(0)->getGroup(0)->getZone(0);
+    f.send(cmsg::AddSampleInZone({testSample("PulseSaw.wav"), 0, 0, 0, 1}));
+    f.send(cmsg::ApplySelectActions({{0, 0, 0, true, true, true}}));
+
+    auto &follower = zone->variantData.variants[0];
+    follower.startSample = 100;
+    follower.endSample = 8000;
+    follower.startLoop = 200;
+    follower.endLoop = 7000;
+    follower.loopFade = 64;
+    const auto before = follower;
+
+    // drag every position on the lead, with edit-all on
+    auto &lead = zone->variantData.variants[1];
+    lead.startSample = 9000;
+    lead.endSample = 90000;
+    lead.startLoop = 9500;
+    lead.endLoop = 80000;
+    lead.loopFade = 4096;
+
+    f.send(cmsg::UpdateLeadZoneAllVariants(fanOut(*zone, 1, VAR_FIELD(startSample))));
+    f.send(cmsg::UpdateLeadZoneAllVariants(fanOut(*zone, 1, VAR_FIELD(endSample))));
+    f.send(cmsg::UpdateLeadZoneAllVariants(fanOut(*zone, 1, VAR_FIELD(startLoop))));
+    f.send(cmsg::UpdateLeadZoneAllVariants(fanOut(*zone, 1, VAR_FIELD(endLoop))));
+    f.send(cmsg::UpdateLeadZoneAllVariants(fanOut(*zone, 1, VAR_FIELD(loopFade))));
+
+    REQUIRE(follower.startSample == before.startSample);
+    REQUIRE(follower.endSample == before.endSample);
+    REQUIRE(follower.startLoop == before.startLoop);
+    REQUIRE(follower.endLoop == before.endLoop);
+    REQUIRE(follower.loopFade == before.loopFade);
+
+    // and the lead kept what it was given
+    REQUIRE(zone->variantData.variants[1].startSample == 9000);
+    REQUIRE(zone->variantData.variants[1].endLoop == 80000);
+}
+
+TEST_CASE("Edit all applies across variants and preserves identity", "[variants]")
+{
+    EditAllFixture f;
+
+    f.send(cmsg::AddSampleWithRange({testSample("Beep.wav"), 60, 48, 72, 0, 127}));
+    auto &part = f.engine().getPatch()->getPart(0);
+    REQUIRE(part->getGroups().size() == 1);
+    auto &zone = part->getGroup(0)->getZone(0);
+
+    f.send(cmsg::AddSampleInZone({testSample("PulseSaw.wav"), 0, 0, 0, 1}));
+    f.send(cmsg::ApplySelectActions({{0, 0, 0, true, true, true}}));
+
+    REQUIRE(zone->variantData.variants[0].active);
+    REQUIRE(zone->variantData.variants[1].active);
+
+    // give variant 0 a normalization so we can prove edit-all leaves it alone
+    f.send(cmsg::NormalizeVariantAmplitude({0, true}));
+    auto keptNorm = zone->variantData.variants[0].normalizationAmplitude;
+    REQUIRE(keptNorm != 1.f);
+    auto keptId = zone->variantData.variants[0].sampleID;
+
+    auto &lead = zone->variantData.variants[1];
+    lead.loopActive = true;
+    lead.playReverse = true;
+    lead.loopMode = Zone::LoopMode::LOOP_WHILE_GATED;
+    lead.loopDirection = Zone::LoopDirection::ALTERNATE_DIRECTIONS;
+    lead.interpolationType = scxt::dsp::InterpolationTypes::Linear;
+    lead.loopCountWhenCounted = 4;
+    lead.playMode = Zone::PlayMode::ON_RELEASE;
+    lead.pan = 0.25f;
+    lead.pitchOffset = -7.f;
+    lead.amplitude = 0.5f;
+
+    // each control is its own edit, so each is its own send
+    f.send(cmsg::UpdateLeadZoneAllVariants(fanOut(*zone, 1, VAR_FIELD(loopActive))));
+    f.send(cmsg::UpdateLeadZoneAllVariants(fanOut(*zone, 1, VAR_FIELD(playReverse))));
+    f.send(cmsg::UpdateLeadZoneAllVariants(fanOut(*zone, 1, VAR_FIELD(loopMode))));
+    f.send(cmsg::UpdateLeadZoneAllVariants(fanOut(*zone, 1, VAR_FIELD(loopDirection))));
+    f.send(cmsg::UpdateLeadZoneAllVariants(fanOut(*zone, 1, VAR_FIELD(interpolationType))));
+    f.send(cmsg::UpdateLeadZoneAllVariants(fanOut(*zone, 1, VAR_FIELD(loopCountWhenCounted))));
+    f.send(cmsg::UpdateLeadZoneAllVariants(fanOut(*zone, 1, VAR_FIELD(playMode))));
+    f.send(cmsg::UpdateLeadZoneAllVariants(fanOut(*zone, 1, VAR_FIELD(pan))));
+    f.send(cmsg::UpdateLeadZoneAllVariants(fanOut(*zone, 1, VAR_FIELD(pitchOffset))));
+    f.send(cmsg::UpdateLeadZoneAllVariants(fanOut(*zone, 1, VAR_FIELD(amplitude))));
+
+    const auto &shrt = zone->variantData.variants[0];
+    REQUIRE(shrt.loopActive);
+    REQUIRE(shrt.playReverse);
+    REQUIRE(shrt.loopMode == Zone::LoopMode::LOOP_WHILE_GATED);
+    REQUIRE(shrt.loopDirection == Zone::LoopDirection::ALTERNATE_DIRECTIONS);
+    REQUIRE(shrt.interpolationType == scxt::dsp::InterpolationTypes::Linear);
+    REQUIRE(shrt.loopCountWhenCounted == 4);
+    REQUIRE(shrt.playMode == Zone::PlayMode::ON_RELEASE);
+    REQUIRE(shrt.pan == Approx(0.25f));
+    REQUIRE(shrt.pitchOffset == Approx(-7.f));
+    REQUIRE(shrt.amplitude == Approx(0.5f));
+
+    // identity and normalization stay with the variant
+    REQUIRE(shrt.sampleID == keptId);
+    REQUIRE(shrt.normalizationAmplitude == Approx(keptNorm));
+}
+
+TEST_CASE("Edit all does not write inactive variants", "[variants]")
+{
+    EditAllFixture f;
+
+    f.send(cmsg::AddSampleWithRange({testSample("Beep.wav"), 60, 48, 72, 0, 127}));
+    auto &zone = f.engine().getPatch()->getPart(0)->getGroup(0)->getZone(0);
+    f.send(cmsg::ApplySelectActions({{0, 0, 0, true, true, true}}));
+
+    auto payload = zone->variantData.variants;
+    for (auto i = 1U; i < maxVariantsPerZone; ++i)
+    {
+        // an active-looking payload for a slot the engine knows is empty
+        payload[i].active = true;
+        payload[i].pan = 0.75f;
+    }
+
+    f.send(cmsg::UpdateLeadZoneAllVariants(payload));
+
+    for (auto i = 1U; i < maxVariantsPerZone; ++i)
+    {
+        REQUIRE(!zone->variantData.variants[i].active);
+        REQUIRE(zone->variantData.variants[i].pan == Approx(0.f));
+    }
+}
+
+TEST_CASE("A variant drag gesture is a single undo entry", "[variants][undo]")
+{
+    EditAllFixture f;
+
+    f.send(cmsg::AddSampleWithRange({testSample("Beep.wav"), 60, 48, 72, 0, 127}));
+    auto &zone = f.engine().getPatch()->getPart(0)->getGroup(0)->getZone(0);
+    f.send(cmsg::ApplySelectActions({{0, 0, 0, true, true, true}}));
+
+    auto originalEnd = zone->variantData.variants[0].endSample;
+    REQUIRE(originalEnd > 400);
+    auto depthBefore = f.engine().undoManager.undoStackSize();
+
+    // what a hot-zone drag sends: begin, an update per mouse move, end
+    f.send(cmsg::BeginEdit({(int32_t)cmsg::EditSubtree::zone_variants, true, (int32_t)-1}));
+    for (int i = 0; i < 12; ++i)
+    {
+        auto v = zone->variantData.variants[0];
+        v.endSample = originalEnd - 10 * (i + 1);
+        f.send(cmsg::UpdateLeadZoneSingleVariant({0, v}));
+    }
+    f.send(cmsg::EndEdit(true));
+
+    REQUIRE(zone->variantData.variants[0].endSample == originalEnd - 120);
+    // twelve moves, one entry
+    REQUIRE(f.engine().undoManager.undoStackSize() == depthBefore + 1);
+
+    f.sendUndo();
+    REQUIRE(zone->variantData.variants[0].endSample == originalEnd);
+}
+
+TEST_CASE("A variant gesture closes so the next edit is its own entry", "[variants][undo]")
+{
+    EditAllFixture f;
+
+    f.send(cmsg::AddSampleWithRange({testSample("Beep.wav"), 60, 48, 72, 0, 127}));
+    auto &zone = f.engine().getPatch()->getPart(0)->getGroup(0)->getZone(0);
+    f.send(cmsg::ApplySelectActions({{0, 0, 0, true, true, true}}));
+
+    auto originalEnd = zone->variantData.variants[0].endSample;
+    auto depthBefore = f.engine().undoManager.undoStackSize();
+
+    f.send(cmsg::BeginEdit({(int32_t)cmsg::EditSubtree::zone_variants, true, (int32_t)-1}));
+    auto v = zone->variantData.variants[0];
+    v.endSample = originalEnd - 100;
+    f.send(cmsg::UpdateLeadZoneSingleVariant({0, v}));
+    f.send(cmsg::EndEdit(true));
+
+    // a later edit outside any gesture must not fold into the drag's entry
+    v.pan = 0.3f;
+    f.send(cmsg::UpdateLeadZoneSingleVariant({0, v}));
+    REQUIRE(f.engine().undoManager.undoStackSize() == depthBefore + 2);
+
+    f.sendUndo();
+    REQUIRE(zone->variantData.variants[0].pan == Approx(0.f));
+    REQUIRE(zone->variantData.variants[0].endSample == originalEnd - 100);
+
+    f.sendUndo();
+    REQUIRE(zone->variantData.variants[0].endSample == originalEnd);
+}
+
+TEST_CASE("Edit all is a single undo entry", "[variants][undo]")
+{
+    EditAllFixture f;
+
+    f.send(cmsg::AddSampleWithRange({testSample("Beep.wav"), 60, 48, 72, 0, 127}));
+    auto &zone = f.engine().getPatch()->getPart(0)->getGroup(0)->getZone(0);
+    f.send(cmsg::AddSampleInZone({testSample("PulseSaw.wav"), 0, 0, 0, 1}));
+    f.send(cmsg::ApplySelectActions({{0, 0, 0, true, true, true}}));
+
+    auto before0 = zone->variantData.variants[0].pan;
+    auto before1 = zone->variantData.variants[1].pan;
+
+    auto payload = zone->variantData.variants;
+    payload[0].pan = 0.4f;
+    payload[1].pan = 0.4f;
+
+    // don't drain the stack: undoing past the sample adds destroys the zone this refers to
+    auto depthBefore = f.engine().undoManager.undoStackSize();
+
+    f.send(cmsg::UpdateLeadZoneAllVariants(payload));
+    REQUIRE(zone->variantData.variants[0].pan == Approx(0.4f));
+    REQUIRE(zone->variantData.variants[1].pan == Approx(0.4f));
+
+    // the whole fan-out is one entry, however many variants it touched
+    REQUIRE(f.engine().undoManager.undoStackSize() == depthBefore + 1);
+
+    f.send(cmsg::Undo(true));
+    REQUIRE(zone->variantData.variants[0].pan == Approx(before0));
+    REQUIRE(zone->variantData.variants[1].pan == Approx(before1));
+    REQUIRE(f.engine().undoManager.undoStackSize() == depthBefore);
+
+    f.send(cmsg::Redo(true));
+    REQUIRE(zone->variantData.variants[0].pan == Approx(0.4f));
+    REQUIRE(zone->variantData.variants[1].pan == Approx(0.4f));
+}

--- a/tests/variant_edit_all_tests.cpp
+++ b/tests/variant_edit_all_tests.cpp
@@ -189,7 +189,7 @@ TEST_CASE("Edit all never crosses positions or identity", "[variants]")
     SECTION("the lead-only offsets really are the per-sample fields")
     {
         // named here so a field rename or reorder cannot silently drop one
-        std::array<size_t, 8> expect{
+        const std::array<size_t, 8> expect{
             VAR_FIELD_OFF(startSample), VAR_FIELD_OFF(endSample),
             VAR_FIELD_OFF(startLoop),   VAR_FIELD_OFF(endLoop),
             VAR_FIELD_OFF(loopFade),    VAR_FIELD_OFF(active),
@@ -534,3 +534,7 @@ TEST_CASE("Edit all is a single undo entry", "[variants][undo]")
     REQUIRE(zone->variantData.variants[0].pan == Approx(0.4f));
     REQUIRE(zone->variantData.variants[1].pan == Approx(0.4f));
 }
+
+// keep the file unity-safe: these must not leak into a batched neighbour
+#undef VAR_FIELD
+#undef VAR_FIELD_OFF


### PR DESCRIPTION
Turns the EDIT ALL button from a coming-soon stub into a toggle. When on, an edit to the displayed variant applies to every other variant in the zone.

Only the field the edit touched crosses over, addressed by its offset in SingleVariant the way the int and float update messages address theirs, so a control added later is covered without being registered anywhere. The exceptions are listed instead: sample start/end, loop start/end and the crossfade are absolute frame positions that mean different things on samples of different lengths, so they stay on the selected variant and get their own copy-endpoints-and-fade-zones gesture later, as do sample identity and the normalization level. Normalizing under edit all is re-run per variant rather than copied, since the level comes from each sample's own peak.

The toggle lives in the tab selection map, so it survives zone changes and sessions.

Sample point edits now bracket themselves as an edit gesture, so dragging a marker or a value is one undo entry rather than one per mouse move.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>