### PR TITLE
Make one shot a property of the zone rather than of a variant

### DIFF
--- a/src/scxt-core/configuration.h
+++ b/src/scxt-core/configuration.h
@@ -33,7 +33,7 @@
 
 namespace scxt
 {
-static constexpr uint64_t currentStreamingVersion{0x2026'07'24};
+static constexpr uint64_t currentStreamingVersion{0x2026'08'11};
 
 static constexpr uint16_t blockSize{16};
 static constexpr uint16_t blockSizeQuad{16 >> 2};

--- a/src/scxt-core/engine/zone.cpp
+++ b/src/scxt-core/engine/zone.cpp
@@ -370,8 +370,6 @@ std::string Zone::toStringPlayMode(const PlayMode &p)
     {
     case NORMAL:
         return "normal";
-    case ONE_SHOT:
-        return "oneshot";
     case ON_RELEASE:
         return "onrelease";
     }

--- a/src/scxt-core/engine/zone.h
+++ b/src/scxt-core/engine/zone.h
@@ -88,10 +88,14 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
     };
     DECLARE_ENUM_STRING(VariantPlaybackMode);
 
+    /*
+     * One shot used to live here. It is a property of the whole zone rather than of one
+     * variant, so it now lives on the AEG as GateMode::SAMPLE_GATED and old streams
+     * migrate onto that.
+     */
     enum PlayMode
     {
         NORMAL,     // AEG gates; play on note on
-        ONE_SHOT,   // SAMPLE playback gates; play on note on
         ON_RELEASE, // SAMPLE playback gates. play on note off
     };
     DECLARE_ENUM_STRING(PlayMode);

--- a/src/scxt-core/json/engine_traits.h
+++ b/src/scxt-core/json/engine_traits.h
@@ -783,6 +783,50 @@ SC_STREAMDEF(scxt::engine::Zone::Variants, SC_FROM({
                  findIf(v, "variantPlaybackMode", result.variantPlaybackMode);
              }));
 
+/*
+ * "oneshot" was a per-variant play mode until August 2026. One shot describes the whole
+ * zone rather than one of its variants, so it now lives on the AEG as SAMPLE_GATED and a
+ * zone with any one-shot variant unstreams onto that. This reads the raw json because the
+ * enum no longer has a value to unstream "oneshot" into.
+ *
+ * This is checked with the streaming versoin stream guard and when we made this change
+ * we updated the version.
+ */
+template <template <typename...> class Traits>
+inline bool anyVariantStreamedAsOneShot(const tao::json::basic_value<Traits> &v)
+{
+    if (!(SC_UNSTREAMING_FROM_PRIOR_TO(0x2026'08'11)))
+        return false;
+    if (!v.is_object())
+        return false;
+    const auto *vd = v.find("variantData");
+    if (!vd)
+        vd = v.find("sampleData");
+    if (!vd || !vd->is_object())
+        return false;
+
+    const auto *vars = vd->find("variants");
+    if (!vars)
+        vars = vd->find("samples");
+    if (!vars || !vars->is_array())
+        return false;
+
+    for (const auto &var : vars->get_array())
+    {
+        if (!var.is_object())
+            continue;
+        const auto *pm = var.find("playMode");
+        if (!pm || !pm->is_object())
+            continue;
+
+        std::string mode;
+        // "e" since streaming version 0x2024'08'04; the enum name before that
+        if (findIf(*pm, {"e", "engine::Zone::PlayMode"}, mode) && mode == "oneshot")
+            return true;
+    }
+    return false;
+}
+
 SC_STREAMDEF(scxt::engine::Zone, SC_FROM({
                  // special case. before given name for empty samples we used id.
                  // crystalize this name for old patches. You can probably remove this
@@ -830,6 +874,11 @@ SC_STREAMDEF(scxt::engine::Zone, SC_FROM({
                  else
                  {
                      SCLOG_IF(warnings, "No EG storage in zone");
+                 }
+                 if (anyVariantStreamedAsOneShot(v))
+                 {
+                     zone.egStorage[0].gateMode =
+                         modulation::modulators::AdsrStorage::GateMode::SAMPLE_GATED;
                  }
                  findOrSet(v, "givenName", "", zone.givenName);
                  zone.onRoutingChanged();

--- a/src/scxt-core/sample/exs_support/exs_import.cpp
+++ b/src/scxt-core/sample/exs_support/exs_import.cpp
@@ -1385,7 +1385,8 @@ bool importEXS(const fs::path &p, engine::Engine &e)
         if (exsGroupPtr && exsGroupPtr->releaseTrigger)
             variant.playMode = engine::Zone::PlayMode::ON_RELEASE;
         else if (z.oneshot)
-            variant.playMode = engine::Zone::PlayMode::ONE_SHOT;
+            zone->egStorage[0].gateMode =
+                modulation::modulators::AdsrStorage::GateMode::SAMPLE_GATED;
 
         if (z.loopOn)
         {

--- a/src/scxt-core/voice/voice.cpp
+++ b/src/scxt-core/voice/voice.cpp
@@ -296,7 +296,6 @@ template <bool OS> bool Voice::processWithOS()
         auto &vdata = zone->variantData.variants[sampleIndex];
 
         envGate = (vdata.playMode == engine::Zone::NORMAL && isGated) ||
-                  (vdata.playMode == engine::Zone::ONE_SHOT && isAnyGeneratorRunning) ||
                   (vdata.playMode == engine::Zone::ON_RELEASE && isAnyGeneratorRunning);
     }
 
@@ -1001,6 +1000,14 @@ void Voice::initializeGenerator()
     }
     numGeneratorsActive = lastIndex - firstIndex;
 
+    /*
+     * A sample gated AEG holds the voice open for exactly as long as the sample plays, so a
+     * loop that never ends would hold it open forever. A counted loop does end, so it still
+     * runs; the open ended modes are ignored and the UI grays them out to say so.
+     */
+    auto aegSampleGated = zone->egStorage[0].gateMode ==
+                          scxt::modulation::modulators::AdsrStorage::GateMode::SAMPLE_GATED;
+
     int currGen{0};
     allGeneratorsMono = true;
     for (auto currIndex = firstIndex; currIndex < lastIndex; currIndex++)
@@ -1008,6 +1015,9 @@ void Voice::initializeGenerator()
         auto &s = zone->samplePointers[currIndex];
 
         auto &variantData = zone->variantData.variants[currIndex];
+        auto loopActive =
+            variantData.loopActive &&
+            (!aegSampleGated || variantData.loopMode == engine::Zone::LoopMode::LOOP_COUNT);
 
         GDIO[currGen].outputL = output[0];
         GDIO[currGen].outputR = output[1];
@@ -1037,7 +1047,7 @@ void Voice::initializeGenerator()
         GD[currGen].direction = 1;
         GD[currGen].isFinished = false;
 
-        if (variantData.loopActive)
+        if (loopActive)
         {
             GD[currGen].loopLowerBound = variantData.startLoop;
             GD[currGen].loopUpperBound = variantData.endLoop;
@@ -1067,7 +1077,7 @@ void Voice::initializeGenerator()
         allGeneratorsMono = allGeneratorsMono && monoGenerator[currGen] &&
                             (variantData.pan < 0.01f && variantData.pan > -0.01f);
         Generator[currGen] = dsp::GetFPtrGeneratorSample(
-            !monoGenerator[currGen], s->bitDepth == sample::Sample::BD_F32, variantData.loopActive,
+            !monoGenerator[currGen], s->bitDepth == sample::Sample::BD_F32, loopActive,
             variantData.loopDirection == engine::Zone::FORWARD_ONLY,
 
             // We doo loop count by gating on loopCount < maxLoopCount

--- a/src/scxt-plugin/app/SCXTEditor.h
+++ b/src/scxt-plugin/app/SCXTEditor.h
@@ -269,6 +269,11 @@ struct SCXTEditor : sst::jucegui::components::WindowPanel,
 
     std::array<std::array<scxt::engine::Macro, scxt::macrosPerPart>, scxt::numParts> macroCache;
 
+    // The lead zone's AEG gate mode reaches past the EG pane - a sample gated AEG changes what
+    // the variant loop controls can do - so the last one sent for the lead zone lives here.
+    modulation::modulators::AdsrStorage::GateMode zoneAegGateMode{
+        modulation::modulators::AdsrStorage::GateMode::GATED};
+
     // Keyswitch keys per part, so the mapping keyboard can mark every switch in the part
     // rather than only the selected group's
     std::array<scxt::engine::partKeySwitchDisplay_t, scxt::numParts> keySwitchDisplay{};

--- a/src/scxt-plugin/app/edit-screen/components/AdsrPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/AdsrPane.cpp
@@ -77,7 +77,7 @@ void AdsrPane::adsrChangedFromModel(const modulation::modulators::AdsrStorage &d
         if (sl)
             sl->setEnabled(true);
 
-    updateSustainBreakpoint();
+    updateForGateMode();
     repaint();
 }
 
@@ -87,7 +87,7 @@ void AdsrPane::adsrChangedFromModel(const modulation::modulators::AdsrStorage &d
     if (cacheIdx - 1 == selectedTab)
     {
         adsrView = d;
-        updateSustainBreakpoint();
+        updateForGateMode();
     }
     for (const auto &sl : sliders.members)
         if (sl)
@@ -122,7 +122,7 @@ void AdsrPane::tabChanged(int newIndex, bool updateState)
     zoneAdsrCache[displayedTabIndex] = adsrView;
     displayedTabIndex = newIndex;
     adsrView = zoneAdsrCache[newIndex];
-    updateSustainBreakpoint();
+    updateForGateMode();
 
     getContentAreaComponent()->removeAllChildren();
     rebuildPanelComponents(newIndex + 1);
@@ -175,15 +175,10 @@ void AdsrPane::rebuildPanelComponents(int useIdx)
 
     if (!forZone)
     {
+        // no widget for this one - it is a hamburger item
         gateToggleA =
             bfac::attachOnly(adsrView, adsrView.gateGroupEGOnAnyPlaying, this, forZone, index);
         assert(gateToggleA);
-        gateToggle = std::make_unique<sst::jucegui::components::ToggleButton>();
-        gateToggle->setDrawMode(sst::jucegui::components::ToggleButton::DrawMode::LABELED);
-        gateToggle->setLabel(u8"\xE2\x88\x80");
-        gateToggle->setSource(gateToggleA.get());
-        setupFloatWidget(gateToggle.get(), gateToggleA.get());
-        getContentAreaComponent()->addAndMakeVisible(*gateToggle);
     }
 
     {
@@ -208,17 +203,18 @@ void AdsrPane::rebuildPanelComponents(int useIdx)
         editor->themeApplier.applyGroupMultiScreenModulationTheme(this);
     }
 
-    updateSustainBreakpoint();
+    updateForGateMode();
 
     resized();
 }
 
-void AdsrPane::updateSustainBreakpoint()
+void AdsrPane::updateForGateMode()
 {
+    using gm_t = modulation::modulators::AdsrStorage::GateMode;
     switch (adsrView.gateMode)
     {
-    case modulation::modulators::AdsrStorage::GateMode::ONESHOT:
-    case modulation::modulators::AdsrStorage::GateMode::SEMI_GATED:
+    case gm_t::ONESHOT:
+    case gm_t::SEMI_GATED:
         attachments.S->labelOverride = "Breakpoint";
         labels.S->setText("B");
         break;
@@ -227,6 +223,39 @@ void AdsrPane::updateSustainBreakpoint()
         labels.S->setText("S");
         break;
     }
+
+    /*
+     * The zone AEG is the one envelope whose gate mode changes what the whole zone does -
+     * it is what makes a zone a one shot - so it wears the mode in its title. The group EGs
+     * and the zone EG2..5 are plain modulators and keep their names.
+     */
+    if (forZone && index == 0)
+    {
+        switch (adsrView.gateMode)
+        {
+        case gm_t::ONESHOT:
+            setName("AMP EG (OneShot)");
+            break;
+        case gm_t::SEMI_GATED:
+            setName("AMP EG (SemiGated)");
+            break;
+        case gm_t::SAMPLE_GATED:
+            setName("AMP EG (SampleGated)");
+            break;
+        case gm_t::GATED:
+            setName("AMP EG");
+            break;
+        }
+    }
+}
+
+void AdsrPane::setGateMode(modulation::modulators::AdsrStorage::GateMode gm)
+{
+    adsrView.gateMode = gm;
+    updateForGateMode();
+    repaint();
+    sendToSerialization(cmsg::UpdateFullAdsrStorageForGroupsOrZones(
+        {forZone, (int)(forZone && index != 0 ? displayedTabIndex + 1 : index), adsrView}));
 }
 
 void AdsrPane::resized()
@@ -260,10 +289,6 @@ void AdsrPane::resized()
     x += w;
     sliders.S->setBounds(x, y, w, h);
     labels.S->setBounds(x, y + h, w, lh);
-    if (!forZone && gateToggle)
-    {
-        gateToggle->setBounds(x + (w - kh) * 0.5, y - lh, kh, kh - 3);
-    }
     x += w;
     sliders.R->setBounds(x, y, w, h);
     labels.R->setBounds(x, y + h, w, lh);
@@ -272,78 +297,34 @@ void AdsrPane::resized()
 
 void AdsrPane::showHamburgerMenu()
 {
+    using gm_t = modulation::modulators::AdsrStorage::GateMode;
+
     juce::PopupMenu p;
-    int aidx = 0;
     if (forZone)
     {
         if (index == 0)
-        {
             p.addSectionHeader("Amp EG");
-            aidx = 0;
-        }
         else
-        {
             p.addSectionHeader("EG " + std::to_string(displayedTabIndex + 2));
-            aidx = displayedTabIndex + 1;
-        }
     }
     else
     {
         p.addSectionHeader("Group EG " + std::to_string(index + 1));
-        aidx = index;
     }
     p.addSeparator();
-    p.addItem("Gated (DAHDSR)", true,
-              adsrView.gateMode == modulation::modulators::AdsrStorage::GateMode::GATED,
-              [aidx, w = juce::Component::SafePointer(this)]() {
-                  if (!w)
-                      return;
-                  w->adsrView.gateMode = modulation::modulators::AdsrStorage::GateMode::GATED;
-                  w->updateSustainBreakpoint();
-                  w->repaint();
-                  w->sendToSerialization(
-                      cmsg::UpdateFullAdsrStorageForGroupsOrZones({w->forZone, aidx, w->adsrView}));
-              });
-    p.addItem("No Sustain", true,
-              adsrView.gateMode == modulation::modulators::AdsrStorage::GateMode::SEMI_GATED,
-              [aidx, w = juce::Component::SafePointer(this)]() {
-                  if (!w)
-                      return;
-                  w->adsrView.gateMode = modulation::modulators::AdsrStorage::GateMode::SEMI_GATED;
-                  w->updateSustainBreakpoint();
-                  w->repaint();
 
-                  w->sendToSerialization(
-                      cmsg::UpdateFullAdsrStorageForGroupsOrZones({w->forZone, aidx, w->adsrView}));
-              });
-    p.addItem("Oneshot", true,
-              adsrView.gateMode == modulation::modulators::AdsrStorage::GateMode::ONESHOT,
-              [aidx, w = juce::Component::SafePointer(this)]() {
-                  if (!w)
-                      return;
-                  w->adsrView.gateMode = modulation::modulators::AdsrStorage::GateMode::ONESHOT;
-                  w->updateSustainBreakpoint();
-                  w->repaint();
-
-                  w->sendToSerialization(
-                      cmsg::UpdateFullAdsrStorageForGroupsOrZones({w->forZone, aidx, w->adsrView}));
-              });
+    auto addGateMode = [&p, this](gm_t gm, const std::string &n) {
+        p.addItem(n, true, adsrView.gateMode == gm, [gm, w = juce::Component::SafePointer(this)]() {
+            if (w)
+                w->setGateMode(gm);
+        });
+    };
+    addGateMode(gm_t::GATED, "Gated (DAHDSR)");
+    addGateMode(gm_t::SEMI_GATED, "No Sustain");
+    addGateMode(gm_t::ONESHOT, "Oneshot");
 
     if (forZone)
-    {
-        p.addItem("Sample Gated", true,
-                  adsrView.gateMode == modulation::modulators::AdsrStorage::GateMode::SAMPLE_GATED,
-                  [aidx, w = juce::Component::SafePointer(this)]() {
-                      if (!w)
-                          return;
-                      w->adsrView.gateMode =
-                          modulation::modulators::AdsrStorage::GateMode::SAMPLE_GATED;
-                      w->updateSustainBreakpoint();
-                      w->repaint();
-                      w->sendToSerialization(cmsg::UpdateFullAdsrStorageForGroupsOrZones(
-                          {w->forZone, aidx, w->adsrView}));
-                  });
-    }
+        addGateMode(gm_t::SAMPLE_GATED, "Sample Gated");
 
     if (!forZone)
     {

--- a/src/scxt-plugin/app/edit-screen/components/AdsrPane.h
+++ b/src/scxt-plugin/app/edit-screen/components/AdsrPane.h
@@ -61,8 +61,7 @@ struct AdsrPane : sst::jucegui::components::NamedPanel, HasEditor
     UIStore<sst::jucegui::components::Label> labels;
     UIStore<sst::jucegui::components::Knob> knobs;
 
-    // used by group
-    std::unique_ptr<sst::jucegui::components::ToggleButton> gateToggle;
+    // used by group; driven only from the hamburger menu
     std::unique_ptr<boolAttachment_t> gateToggleA;
 
     // blanket temposync toggle (all-or-none) shown in the panel header
@@ -89,7 +88,9 @@ struct AdsrPane : sst::jucegui::components::NamedPanel, HasEditor
     void adsrChangedFromModel(const modulation::modulators::AdsrStorage &, int index);
     void adsrDeactivated();
     void tabChanged(int newIndex, bool updateState);
-    void updateSustainBreakpoint();
+    // the sustain slider's meaning and, for the zone AEG, the panel title both follow gateMode
+    void updateForGateMode();
+    void setGateMode(modulation::modulators::AdsrStorage::GateMode);
 
     void rebuildPanelComponents(int newIndex);
 

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
@@ -27,6 +27,8 @@
 
 #include "VariantDisplay.h"
 #include "app/SCXTEditor.h"
+#include "app/edit-screen/EditScreen.h"
+#include "app/edit-screen/components/AdsrPane.h"
 #include "messaging/client/client_serial.h"
 #include "messaging/client/structure_messages.h"
 #include "SampleWaveform.h"
@@ -556,15 +558,17 @@ void VariantDisplay::resized()
     noSelectionOverlay->setBounds(getLocalBounds());
 }
 
+bool VariantDisplay::aegIsSampleGated() const
+{
+    return editor->zoneAegGateMode == modulation::modulators::AdsrStorage::GateMode::SAMPLE_GATED;
+}
+
 void VariantDisplay::rebuild()
 {
     switch (variantView.variants[selectedVariation].playMode)
     {
     case engine::Zone::NORMAL:
         playModeButton->setLabel("NORMAL");
-        break;
-    case engine::Zone::ONE_SHOT:
-        playModeButton->setLabel("ONE-SHOT");
         break;
     case engine::Zone::ON_RELEASE:
         playModeButton->setLabel("ON RELEASE");
@@ -647,6 +651,15 @@ void VariantDisplay::rebuild()
     }
 
     bool hasLoop = variantView.variants[selectedVariation].loopActive;
+
+    /*
+     * A sample gated AEG ends the voice with the sample, so a loop with no end would hold it
+     * open forever and the engine ignores it. A counted loop does end, so the loop power and
+     * the mode menu stay live and only the loop's own points gray out.
+     */
+    bool loopRuns = !aegIsSampleGated() || variantView.variants[selectedVariation].loopMode ==
+                                               engine::Zone::LoopMode::LOOP_COUNT;
+
     loopModeButton->setEnabled(hasLoop);
     loopCnt->setEnabled(hasLoop);
     discreteSampleEditors[startL]->setVisible(hasLoop);
@@ -659,6 +672,15 @@ void VariantDisplay::rebuild()
     labels[endL]->setVisible(hasLoop);
     labels[fadeL]->setVisible(hasLoop);
     glyphLabels[curve]->setVisible(hasLoop);
+
+    for (const auto c : {startL, endL, fadeL})
+    {
+        discreteSampleEditors[c]->setEnabled(loopRuns);
+        labels[c]->setEnabled(loopRuns);
+    }
+    sampleEditors[curve]->setEnabled(loopRuns);
+    glyphLabels[curve]->setEnabled(loopRuns);
+    zoomButton->setEnabled(loopRuns);
 
     loopCnt->setVisible(variantView.variants[selectedVariation].loopMode ==
                         engine::Zone::LoopMode::LOOP_COUNT);
@@ -863,8 +885,24 @@ void VariantDisplay::showPlayModeMenu()
         });
     };
     add(engine::Zone::PlayMode::NORMAL, "Normal");
-    add(engine::Zone::PlayMode::ONE_SHOT, "OneShot");
     add(engine::Zone::PlayMode::ON_RELEASE, "On Release (t/k)");
+
+    /*
+     * One shot used to be a play mode here. It is a property of the whole zone rather than of
+     * one variant, so it is the AEG's sample gated mode now and this is the shortcut to it.
+     */
+    p.addSeparator();
+    p.addItem("Set AMP EG to Sample Gated", true, aegIsSampleGated(),
+              [sg = aegIsSampleGated(), w = juce::Component::SafePointer(this)]() {
+                  if (!w)
+                      return;
+                  const auto &aeg = w->editor->editScreen->getZoneElements()->eg[0];
+                  if (!aeg)
+                      return;
+                  using gm_t = modulation::modulators::AdsrStorage::GateMode;
+                  // ticking it off puts the AMP EG back to plain gated
+                  aeg->setGateMode(sg ? gm_t::GATED : gm_t::SAMPLE_GATED);
+              });
 
     p.showMenuAsync(editor->defaultPopupMenuOptions());
 }
@@ -875,9 +913,13 @@ void VariantDisplay::showLoopModeMenu()
     p.addSectionHeader("Loop Mode");
     p.addSeparator();
 
-    auto add = [&p, this](auto e, bool alt, auto n) {
+    // A sample gated AEG lasts exactly as long as the sample, so only a loop that counts
+    // itself out still ends; the open ended modes are unreachable while it is on.
+    auto openEndedOK = !aegIsSampleGated();
+
+    auto add = [&p, this, openEndedOK](auto e, bool alt, auto n) {
         auto that = this;
-        p.addItem(n, true,
+        p.addItem(n, openEndedOK || e == engine::Zone::LoopMode::LOOP_COUNT,
                   variantView.variants[selectedVariation].loopMode == e &&
                       variantView.variants[selectedVariation].loopDirection ==
                           (alt ? engine::Zone::LoopDirection::ALTERNATE_DIRECTIONS

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.h
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.h
@@ -232,6 +232,9 @@ struct VariantDisplay : juce::Component, HasEditor
         fileInfos->setVisible(show);
     }
 
+    // one shot is the zone AEG's sample gated mode now, and it governs what looping can do
+    bool aegIsSampleGated() const;
+
     void showPlayModeMenu();
     void showLoopModeMenu();
     void showVariantPlaymodeMenu();

--- a/src/scxt-plugin/app/editor-impl/SCXTEditorResponseHandlers.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditorResponseHandlers.cpp
@@ -67,6 +67,15 @@ void SCXTEditorReceiver::onGroupOrZoneEnvelopeUpdated(
             {
                 editor.editScreen->getZoneElements()->eg[which]->adsrDeactivated();
             }
+
+            /*
+             * A sample gated AEG takes the open ended loop modes away from every variant, so
+             * the sample pane redraws whenever the lead zone's AEG lands.
+             */
+            editor.zoneAegGateMode =
+                active ? env.gateMode : modulation::modulators::AdsrStorage::GateMode::GATED;
+            if (editor.editScreen->mappingPane && editor.editScreen->mappingPane->sampleDisplay)
+                editor.editScreen->mappingPane->sampleDisplay->rebuild();
         }
         else
         {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(scxt-test
 		group_trigger_tests.cpp
 		glide_tests.cpp
 		legato_tests.cpp
+		sample_gated_tests.cpp
 		undo_tests.cpp
 		importer_tests.cpp
 		midi_channel_tests.cpp

--- a/tests/sample_gated_tests.cpp
+++ b/tests/sample_gated_tests.cpp
@@ -1,0 +1,157 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "catch2/catch2.hpp"
+
+#include <filesystem>
+#include <memory>
+
+#include "engine/engine.h"
+#include "engine/part.h"
+#include "engine/zone.h"
+#include "messaging/messaging.h"
+#include "voice/voice.h"
+
+#include "test_utils.h"
+
+/*
+ * A sample gated AEG is what "one shot" means now that the per-variant play mode is gone:
+ * the voice lasts exactly as long as the sample plays. A loop with no end would hold it
+ * open forever, so the generator ignores those; a counted loop does end, so it still runs.
+ */
+
+namespace fs = std::filesystem;
+
+namespace
+{
+namespace mm = scxt::modulation::modulators;
+using zone_t = scxt::engine::Zone;
+
+struct SampleGatedFixture
+{
+    std::unique_ptr<scxt::engine::Engine> eng;
+    scxt::engine::Group *group{nullptr};
+    zone_t *zone{nullptr};
+
+    SampleGatedFixture()
+    {
+        eng = std::make_unique<scxt::engine::Engine>();
+        eng->prepareToPlay(TEST_SAMPLE_RATE);
+        eng->midikeyRetuner.setTuningMode(scxt::tuning::MidikeyRetuner::TWELVE_TET);
+
+        auto &part = *eng->getPatch()->getPart(0);
+        part.addGroup();
+        group = part.getGroup(0).get();
+
+        auto z = std::make_unique<zone_t>();
+        z->mapping.keyboardRange = {48, 84};
+        z->mapping.velocityRange = {0, 127};
+        z->mapping.rootKey = 60;
+        z->initialize();
+        group->addZone(z);
+        zone = group->getZone(0).get();
+
+        auto p = samplePath("WavStereo48k.wav");
+        REQUIRE(fs::exists(p));
+
+        // loadSampleByPath asserts it is on the serial thread; we are the only thread.
+        auto bypass = eng->getMessageController()->threadingChecker.bypassChecksInScope();
+        auto sid = eng->getSampleManager()->loadSampleByPath(p);
+        REQUIRE(sid.has_value());
+
+        zone->variantData.variants[0].sampleID = *sid;
+        zone->variantData.variants[0].active = true;
+        // ENDPOINTS only — MAPPING would let the wav's chunks overwrite our key range.
+        REQUIRE(zone->attachToSample(*eng->getSampleManager(), 0,
+                                     zone_t::SampleInformationRead::ENDPOINTS));
+    }
+
+    // a loop well inside the sample, so the generator's bounds say which rule won
+    void setLoop(zone_t::LoopMode mode)
+    {
+        auto &v = zone->variantData.variants[0];
+        v.loopActive = true;
+        v.loopMode = mode;
+        v.startLoop = v.startSample + 100;
+        v.endLoop = v.endSample - 100;
+        v.loopCountWhenCounted = 2;
+    }
+
+    void setAegGateMode(mm::AdsrStorage::GateMode gm) { zone->egStorage[0].gateMode = gm; }
+
+    // the generator bounds are set once, when the voice starts
+    scxt::voice::Voice *playAndFindVoice(int key = 60)
+    {
+        eng->processNoteOnEvent(0, 0, key, -1, 1.f, 0.f);
+        eng->processAudio();
+
+        for (int i = 0; i < (int)scxt::maxVoices; ++i)
+        {
+            auto *v = zone->voiceWeakPointers[i];
+            if (v && v->isVoiceAssigned && v->isVoicePlaying)
+                return v;
+        }
+        return nullptr;
+    }
+};
+} // namespace
+
+TEST_CASE("A sample gated AEG only allows a loop that ends", "[dsp]")
+{
+    SECTION("A gated AEG loops as asked")
+    {
+        SampleGatedFixture f;
+        f.setLoop(zone_t::LoopMode::LOOP_DURING_VOICE);
+
+        auto *v = f.playAndFindVoice();
+        REQUIRE(v != nullptr);
+        REQUIRE(v->GD[0].loopUpperBound == f.zone->variantData.variants[0].endLoop);
+    }
+
+    SECTION("A sample gated AEG ignores an open ended loop")
+    {
+        SampleGatedFixture f;
+        f.setLoop(zone_t::LoopMode::LOOP_DURING_VOICE);
+        f.setAegGateMode(mm::AdsrStorage::GateMode::SAMPLE_GATED);
+
+        auto *v = f.playAndFindVoice();
+        REQUIRE(v != nullptr);
+        // playing straight through to the end, not around the loop
+        REQUIRE(v->GD[0].loopUpperBound == f.zone->variantData.variants[0].endSample);
+    }
+
+    SECTION("A sample gated AEG keeps a counted loop")
+    {
+        SampleGatedFixture f;
+        f.setLoop(zone_t::LoopMode::LOOP_COUNT);
+        f.setAegGateMode(mm::AdsrStorage::GateMode::SAMPLE_GATED);
+
+        auto *v = f.playAndFindVoice();
+        REQUIRE(v != nullptr);
+        REQUIRE(v->GD[0].loopUpperBound == f.zone->variantData.variants[0].endLoop);
+    }
+}

--- a/tests/streaming.cpp
+++ b/tests/streaming.cpp
@@ -158,6 +158,58 @@ TEST_CASE("Stream scxt::engine::Zone")
     // TODO: Expand this test
 }
 
+TEST_CASE("A one shot variant unstreams as a sample gated AEG")
+{
+    namespace mm = scxt::modulation::modulators;
+    using pm_t = scxt::engine::Zone::PlayMode;
+
+    scxt::engine::Zone k1;
+    k1.variantData.variants[0].active = true;
+    k1.variantData.variants[0].playMode = pm_t::ON_RELEASE;
+    REQUIRE(k1.egStorage[0].gateMode == mm::AdsrStorage::GateMode::GATED);
+
+    auto s = testStream(k1);
+    auto at = s.find("onrelease");
+    REQUIRE(at != std::string::npos);
+
+    // what a pre-August-2026 patch with a one shot variant looks like
+    auto old = s;
+    old.replace(at, std::string("onrelease").size(), "oneshot");
+
+    SECTION("A play mode we still have round trips untouched")
+    {
+        scxt::engine::Zone k2;
+        testUnstream(s, k2);
+        REQUIRE(k2.variantData.variants[0].playMode == pm_t::ON_RELEASE);
+        REQUIRE(k2.egStorage[0].gateMode == mm::AdsrStorage::GateMode::GATED);
+    }
+
+    SECTION("A one shot variant lands on the AEG instead")
+    {
+        scxt::engine::Engine::UnstreamGuard sg(0x2026'07'24);
+
+        scxt::engine::Zone k2;
+        testUnstream(old, k2);
+        // the play mode is gone, so it falls back to normal
+        REQUIRE(k2.variantData.variants[0].playMode == pm_t::NORMAL);
+        REQUIRE(k2.egStorage[0].gateMode == mm::AdsrStorage::GateMode::SAMPLE_GATED);
+    }
+
+    SECTION("Only an old stream is searched for it")
+    {
+        // no guard, so this reads as an in-process stream from this build
+        scxt::engine::Zone k2;
+        testUnstream(old, k2);
+        REQUIRE(k2.egStorage[0].gateMode == mm::AdsrStorage::GateMode::GATED);
+
+        // and neither is one streamed at or past the version that dropped it
+        scxt::engine::Engine::UnstreamGuard sg(scxt::currentStreamingVersion);
+        scxt::engine::Zone k3;
+        testUnstream(old, k3);
+        REQUIRE(k3.egStorage[0].gateMode == mm::AdsrStorage::GateMode::GATED);
+    }
+}
+
 // TODO: Add test for Group streaming
 // TODO: Add test for Part streaming
 // TODO: Add test for Patch streaming

--- a/tests/variant_edit_all_tests.cpp
+++ b/tests/variant_edit_all_tests.cpp
@@ -250,7 +250,7 @@ TEST_CASE("Edit all never crosses positions or identity", "[variants]")
         SV lead, t;
         lead.pan = 0.5f;
         lead.pitchOffset = 3.f;
-        lead.playMode = Zone::PlayMode::ONE_SHOT;
+        lead.playMode = Zone::PlayMode::ON_RELEASE;
         const auto before = t;
 
         Zone::applyVariantEdit(t, lead, VAR_FIELD(pan));
@@ -260,7 +260,7 @@ TEST_CASE("Edit all never crosses positions or identity", "[variants]")
         REQUIRE(t.playMode == before.playMode);
 
         Zone::applyVariantEdit(t, lead, VAR_FIELD(playMode));
-        REQUIRE(t.playMode == Zone::PlayMode::ONE_SHOT);
+        REQUIRE(t.playMode == Zone::PlayMode::ON_RELEASE);
         REQUIRE(t.pitchOffset == Approx(before.pitchOffset));
     }
 }


### PR DESCRIPTION
The variant OneShot play mode is gone. One shot describes a whole zone, so it is the AMP EG's sample gated mode now: the sample play menu offers a checkable "Set AMP EG to Sample Gated" instead, and the zone AMP EG names a non-standard gate mode in its title.

A sample gated AMP EG lasts exactly as long as the sample, so a loop with no end would hold the voice open forever. Those modes stop looping in the DSP and gray out in the UI; a counted loop still ends, so it keeps working.

Patches with any one-shot variant unstream onto a sample gated AMP EG, as do one-shot EXS zones.

Also drops the upside down A from the group EG pane, which the hamburger menu already offers.

Closes #2184

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>