### PR TITLE
Play a variant on release rather than on note on

### DIFF
--- a/src/scxt-core/engine/zone.h
+++ b/src/scxt-core/engine/zone.h
@@ -95,10 +95,22 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
      */
     enum PlayMode
     {
-        NORMAL,     // AEG gates; play on note on
-        ON_RELEASE, // SAMPLE playback gates. play on note off
+        NORMAL,     // play on note on
+        ON_RELEASE, // voice runs from note on, sample waits at its start for the AEG release
     };
     DECLARE_ENUM_STRING(PlayMode);
+
+    /*
+     * ON_RELEASE parks the sample at its start point until the AEG releases, and a sample gated
+     * AEG takes its gate from the sample - so taken separately the two would wait on each other
+     * forever. Together they mean one thing instead: the AEG opens in its release stage at full
+     * level, which starts the sample at note on and plays it out under the release curve.
+     */
+    static bool aegStartsInRelease(PlayMode pm, modulation::modulators::AdsrStorage::GateMode gm)
+    {
+        return pm == ON_RELEASE &&
+               gm == modulation::modulators::AdsrStorage::GateMode::SAMPLE_GATED;
+    }
 
     enum LoopMode
     {

--- a/src/scxt-core/voice/voice.cpp
+++ b/src/scxt-core/voice/voice.cpp
@@ -193,14 +193,32 @@ void Voice::voiceStarted()
     }
 
     auto &aegp = endpoints->egTarget[0];
-    if (*aegp.dlyP < 1e-5)
-    {
-        aeg.attackFrom(0.0, *(aegp.aP) == 0.0); // TODO Envelope Legato Mode
-    }
-    else
-    {
-        aeg.attackFromWithDelay(0.0, *aegp.dlyP, *aegp.aP);
-    }
+    /*
+     * See Zone::aegStartsInRelease. Opening in release at full level is the whole of what On
+     * Release plus a sample gated AEG means, and it needs no gate: release is only ever entered
+     * from an earlier stage, so nothing pulls the envelope back out of it.
+     */
+    auto openInRelease = sampleIndex >= 0 && engine::Zone::aegStartsInRelease(
+                                                 zone->variantData.variants[sampleIndex].playMode,
+                                                 zone->egStorage[0].gateMode);
+    auto startAeg = [openInRelease, &aegp](auto &env) {
+        if (openInRelease)
+        {
+            env.releaseStartValue = 1.f;
+            env.outBlock0 = 1.f;
+            env.phase = 0.f;
+            env.stage = std::remove_reference_t<decltype(env)>::s_release;
+        }
+        else if (*aegp.dlyP < 1e-5)
+        {
+            env.attackFrom(0.0, *(aegp.aP) == 0.0); // TODO Envelope Legato Mode
+        }
+        else
+        {
+            env.attackFromWithDelay(0.0, *aegp.dlyP, *aegp.aP);
+        }
+    };
+    startAeg(aeg);
     for (int i = 1; i < egsPerZone; ++i)
     {
         if (egsActive[i])
@@ -218,12 +236,7 @@ void Voice::voiceStarted()
     }
     if (forceOversample)
     {
-        if (*aegp.dlyP < 1e-5)
-            aegOS.attackFrom(0.0, *(aegp.aP) == 0.0); // TODO Envelope Legato Mode
-        else
-        {
-            aegOS.attackFromWithDelay(0.0, *aegp.dlyP, *aegp.aP);
-        }
+        startAeg(aegOS);
         // only the AEG needs oversampling since EG2 3 4 is only used at endpoint
     }
 
@@ -290,14 +303,11 @@ template <bool OS> bool Voice::processWithOS()
         return true;
     }
 
+    /*
+     * The play mode no longer steers the env gate - GateMode::SAMPLE_GATED is how an envelope
+     * follows the sample now, and ON_RELEASE moves the sample rather than the envelope.
+     */
     bool envGate{isGated};
-    if (sampleIndex >= 0)
-    {
-        auto &vdata = zone->variantData.variants[sampleIndex];
-
-        envGate = (vdata.playMode == engine::Zone::NORMAL && isGated) ||
-                  (vdata.playMode == engine::Zone::ON_RELEASE && isAnyGeneratorRunning);
-    }
 
     /*
      * Voice always runs the AEG which is default routed, so ignore
@@ -368,6 +378,17 @@ template <bool OS> bool Voice::processWithOS()
     modMatrix->process();
 
     bool samplePlaying = *endpoints->sampleTarget.playSampleP > 0.1;
+
+    /*
+     * ON_RELEASE sounds the voice from note on but parks the sample at its start point until
+     * the AEG releases, so the sample plays under the release rather than under the key. The
+     * generator simply doesn't run until then, which leaves firstSamplePlayback set to place
+     * the read head at the start point on the block the release begins.
+     */
+    if (holdSampleUntilAegRelease && aeg.stage < ahdsrenv_t::s_release)
+    {
+        samplePlaying = false;
+    }
 
     if (firstSamplePlayback && samplePlaying)
     {
@@ -982,6 +1003,7 @@ void Voice::initializeGenerator()
     numGeneratorsActive = 0;
     allGeneratorsMono = true;
     isAnyGeneratorRunning = false;
+    holdSampleUntilAegRelease = false;
 
     if (sampleIndex < 0)
     {
@@ -1007,6 +1029,10 @@ void Voice::initializeGenerator()
      */
     auto aegSampleGated = zone->egStorage[0].gateMode ==
                           scxt::modulation::modulators::AdsrStorage::GateMode::SAMPLE_GATED;
+
+    // fixed for the life of the voice, the same way the loop decision above is
+    holdSampleUntilAegRelease =
+        zone->variantData.variants[sampleIndex].playMode == engine::Zone::ON_RELEASE;
 
     int currGen{0};
     allGeneratorsMono = true;

--- a/src/scxt-core/voice/voice.h
+++ b/src/scxt-core/voice/voice.h
@@ -297,6 +297,9 @@ struct alignas(16) Voice : MoveableOnly<Voice>,
     bool isAnyGeneratorRunning{};
     bool isAEGRunning{false};
 
+    // PlayMode::ON_RELEASE parks the sample until the AEG releases; latched at voice start
+    bool holdSampleUntilAegRelease{false};
+
     bool isVoicePlaying{false};
     bool isVoiceAssigned{false};
 

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.cpp
@@ -885,7 +885,7 @@ void VariantDisplay::showPlayModeMenu()
         });
     };
     add(engine::Zone::PlayMode::NORMAL, "Normal");
-    add(engine::Zone::PlayMode::ON_RELEASE, "On Release (t/k)");
+    add(engine::Zone::PlayMode::ON_RELEASE, "On Release");
 
     /*
      * One shot used to be a play mode here. It is a property of the whole zone rather than of

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(scxt-test
 		glide_tests.cpp
 		legato_tests.cpp
 		sample_gated_tests.cpp
+		play_mode_tests.cpp
 		undo_tests.cpp
 		importer_tests.cpp
 		midi_channel_tests.cpp

--- a/tests/play_mode_tests.cpp
+++ b/tests/play_mode_tests.cpp
@@ -1,0 +1,233 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "catch2/catch2.hpp"
+
+#include <filesystem>
+#include <memory>
+
+#include "engine/engine.h"
+#include "engine/part.h"
+#include "engine/zone.h"
+#include "messaging/messaging.h"
+#include "voice/voice.h"
+
+#include "test_utils.h"
+
+/*
+ * PlayMode::ON_RELEASE sounds the voice from note on but parks the sample at its start point
+ * until the AEG releases, so the sample plays under the release rather than under the key.
+ * A sample gated AEG takes its gate from the sample, so on their own the two would wait on
+ * each other forever; together they mean the AEG opens in release at full level instead.
+ */
+
+namespace fs = std::filesystem;
+
+namespace
+{
+namespace mm = scxt::modulation::modulators;
+using zone_t = scxt::engine::Zone;
+using gm_t = mm::AdsrStorage::GateMode;
+using env_t = scxt::voice::Voice::ahdsrenv_t;
+
+struct PlayModeFixture
+{
+    std::unique_ptr<scxt::engine::Engine> eng;
+    scxt::engine::Group *group{nullptr};
+    zone_t *zone{nullptr};
+
+    PlayModeFixture()
+    {
+        eng = std::make_unique<scxt::engine::Engine>();
+        eng->prepareToPlay(TEST_SAMPLE_RATE);
+        eng->midikeyRetuner.setTuningMode(scxt::tuning::MidikeyRetuner::TWELVE_TET);
+
+        auto &part = *eng->getPatch()->getPart(0);
+        part.addGroup();
+        group = part.getGroup(0).get();
+
+        auto z = std::make_unique<zone_t>();
+        z->mapping.keyboardRange = {48, 84};
+        z->mapping.velocityRange = {0, 127};
+        z->mapping.rootKey = 60;
+        z->initialize();
+        group->addZone(z);
+        zone = group->getZone(0).get();
+
+        auto p = samplePath("WavStereo48k.wav");
+        REQUIRE(fs::exists(p));
+
+        // loadSampleByPath asserts it is on the serial thread; we are the only thread.
+        auto bypass = eng->getMessageController()->threadingChecker.bypassChecksInScope();
+        auto sid = eng->getSampleManager()->loadSampleByPath(p);
+        REQUIRE(sid.has_value());
+
+        zone->variantData.variants[0].sampleID = *sid;
+        zone->variantData.variants[0].active = true;
+        // ENDPOINTS only — MAPPING would let the wav's chunks overwrite our key range.
+        REQUIRE(zone->attachToSample(*eng->getSampleManager(), 0,
+                                     zone_t::SampleInformationRead::ENDPOINTS));
+    }
+
+    void setPlayMode(zone_t::PlayMode pm) { zone->variantData.variants[0].playMode = pm; }
+    void setAegGateMode(gm_t gm) { zone->egStorage[0].gateMode = gm; }
+
+    int64_t startSample() const { return zone->variantData.variants[0].startSample; }
+
+    scxt::voice::Voice *playAndFindVoice(int key = 60)
+    {
+        eng->processNoteOnEvent(0, 0, key, -1, 1.f, 0.f);
+        eng->processAudio();
+
+        for (int i = 0; i < (int)scxt::maxVoices; ++i)
+        {
+            auto *v = zone->voiceWeakPointers[i];
+            if (v && v->isVoiceAssigned && v->isVoicePlaying)
+                return v;
+        }
+        return nullptr;
+    }
+
+    void releaseAndRun(int key = 60, int blocks = 1)
+    {
+        eng->processNoteOffEvent(0, 0, key, -1, 0.f);
+        for (int i = 0; i < blocks; ++i)
+            eng->processAudio();
+    }
+
+    void run(int blocks)
+    {
+        for (int i = 0; i < blocks; ++i)
+            eng->processAudio();
+    }
+};
+
+} // namespace
+
+TEST_CASE("On Release holds the sample until the AEG releases", "[dsp]")
+{
+    SECTION("A normal zone moves the read head from note on")
+    {
+        PlayModeFixture f;
+
+        auto *v = f.playAndFindVoice();
+        REQUIRE(v != nullptr);
+        REQUIRE_FALSE(v->holdSampleUntilAegRelease);
+        REQUIRE(v->GD[0].samplePos > f.startSample());
+    }
+
+    SECTION("On Release parks the read head and still sounds the voice")
+    {
+        PlayModeFixture f;
+        f.setPlayMode(zone_t::PlayMode::ON_RELEASE);
+
+        auto *v = f.playAndFindVoice();
+        REQUIRE(v != nullptr);
+        REQUIRE(v->holdSampleUntilAegRelease);
+
+        f.run(20);
+        REQUIRE(v->GD[0].samplePos == f.startSample());
+        // the voice is alive and holding, not finished
+        REQUIRE(v->isVoicePlaying);
+        REQUIRE(v->isAEGRunning);
+
+        // and a parked read head is silence, whatever the AEG is doing
+        for (int i = 0; i < (int)scxt::blockSize; ++i)
+        {
+            REQUIRE(v->output[0][i] == 0.f);
+            REQUIRE(v->output[1][i] == 0.f);
+        }
+    }
+
+    SECTION("The read head starts moving once the AEG releases")
+    {
+        PlayModeFixture f;
+        f.setPlayMode(zone_t::PlayMode::ON_RELEASE);
+
+        auto *v = f.playAndFindVoice();
+        REQUIRE(v != nullptr);
+        f.run(20);
+        REQUIRE(v->GD[0].samplePos == f.startSample());
+
+        f.releaseAndRun();
+        REQUIRE(v->GD[0].samplePos > f.startSample());
+    }
+
+    SECTION("A held note never gets there, and never sounds")
+    {
+        PlayModeFixture f;
+        f.setPlayMode(zone_t::PlayMode::ON_RELEASE);
+
+        auto *v = f.playAndFindVoice();
+        REQUIRE(v != nullptr);
+        f.run(200);
+        REQUIRE(v->GD[0].samplePos == f.startSample());
+        REQUIRE(v->isVoicePlaying);
+    }
+}
+
+TEST_CASE("On Release with a sample gated AEG opens in release", "[dsp]")
+{
+    SECTION("Only the pair does this")
+    {
+        REQUIRE(zone_t::aegStartsInRelease(zone_t::ON_RELEASE, gm_t::SAMPLE_GATED));
+        REQUIRE_FALSE(zone_t::aegStartsInRelease(zone_t::NORMAL, gm_t::SAMPLE_GATED));
+        REQUIRE_FALSE(zone_t::aegStartsInRelease(zone_t::ON_RELEASE, gm_t::GATED));
+        REQUIRE_FALSE(zone_t::aegStartsInRelease(zone_t::ON_RELEASE, gm_t::ONESHOT));
+    }
+
+    SECTION("The AEG opens in release at full level, so the sample plays from note on")
+    {
+        PlayModeFixture f;
+        f.setPlayMode(zone_t::PlayMode::ON_RELEASE);
+        f.setAegGateMode(gm_t::SAMPLE_GATED);
+
+        auto *v = f.playAndFindVoice();
+        REQUIRE(v != nullptr);
+        // the hold is still on - it is just satisfied from the very first block
+        REQUIRE(v->holdSampleUntilAegRelease);
+        REQUIRE(v->aeg.stage == env_t::s_release);
+        REQUIRE(v->aeg.outBlock0 > 0.9f);
+        REQUIRE(v->GD[0].samplePos > f.startSample());
+    }
+
+    SECTION("And decays from there rather than holding")
+    {
+        PlayModeFixture f;
+        f.setPlayMode(zone_t::PlayMode::ON_RELEASE);
+        f.setAegGateMode(gm_t::SAMPLE_GATED);
+
+        auto *v = f.playAndFindVoice();
+        REQUIRE(v != nullptr);
+        auto opened = v->aeg.outBlock0;
+
+        // a sample gated AEG would be held open by the sample it is now playing; release isn't
+        f.run(200);
+        REQUIRE(v->aeg.stage == env_t::s_release);
+        REQUIRE(v->aeg.outBlock0 < opened);
+    }
+}


### PR DESCRIPTION
A zone whose variant play mode is On Release now sounds its voice from note on but holds the sample at its start point until the AEG reaches its release stage, so the sample plays under the release rather than under the key. It was a placeholder before, marked t/k in the menu.

A sample gated AEG takes its gate from the sample, so on their own the two settings would wait on each other forever. Together they mean one thing instead: the AEG opens in its release stage at full level, which starts the sample at note on and plays it out under the release curve.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>