### PR TITLE
Make the panic button stop all sounds on press

### DIFF
--- a/src/scxt-plugin/app/shared/HeaderRegion.cpp
+++ b/src/scxt-plugin/app/shared/HeaderRegion.cpp
@@ -197,6 +197,11 @@ HeaderRegion::HeaderRegion(SCXTEditor *e) : HasEditor(e)
     panicButton->setOnCallback([w = juce::Component::SafePointer(this)]() {
         if (!w)
             return;
+        w->sendToSerialization(cmsg::StopSounds{true});
+    });
+    panicButton->setOnRightMouseCallback([w = juce::Component::SafePointer(this)]() {
+        if (!w)
+            return;
         juce::PopupMenu p;
         p.addSectionHeader("Panic");
         p.addSeparator();


### PR DESCRIPTION
Pressing '!' now sends all sounds off immediately. The panic menu, with its all sounds off and all notes off choices, moves to the right button.

Picks up an sst-jucegui bump adding setOnRightMouseCallback to the callback buttons.

Closes #2591

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>