### PR TITLE
Release Groups Phase 1

### DIFF
--- a/src/scxt-core/engine/engine.cpp
+++ b/src/scxt-core/engine/engine.cpp
@@ -347,6 +347,8 @@ void Engine::immediatelyTerminateAllVoices()
             tc->cleanupVoice();
         }
     }
+    // Nothing is sounding, so nothing is held; a later stray note-off must not trigger anything
+    heldNotes.clear();
     forceVoiceUpdate = true;
 }
 
@@ -1698,12 +1700,37 @@ void Engine::setMacro01ValueFromPlugin(int part, int index, float value01)
 
 void Engine::processMIDI1Event(uint16_t idx, const uint8_t data[3])
 {
+    auto msg = data[0] & 0xf0;
+    auto chan = data[0] & 0x0f;
+
     // The voice manager has no notion of program change, so peel it off here
-    if ((data[0] & 0xf0) == 0xc0)
+    if (msg == 0xc0)
     {
-        processProgramChangeEvent(idx, data[0] & 0x0f, data[1] & 0x7f);
+        processProgramChangeEvent(idx, chan, data[1] & 0x7f);
         return;
     }
+
+    /*
+     * Notes go through our own entry points rather than straight to the voice manager, so that
+     * a MIDI 1 host and a CLAP host reach release triggers by the same road. Velocity zero on a
+     * note-on is a note-off, as everywhere.
+     */
+    auto vel = sst::voicemanager::midiToFloatVelocity(data[2]);
+    if (msg == 0x90 && data[2] != 0)
+    {
+        processNoteOnEvent(idx, chan, data[1], -1, vel, 0.f);
+        return;
+    }
+    if (msg == 0x80 || msg == 0x90)
+    {
+        processNoteOffEvent(idx, chan, data[1], -1, vel);
+        return;
+    }
+
+    // 120 all sounds off / 123 all notes off leave nothing held to release
+    if (msg == 0xb0 && (data[1] == 120 || data[1] == 123))
+        heldNotes.clear();
+
     sst::voicemanager::applyMidi1Message(voiceManager, idx, data);
 }
 
@@ -1721,12 +1748,48 @@ void Engine::processProgramChangeEvent(int16_t port, int16_t channel, int16_t pr
 void Engine::processNoteOnEvent(int16_t port, int16_t channel, int16_t key, int32_t note_id,
                                 double velocity, float retune)
 {
+    heldNotes.noteOn(channel, key, note_id, (float)velocity);
     voiceManager.processNoteOnEvent(port, channel, key, note_id, velocity, retune);
 }
+
 void Engine::processNoteOffEvent(int16_t port, int16_t channel, int16_t key, int32_t note_id,
                                  double velocity)
 {
+    fireReleaseTriggers(port, channel, key, note_id);
     voiceManager.processNoteOffEvent(port, channel, key, note_id, velocity);
+}
+
+bool Engine::anyGroupCreatesVoicesOnRelease() const
+{
+    for (const auto &part : *patch)
+    {
+        if (!part->configuration.active)
+            continue;
+        for (const auto &group : *part)
+            if (group->triggerConditions.createsVoicesOnRelease())
+                return true;
+    }
+    return false;
+}
+
+void Engine::fireReleaseTriggers(int16_t port, int16_t channel, int16_t key, int32_t note_id)
+{
+    /*
+     * releaseNote consumes, so it has to run whether or not anyone is listening - otherwise a
+     * patch which gains a release group mid-session would find the table full of stale presses.
+     * The velocity is the one the note came in with: that is what the release voice plays at,
+     * and what decides which of its zones the note lands in.
+     */
+    auto velocity = heldNotes.releaseNote(channel, key, note_id);
+    if (velocity < 0.f)
+        return;
+
+    if (!anyGroupCreatesVoicesOnRelease())
+        return;
+
+    inReleaseTriggerPass = true;
+    voiceManager.processNoteOnEvent(port, channel, key, note_id, velocity, 0.f);
+    inReleaseTriggerPass = false;
 }
 
 void Engine::onPartConfigurationUpdated()

--- a/src/scxt-core/engine/engine.h
+++ b/src/scxt-core/engine/engine.h
@@ -53,6 +53,7 @@
 
 #include "selection/selection_manager.h"
 #include "memory_pool.h"
+#include "held_notes.h"
 #include "tuning/midikey_retuner.h"
 #include "sst/basic-blocks/dsp/RNG.h"
 
@@ -129,6 +130,19 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     void processNoteOffEvent(int16_t port, int16_t channel, int16_t key, int32_t note_id,
                              double velocity);
 
+    /*
+     * Groups which create voices on release. The press is remembered in heldNotes so the
+     * release can play it at the velocity it arrived with; fireReleaseTriggers then runs a
+     * second note-on through the voice manager just before the note-off which lets it go, with
+     * inReleaseTriggerPass telling findZone to look at exactly those groups. Making the voices
+     * a hair before the note-off means the voice manager does its ordinary bookkeeping for one
+     * press rather than being handed a voice it never saw start.
+     */
+    HeldNotes heldNotes;
+    bool inReleaseTriggerPass{false};
+    void fireReleaseTriggers(int16_t port, int16_t channel, int16_t key, int32_t note_id);
+    bool anyGroupCreatesVoicesOnRelease() const;
+
     struct pathToZone_t
     {
         pathToZone_t() {}
@@ -152,6 +166,10 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
      * key is post-retune, so zone mapping follows MTS-ESP and friends. midiKey is what the MIDI
      * stream actually sent; group trigger conditions use it so a keyswitch stays put on the
      * keyboard no matter what the tuning does.
+     *
+     * Runs over half the groups at a time. On a note-on it skips groups which create their
+     * voices on release, and on the release pass (see fireReleaseTriggers) it considers only
+     * those, so one note event never sounds a group twice.
      */
     size_t findZone(int16_t channel, int16_t key, int16_t midiKey, int32_t noteId, int16_t velocity,
                     std::array<pathToZone_t, maxVoices> &res)
@@ -168,11 +186,14 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
 
                 /*
                  * Round robin is a question about a whole set of groups at once, so the part
-                 * settles which slot is live before any group's conditions get asked.
+                 * settles which slot is live before any group's conditions get asked. The press
+                 * settles it for both passes - a release group reads back the slot its own
+                 * note-on chose rather than spending a second one on the way up.
                  */
-                part->advanceRoundRobinSets(*this, part->roundRobinSetsForNote(*this, channel, key,
-                                                                               midiKey, velocity,
-                                                                               (int16_t)kt));
+                if (!inReleaseTriggerPass)
+                    part->advanceRoundRobinSets(
+                        *this, part->roundRobinSetsForNote(*this, channel, key, midiKey, velocity,
+                                                           (int16_t)kt));
 
                 for (const auto &[gidx, group] : sst::cpputils::enumerate(*part))
                 {
@@ -194,22 +215,33 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
                                                                            << group->id.to_string()
                                                                            << " " << group->name);
 
-                            // This second iteration is a wee bit annoying but
-                            for (auto &gkt : *part)
+                            /*
+                             * Only the press moves the switch. The release comes back through
+                             * here on its own pass and must leave the articulation where the
+                             * press put it - but it is still a switch key, so it is consumed
+                             * either way rather than sounding anybody.
+                             */
+                            if (!inReleaseTriggerPass)
                             {
-                                SCLOG_IF(groupTrigggers, "Checking group " << gkt->id.to_string());
-                                if (!gkt->triggerConditions.containsKeySwitchLatch)
+                                // This second iteration is a wee bit annoying but
+                                for (auto &gkt : *part)
                                 {
-                                    SCLOG_IF(groupTrigggers, "   Not a keyswitch - mute false");
-                                    gkt->mutedByLatch = false;
-                                    continue;
+                                    SCLOG_IF(groupTrigggers,
+                                             "Checking group " << gkt->id.to_string());
+                                    if (!gkt->triggerConditions.containsKeySwitchLatch)
+                                    {
+                                        SCLOG_IF(groupTrigggers, "   Not a keyswitch - mute false");
+                                        gkt->mutedByLatch = false;
+                                        continue;
+                                    }
+                                    // Several groups can share a switch key, so bring up
+                                    // everything latched to this key rather than only the group
+                                    // we matched
+                                    gkt->mutedByLatch = !gkt->triggerConditions.keySwitchLatchHolds(
+                                        *this, *gkt, channel, midiKey);
+                                    SCLOG_IF(groupTrigggers,
+                                             "   Muted by latch: " << gkt->mutedByLatch);
                                 }
-                                // Several groups can share a switch key, so bring up everything
-                                // latched to this key rather than only the group we matched
-                                gkt->mutedByLatch = !gkt->triggerConditions.keySwitchLatchHolds(
-                                    *this, *gkt, channel, midiKey);
-                                SCLOG_IF(groupTrigggers,
-                                         "   Muted by latch: " << gkt->mutedByLatch);
                             }
 
                             // Ignore any voices found here
@@ -232,6 +264,14 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
                     {
                         continue;
                     }
+
+                    /*
+                     * Everything above is about whether the group is live at all, and both
+                     * passes need the same answer. Only voice creation splits: the press makes
+                     * voices for note-on groups, the release for release groups.
+                     */
+                    if (group->triggerConditions.createsVoicesOnRelease() != inReleaseTriggerPass)
+                        continue;
 
                     for (const auto &[zidx, zone] : sst::cpputils::enumerate(*group))
                     {

--- a/src/scxt-core/engine/engine_voice_responder.cpp
+++ b/src/scxt-core/engine/engine_voice_responder.cpp
@@ -99,6 +99,10 @@ int32_t Engine::VoiceManagerResponder::initializeMultipleVoices(
             v->startGlideFrom(voiceInstructionBuffer[idx].continuationData.pitch);
     };
 
+    // A release trigger's voices are let go by the very note-off which made them, so no
+    // envelope on them can wait on the gate - see Voice::createdByReleaseTrigger
+    auto byReleaseTrigger = engine.inReleaseTriggerPass;
+
     for (auto idx = 0; idx < nts; ++idx)
     {
         if (voiceInstructionBuffer[idx].instruction ==
@@ -126,6 +130,7 @@ int32_t Engine::VoiceManagerResponder::initializeMultipleVoices(
                 v->velocity = velocity;
                 v->originalMidiKey = key;
 
+                v->createdByReleaseTrigger = byReleaseTrigger;
                 v->attack();
                 glideFromPriorVoice(v, idx);
 
@@ -158,6 +163,7 @@ int32_t Engine::VoiceManagerResponder::initializeMultipleVoices(
                         (int16_t)std::clamp(velocity * 127.0, 0., 127.));
 
                     v->originalMidiKey = key;
+                    v->createdByReleaseTrigger = byReleaseTrigger;
                     v->attack();
                     glideFromPriorVoice(v, idx);
 

--- a/src/scxt-core/engine/group.cpp
+++ b/src/scxt-core/engine/group.cpp
@@ -211,13 +211,20 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
     }
     phasorEvaluator.step(e.transport, miscSourceStorage);
 
+    // Voices this group makes on release come up already let go, so its own EGs run as one
+    // shots too - otherwise they would release under a gate that was never held. These are
+    // all modulation EGs with no sample of their own, so one shot rather than sample gated.
+    auto egSub = triggerConditions.createsVoicesOnRelease()
+                     ? scxt::modulation::shared::ReleaseGateSubstitution::ONE_SHOT
+                     : scxt::modulation::shared::ReleaseGateSubstitution::NONE;
+
     for (int i = 0; i < egsPerGroup; ++i)
     {
         bool envGate = gated;
         if (gegStorage[i].gateGroupEGOnAnyPlaying)
             envGate = (fVoiceCount > 0);
 
-        auto egiGate = getEnvSpecificGate(envGate, gegStorage[i], eg[i].stage, false);
+        auto egiGate = getEnvSpecificGate(envGate, gegStorage[i], eg[i].stage, false, egSub);
 
         if (egsActive[i])
         {
@@ -226,7 +233,7 @@ template <bool OS> void Group::processWithOS(scxt::engine::Engine &e)
             {
                 doEGRetrigger[i] = false;
                 eg[i].attackFromWithDelay(eg[i].outBlock0, *aegp.dlyP, *aegp.aP);
-                egiGate = getEnvSpecificGate(envGate, gegStorage[i], eg[i].stage, false);
+                egiGate = getEnvSpecificGate(envGate, gegStorage[i], eg[i].stage, false, egSub);
             }
             auto egiRM = dsp::twoToTheXTable.twoToThe(*aegp.rateMulP);
             eg[i].processBlockWithDelayAndRateMul(

--- a/src/scxt-core/engine/group_triggers.cpp
+++ b/src/scxt-core/engine/group_triggers.cpp
@@ -87,6 +87,27 @@ GroupTriggerID fromStringGroupTriggerID(const std::string &s)
     return p->second;
 }
 
+std::string toStringVoiceCreationMode(const VoiceCreationMode &p)
+{
+    switch (p)
+    {
+    case VoiceCreationMode::ON_NOTE_ON:
+        return "on";
+    case VoiceCreationMode::ON_NOTE_OFF:
+        return "off";
+    }
+    return "on";
+}
+VoiceCreationMode fromStringVoiceCreationMode(const std::string &s)
+{
+    static auto inverse = makeEnumInverse<VoiceCreationMode, toStringVoiceCreationMode>(
+        VoiceCreationMode::ON_NOTE_ON, VoiceCreationMode::ON_NOTE_OFF);
+    auto p = inverse.find(s);
+    if (p == inverse.end())
+        return VoiceCreationMode::ON_NOTE_ON;
+    return p->second;
+}
+
 std::string GroupTriggerConditions::toStringGroupConditionsConjunction(const Conjunction &p)
 {
     switch (p)

--- a/src/scxt-core/engine/group_triggers.h
+++ b/src/scxt-core/engine/group_triggers.h
@@ -96,6 +96,21 @@ using roundRobinMask_t = std::array<uint32_t, numRoundRobinKinds>;
 std::string toStringGroupTriggerID(const GroupTriggerID &p);
 GroupTriggerID fromStringGroupTriggerID(const std::string &p);
 
+/*
+ * When a group makes its voices. ON_NOTE_ON is what everything has always done. ON_NOTE_OFF
+ * makes the press do nothing but be remembered, and sounds the group when the key comes back
+ * up, playing it at the velocity it was pressed with. More modes (sustain pedal release and
+ * friends) are coming, hence an enum rather than a bool - see issue #2186.
+ */
+enum struct VoiceCreationMode : int32_t
+{
+    ON_NOTE_ON = 0,
+    ON_NOTE_OFF
+};
+
+std::string toStringVoiceCreationMode(const VoiceCreationMode &p);
+VoiceCreationMode fromStringVoiceCreationMode(const std::string &p);
+
 /**
  * Maintain the state of keys ccs etc... for a particular instrument
  */
@@ -204,6 +219,17 @@ struct GroupTriggerConditions
     }
     std::array<GroupTriggerStorage, scxt::triggerConditionsPerGroup> storage{};
     std::array<bool, scxt::triggerConditionsPerGroup> active{};
+
+    /*
+     * Not a condition - the conditions decide whether the group sounds, this decides which
+     * note event asks them. It lives here because it is the same question ("when does this
+     * group trigger") and it shares the client's trigger payload and undo entry.
+     */
+    VoiceCreationMode voiceCreationMode{VoiceCreationMode::ON_NOTE_ON};
+    bool createsVoicesOnRelease() const
+    {
+        return voiceCreationMode == VoiceCreationMode::ON_NOTE_OFF;
+    }
 
     bool alwaysReturnsTrue{true};
     bool containsKeySwitchLatch{false};

--- a/src/scxt-core/engine/held_notes.h
+++ b/src/scxt-core/engine/held_notes.h
@@ -1,0 +1,146 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#ifndef SCXT_SRC_SCXT_CORE_ENGINE_HELD_NOTES_H
+#define SCXT_SRC_SCXT_CORE_ENGINE_HELD_NOTES_H
+
+#include <array>
+#include <cstdint>
+
+#include "configuration.h"
+#include "utils.h"
+
+namespace scxt::engine
+{
+
+/**
+ * A group set to create voices on release plays the note at the velocity it was pressed with,
+ * so the press has to outlive its note-on event. This is the table which remembers it.
+ *
+ * Fixed capacity with a linear scan: every note event on the audio thread touches it, so it
+ * must not allocate, and the scan is cheap next to findZone which runs on the same events.
+ *
+ * Matching follows the same wildcard rules the voice manager uses, so it behaves the same for
+ * CLAP notes (which carry a note id) and MIDI 1 notes (which do not, and arrive as -1).
+ */
+struct HeldNotes
+{
+    static constexpr size_t capacity{256};
+
+    struct Entry
+    {
+        int16_t channel{-1};
+        int16_t key{-1};
+        int32_t noteId{-1};
+        float velocity{0.f};
+        uint64_t order{0}; // press order, so the newest of several matches wins
+        bool inUse{false};
+    };
+
+    std::array<Entry, capacity> entries{};
+    uint64_t nextOrder{1};
+
+    void clear()
+    {
+        entries.fill(Entry());
+        nextOrder = 1;
+    }
+
+    void noteOn(int16_t channel, int16_t key, int32_t noteId, float velocity)
+    {
+        for (auto &e : entries)
+        {
+            if (e.inUse)
+                continue;
+            e = {channel, key, noteId, velocity, nextOrder++, true};
+            return;
+        }
+        SCLOG_IF(warnings, "HeldNotes full at " << capacity << " notes; release triggers for "
+                                                << "this press will not fire");
+    }
+
+    /*
+     * Free every entry this note-off lets go of and hand back the velocity of the most recent
+     * of them. Returns -1 when the key was never pressed, which is how the caller knows there
+     * is no release trigger to fire.
+     */
+    float releaseNote(int16_t channel, int16_t key, int32_t noteId)
+    {
+        float res{-1.f};
+        uint64_t best{0};
+        for (auto &e : entries)
+        {
+            if (!e.inUse || !matches(e, channel, key, noteId))
+                continue;
+
+            if (e.order >= best)
+            {
+                best = e.order;
+                res = e.velocity;
+            }
+            e = Entry();
+        }
+        return res;
+    }
+
+    // Peek without consuming. Tests and asserts only; the engine always releases.
+    float velocityFor(int16_t channel, int16_t key, int32_t noteId) const
+    {
+        float res{-1.f};
+        uint64_t best{0};
+        for (const auto &e : entries)
+        {
+            if (e.inUse && matches(e, channel, key, noteId) && e.order >= best)
+            {
+                best = e.order;
+                res = e.velocity;
+            }
+        }
+        return res;
+    }
+
+    size_t heldCount() const
+    {
+        size_t n{0};
+        for (const auto &e : entries)
+            n += (e.inUse ? 1 : 0);
+        return n;
+    }
+
+  private:
+    static bool matches(const Entry &e, int16_t channel, int16_t key, int32_t noteId)
+    {
+        auto res = (channel == -1 || e.channel == -1 || channel == e.channel);
+        res = res && (key == -1 || e.key == -1 || key == e.key);
+        if (noteId != -1 && e.noteId != -1)
+            res = res && (noteId == e.noteId);
+        return res;
+    }
+};
+
+} // namespace scxt::engine
+#endif // SCXT_SRC_SCXT_CORE_ENGINE_HELD_NOTES_H

--- a/src/scxt-core/json/engine_traits.h
+++ b/src/scxt-core/json/engine_traits.h
@@ -440,6 +440,9 @@ STREAM_ENUM(engine::GroupTriggerConditions::Conjunction,
             engine::GroupTriggerConditions::toStringGroupConditionsConjunction,
             engine::GroupTriggerConditions::fromStringConditionsConjunction);
 
+STREAM_ENUM(engine::VoiceCreationMode, engine::toStringVoiceCreationMode,
+            engine::fromStringVoiceCreationMode);
+
 SC_STREAMDEF(scxt::engine::GroupTriggerConditions, SC_FROM({
                  bool anyConfigured{false};
                  for (const auto &c : from.storage)
@@ -454,11 +457,16 @@ SC_STREAMDEF(scxt::engine::GroupTriggerConditions, SC_FROM({
                  {
                      v = tao::json::empty_object;
                  }
+                 // Almost every group triggers on note on, so only the odd one out costs bytes
+                 addUnlessDefault<val_t>(v, "vcm", scxt::engine::VoiceCreationMode::ON_NOTE_ON,
+                                         from.voiceCreationMode);
              }),
              SC_TO({
                  findIf(v, "st", to.storage);
                  findIf(v, "ac", to.active);
                  findIf(v, "conj", to.conjunctions);
+                 findOrSet(v, "vcm", scxt::engine::VoiceCreationMode::ON_NOTE_ON,
+                           to.voiceCreationMode);
              }));
 
 STREAM_ENUM(engine::Group::GlideRateMode, engine::Group::toStringGlideRateMode,

--- a/src/scxt-core/messaging/client/interaction_messages.h
+++ b/src/scxt-core/messaging/client/interaction_messages.h
@@ -100,15 +100,16 @@ inline void processMidiFromGUI(const noteOnOff_t &g, const engine::Engine &engin
 
     if (onoff)
     {
+        // via the engine, not straight to the voice manager, so the onscreen keyboard
+        // reaches release triggers the same way a MIDI or CLAP note does
         cont.scheduleAudioThreadCallback([ch, vel = v, note = n](auto &eng) {
-            eng.voiceManager.processNoteOnEvent(0, ch, note, -1, vel, 0.f);
+            eng.processNoteOnEvent(0, ch, note, -1, vel, 0.f);
         });
     }
     else
     {
-        cont.scheduleAudioThreadCallback([ch, vel = v, note = n](auto &eng) {
-            eng.voiceManager.processNoteOffEvent(0, ch, note, -1, vel);
-        });
+        cont.scheduleAudioThreadCallback(
+            [ch, vel = v, note = n](auto &eng) { eng.processNoteOffEvent(0, ch, note, -1, vel); });
     }
 }
 CLIENT_TO_SERIAL(NoteFromGUI, c2s_noteonoff, noteOnOff_t, processMidiFromGUI(payload, engine, cont))

--- a/src/scxt-core/modulation/has_modulators.h
+++ b/src/scxt-core/modulation/has_modulators.h
@@ -47,6 +47,19 @@ namespace scxt::modulation::shared
 static_assert(lfosPerGroup == lfosPerZone,
               "If this is false you need to template out the count below");
 
+/*
+ * What a gate-following envelope should run as when nothing is holding the key down - the
+ * release trigger case, where the voice is made by the key coming up. The AEG follows the
+ * sample, since a release trigger is a sound of its own length rather than one somebody is
+ * holding; the modulation EGs have no sample to follow and run their one shot shape.
+ */
+enum struct ReleaseGateSubstitution
+{
+    NONE = 0,
+    ONE_SHOT,
+    SAMPLE_GATED
+};
+
 template <typename T, size_t egsPerObject> struct HasModulators
 {
     struct DoubleRate
@@ -378,10 +391,27 @@ template <typename T, size_t egsPerObject> struct HasModulators
         return keyGate;
     }
 
+    /*
+     * sub rewrites the gate mode for anything triggered by a key coming up rather than going
+     * down: with no gate to wait on, a GATED or SEMI_GATED envelope would release the instant
+     * it started. Modes which never look at the gate are already right and are left alone, so
+     * an envelope somebody deliberately set to one shot or sample gated keeps what it was given.
+     */
     bool getEnvSpecificGate(bool keyGate, const modulation::modulators::AdsrStorage &adsr,
-                            ahdsrenv_t::Stage stage, bool samplePlaying = false)
+                            ahdsrenv_t::Stage stage, bool samplePlaying = false,
+                            ReleaseGateSubstitution sub = ReleaseGateSubstitution::NONE)
     {
-        return evaluateGate(keyGate, adsr.gateMode, stage, samplePlaying);
+        using gm_t = modulation::modulators::AdsrStorage::GateMode;
+
+        auto mode = adsr.gateMode;
+        if (sub != ReleaseGateSubstitution::NONE &&
+            (mode == gm_t::GATED || mode == gm_t::SEMI_GATED))
+        {
+            mode =
+                (sub == ReleaseGateSubstitution::SAMPLE_GATED) ? gm_t::SAMPLE_GATED : gm_t::ONESHOT;
+        }
+
+        return evaluateGate(keyGate, mode, stage, samplePlaying);
     }
 };
 } // namespace scxt::modulation::shared

--- a/src/scxt-core/voice/voice.cpp
+++ b/src/scxt-core/voice/voice.cpp
@@ -290,6 +290,17 @@ template <bool OS> bool Voice::processWithOS()
         return true;
     }
 
+    /*
+     * A release trigger's voice was let go by the same note off which made it, so no envelope
+     * here can wait on the gate. The AEG follows the sample; the modulation EGs, which have no
+     * sample to follow, run their one shot shape.
+     */
+    namespace mshared = scxt::modulation::shared;
+    auto aegSub = createdByReleaseTrigger ? mshared::ReleaseGateSubstitution::SAMPLE_GATED
+                                          : mshared::ReleaseGateSubstitution::NONE;
+    auto egSub = createdByReleaseTrigger ? mshared::ReleaseGateSubstitution::ONE_SHOT
+                                         : mshared::ReleaseGateSubstitution::NONE;
+
     bool envGate{isGated};
     if (sampleIndex >= 0)
     {
@@ -307,16 +318,16 @@ template <bool OS> bool Voice::processWithOS()
     auto rtaeg = doEGRetrigger[0];
     doEGRetrigger[0] = false;
     auto aegGate =
-        getEnvSpecificGate(envGate, zone->egStorage[0], aeg.stage, isAnyGeneratorRunning);
+        getEnvSpecificGate(envGate, zone->egStorage[0], aeg.stage, isAnyGeneratorRunning, aegSub);
     auto aegRM = dsp::twoToTheXTable.twoToThe(*aegp.rateMulP);
     if constexpr (OS)
     {
         if (rtaeg)
         {
             aegOS.attackFromWithDelay(aegOS.outBlock0, *aegp.dlyP, *aegp.aP);
-            aegGate =
-                getEnvSpecificGate(envGate, zone->egStorage[0],
-                                   (ahdsrenv_t::Stage)((int)aegOS.stage), isAnyGeneratorRunning);
+            aegGate = getEnvSpecificGate(envGate, zone->egStorage[0],
+                                         (ahdsrenv_t::Stage)((int)aegOS.stage),
+                                         isAnyGeneratorRunning, aegSub);
         }
         // we need the aegOS for the curve in oversample space
         aegOS.processBlockWithDelayAndRateMul(*aegp.dlyP, *aegp.aP, *aegp.hP, *aegp.dP, *aegp.sP,
@@ -329,7 +340,8 @@ template <bool OS> bool Voice::processWithOS()
     if (rtaeg)
     {
         aeg.attackFromWithDelay(aeg.outBlock0, *aegp.dlyP, *aegp.aP);
-        aegGate = getEnvSpecificGate(envGate, zone->egStorage[0], aeg.stage, isAnyGeneratorRunning);
+        aegGate = getEnvSpecificGate(envGate, zone->egStorage[0], aeg.stage, isAnyGeneratorRunning,
+                                     aegSub);
     }
     aeg.processBlockWithDelayAndRateMul(*aegp.dlyP, *aegp.aP, *aegp.hP, *aegp.dP, *aegp.sP,
                                         *aegp.rP, *aegp.asP, *aegp.dsP, *aegp.rsP, aegRM, aegGate,
@@ -344,15 +356,15 @@ template <bool OS> bool Voice::processWithOS()
         {
             auto &eg2p = endpoints->egTarget[i];
 
-            auto egiGate =
-                getEnvSpecificGate(envGate, zone->egStorage[i], eg[i].stage, isAnyGeneratorRunning);
+            auto egiGate = getEnvSpecificGate(envGate, zone->egStorage[i], eg[i].stage,
+                                              isAnyGeneratorRunning, egSub);
 
             if (doEGRetrigger[i])
             {
                 doEGRetrigger[i] = false;
                 eg[i].attackFromWithDelay(eg[i].outBlock0, *eg2p.dlyP, *eg2p.aP);
                 egiGate = getEnvSpecificGate(envGate, zone->egStorage[i], eg[i].stage,
-                                             isAnyGeneratorRunning);
+                                             isAnyGeneratorRunning, egSub);
             }
 
             auto egiRM = dsp::twoToTheXTable.twoToThe(*eg2p.rateMulP);

--- a/src/scxt-core/voice/voice.h
+++ b/src/scxt-core/voice/voice.h
@@ -301,6 +301,14 @@ struct alignas(16) Voice : MoveableOnly<Voice>,
     bool isVoiceAssigned{false};
 
     /*
+     * Set when a release trigger made this voice. Its key is already up, so no envelope here
+     * can wait on the gate: the AEG follows the sample and the modulation EGs run one shot -
+     * see ReleaseGateSubstitution. Captured at attack rather than read back off the group, so
+     * editing the group mid-note can't cut a sounding voice short.
+     */
+    bool createdByReleaseTrigger{false};
+
+    /*
      * A voice in a LEGATO group which runs out of sound doesn't die - it parks. It stays
      * assigned and registered with the voice manager, runs its modulators but none of its
      * audio chain, and can be re-attacked in place by a subsequent legato move. That keeps

--- a/src/scxt-plugin/app/edit-screen/components/GroupTriggersCard.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/GroupTriggersCard.cpp
@@ -368,8 +368,50 @@ struct GroupTriggersCard::ConditionRow : juce::Component, HasEditor
     std::array<std::unique_ptr<jcmp::DraggableTextEditableDiscreteValue>, numArgs> argDM;
     std::array<juce::Component *, numArgs> argM{};
 };
+/*
+ * Just the toggle and its attachment. Nested and defined here for the same reason ConditionRow
+ * is - it keeps the attachment types out of the header.
+ */
+struct GroupTriggersCard::ReleaseRow
+{
+    using booleanAttachment_t =
+        connectors::BooleanPayloadDataAttachment<scxt::engine::GroupTriggerConditions>;
+
+    ReleaseRow(GroupTriggersCard *p) : parent(p)
+    {
+        attachment = std::make_unique<booleanAttachment_t>(
+            "Release Trigger",
+            [w = juce::Component::SafePointer(p)](const auto &a) {
+                if (!w)
+                    return;
+                w->cond.voiceCreationMode = w->releaseTriggerOn
+                                                ? engine::VoiceCreationMode::ON_NOTE_OFF
+                                                : engine::VoiceCreationMode::ON_NOTE_ON;
+                w->pushUpdate();
+            },
+            p->releaseTriggerOn);
+
+        button = std::make_unique<jcmp::ToggleButton>();
+        button->setLabel("RELEASE TRIGGER");
+        button->setSource(attachment.get());
+        p->addAndMakeVisible(*button);
+    }
+
+    void setupValuesFromData()
+    {
+        parent->releaseTriggerOn = parent->cond.createsVoicesOnRelease();
+        button->repaint();
+    }
+
+    GroupTriggersCard *parent{nullptr};
+    std::unique_ptr<booleanAttachment_t> attachment;
+    std::unique_ptr<jcmp::ToggleButton> button;
+};
+
 GroupTriggersCard::GroupTriggersCard(SCXTEditor *e) : HasEditor(e)
 {
+    releaseRow = std::make_unique<ReleaseRow>(this);
+
     for (int i = 0; i < scxt::triggerConditionsPerGroup; ++i)
     {
         rows[i] = std::make_unique<ConditionRow>(this, i, i != scxt::triggerConditionsPerGroup - 1);
@@ -384,7 +426,9 @@ void GroupTriggersCard::resized()
     int componentHeight = 16;
     auto b = getLocalBounds().withTrimmedTop(rowHeight - 4);
 
-    auto r = b.withHeight(componentHeight);
+    releaseRow->button->setBounds(b.withHeight(componentHeight));
+
+    auto r = b.withTrimmedTop(releaseBlockHeight).withHeight(componentHeight);
     for (int i = 0; i < scxt::triggerConditionsPerGroup; ++i)
     {
         rows[i]->setBounds(r);
@@ -399,11 +443,17 @@ void GroupTriggersCard::paint(juce::Graphics &g)
     g.setFont(ft);
     g.setColour(co);
     g.drawText("TRIGGER CONDITIONS", getLocalBounds(), juce::Justification::topLeft);
+
+    // rule between the release trigger and the conditions it decides the timing of
+    auto ruleY = 20 + releaseBlockHeight - 5;
+    g.setColour(co.withAlpha(0.4f));
+    g.drawHorizontalLine(ruleY, 0.f, (float)getWidth());
 }
 
 void GroupTriggersCard::setGroupTriggerConditions(const scxt::engine::GroupTriggerConditions &c)
 {
     cond = c;
+    releaseRow->setupValuesFromData();
     for (auto &r : rows)
         r->setupValuesFromData();
     repaint();

--- a/src/scxt-plugin/app/edit-screen/components/GroupTriggersCard.h
+++ b/src/scxt-plugin/app/edit-screen/components/GroupTriggersCard.h
@@ -52,6 +52,18 @@ struct GroupTriggersCard : juce::Component, HasEditor
     void setGroupTriggerConditions(const scxt::engine::GroupTriggerConditions &);
     void pushUpdate();
     scxt::engine::GroupTriggerConditions cond;
+
+    /*
+     * The release trigger sits above the conditions rather than among them: it says which note
+     * event asks them, not whether they hold. The widget wants a bool and the engine carries an
+     * enum (more modes are coming - see #2186), so the two are kept in step by hand.
+     */
+    struct ReleaseRow;
+    std::unique_ptr<ReleaseRow> releaseRow;
+    bool releaseTriggerOn{false};
+
+    // the release trigger and the rule under it, above the condition stack
+    static constexpr int releaseBlockHeight{26};
 };
 } // namespace scxt::ui::app::edit_screen
 #endif // GROUPTRIGGERSCARD_H

--- a/src/scxt-plugin/app/edit-screen/components/PartGroupSidebar.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/PartGroupSidebar.cpp
@@ -629,7 +629,8 @@ struct GroupSidebar : GroupZoneSidebarBase<GroupSidebar, false>
     void resized() override
     {
         auto b = baseResize();
-        auto trigHeight = 116;
+        // the release trigger and its rule sit above the condition stack
+        auto trigHeight = 116 + GroupTriggersCard::releaseBlockHeight;
         auto settingsHeight = 146;
         auto dividerHeight = 8;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(scxt-test
 		exclusive_group_tests.cpp
 		keyswitch_tests.cpp
 		group_trigger_tests.cpp
+		release_trigger_tests.cpp
 		glide_tests.cpp
 		legato_tests.cpp
 		sample_gated_tests.cpp

--- a/tests/release_trigger_tests.cpp
+++ b/tests/release_trigger_tests.cpp
@@ -1,0 +1,628 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "catch2/catch2.hpp"
+
+#include <filesystem>
+
+#include "engine/engine.h"
+#include "engine/group_triggers.h"
+#include "engine/held_notes.h"
+#include "json/engine_traits.h"
+
+#include "test_utils.h"
+
+/*
+ * Groups which make their voices when the key comes up rather than when it goes down. The
+ * press sounds nothing but is remembered, and the release plays the group at the velocity the
+ * press arrived with. Its gate-following envelopes are rewritten, since nothing is holding
+ * the key: the AEG follows the sample and the modulation EGs run one shot. See issue #2186.
+ */
+
+// Named, not anonymous: a unity build would fold these helpers in with the identically
+// shaped ones in the other engine test files
+namespace releasetrigger_test
+{
+
+namespace mm = scxt::modulation::modulators;
+using VCM = scxt::engine::VoiceCreationMode;
+
+static constexpr int PLAY_KEY{60};
+
+static void addZone(scxt::engine::Part &part, int groupIdx, int keyLo, int keyHi, int velLo = 0,
+                    int velHi = 127)
+{
+    auto z = std::make_unique<scxt::engine::Zone>();
+    z->mapping.keyboardRange = {keyLo, keyHi};
+    z->mapping.velocityRange = {velLo, velHi};
+    z->mapping.rootKey = 60;
+    z->initialize();
+    part.getGroup(groupIdx)->addZone(z);
+}
+
+// A part with `n` groups, each holding one zone over 48..72, all triggering on note on
+static scxt::engine::Part &setupGroups(scxt::engine::Engine &eng, int n)
+{
+    auto &part = *eng.getPatch()->getPart(0);
+    for (int i = 0; i < n; ++i)
+    {
+        part.addGroup();
+        addZone(part, i, 48, 72);
+    }
+    return part;
+}
+
+static void setVoiceCreation(scxt::engine::Part &part, int groupIdx, VCM mode)
+{
+    part.getGroup(groupIdx)->triggerConditions.voiceCreationMode = mode;
+}
+
+static int liveVoices(scxt::engine::Part &part, int groupIdx)
+{
+    return countLiveVoicesInGroup(*part.getGroup(groupIdx));
+}
+
+// Voices belonging to one specific zone of a group, so a velocity split can be read off
+static int liveVoicesInZone(scxt::engine::Part &part, int groupIdx, int zoneIdx)
+{
+    int n{0};
+    const auto &zone = part.getGroup(groupIdx)->getZone(zoneIdx);
+    for (int i = 0; i < (int)scxt::maxVoices; ++i)
+    {
+        const auto *v = zone->voiceWeakPointers[i];
+        if (v && v->isVoiceAssigned && v->terminationSequence < 0)
+            n++;
+    }
+    return n;
+}
+
+static scxt::voice::Voice *firstVoiceIn(scxt::engine::Part &part, int groupIdx)
+{
+    for (const auto &zone : part.getGroup(groupIdx)->getZones())
+        for (int i = 0; i < (int)scxt::maxVoices; ++i)
+        {
+            auto *v = zone->voiceWeakPointers[i];
+            if (v && v->isVoiceAssigned)
+                return v;
+        }
+    return nullptr;
+}
+
+static void midiNoteOn(scxt::engine::Engine &eng, int channel, int key, int vel)
+{
+    uint8_t data[3]{(uint8_t)(0x90 | channel), (uint8_t)key, (uint8_t)vel};
+    eng.processMIDI1Event(0, data);
+}
+
+static void midiNoteOff(scxt::engine::Engine &eng, int channel, int key, int vel = 0)
+{
+    uint8_t data[3]{(uint8_t)(0x80 | channel), (uint8_t)key, (uint8_t)vel};
+    eng.processMIDI1Event(0, data);
+}
+
+static void midiCC(scxt::engine::Engine &eng, int channel, int cc, int val)
+{
+    uint8_t data[3]{(uint8_t)(0xb0 | channel), (uint8_t)cc, (uint8_t)val};
+    eng.processMIDI1Event(0, data);
+}
+
+} // namespace releasetrigger_test
+
+using namespace releasetrigger_test;
+
+TEST_CASE("Held notes remembers the press", "[releasetrigger]")
+{
+    SECTION("A MIDI 1 note round trips")
+    {
+        scxt::engine::HeldNotes hn;
+        REQUIRE(hn.heldCount() == 0);
+
+        hn.noteOn(0, 60, -1, 0.75f);
+        REQUIRE(hn.heldCount() == 1);
+        REQUIRE(hn.releaseNote(0, 60, -1) == Approx(0.75f));
+        REQUIRE(hn.heldCount() == 0);
+    }
+
+    SECTION("A note which was never pressed reports nothing")
+    {
+        scxt::engine::HeldNotes hn;
+        REQUIRE(hn.releaseNote(0, 60, -1) < 0.f);
+
+        // and a different key doesn't answer for this one
+        hn.noteOn(0, 61, -1, 0.5f);
+        REQUIRE(hn.releaseNote(0, 60, -1) < 0.f);
+        REQUIRE(hn.heldCount() == 1);
+    }
+
+    SECTION("Channels are kept apart")
+    {
+        scxt::engine::HeldNotes hn;
+        hn.noteOn(0, 60, -1, 0.25f);
+        hn.noteOn(3, 60, -1, 0.9f);
+
+        REQUIRE(hn.releaseNote(3, 60, -1) == Approx(0.9f));
+        REQUIRE(hn.releaseNote(0, 60, -1) == Approx(0.25f));
+    }
+
+    SECTION("CLAP note ids release independently")
+    {
+        scxt::engine::HeldNotes hn;
+        hn.noteOn(0, 60, 11, 0.2f);
+        hn.noteOn(0, 60, 12, 0.8f);
+        REQUIRE(hn.heldCount() == 2);
+
+        REQUIRE(hn.releaseNote(0, 60, 11) == Approx(0.2f));
+        REQUIRE(hn.heldCount() == 1);
+        REQUIRE(hn.releaseNote(0, 60, 12) == Approx(0.8f));
+        REQUIRE(hn.heldCount() == 0);
+    }
+
+    SECTION("A MIDI 1 note off lets go of every press on that key")
+    {
+        /*
+         * No note ids means no way to tell two presses of one key apart, which is exactly how
+         * the voice manager sees it too - one note off releases both. The newest press is the
+         * one the release plays at.
+         */
+        scxt::engine::HeldNotes hn;
+        hn.noteOn(0, 60, -1, 0.2f);
+        hn.noteOn(0, 60, -1, 0.8f);
+        REQUIRE(hn.heldCount() == 2);
+
+        REQUIRE(hn.releaseNote(0, 60, -1) == Approx(0.8f));
+        REQUIRE(hn.heldCount() == 0);
+    }
+
+    SECTION("A wildcard note off matches a note which carries an id")
+    {
+        scxt::engine::HeldNotes hn;
+        hn.noteOn(0, 60, 7, 0.4f);
+        REQUIRE(hn.releaseNote(0, 60, -1) == Approx(0.4f));
+        REQUIRE(hn.heldCount() == 0);
+    }
+
+    SECTION("Clearing forgets everything")
+    {
+        scxt::engine::HeldNotes hn;
+        for (int k = 40; k < 60; ++k)
+            hn.noteOn(0, k, -1, 0.5f);
+        REQUIRE(hn.heldCount() == 20);
+
+        hn.clear();
+        REQUIRE(hn.heldCount() == 0);
+        REQUIRE(hn.releaseNote(0, 45, -1) < 0.f);
+    }
+
+    SECTION("Overflow drops the press rather than growing")
+    {
+        scxt::engine::HeldNotes hn;
+        for (size_t i = 0; i < scxt::engine::HeldNotes::capacity + 20; ++i)
+            hn.noteOn(0, 60, (int32_t)i, 0.5f);
+
+        REQUIRE(hn.heldCount() == scxt::engine::HeldNotes::capacity);
+        REQUIRE(hn.velocityFor(0, 60, (int32_t)scxt::engine::HeldNotes::capacity + 5) < 0.f);
+    }
+}
+
+TEST_CASE("A note on group is unchanged", "[releasetrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = setupGroups(*eng, 1);
+
+    REQUIRE(liveVoices(part, 0) == 0);
+    eng->processNoteOnEvent(0, 0, PLAY_KEY, -1, 1.f, 0.f);
+    REQUIRE(liveVoices(part, 0) == 1);
+
+    // and letting go doesn't add a second one
+    eng->processNoteOffEvent(0, 0, PLAY_KEY, -1, 0.f);
+    REQUIRE(liveVoices(part, 0) == 1);
+    REQUIRE(firstVoiceIn(part, 0)->createdByReleaseTrigger == false);
+}
+
+TEST_CASE("A release group sounds on the way up, not the way down", "[releasetrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = setupGroups(*eng, 1);
+    setVoiceCreation(part, 0, VCM::ON_NOTE_OFF);
+
+    eng->processNoteOnEvent(0, 0, PLAY_KEY, -1, 1.f, 0.f);
+    REQUIRE(liveVoices(part, 0) == 0);
+
+    eng->processNoteOffEvent(0, 0, PLAY_KEY, -1, 0.f);
+    REQUIRE(liveVoices(part, 0) == 1);
+
+    auto *v = firstVoiceIn(part, 0);
+    REQUIRE(v != nullptr);
+    REQUIRE(v->key == PLAY_KEY);
+    REQUIRE(v->createdByReleaseTrigger == true);
+    // the note-off which made it also let it go
+    REQUIRE(v->isGated == false);
+}
+
+TEST_CASE("A release with no press behind it sounds nothing", "[releasetrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = setupGroups(*eng, 1);
+    setVoiceCreation(part, 0, VCM::ON_NOTE_OFF);
+
+    eng->processNoteOffEvent(0, 0, PLAY_KEY, -1, 0.f);
+    REQUIRE(liveVoices(part, 0) == 0);
+
+    // one press is one release, not two
+    eng->processNoteOnEvent(0, 0, PLAY_KEY, -1, 1.f, 0.f);
+    eng->processNoteOffEvent(0, 0, PLAY_KEY, -1, 0.f);
+    REQUIRE(liveVoices(part, 0) == 1);
+    eng->processNoteOffEvent(0, 0, PLAY_KEY, -1, 0.f);
+    REQUIRE(liveVoices(part, 0) == 1);
+}
+
+TEST_CASE("A note on group and a release group split one key", "[releasetrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = setupGroups(*eng, 2);
+    setVoiceCreation(part, 1, VCM::ON_NOTE_OFF);
+
+    eng->processNoteOnEvent(0, 0, PLAY_KEY, -1, 1.f, 0.f);
+    REQUIRE(liveVoices(part, 0) == 1);
+    REQUIRE(liveVoices(part, 1) == 0);
+
+    eng->processNoteOffEvent(0, 0, PLAY_KEY, -1, 0.f);
+    REQUIRE(liveVoices(part, 0) == 1); // released, still ringing, not doubled
+    REQUIRE(liveVoices(part, 1) == 1);
+}
+
+TEST_CASE("A release voice plays at the press velocity", "[releasetrigger]")
+{
+    // one group, two zones over the same keys, split by velocity
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = *eng->getPatch()->getPart(0);
+    part.addGroup();
+    addZone(part, 0, 48, 72, 0, 63);   // zone 0: soft
+    addZone(part, 0, 48, 72, 64, 127); // zone 1: loud
+    setVoiceCreation(part, 0, VCM::ON_NOTE_OFF);
+
+    SECTION("A hard press lands in the loud zone even when let go gently")
+    {
+        eng->processNoteOnEvent(0, 0, PLAY_KEY, -1, 0.9f, 0.f);
+        eng->processNoteOffEvent(0, 0, PLAY_KEY, -1, 0.f);
+
+        REQUIRE(liveVoicesInZone(part, 0, 0) == 0);
+        REQUIRE(liveVoicesInZone(part, 0, 1) == 1);
+        REQUIRE(firstVoiceIn(part, 0)->velocity == Approx(0.9f));
+    }
+
+    SECTION("A soft press lands in the soft zone even when let go hard")
+    {
+        eng->processNoteOnEvent(0, 0, PLAY_KEY, -1, 0.1f, 0.f);
+        eng->processNoteOffEvent(0, 0, PLAY_KEY, -1, 1.f);
+
+        REQUIRE(liveVoicesInZone(part, 0, 0) == 1);
+        REQUIRE(liveVoicesInZone(part, 0, 1) == 0);
+        REQUIRE(firstVoiceIn(part, 0)->velocity == Approx(0.1f));
+    }
+}
+
+TEST_CASE("Release triggers arrive by MIDI 1 as well as by note event", "[releasetrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = *eng->getPatch()->getPart(0);
+    part.addGroup();
+    addZone(part, 0, 48, 72, 0, 63);
+    addZone(part, 0, 48, 72, 64, 127);
+    setVoiceCreation(part, 0, VCM::ON_NOTE_OFF);
+
+    SECTION("A note off message")
+    {
+        midiNoteOn(*eng, 0, PLAY_KEY, 100);
+        REQUIRE(liveVoices(part, 0) == 0);
+
+        midiNoteOff(*eng, 0, PLAY_KEY);
+        REQUIRE(liveVoicesInZone(part, 0, 1) == 1); // 100 is in the loud zone
+    }
+
+    SECTION("A note on with velocity zero, which is a note off")
+    {
+        midiNoteOn(*eng, 0, PLAY_KEY, 30);
+        REQUIRE(liveVoices(part, 0) == 0);
+
+        midiNoteOn(*eng, 0, PLAY_KEY, 0);
+        REQUIRE(liveVoicesInZone(part, 0, 0) == 1); // 30 is in the soft zone
+    }
+
+    SECTION("All notes off leaves nothing to release")
+    {
+        midiNoteOn(*eng, 0, PLAY_KEY, 100);
+        midiCC(*eng, 0, 123, 0);
+        midiNoteOff(*eng, 0, PLAY_KEY);
+        REQUIRE(liveVoices(part, 0) == 0);
+    }
+}
+
+TEST_CASE("Two CLAP notes on one key release one at a time", "[releasetrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = setupGroups(*eng, 1);
+    setVoiceCreation(part, 0, VCM::ON_NOTE_OFF);
+
+    eng->processNoteOnEvent(0, 0, PLAY_KEY, 100, 0.5f, 0.f);
+    eng->processNoteOnEvent(0, 0, PLAY_KEY, 101, 0.5f, 0.f);
+    REQUIRE(liveVoices(part, 0) == 0);
+
+    eng->processNoteOffEvent(0, 0, PLAY_KEY, 100, 0.f);
+    REQUIRE(liveVoices(part, 0) == 1);
+
+    eng->processNoteOffEvent(0, 0, PLAY_KEY, 101, 0.f);
+    REQUIRE(liveVoices(part, 0) == 2);
+}
+
+TEST_CASE("Trigger conditions still gate a release group", "[releasetrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = setupGroups(*eng, 1);
+    setVoiceCreation(part, 0, VCM::ON_NOTE_OFF);
+
+    auto &tc = part.getGroup(0)->triggerConditions;
+    tc.storage[0].id = scxt::engine::GroupTriggerID::PROGRAM_CHANGE;
+    tc.storage[0].args[0] = 3;
+    tc.storage[0].args[1] = 5;
+    tc.active[0] = true;
+    tc.setupOnUnstream(part.groupTriggerInstrumentState);
+
+    // program 0 is outside 3..5, so the release finds nothing to play
+    eng->processNoteOnEvent(0, 0, PLAY_KEY, -1, 1.f, 0.f);
+    eng->processNoteOffEvent(0, 0, PLAY_KEY, -1, 0.f);
+    REQUIRE(liveVoices(part, 0) == 0);
+
+    uint8_t pc[3]{0xc0, 4, 0};
+    eng->processMIDI1Event(0, pc);
+
+    eng->processNoteOnEvent(0, 0, PLAY_KEY, -1, 1.f, 0.f);
+    eng->processNoteOffEvent(0, 0, PLAY_KEY, -1, 0.f);
+    REQUIRE(liveVoices(part, 0) == 1);
+}
+
+TEST_CASE("A keyswitch still picks which release group sounds", "[releasetrigger]")
+{
+    static constexpr int SW_A{24}, SW_B{25};
+
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = setupGroups(*eng, 2);
+
+    for (auto [gi, key] : {std::make_pair(0, SW_A), std::make_pair(1, SW_B)})
+    {
+        setVoiceCreation(part, gi, VCM::ON_NOTE_OFF);
+        auto &tc = part.getGroup(gi)->triggerConditions;
+        tc.storage[0].id = scxt::engine::GroupTriggerID::KEYSWITCH_LATCH;
+        tc.storage[0].args[0] = key;
+        tc.active[0] = true;
+        tc.setupOnUnstream(part.groupTriggerInstrumentState);
+    }
+    part.guaranteeKeyswitchLatchCoherence(*eng);
+
+    // switch to B, then play and release
+    eng->processNoteOnEvent(0, 0, SW_B, -1, 1.f, 0.f);
+    eng->processNoteOffEvent(0, 0, SW_B, -1, 0.f);
+    REQUIRE(liveVoices(part, 0) == 0);
+    REQUIRE(liveVoices(part, 1) == 0);
+
+    eng->processNoteOnEvent(0, 0, PLAY_KEY, -1, 1.f, 0.f);
+    eng->processNoteOffEvent(0, 0, PLAY_KEY, -1, 0.f);
+    REQUIRE(liveVoices(part, 0) == 0);
+    REQUIRE(liveVoices(part, 1) == 1);
+}
+
+TEST_CASE("Voice creation mode streams", "[releasetrigger]")
+{
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = setupGroups(*eng, 2);
+    setVoiceCreation(part, 1, VCM::ON_NOTE_OFF);
+
+    auto json = scxt::json::streamEngineState(*eng);
+
+    // These tests run on the test thread, so the stream path's thread assert needs waiving
+    std::unique_ptr<scxt::engine::Engine> other(makeEngine());
+    {
+        auto bg = other->getMessageController()->threadingChecker.bypassChecksInScope();
+        scxt::json::unstreamEngineState(*other, json);
+    }
+
+    auto &opart = *other->getPatch()->getPart(0);
+    REQUIRE(opart.getGroup(0)->triggerConditions.voiceCreationMode == VCM::ON_NOTE_ON);
+    REQUIRE(opart.getGroup(1)->triggerConditions.voiceCreationMode == VCM::ON_NOTE_OFF);
+    REQUIRE(opart.getGroup(1)->triggerConditions.createsVoicesOnRelease());
+}
+
+TEST_CASE("The release gate substitution only rewrites gate-following modes", "[releasetrigger]")
+{
+    /*
+     * The rule itself, in isolation: a release voice has no gate, so GATED and SEMI_GATED are
+     * rewritten - the AEG to sample gated, everything else to one shot. Modes somebody chose
+     * deliberately because they ignore the gate are left exactly as they were.
+     */
+    using gm_t = mm::AdsrStorage::GateMode;
+    using sub_t = scxt::modulation::shared::ReleaseGateSubstitution;
+    using stage_t = scxt::voice::Voice::ahdsrenv_t;
+
+    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+    auto &part = setupGroups(*eng, 1);
+    eng->processNoteOnEvent(0, 0, PLAY_KEY, -1, 1.f, 0.f);
+    auto *v = firstVoiceIn(part, 0);
+    REQUIRE(v != nullptr);
+
+    mm::AdsrStorage adsr;
+    // keyGate false and a mid-shape stage, so each mode gives a distinguishable answer
+    auto gateFor = [&](gm_t mode, sub_t sub, bool samplePlaying) {
+        adsr.gateMode = mode;
+        return v->getEnvSpecificGate(false, adsr, stage_t::s_decay, samplePlaying, sub);
+    };
+
+    SECTION("With no substitution the stored mode stands")
+    {
+        REQUIRE(gateFor(gm_t::GATED, sub_t::NONE, true) == false); // follows the absent key
+        REQUIRE(gateFor(gm_t::SEMI_GATED, sub_t::NONE, true) == false);
+    }
+
+    SECTION("The AEG is rewritten to follow the sample")
+    {
+        REQUIRE(gateFor(gm_t::GATED, sub_t::SAMPLE_GATED, true) == true);
+        REQUIRE(gateFor(gm_t::GATED, sub_t::SAMPLE_GATED, false) == false);
+        REQUIRE(gateFor(gm_t::SEMI_GATED, sub_t::SAMPLE_GATED, true) == true);
+    }
+
+    SECTION("Other EGs are rewritten to one shot, which reads the stage not the sample")
+    {
+        REQUIRE(gateFor(gm_t::GATED, sub_t::ONE_SHOT, false) == true); // s_decay < s_sustain
+        REQUIRE(gateFor(gm_t::SEMI_GATED, sub_t::ONE_SHOT, false) == true);
+    }
+
+    SECTION("Gate independent modes are left alone by either substitution")
+    {
+        for (auto sub : {sub_t::ONE_SHOT, sub_t::SAMPLE_GATED})
+        {
+            REQUIRE(gateFor(gm_t::ONESHOT, sub, false) == true);       // still stage driven
+            REQUIRE(gateFor(gm_t::SAMPLE_GATED, sub, false) == false); // still sample driven
+            REQUIRE(gateFor(gm_t::SAMPLE_GATED, sub, true) == true);
+        }
+    }
+}
+
+namespace releasetrigger_test
+{
+/*
+ * The substitution only shows up once audio runs, and a sample gated AEG needs a generator to
+ * follow - a blank zone has none, so these need a real sample under the zone.
+ */
+struct SoundingFixture
+{
+    std::unique_ptr<scxt::engine::Engine> eng;
+    scxt::engine::Part *part{nullptr};
+
+    SoundingFixture()
+    {
+        eng.reset(makeEngine());
+        part = eng->getPatch()->getPart(0).get();
+
+        auto p = samplePath("WavStereo48k.wav");
+        REQUIRE(std::filesystem::exists(p));
+
+        auto bypass = eng->getMessageController()->threadingChecker.bypassChecksInScope();
+        auto sid = eng->getSampleManager()->loadSampleByPath(p);
+        REQUIRE(sid.has_value());
+
+        for (int gi = 0; gi < 2; ++gi)
+        {
+            part->addGroup();
+            addZone(*part, gi, 48, 72);
+            auto &zone = part->getGroup(gi)->getZone(0);
+            zone->variantData.variants[0].sampleID = *sid;
+            zone->variantData.variants[0].active = true;
+            REQUIRE(zone->attachToSample(*eng->getSampleManager(), 0,
+                                         scxt::engine::Zone::SampleInformationRead::ENDPOINTS));
+
+            // straight to sustain, so "did the gate hold it up" is the only question left
+            auto &aeg = zone->egStorage[0];
+            aeg.gateMode = mm::AdsrStorage::GateMode::GATED;
+            aeg.a = 0.f;
+            aeg.h = 0.f;
+            aeg.d = 0.f;
+            aeg.s = 1.f;
+            aeg.r = 0.4f;
+        }
+        // group 0 sounds on the way down, group 1 on the way up
+        setVoiceCreation(*part, 1, VCM::ON_NOTE_OFF);
+    }
+
+    // Cut the release group's playback short so its generator finishes in a few blocks
+    void shortenReleaseZone(int64_t samples)
+    {
+        auto &v = part->getGroup(1)->getZone(0)->variantData.variants[0];
+        v.endSample = v.startSample + samples;
+    }
+
+    void runBlocks(int n)
+    {
+        for (int i = 0; i < n; ++i)
+            eng->processAudio();
+    }
+};
+} // namespace releasetrigger_test
+
+TEST_CASE("A gated AEG on a release voice follows the sample, not the key", "[releasetrigger]")
+{
+    using stage_t = scxt::voice::Voice::ahdsrenv_t;
+
+    SoundingFixture f;
+    f.eng->processNoteOnEvent(0, 0, PLAY_KEY, -1, 1.f, 0.f);
+    f.eng->processNoteOffEvent(0, 0, PLAY_KEY, -1, 0.f);
+    f.runBlocks(20);
+
+    auto *held = firstVoiceIn(*f.part, 0);
+    auto *rel = firstVoiceIn(*f.part, 1);
+    REQUIRE(held != nullptr);
+    REQUIRE(rel != nullptr);
+    REQUIRE(rel->createdByReleaseTrigger);
+    REQUIRE(held->createdByReleaseTrigger == false);
+
+    // both were let go by the same note off
+    REQUIRE(held->isGated == false);
+    REQUIRE(rel->isGated == false);
+
+    // the ordinary voice lost its gate and is on its way out
+    REQUIRE(held->aeg.stage >= stage_t::s_release);
+
+    // the release voice is held up by its sample instead, so it is still sounding
+    REQUIRE(rel->aeg.stage < stage_t::s_release);
+    REQUIRE(rel->isVoicePlaying);
+    REQUIRE(rel->aeg.outBlock0 > 0.f);
+}
+
+TEST_CASE("A release voice ends when its sample does", "[releasetrigger]")
+{
+    using stage_t = scxt::voice::Voice::ahdsrenv_t;
+
+    SoundingFixture f;
+    f.shortenReleaseZone(512); // 32 blocks at blockSize 16
+
+    f.eng->processNoteOnEvent(0, 0, PLAY_KEY, -1, 1.f, 0.f);
+    f.eng->processNoteOffEvent(0, 0, PLAY_KEY, -1, 0.f);
+
+    auto *rel = firstVoiceIn(*f.part, 1);
+    REQUIRE(rel != nullptr);
+
+    // still going while there is sample left
+    f.runBlocks(4);
+    REQUIRE(rel->aeg.stage < stage_t::s_release);
+    REQUIRE(rel->isVoicePlaying);
+
+    /*
+     * And gone once there isn't. The gate is read at the top of a block and the generator
+     * finishes at the bottom of it, so the voice ends on the block the sample runs out rather
+     * than stepping the envelope to release first - the sample is the whole length of the note.
+     */
+    f.runBlocks(80);
+    REQUIRE(rel->isVoicePlaying == false);
+}


### PR DESCRIPTION
Add a per-group choice of whether voices are made when a key goes down or when it comes back up. A release group stays silent on note on, remembering the press, and sounds on note off at the velocity it was pressed with. Its gate following envelopes are rewritten, since nothing is holding the key: the AEG follows the sample and the modulation EGs run one shot.

This is the boolean and nothing else. The trigger fires on the note off message itself, so there is no sustain pedal handling - with the pedal down a release group speaks while the held note is still ringing. There is no countdown from note on modulation source and so no way to make the release depend on how long the key was held, and the UI is a plain toggle with none of the options that belong behind it.

The stored setting is an enum rather than a bool so those modes have somewhere to go. This is the start of, not the whole of, #2186.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>