### PR TITLE
Next swath of fixes from a codebase-wide detailed ai review

### DIFF
--- a/src/scxt-core/engine/part.cpp
+++ b/src/scxt-core/engine/part.cpp
@@ -114,9 +114,11 @@ void Part::process(Engine &e)
         }
     }
 
-    if (noGroups)
+    // active groups which all route elsewhere leave defOut unwritten, and the silence
+    // check below reads it either way
+    if (!defaultAssigned)
         memset(defOut, 0, sizeof(defOut));
-    else
+    if (!noGroups)
         silenceTime = 0;
 
     if (defaultAssigned || noGroups)

--- a/src/scxt-core/engine/zone.h
+++ b/src/scxt-core/engine/zone.h
@@ -184,7 +184,12 @@ struct Zone : MoveableOnly<Zone>, HasGroupZoneProcessors<Zone>, SampleRateSuppor
     {
         static_assert(std::is_standard_layout_v<SingleVariant>);
         static_assert(std::is_trivially_copyable_v<SingleVariant>);
-        assert(off >= 0 && off + (ptrdiff_t)sz <= (ptrdiff_t)sizeof(SingleVariant));
+        assert(off >= 0 && sz <= sizeof(SingleVariant) &&
+               off + (ptrdiff_t)sz <= (ptrdiff_t)sizeof(SingleVariant));
+        // off/sz arrive from a client message, so bound them in release too
+        if (off < 0 || sz > sizeof(SingleVariant) ||
+            off + (ptrdiff_t)sz > (ptrdiff_t)sizeof(SingleVariant))
+            return;
         memcpy((uint8_t *)&t + off, (const uint8_t *)&lead + off, sz);
     }
 

--- a/src/scxt-core/json/engine_traits.h
+++ b/src/scxt-core/json/engine_traits.h
@@ -214,6 +214,9 @@ SC_STREAMDEF(scxt::engine::Patch,
                  size_t idx{0};
                  for (const auto vz : vzones)
                  {
+                     // a corrupt or future-format stream can carry more parts than we have
+                     if (idx >= numParts)
+                         break;
                      vz.to(*(patch.getPart(idx)));
                      idx++;
                  }

--- a/src/scxt-core/json/extensions.h
+++ b/src/scxt-core/json/extensions.h
@@ -61,6 +61,8 @@ void fromIndexedArray(const tao::json::basic_value<Traits> &s, Target &t)
         auto elo = arr[i].get_object();
         size_t idx;
         elo.at("idx").to(idx);
+        if (idx >= t.size()) // stream is wider than the target; drop rather than write OOB
+            continue;
         elo.at("entry").to(t[idx]);
     }
 }

--- a/src/scxt-core/json/scxt_traits.h
+++ b/src/scxt-core/json/scxt_traits.h
@@ -227,15 +227,17 @@ inline fs::path unstreamPathFromString(const std::string &s)
     // to keep the same-store-os case working properly.
     //
     // Also handle the \\server\foo case here
-    if (s.length() > 2 && (s[1] == ':' && (s[2] == '\\') || (s[2] == '/')) ||
-        (s[0] == s[1] && (s[0] == '\\' || s[0] == '/')))
+    auto hasDriveLetter = s.length() > 2 && s[1] == ':' && (s[2] == '\\' || s[2] == '/');
+    auto isUNC = s.length() > 1 && s[0] == s[1] && (s[0] == '\\' || s[0] == '/');
+
+    if (hasDriveLetter || isUNC)
     {
         // We know at this point we are a windows path, so
         // any \ in the string are a separator, unlike posix
         // where \ can be part of a filename
         std::string r, mnt;
 
-        if (s[1] == ':')
+        if (hasDriveLetter)
         {
             // c:\foo\bar
             auto drv = s.substr(0, 1);
@@ -244,8 +246,8 @@ inline fs::path unstreamPathFromString(const std::string &s)
         }
         else
         {
-            // //server/foo/bar
-            r = r.substr(1);
+            // \\server\foo\bar
+            r = s.substr(1);
             mnt = "";
         }
 

--- a/src/scxt-core/json/selection_traits.h
+++ b/src/scxt-core/json/selection_traits.h
@@ -141,6 +141,10 @@ SC_STREAMDEF(
             findIf(v, "state", z.state);
         }
 
+        // selectedPart comes from the stream and indexes state below
+        if (z.selectedPart < 0 || z.selectedPart >= (int)scxt::numParts)
+            z.selectedPart = 0;
+
         if (!z.state[z.selectedPart].selectedZones.empty())
         {
             selection::SelectionManager::SelectActionContents sac{z.state[z.selectedPart].leadZone};

--- a/src/scxt-core/messaging/audio/audio_messages.h
+++ b/src/scxt-core/messaging/audio/audio_messages.h
@@ -34,7 +34,6 @@
 namespace scxt::messaging::audio
 {
 // Audio thread
-void sendVoiceState(uint32_t voiceCount, MessageController &mc);
 void sendStructureRefresh(MessageController &mc);
 
 } // namespace scxt::messaging::audio

--- a/src/scxt-core/messaging/audio/audio_serial.h
+++ b/src/scxt-core/messaging/audio/audio_serial.h
@@ -48,8 +48,6 @@ enum AudioToSerializationMessageId
 {
     a2s_none,
     a2s_pointer_complete,
-    a2s_note_on,
-    a2s_note_off,
     a2s_structure_refresh,
     a2s_processor_refresh,
     a2s_macro_updated,

--- a/src/scxt-core/messaging/client/macro_messages.h
+++ b/src/scxt-core/messaging/client/macro_messages.h
@@ -127,6 +127,12 @@ CLIENT_TO_SERIAL(SetMacroFullState, c2s_set_macro_full_state, macroFullState_t,
 inline void updateMacroValue(const macroValue_t &t, engine::Engine &engine, MessageController &cont)
 {
     const auto &[p, i, f] = t;
+    if (p < 0 || p >= numParts || i < 0 || i >= macrosPerPart)
+    {
+        SCLOG_IF(warnings, "Invalid part/index in updateMacroValue: " << p << "/" << i);
+        return;
+    }
+
     undo::pushUndoTagged<undo::MacroFullStateItem>(engine, macroGestureTag(p, i),
                                                    undo::UndoGesture::Discrete, p, i);
     cont.scheduleAudioThreadCallback(
@@ -159,6 +165,11 @@ inline void doMacroBeginEndEdit(const macroBeginEndEdit_t &payload, engine::Engi
                                 messaging::MessageController &cont)
 {
     auto [doIt, part, index] = payload;
+    if (part < 0 || part >= numParts || index < 0 || index >= macrosPerPart)
+    {
+        SCLOG_IF(warnings, "Invalid part/index in doMacroBeginEndEdit: " << part << "/" << index);
+        return;
+    }
 
     if (doIt)
     {

--- a/src/scxt-core/messaging/client/modulation_messages.h
+++ b/src/scxt-core/messaging/client/modulation_messages.h
@@ -279,6 +279,13 @@ inline void doReorderModRow(const modRowReorderPayload_t &payload, engine::Engin
 {
     const auto &[forZone, fromRow, toRow, isMove] = payload;
 
+    auto nRows = (int)(forZone ? modMatrixRowsPerZone : modMatrixRowsPerGroup);
+    if (fromRow < 0 || fromRow >= nRows || toRow < 0 || toRow >= nRows)
+    {
+        SCLOG_IF(warnings, "Invalid row in doReorderModRow: " << fromRow << "/" << toRow);
+        return;
+    }
+
     if (forZone)
     {
         auto sz = engine.getSelectionManager()->currentlySelectedZones();

--- a/src/scxt-core/messaging/client/structure_messages.h
+++ b/src/scxt-core/messaging/client/structure_messages.h
@@ -176,7 +176,7 @@ CLIENT_TO_SERIAL(AddCompoundElementInZone, c2s_add_compound_element_in_zone,
 
 inline void createGroupIn(int partNumber, engine::Engine &engine, MessageController &cont)
 {
-    if (partNumber < 0 || partNumber > numParts)
+    if (partNumber < 0 || partNumber >= numParts)
         partNumber = 0;
     SCLOG_IF(groupZoneMutation, "Creating group in part " << partNumber);
 
@@ -316,7 +316,7 @@ inline void deleteGroupHandler(const selection::SelectionManager::ZoneAddress &a
                 if (part->getGroup(g)->getZones().empty())
                     addrs.emplace_back((int16_t)a.part, g);
         }
-        else if (a.group < (int32_t)part->getGroups().size())
+        else if (a.group >= 0 && a.group < (int32_t)part->getGroups().size())
         {
             addrs.emplace_back((int16_t)a.part, a.group);
         }
@@ -347,7 +347,8 @@ inline void deleteGroupHandler(const selection::SelectionManager::ZoneAddress &a
             }
             else
             {
-                if (e.getPatch()->getPart(s.part)->getGroups().size() < s.group)
+                if (s.group < 0 ||
+                    s.group >= (int32_t)e.getPatch()->getPart(s.part)->getGroups().size())
                     return;
                 deleteOneGroup(s.group);
             }

--- a/src/scxt-core/messaging/client/zone_messages.h
+++ b/src/scxt-core/messaging/client/zone_messages.h
@@ -81,6 +81,11 @@ inline void doApplyZoneDelta(const applyZoneDeltaPayload_t &payload, engine::Eng
                              MessageController &cont)
 {
     auto part = std::get<2>(payload);
+    if (part < 0 || part >= numParts)
+    {
+        SCLOG_IF(warnings, "Invalid part in doApplyZoneDelta: " << part);
+        return;
+    }
     auto &sc = engine.getSelectionManager()->state[part].selectedZones;
     auto lz = engine.getSelectionManager()->currentLeadZone(engine);
     if (!sc.empty())
@@ -211,6 +216,18 @@ using updateVariantFieldPayload_t =
 inline void doUpdateVariantField(const updateVariantFieldPayload_t &payload, engine::Engine &engine,
                                  MessageController &cont)
 {
+    // the offset/size name a field of SingleVariant and end up in a memcpy, so bound them
+    // here rather than on the audio thread
+    const auto &foff = std::get<2>(payload);
+    const auto &fsz = std::get<3>(payload);
+    if (foff < 0 || fsz > sizeof(engine::Zone::SingleVariant) ||
+        foff + (ptrdiff_t)fsz > (ptrdiff_t)sizeof(engine::Zone::SingleVariant))
+    {
+        SCLOG_IF(warnings,
+                 "Invalid field offset/size in doUpdateVariantField: " << foff << "/" << fsz);
+        return;
+    }
+
     auto sel = engine.getSelectionManager()->currentlySelectedZones();
     if (sel.empty())
         return;

--- a/src/scxt-core/messaging/messaging.cpp
+++ b/src/scxt-core/messaging/messaging.cpp
@@ -72,9 +72,6 @@ void MessageController::parseAudioMessageOnSerializationThread(
     case audio::a2s_pointer_complete:
         returnAudioThreadCallback(static_cast<AudioThreadCallback *>(as.payload.p));
         break;
-    case audio::a2s_note_on:
-    case audio::a2s_note_off:
-        throw std::logic_error("Implement this");
     case audio::a2s_structure_refresh:
         // TODO: Factor this a bit better
         serializationSendToClient(client::s2c_send_pgz_structure,

--- a/src/scxt-core/selection/selection_manager.cpp
+++ b/src/scxt-core/selection/selection_manager.cpp
@@ -1151,7 +1151,8 @@ bool SelectionManager::acrossSelectionConsistency(bool forZone, ConsistencyCheck
     if (forZone)
     {
         auto &lza = state[selectedPart].leadZone;
-        if (!lza.isInWithPartials(engine))
+        // isIn not isInWithPartials; a partial address has no zone to dereference
+        if (!lza.isIn(engine))
             return true;
 
         const auto &lz =
@@ -1159,7 +1160,7 @@ bool SelectionManager::acrossSelectionConsistency(bool forZone, ConsistencyCheck
 
         for (auto &s : state[selectedPart].selectedZones)
         {
-            if (!s.isInWithPartials(engine))
+            if (!s.isIn(engine))
                 continue;
             const auto &it = engine.getPatch()->getPart(s.part)->getGroup(s.group)->getZone(s.zone);
             if (!doCheck(lz, it))

--- a/src/scxt-plugin/clap/scxt-plugin.cpp
+++ b/src/scxt-plugin/clap/scxt-plugin.cpp
@@ -579,9 +579,8 @@ void SCXTPlugin::handleParamValueEvent(const clap_event_param_value *pev)
 }
 void SCXTPlugin::onMainThread() noexcept
 {
-    // Fixme - better atomics
-    uint64_t a = nextMainThreadAction;
-    nextMainThreadAction = 0;
+    // read-and-clear in one step so a flag OR'd in from the audio thread isn't dropped
+    uint64_t a = nextMainThreadAction.exchange(0);
     if (a & RESCAN_PARAM_IVT)
     {
         if (_host.canUseParams())

--- a/src/scxt-plugin/clap/scxt-plugin.cpp
+++ b/src/scxt-plugin/clap/scxt-plugin.cpp
@@ -231,6 +231,11 @@ bool SCXTPlugin::audioPortsInfo(uint32_t index, bool isInput,
         info->channel_count = 2;
         info->port_type = CLAP_PORT_STEREO;
     }
+    else
+    {
+        SCLOG_IF(debug, "Invalid port index: " << (int)index);
+        return false;
+    }
 
     return true;
 }

--- a/src/scxt-plugin/clap/scxt-plugin.h
+++ b/src/scxt-plugin/clap/scxt-plugin.h
@@ -85,7 +85,7 @@ struct SCXTPlugin : public plugHelper_t, sst::clap_juce_shim::EditorProvider
         RESCAN_PARAM_IVT = 1 << 0,
         STATE_MARK_DIRTY = 1 << 1,
     };
-    std::atomic<uint64_t> nextMainThreadAction;
+    std::atomic<uint64_t> nextMainThreadAction{0};
     void onMainThread() noexcept override;
 
     bool implementsAudioPorts() const noexcept override { return true; }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(scxt-test
 		ui_basics.cpp
 
 		selection_tests.cpp
+		message_bounds_tests.cpp
 		modify_structure.cpp
 		modulator_tests.cpp
 		mod_matrix_operations_tests.cpp

--- a/tests/message_bounds_tests.cpp
+++ b/tests/message_bounds_tests.cpp
@@ -1,0 +1,155 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+/*
+ * A client can send anything. These check that payload indices which are out of range
+ * are refused on the serialization thread rather than indexing the engine out of bounds.
+ */
+
+#include "catch2/catch2.hpp"
+#include "engine/engine.h"
+#include "console_harness.h"
+
+namespace cmsg = scxt::messaging::client;
+using ZoneAddress = scxt::selection::SelectionManager::ZoneAddress;
+
+TEST_CASE("Out of range macro messages are refused")
+{
+    scxt::clients::console_ui::ConsoleHarness th;
+    th.start();
+    th.stepUI();
+
+    auto &part = th.engine->getPatch()->getPart(0);
+    auto before = part->macros[0].value;
+
+    th.sendToSerialization(cmsg::SetMacroValue({scxt::numParts, 0, 0.75f}));
+    th.sendToSerialization(cmsg::SetMacroValue({-1, 0, 0.75f}));
+    th.sendToSerialization(cmsg::SetMacroValue({0, (int16_t)scxt::macrosPerPart, 0.75f}));
+    th.sendToSerialization(cmsg::SetMacroValue({0, -1, 0.75f}));
+    th.stepUI();
+
+    REQUIRE(part->macros[0].value == before);
+
+    th.sendToSerialization(cmsg::MacroBeginEndEdit({true, scxt::numParts, 0}));
+    th.sendToSerialization(cmsg::MacroBeginEndEdit({true, 0, (int16_t)scxt::macrosPerPart}));
+    th.sendToSerialization(cmsg::MacroBeginEndEdit({false, -1, -1}));
+    th.stepUI();
+
+    // and an in-range one still lands
+    th.sendToSerialization(cmsg::SetMacroValue({0, 0, 0.75f}));
+    th.stepUI();
+    REQUIRE(part->macros[0].value == 0.75f);
+}
+
+TEST_CASE("Out of range mod row reorder is refused")
+{
+    scxt::clients::console_ui::ConsoleHarness th;
+    th.start();
+    th.stepUI();
+
+    th.sendToSerialization(cmsg::AddBlankZone({0, 0, 48, 60, 0, 127}));
+    th.stepUI();
+
+    auto &zone = th.engine->getPatch()->getPart(0)->getGroup(0)->getZone(0);
+    auto &routes = zone->routingTable.routes;
+    routes[0].active = false;
+    routes[1].active = true;
+
+    const auto n = (int)scxt::modMatrixRowsPerZone;
+    for (auto bad : {n, n + 40, -1})
+    {
+        th.sendToSerialization(cmsg::ReorderModRow({true, bad, 0, false}));
+        th.sendToSerialization(cmsg::ReorderModRow({true, 0, bad, true}));
+        th.sendToSerialization(cmsg::ReorderModRow({false, bad, 0, false}));
+        th.sendToSerialization(cmsg::ReorderModRow({false, 0, bad, true}));
+    }
+    th.stepUI();
+
+    REQUIRE_FALSE(routes[0].active);
+    REQUIRE(routes[1].active);
+
+    // an in-range swap still works
+    th.sendToSerialization(cmsg::ReorderModRow({true, 0, 1, false}));
+    th.stepUI();
+    REQUIRE(routes[0].active);
+    REQUIRE_FALSE(routes[1].active);
+}
+
+TEST_CASE("An out of range variant field offset is refused")
+{
+    scxt::clients::console_ui::ConsoleHarness th;
+    th.start();
+    th.stepUI();
+
+    th.sendToSerialization(cmsg::AddBlankZone({0, 0, 48, 60, 0, 127}));
+    th.stepUI();
+
+    auto &zone = th.engine->getPatch()->getPart(0)->getGroup(0)->getZone(0);
+    auto before = zone->variantData.variants[0];
+
+    scxt::engine::Zone::SingleVariant edited;
+    edited.startSample = 12345;
+
+    const auto vsz = sizeof(scxt::engine::Zone::SingleVariant);
+    th.sendToSerialization(cmsg::UpdateVariantField({0, false, (ptrdiff_t)vsz, 8, edited}));
+    th.sendToSerialization(cmsg::UpdateVariantField({0, false, -8, 8, edited}));
+    th.sendToSerialization(cmsg::UpdateVariantField({0, false, 0, vsz + 8, edited}));
+    th.sendToSerialization(cmsg::UpdateVariantField({0, true, 0, (size_t)-1, edited}));
+    th.stepUI();
+
+    REQUIRE(zone->variantData.variants[0].startSample == before.startSample);
+
+    // the control: the same field named legally does copy. Direct rather than through a
+    // message, since a blank zone has no sample for a frame position to be meaningful on -
+    // variant_edit_all_tests covers the message path on loaded samples.
+    scxt::engine::Zone::Variants vd;
+    scxt::engine::Zone::applyVariantFieldEdit(
+        vd, edited, offsetof(scxt::engine::Zone::SingleVariant, startSample),
+        sizeof(edited.startSample), 0, false, true);
+    REQUIRE(vd.variants[0].startSample == 12345);
+}
+
+TEST_CASE("Out of range part in a zone delta is refused")
+{
+    scxt::clients::console_ui::ConsoleHarness th;
+    th.start();
+    th.stepUI();
+
+    th.sendToSerialization(cmsg::AddBlankZone({0, 0, 48, 60, 0, 127}));
+    th.stepUI();
+
+    auto &zone = th.engine->getPatch()->getPart(0)->getGroup(0)->getZone(0);
+    auto keyStart = zone->mapping.keyboardRange.keyStart;
+
+    // dim 0 is the keyboard range; the part index is the third element
+    th.sendToSerialization(cmsg::ApplyZoneDelta({false, false, scxt::numParts, 0, 1, 0}));
+    th.sendToSerialization(cmsg::ApplyZoneDelta({false, false, 4096, 0, 1, 0}));
+    th.sendToSerialization(cmsg::ApplyZoneDelta({false, false, -1, 0, 1, 0}));
+    th.stepUI();
+
+    REQUIRE(zone->mapping.keyboardRange.keyStart == keyStart);
+}

--- a/tests/modify_structure.cpp
+++ b/tests/modify_structure.cpp
@@ -184,3 +184,50 @@ TEST_CASE("Paste Group Does Nothing When Clipboard Holds Zone")
     // Still one group
     REQUIRE(part->getGroups().size() == 1);
 }
+
+TEST_CASE("Create Group In An Out Of Range Part Falls Back To Part 0")
+{
+    scxt::clients::console_ui::ConsoleHarness th;
+    th.start();
+    th.stepUI();
+
+    auto &part = th.engine->getPatch()->getPart(0);
+    auto n = part->getGroups().size();
+
+    // numParts is one past the last valid part index
+    th.sendToSerialization(cmsg::CreateGroup((int)scxt::numParts));
+    th.stepUI();
+
+    REQUIRE(part->getGroups().size() == n + 1);
+}
+
+TEST_CASE("Delete Group With An Out Of Range Index Is A No-op")
+{
+    scxt::clients::console_ui::ConsoleHarness th;
+    th.start();
+    th.stepUI();
+
+    th.sendToSerialization(cmsg::AddBlankZone({0, 0, 48, 60, 0, 127}));
+    th.stepUI();
+
+    auto &part = th.engine->getPatch()->getPart(0);
+    REQUIRE(part->getGroups().size() == 1);
+
+    // group == size() is one past the end
+    th.sendToSerialization(cmsg::DeleteGroup(ZoneAddress{0, 1, -1}));
+    th.stepUI();
+    REQUIRE(part->getGroups().size() == 1);
+
+    th.sendToSerialization(cmsg::DeleteGroup(ZoneAddress{0, 74, -1}));
+    th.stepUI();
+    REQUIRE(part->getGroups().size() == 1);
+
+    th.sendToSerialization(cmsg::DeleteGroup(ZoneAddress{0, -1, -1}));
+    th.stepUI();
+    REQUIRE(part->getGroups().size() == 1);
+
+    // and the in-range one still works
+    th.sendToSerialization(cmsg::DeleteGroup(ZoneAddress{0, 0, -1}));
+    th.stepUI();
+    REQUIRE(part->getGroups().empty());
+}

--- a/tests/selection_tests.cpp
+++ b/tests/selection_tests.cpp
@@ -30,8 +30,10 @@
 #include "engine/feature_enums.h"
 #include "engine/zone.h"
 #include "patch_io/patch_io.h"
+#include "json/selection_traits.h"
 
 #include "console_harness.h"
+#include "test_utils.h"
 
 #include <filesystem>
 
@@ -611,4 +613,17 @@ TEST_CASE("SCP preserves selection across parts", "[selection]")
     }
 
     std::filesystem::remove(tmp);
+}
+
+TEST_CASE("An out of range streamed selectedPart is clamped", "[selection]")
+{
+    // a bare engine, so the unstream runs right here rather than on a serialization thread
+    auto e = std::unique_ptr<scxt::engine::Engine>(makeEngine());
+    auto &sm = e->getSelectionManager();
+
+    auto v = scxt::json::scxt_value(*sm);
+    v["selectedPart"] = (int16_t)(scxt::numParts + 3);
+
+    REQUIRE_NOTHROW(v.to(*sm));
+    REQUIRE(sm->selectedPart == 0);
 }

--- a/tests/streaming.cpp
+++ b/tests/streaming.cpp
@@ -210,6 +210,45 @@ TEST_CASE("A one shot variant unstreams as a sample gated AEG")
     }
 }
 
+TEST_CASE("fromIndexedArray is bounded by the target")
+{
+    auto parse = [](const std::string &s) {
+        tao::json::events::transformer<tao::json::events::to_basic_value<scxt::json::scxt_traits>>
+            consumer;
+        tao::json::events::from_string(consumer, s);
+        return std::move(consumer.value);
+    };
+
+    SECTION("In range indices land where they say")
+    {
+        auto v = parse(R"([{"idx":0,"entry":11},{"idx":2,"entry":13}])");
+        std::array<int, 3> t{0, 0, 0};
+        fromIndexedArray(v, t);
+        REQUIRE(t[0] == 11);
+        REQUIRE(t[1] == 0);
+        REQUIRE(t[2] == 13);
+    }
+
+    SECTION("An out of range index is dropped rather than written")
+    {
+        auto v = parse(R"([{"idx":0,"entry":11},{"idx":7,"entry":99},{"idx":1,"entry":12}])");
+        std::array<int, 3> t{0, 0, 0};
+        REQUIRE_NOTHROW(fromIndexedArray(v, t));
+        REQUIRE(t[0] == 11);
+        REQUIRE(t[1] == 12);
+        REQUIRE(t[2] == 0);
+    }
+
+    SECTION("A round trip through toIndexedArrayIf is unchanged")
+    {
+        std::array<int, 4> src{7, 0, 9, 0};
+        auto v = toIndexedArrayIf<scxt::json::scxt_traits>(src, [](auto e) { return e != 0; });
+        std::array<int, 4> t{0, 0, 0, 0};
+        fromIndexedArray(v, t);
+        REQUIRE(t == src);
+    }
+}
+
 // TODO: Add test for Group streaming
 // TODO: Add test for Part streaming
 // TODO: Add test for Patch streaming

--- a/tests/streaming.cpp
+++ b/tests/streaming.cpp
@@ -210,6 +210,86 @@ TEST_CASE("A one shot variant unstreams as a sample gated AEG")
     }
 }
 
+TEST_CASE("Only a real windows path is remapped on unstream")
+{
+    auto un = [](const std::string &s) { return scxt::json::unstreamPathFromString(s).string(); };
+    auto sentinel = std::string(scxt::relativeSentinel);
+
+    // Every shape the unstream has to sort out. On windows none of them move; the remap
+    // is what a mac or linux host does to a path a windows host wrote.
+    const std::vector<std::string> everyShape{"My/sample.wav",
+                                              "/a/b.wav",
+                                              "ab/c/d.wav",
+                                              "/Users/paul/samples/kick.wav",
+                                              "",
+                                              "a",
+                                              "ab",
+                                              "a/b",
+                                              "C:\\foo\\bar.wav",
+                                              "C:/foo/bar.wav",
+                                              "d:\\x.wav",
+                                              "\\\\server\\share\\x.wav",
+                                              "//server/share/x.wav",
+                                              sentinel + "\\x.wav",
+                                              sentinel + "/x.wav"};
+
+#if defined(WINDOWS) && WINDOWS
+    SECTION("On windows nothing is rewritten")
+    {
+        for (const auto &p : everyShape)
+        {
+            INFO(p);
+            REQUIRE(un(p) == p);
+        }
+    }
+#else
+    SECTION("Nothing throws")
+    {
+        for (const auto &p : everyShape)
+        {
+            INFO(p);
+            REQUIRE_NOTHROW(un(p));
+        }
+    }
+
+    SECTION("A posix path is left alone")
+    {
+        // any of these has a '/' third character, which used to be enough to call it windows
+        REQUIRE(un("My/sample.wav") == "My/sample.wav");
+        REQUIRE(un("/a/b.wav") == "/a/b.wav");
+        REQUIRE(un("ab/c/d.wav") == "ab/c/d.wav");
+        REQUIRE(un("/Users/paul/samples/kick.wav") == "/Users/paul/samples/kick.wav");
+    }
+
+    SECTION("Short and empty strings do not index off the end")
+    {
+        REQUIRE(un("") == "");
+        REQUIRE(un("a") == "a");
+        REQUIRE(un("ab") == "ab");
+        REQUIRE(un("a/b") == "a/b");
+    }
+
+    SECTION("A drive letter path is mounted")
+    {
+        REQUIRE(un("C:\\foo\\bar.wav") == "/mnt/C/foo/bar.wav");
+        REQUIRE(un("C:/foo/bar.wav") == "/mnt/C/foo/bar.wav");
+        REQUIRE(un("d:\\x.wav") == "/mnt/d/x.wav");
+    }
+
+    SECTION("A UNC path drops one leading separator")
+    {
+        REQUIRE(un("\\\\server\\share\\x.wav") == "/server/share/x.wav");
+        REQUIRE(un("//server/share/x.wav") == "/server/share/x.wav");
+    }
+
+    SECTION("The relative sentinel still takes its own branch")
+    {
+        REQUIRE(un(sentinel + "\\x.wav") == sentinel + "/x.wav");
+        REQUIRE(un(sentinel + "/x.wav") == sentinel + "/x.wav");
+    }
+#endif
+}
+
 TEST_CASE("A patch stream with too many parts is truncated")
 {
     scxt::engine::Patch p1;

--- a/tests/streaming.cpp
+++ b/tests/streaming.cpp
@@ -210,6 +210,26 @@ TEST_CASE("A one shot variant unstreams as a sample gated AEG")
     }
 }
 
+TEST_CASE("A patch stream with too many parts is truncated")
+{
+    scxt::engine::Patch p1;
+    p1.getPart(0)->configuration.channel = 3;
+    p1.getPart(1)->configuration.channel = 5;
+
+    auto v = scxt::json::scxt_value(p1);
+    auto &parts = v.at("parts").get_array();
+    REQUIRE(parts.size() == scxt::numParts);
+
+    // a corrupt or future-format file with more parts than this build has
+    while (parts.size() < scxt::numParts + 4)
+        parts.push_back(parts[0]);
+
+    scxt::engine::Patch p2;
+    REQUIRE_NOTHROW(v.to(p2));
+    REQUIRE(p2.getPart(0)->configuration.channel == 3);
+    REQUIRE(p2.getPart(1)->configuration.channel == 5);
+}
+
 TEST_CASE("fromIndexedArray is bounded by the target")
 {
     auto parse = [](const std::string &s) {


### PR DESCRIPTION
Continuing addressing issues from the fable review. This one mostly contains fixes for mistaken bounds checks and error paths. Ideally we would rebase not squash this into main once CI passes to leave these as individual bisect points.