### PR TITLE
Make the invert scroll setting work and add wheel to part and tab sel…

### DIFF
--- a/src/scxt-plugin/app/edit-screen/components/MacroMappingVariantPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/MacroMappingVariantPane.cpp
@@ -182,16 +182,6 @@ void MacroMappingVariantPane::editorSelectionChanged()
     repaint();
 }
 
-void MacroMappingVariantPane::invertScroll(bool invert)
-{
-    SCLOG_IF(debug, "InvertScroll todo");
-    // mappingDisplay->mappingViewport->invertScroll(invert);
-    for (auto &w : sampleDisplay->waveforms)
-    {
-        // w.waveformViewport->invertScroll(invert);
-    }
-}
-
 void MacroMappingVariantPane::addSamplePlaybackPosition(size_t sampleIndex, int64_t samplePos)
 {
     if (sampleDisplay->isVisible() && sampleIndex == sampleDisplay->selectedVariation)

--- a/src/scxt-plugin/app/edit-screen/components/MacroMappingVariantPane.h
+++ b/src/scxt-plugin/app/edit-screen/components/MacroMappingVariantPane.h
@@ -70,9 +70,6 @@ struct MacroMappingVariantPane : sst::jucegui::components::NamedPanel, HasEditor
     void addSamplePlaybackPosition(size_t sampleIndex, int64_t samplePos);
     void clearSamplePlaybackPositions();
 
-    void invertScroll(bool invert);
-    bool invertScroll() const;
-
     void showHamburgerMenu();
 };
 } // namespace scxt::ui::app::edit_screen

--- a/src/scxt-plugin/app/edit-screen/components/PartGroupSidebar.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/PartGroupSidebar.cpp
@@ -541,8 +541,31 @@ struct GroupZoneSidebarBase : juce::Component,
             if (w)
                 w->showPartSelectorMenu();
         });
+        partSelector->setOnJogCallback([w = juce::Component::SafePointer(this)](int dir) {
+            if (w)
+                w->jogSelectedPart(dir);
+        });
         partSelector->setLabel("Part 1");
         addAndMakeVisible(*partSelector);
+    }
+
+    // dir is a list delta, so +1 walks towards Part 16. Only active parts are
+    // offered in the menu, so only active parts are jogged to, and we stop at
+    // the ends rather than wrapping round.
+    void jogSelectedPart(int dir)
+    {
+        if (dir == 0)
+            return;
+
+        auto step = dir > 0 ? 1 : -1;
+        for (auto p = editor->selectedPart + step; p >= 0 && p < scxt::numParts; p += step)
+        {
+            if (editor->partConfigurations[p].active)
+            {
+                sendToSerialization(cmsg::SelectPart(p));
+                return;
+            }
+        }
     }
 
     void showPartSelectorMenu()

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/SampleWaveform.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/SampleWaveform.cpp
@@ -337,6 +337,14 @@ void SampleWaveform::mouseDown(const juce::MouseEvent &e)
         onPopupMenu();
         return;
     }
+
+    // middle drag pans the zoom container, so don't grab a marker under it
+    if (e.mods.isMiddleButtonDown())
+    {
+        mouseState = MouseState::NONE;
+        return;
+    }
+
     auto posi = e.position.roundToInt();
     if (startSampleHZ.contains(posi))
         mouseState = MouseState::HZ_DRAG_SAMPSTART;

--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/ZoneLayoutDisplay.cpp
@@ -41,6 +41,12 @@ void ZoneLayoutDisplay::mouseDown(const juce::MouseEvent &e)
     if (!display)
         return;
     mouseState = NONE;
+
+    // middle drag pans the zoom container, so stay out of its way. leaving
+    // mouseState at NONE is what makes the subsequent drag inert here.
+    if (e.mods.isMiddleButtonDown())
+        return;
+
     display->mayBeAboutToMutate = true;
 
     if (e.mods.isPopupMenu())

--- a/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditor.cpp
@@ -37,6 +37,7 @@
 
 #include "app/play-screen/PlayScreen.h"
 #include "sst/jucegui/style/StyleSheet.h"
+#include "sst/jucegui/util/WheelCalibration.h"
 
 #include "infrastructure/user_defaults.h"
 
@@ -85,6 +86,9 @@ SCXTEditor::SCXTEditor(messaging::MessageController &e, infrastructure::Defaults
 
     sst::basic_blocks::params::ParamMetaData::defaultMidiNoteOctaveOffset =
         defaultsProvider.getUserDefaultValue(infrastructure::octave0, 0);
+
+    sst::jucegui::util::setWheelInverted(
+        defaultsProvider.getUserDefaultValue(infrastructure::invertScroll, 0) == 1);
 
     setStyle(sst::jucegui::style::StyleSheet::getBuiltInStyleSheet(
         sst::jucegui::style::StyleSheet::EMPTY));

--- a/src/scxt-plugin/app/editor-impl/SCXTEditorMenus.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditorMenus.cpp
@@ -36,6 +36,7 @@
 #include "sst/plugininfra/version_information.h"
 #include "sst/jucegui/component-adapters/ComponentTags.h"
 #include "sst/jucegui/components/DraggableTextEditableValue.h"
+#include "sst/jucegui/util/WheelCalibration.h"
 #include "sst/clap_juce_shim/menu_helper.h"
 
 #include "app/SCXTEditor.h"
@@ -480,7 +481,7 @@ void SCXTEditor::addZoomMenu(juce::PopupMenu &p, bool addTitle)
                       w->defaultsProvider.updateUserDefaultValue(
                           infrastructure::DefaultKeys::invertScroll, newScrollBehavior ? 1 : 0);
 
-                      w->editScreen->mappingPane->invertScroll(newScrollBehavior);
+                      sst::jucegui::util::setWheelInverted(newScrollBehavior);
                   }
               });
 


### PR DESCRIPTION
…ectors

The Invert Mouse Scroll Direction menu item wrote a user default whose only consumer was a stub that logged "InvertScroll todo", so the setting did nothing at all. Point it at the shared jucegui preference instead, and apply the stored value at editor startup rather than only when the menu is used.

Also allow the wheel to walk the part dropdown in the groups and zones sidebar, and keep the mapping and sample panes out of the way of the middle button so it can pan the zoomed view.

Picks up the sst-jucegui wheel calibration work from sst-jucegui#239.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>