### PR TITLE
Stop offering waveform zoom when no sample is loaded

### DIFF
--- a/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.h
+++ b/src/scxt-plugin/app/edit-screen/components/mapping-pane/VariantDisplay.h
@@ -218,6 +218,15 @@ struct VariantDisplay : juce::Component, HasEditor
         for (const auto &[k, l] : labels)
             l->setVisible(b);
 
+        /*
+         * With no sample there is nothing in the waveform to look at, so zooming
+         * it is meaningless. This hides the scrollbars and the magnifier and
+         * stops the wheel and middle drag acting on an empty view.
+         */
+        for (auto &w : waveforms)
+            if (w.waveformViewport)
+                w.waveformViewport->setZoomEnabled(b);
+
         if (active)
             rebuild();
         repaint();


### PR DESCRIPTION
There is nothing in the waveform to look at until a sample is loaded, so the scrollbars and the magnifier button were offering to adjust a view of nothing. Switch zooming off from setActive, alongside the other controls it already shows and hides for the same reason.

Also picks up the reworked tilt wheel rate and direction, and the middle drag zoom gesture, from sst-jucegui#240.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>