### PR TITLE
Guarantee the save-as extension the file chooser didn't add

### DIFF
--- a/src/scxt-core/utils.h
+++ b/src/scxt-core/utils.h
@@ -416,6 +416,41 @@ inline bool extensionMatches(const fs::path &p, const std::string &s)
     return extensionStringMatches(pes, s);
 }
 
+/*
+ * Native save dialogs don't all append the filter's extension to the name the
+ * user typed - the GTK one on linux hands back "FooBaz" verbatim - which
+ * leaves a patch the browser will never match again. So force it on at every
+ * save-as and export site.
+ *
+ * This appends rather than replacing. The two only differ once the typed name
+ * contains a dot, and there replace_extension discards everything after the
+ * last one: a user saving "Bass 3.2" gets "Bass 3.scm" and loses half the name
+ * they typed. Appending gives "Bass 3.2.scm" and can never destroy input.
+ *
+ * `ext` takes "scm", ".scm" or a file chooser's own "*.scm" filter, so a call
+ * site can hand over the exact string it built the chooser with and the two
+ * can't drift apart. A single extension only, not a ";" pattern list.
+ */
+inline fs::path guaranteeExtension(const fs::path &p, const std::string &ext)
+{
+    auto dotted = ext;
+    if (!dotted.empty() && dotted.front() == '*')
+        dotted = dotted.substr(1);
+    if (!dotted.empty() && dotted.front() != '.')
+        dotted = "." + dotted;
+
+    // Nothing to guarantee, or nothing to guarantee it onto
+    if (dotted.size() < 2 || p.empty() || p.filename().empty())
+        return p;
+
+    if (extensionMatches(p, dotted))
+        return p;
+
+    auto res = p;
+    res += dotted;
+    return res;
+}
+
 inline std::string humanReadableVersion(uint64_t v)
 {
     return fmt::format("{:04x}-{:02x}-{:02x}", (v >> 16) & 0xFFFF, (v >> 8) & 0xFF, v & 0xFF);

--- a/src/scxt-plugin/app/edit-screen/components/LFOPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/LFOPane.cpp
@@ -49,6 +49,7 @@
 #include "modulation/modulators/steplfo.h"
 #include "app/edit-screen/EditScreen.h"
 #include "app/shared/MenuValueTypein.h"
+#include "app/shared/UIHelpers.h"
 #include "sst/jucegui/components/TextPushButton.h"
 
 #include <tao/json/to_string.hpp>
@@ -2025,7 +2026,7 @@ void LfoPane::doSavePreset()
                                  {
                                      return;
                                  }
-                                 auto f = result.getFirst();
+                                 auto f = shared::guaranteeExtension(result.getFirst(), "*.scmod");
                                  if (f.existsAsFile() || f.create())
                                  {
                                      auto s = w->streamToJSON();

--- a/src/scxt-plugin/app/edit-screen/components/ProcessorPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/ProcessorPane.cpp
@@ -420,11 +420,12 @@ void ProcessorPane::savePreset()
             {
                 return;
             }
+            auto f = shared::guaranteeExtension(result[0], "*.vcfx");
             auto ppa = PresetProviderAdapter(*w);
             auto psv = sst::voice_effects::presets::toPreset(ppa);
             if (!psv.empty())
             {
-                if (!result[0].replaceWithText(psv))
+                if (!f.replaceWithText(psv))
                 {
                     w->editor->displayError("File Save", "Unable to save file");
                 }

--- a/src/scxt-plugin/app/editor-impl/SCXTEditorMenus.cpp
+++ b/src/scxt-plugin/app/editor-impl/SCXTEditorMenus.cpp
@@ -699,8 +699,9 @@ void SCXTEditor::promptForSaveTheme()
             auto result = c.getResults();
             if (result.isEmpty() || result.size() > 1)
                 return;
+            auto f = shared::guaranteeExtension(result[0], "*.sctheme");
             auto &cm = w->themeApplier.currentColorMap();
-            result[0].replaceWithText(cm.toJson());
+            f.replaceWithText(cm.toJson());
             // Save promotes the current (likely custom) map to a file-backed
             // one: tag the id, persist the path, and drop the edited DES so a
             // subsequent reload picks up the saved file as the baseline. Any
@@ -713,7 +714,7 @@ void SCXTEditor::promptForSaveTheme()
                                                        theme::ColorMap::FILE_COLORMAP_ID);
             w->defaultsProvider.updateUserDefaultValue(
                 infrastructure::DefaultKeys::colormapPathIfFile,
-                shared::juceFileToFSPath(result[0]).u8string());
+                shared::juceFileToFSPath(f).u8string());
             w->sendToSerialization(cmsg::StoreColormap{std::string{}});
         });
 }

--- a/src/scxt-plugin/app/shared/PartEffectsPane.cpp
+++ b/src/scxt-plugin/app/shared/PartEffectsPane.cpp
@@ -30,6 +30,7 @@
 #include "messaging/client/mixer_messages.h"
 #include "app/mixer-screen/MixerScreen.h"
 #include "app/edit-screen/components/PartEditScreen.h"
+#include "app/shared/UIHelpers.h"
 
 #include "connectors/JsonLayoutEngineSupport.h"
 
@@ -636,11 +637,12 @@ template <bool forBus> void PartEffectsPane<forBus>::savePreset()
             {
                 return;
             }
+            auto f = guaranteeExtension(result[0], "*.busfx");
             auto ppa = PresetProviderAdapter<forBus>(*w);
             auto psv = sst::effects::presets::toPreset(ppa);
             if (!psv.empty())
             {
-                if (!result[0].replaceWithText(psv))
+                if (!f.replaceWithText(psv))
                 {
                     w->editor->displayError("File Save", "Unable to save file");
                 }

--- a/src/scxt-plugin/app/shared/PatchMultiIO.h
+++ b/src/scxt-plugin/app/shared/PatchMultiIO.h
@@ -60,6 +60,13 @@ template <typename T> void rememberSaveDirectory(T *that, const juce::File &resu
                                                          juceFileToFSPath(dir));
 }
 
+inline std::string multiExtension() { return "*.scm"; }
+
+inline std::string partExtension(patch_io::SaveStyles style)
+{
+    return style == patch_io::SaveStyles::AS_SFZ ? "*.sfz" : "*.scp";
+}
+
 template <typename T>
 void doSaveMulti(T *that, std::unique_ptr<juce::FileChooser> &fileChooser,
                  patch_io::SaveStyles style)
@@ -69,7 +76,6 @@ void doSaveMulti(T *that, std::unique_ptr<juce::FileChooser> &fileChooser,
     auto flags = juce::FileBrowserComponent::canSelectFiles | juce::FileBrowserComponent::saveMode |
                  juce::FileBrowserComponent::warnAboutOverwriting;
 
-    std::string ext = "*.scm";
     std::string title = "Save Multi";
     if (style == patch_io::SaveStyles::AS_SFZ)
     {
@@ -81,7 +87,8 @@ void doSaveMulti(T *that, std::unique_ptr<juce::FileChooser> &fileChooser,
         flags = juce::FileBrowserComponent::canSelectDirectories;
         title = "Collect Samples";
     }
-    fileChooser = std::make_unique<juce::FileChooser>(title, lastSaveDirectory(that), "*.scm");
+    fileChooser =
+        std::make_unique<juce::FileChooser>(title, lastSaveDirectory(that), multiExtension());
     fileChooser->launchAsync(
         flags, [style, w = juce::Component::SafePointer(that)](const juce::FileChooser &c) {
             if (!w)
@@ -94,6 +101,9 @@ void doSaveMulti(T *that, std::unique_ptr<juce::FileChooser> &fileChooser,
             rememberSaveDirectory(w.getComponent(), result[0]);
             // send a 'save multi' message
             auto fsp = juceFileToFSPath(result[0]);
+            // ONLY_COLLECT picks a directory, every other style names a file
+            if (style != patch_io::SaveStyles::ONLY_COLLECT)
+                fsp = scxt::guaranteeExtension(fsp, multiExtension());
             w->sendToSerialization(cmsg::SaveMulti({fsp.u8string(), (int)style}));
         });
 }
@@ -127,11 +137,9 @@ void doSavePart(T *that, std::unique_ptr<juce::FileChooser> &fileChooser, int pa
 
     auto flags = juce::FileBrowserComponent::canSelectFiles | juce::FileBrowserComponent::saveMode |
                  juce::FileBrowserComponent::warnAboutOverwriting;
-    std::string ext = "*.scp";
     std::string title = "Save Part";
     if (style == patch_io::SaveStyles::AS_SFZ)
     {
-        ext = "*.sfz";
         title = "Export to SFZ";
     }
     if (style == patch_io::SaveStyles::ONLY_COLLECT)
@@ -140,7 +148,8 @@ void doSavePart(T *that, std::unique_ptr<juce::FileChooser> &fileChooser, int pa
         title = "Collect Samples";
     }
 
-    fileChooser = std::make_unique<juce::FileChooser>(title, lastSaveDirectory(that), ext);
+    fileChooser =
+        std::make_unique<juce::FileChooser>(title, lastSaveDirectory(that), partExtension(style));
     fileChooser->launchAsync(
         flags, [style, part, w = juce::Component::SafePointer(that)](const juce::FileChooser &c) {
             if (!w)
@@ -153,6 +162,9 @@ void doSavePart(T *that, std::unique_ptr<juce::FileChooser> &fileChooser, int pa
             rememberSaveDirectory(w.getComponent(), result[0]);
             // send a 'save multi' message
             auto fsp = juceFileToFSPath(result[0]);
+            // ONLY_COLLECT picks a directory, every other style names a file
+            if (style != patch_io::SaveStyles::ONLY_COLLECT)
+                fsp = scxt::guaranteeExtension(fsp, partExtension(style));
             w->sendToSerialization(cmsg::SavePart({fsp.u8string(), part, (int)style}));
         });
 }

--- a/src/scxt-plugin/app/shared/UIHelpers.h
+++ b/src/scxt-plugin/app/shared/UIHelpers.h
@@ -34,6 +34,7 @@
 #include <sstream>
 #include <string>
 #include "filesystem/import.h"
+#include "utils.h"
 
 namespace scxt::ui::app::shared
 {
@@ -70,6 +71,12 @@ inline juce::File fsPathToJuceFile(const fs::path &p)
 #else
     return juce::File(p.u8string());
 #endif
+}
+
+// Force the save-as extension on, see scxt::guaranteeExtension
+inline juce::File guaranteeExtension(const juce::File &f, const std::string &ext)
+{
+    return fsPathToJuceFile(scxt::guaranteeExtension(juceFileToFSPath(f), ext));
 }
 
 // Slurp a text file, or nullopt if it won't open

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(scxt-test
 		value_edit_lag_tests.cpp
 		voice_oversampling_tests.cpp
 		file_map_view_tests.cpp
+		extension_guarantee_tests.cpp
 )
 
 target_compile_definitions(scxt-test PRIVATE

--- a/tests/extension_guarantee_tests.cpp
+++ b/tests/extension_guarantee_tests.cpp
@@ -1,0 +1,90 @@
+/*
+ * Shortcircuit XT - a Surge Synth Team product
+ *
+ * A fully featured creative sampler, available as a standalone
+ * and plugin for multiple platforms.
+ *
+ * Copyright 2019 - 2026, Various authors, as described in the github
+ * transaction log.
+ *
+ * This source file and all other files in the shortcircuit-xt repo outside of
+ * `libs/` are licensed under the MIT license, available in the
+ * file LICENSE or at https://opensource.org/license/mit.
+ *
+ * As some dependencies of ShortcircuitXT are released under the GNU General
+ * Public License 3, if you distribute a binary of ShortcircuitXT
+ * without breaking those dependencies, the combined work must be
+ * distributed under GPL3.
+ *
+ * ShortcircuitXT is inspired by, and shares a small amount of code with,
+ * the commercial product Shortcircuit 1 and 2, released by VemberTech
+ * in the mid 2000s. The code for Shortcircuit 2 was opensourced in
+ * 2020 at the outset of this project.
+ *
+ * All source for ShortcircuitXT is available at
+ * https://github.com/surge-synthesizer/shortcircuit-xt
+ */
+
+#include "catch2/catch2.hpp"
+
+#include <string>
+
+#include "utils.h"
+#include "filesystem/import.h"
+
+TEST_CASE("Guarantee Extension")
+{
+    using scxt::guaranteeExtension;
+
+    SECTION("Adds a missing extension")
+    {
+        // Issue 2442: the linux save dialog returns the typed name verbatim
+        REQUIRE(guaranteeExtension(fs::path{"FooBaz"}, ".scm").u8string() == "FooBaz.scm");
+        REQUIRE(guaranteeExtension(fs::path{"/a/b/FooBaz"}, ".scm").u8string() ==
+                "/a/b/FooBaz.scm");
+    }
+
+    SECTION("Leaves an extension it already has alone")
+    {
+        REQUIRE(guaranteeExtension(fs::path{"FooBaz.scm"}, ".scm").u8string() == "FooBaz.scm");
+        // and doesn't double up on a differently cased one
+        REQUIRE(guaranteeExtension(fs::path{"FooBaz.SCM"}, ".scm").u8string() == "FooBaz.SCM");
+        REQUIRE(guaranteeExtension(fs::path{"FooBaz.Scm"}, ".scm").u8string() == "FooBaz.Scm");
+    }
+
+    SECTION("Takes the extension in any of the three spellings")
+    {
+        REQUIRE(guaranteeExtension(fs::path{"FooBaz"}, "scm").u8string() == "FooBaz.scm");
+        REQUIRE(guaranteeExtension(fs::path{"FooBaz"}, ".scm").u8string() == "FooBaz.scm");
+        REQUIRE(guaranteeExtension(fs::path{"FooBaz"}, "*.scm").u8string() == "FooBaz.scm");
+    }
+
+    SECTION("Appends rather than replacing, so a dotted name survives")
+    {
+        // replace_extension would turn this into "Bass 3.scm" and lose the .2
+        REQUIRE(guaranteeExtension(fs::path{"Bass 3.2"}, ".scm").u8string() == "Bass 3.2.scm");
+        REQUIRE(guaranteeExtension(fs::path{"Kick.wav"}, ".scm").u8string() == "Kick.wav.scm");
+    }
+
+    SECTION("Handles each of the formats we save")
+    {
+        REQUIRE(guaranteeExtension(fs::path{"P"}, "*.scm").u8string() == "P.scm");
+        REQUIRE(guaranteeExtension(fs::path{"P"}, "*.scp").u8string() == "P.scp");
+        REQUIRE(guaranteeExtension(fs::path{"P"}, "*.sfz").u8string() == "P.sfz");
+        REQUIRE(guaranteeExtension(fs::path{"P"}, "*.scmod").u8string() == "P.scmod");
+        REQUIRE(guaranteeExtension(fs::path{"P"}, "*.sctheme").u8string() == "P.sctheme");
+        REQUIRE(guaranteeExtension(fs::path{"P"}, "*.vcfx").u8string() == "P.vcfx");
+        REQUIRE(guaranteeExtension(fs::path{"P"}, "*.busfx").u8string() == "P.busfx");
+    }
+
+    SECTION("Won't make a path out of nothing")
+    {
+        REQUIRE(guaranteeExtension(fs::path{}, ".scm").u8string().empty());
+        // a trailing separator means no filename to extend
+        REQUIRE(guaranteeExtension(fs::path{"/a/b/"}, ".scm").u8string() == "/a/b/");
+        // and an empty extension is a no-op rather than a trailing dot
+        REQUIRE(guaranteeExtension(fs::path{"FooBaz"}, "").u8string() == "FooBaz");
+        REQUIRE(guaranteeExtension(fs::path{"FooBaz"}, "*").u8string() == "FooBaz");
+        REQUIRE(guaranteeExtension(fs::path{"FooBaz"}, ".").u8string() == "FooBaz");
+    }
+}


### PR DESCRIPTION
The GTK save dialog on linux hands back exactly the name the user typed, so saving a multi as "FooBaz" produced an extensionless file the browser would never match again. scxt::guaranteeExtension forces the extension on at every save-as and export site: multi, part, SFZ export, modulator preset, theme, voice effect preset and bus effect preset.

It appends rather than replacing. The two only differ once the typed name contains a dot, and there replace_extension discards everything after the last one, turning a patch named "Bass 3.2" into "Bass 3.scm". Collect samples is left alone, since it picks a directory and not a file.

The extension each chooser filters on is now named once per format so the filter and the forced extension can't drift apart.

Closes #2442

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>