### PR TITLE
Stop the LFO pane rebuilding under an in-flight drag

### DIFF
--- a/src/scxt-core/messaging/client/group_or_zone_messages.h
+++ b/src/scxt-core/messaging/client/group_or_zone_messages.h
@@ -140,7 +140,6 @@ CLIENT_TO_SERIAL_CONSTRAINED(
                 eng.getSelectionManager()->sendDisplayDataForLeadSelection(std::get<0>(payload));
         }));
 
-// int updates can change shape. For now lets just always assume they do
 CLIENT_TO_SERIAL_CONSTRAINED(
     UpdateZoneOrGroupModStorageInt16TValue, c2s_update_zone_or_group_modstorage_int16_t_value,
     detail::indexedZoneOrGroupDiffMsg_t<int16_t>, modulation::ModulatorStorage,
@@ -148,6 +147,9 @@ CLIENT_TO_SERIAL_CONSTRAINED(
                                                 undo::GroupModStorageSpec>(
         &engine::Zone::modulatorStorage, &engine::Group::modulatorStorage, payload, engine, cont,
         [payload](auto &eng) {
+            if (!modulation::modStorageInt16EditRestructuresPanel(std::get<2>(payload)))
+                return;
+
             auto forZone = std::get<0>(payload);
             if (forZone)
             {

--- a/src/scxt-core/modulation/modulator_storage.h
+++ b/src/scxt-core/modulation/modulator_storage.h
@@ -29,6 +29,7 @@
 #define SCXT_SRC_SCXT_CORE_MODULATION_MODULATOR_STORAGE_H
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 
 #include "sst/basic-blocks/modulators/StepLFO.h"
@@ -215,6 +216,13 @@ struct ModulatorStorage
 
     bool modulatorConsistent{true};
 };
+
+// only these restructure the panel; a resend on the others rebuilds the pane mid-drag
+inline bool modStorageInt16EditRestructuresPanel(ptrdiff_t offset)
+{
+    return offset == (ptrdiff_t)offsetof(ModulatorStorage, modulatorShape) ||
+           offset == (ptrdiff_t)offsetof(ModulatorStorage, triggerMode);
+}
 
 struct MiscSourceStorage
 {

--- a/tests/modulator_tests.cpp
+++ b/tests/modulator_tests.cpp
@@ -512,3 +512,21 @@ TEST_CASE("Non-ONESHOT step LFO loops the sequence")
 
     REQUIRE(maxAbsOver(out, 2 * blocksPerSecond, 3 * blocksPerSecond) > 0.9f);
 }
+
+TEST_CASE("Only shape and trigger mode resend display data on an int16 mod storage edit")
+{
+    scxt::modulation::ModulatorStorage ms;
+
+    // the offset the UI puts in the message is the one the attachment computes this way
+    auto offsetOf = [&ms](const auto &m) {
+        return (ptrdiff_t)((const uint8_t *)&m - (const uint8_t *)&ms);
+    };
+
+    // the panel picks its sub pane off these two, so a change has to reach the client
+    REQUIRE(scxt::modulation::modStorageInt16EditRestructuresPanel(offsetOf(ms.modulatorShape)));
+    REQUIRE(scxt::modulation::modStorageInt16EditRestructuresPanel(offsetOf(ms.triggerMode)));
+
+    // step count is dragged, and a resend rebuilds the pane out from under the drag
+    REQUIRE(!scxt::modulation::modStorageInt16EditRestructuresPanel(
+        offsetOf(ms.stepLfoStorage.repeat)));
+}

--- a/tests/selection_tests.cpp
+++ b/tests/selection_tests.cpp
@@ -175,7 +175,7 @@ TEST_CASE("Selecting an empty group clears prior zone selections")
     th.sendToSerialization(cmsg::AddBlankZone({0, 0, 48, 60, 0, 127}));
     th.sendToSerialization(cmsg::AddBlankZone({0, 0, 61, 72, 0, 127}));
     th.sendToSerialization(cmsg::CreateGroup(0));
-    th.stepUI();
+    th.stepUI(30); // the adds and the group create hop the audio thread
 
     REQUIRE(sm->state[0].leadZone == zad{0, 0, 1});
     REQUIRE(!sm->state[0].selectedZones.empty());
@@ -393,7 +393,7 @@ TEST_CASE("Fold: delete-fixup drops the deleted group's fold bit and clamps out-
 
     // Delete the folded group 2. Group 2's bit is gone; group 4's bit shifts to 3.
     th.sendToSerialization(cmsg::DeleteGroup(zad{0, 2, -1}));
-    th.stepUI();
+    th.stepUI(30); // the delete and its fold fixup hop the audio thread
     REQUIRE(th.engine->getPatch()->getPart(0)->getGroups().size() == 4);
     REQUIRE(!sm->isGroupCollapsed(0, 2));
     REQUIRE(sm->isGroupCollapsed(0, 3));


### PR DESCRIPTION
Addresses #2644 — dragging the step sequencer LFO step count stalls after one or two jogs.

The widget and its drag handler are fine. The pane deletes the widget out from under the mouse:

1. Dragging the step count edits `stepLfoStorage.repeat` through `UpdateZoneOrGroupModStorageInt16TValue`.
2. That message unconditionally resent the lead selection's display data — the comment there said as much: `// int updates can change shape. For now lets just always assume they do`.
3. `sendDisplayDataForZonesBasedOnLead` sends the full modulator storage back for all four LFOs.
4. `LfoPane::setModulatorStorage` responds with `removeAllChildren()` + `rebuildPanelComponents()`.
5. That reassigns `stepLfoPane`, destroying the `DraggableTextEditableDiscreteValue` that owns the drag.

JUCE routes drag events to the component that received the mouseDown, so the drag ends there. The "one or two moves" is however many jogs land before the echo arrives on the next serialization wake.

`modulatorShape` and `triggerMode` are the only int16 members that restructure the panel, so `modStorageInt16EditRestructuresPanel` now gates the resend to those two. This mirrors what the EG and modulator bool messages already do for `temposync`. `repeat` restructures nothing, and the attachment has already written the local value, so the echo bought nothing and cost the drag.

Rate, Deform and Phase were never affected — they go through the float message, which has no such resend.

Tested with a case in `modulator_tests.cpp` asserting shape and trigger mode resend and `stepLfoStorage.repeat` does not, using the same pointer arithmetic the attachment uses to build the offset. Verified it fails against the old always-resend behaviour. Full suite green, 305 cases.

Draft: not yet confirmed against a running instance, so the drag wants a manual try before this merges.
