### PR TITLE
Add bipolar and three state alternate modulators

### DIFF
--- a/src/scxt-core/engine/engine.h
+++ b/src/scxt-core/engine/engine.h
@@ -490,8 +490,10 @@ struct Engine : MoveableOnly<Engine>, SampleRateSupport
     std::atomic<uint32_t> activeVoices{0};
     uint64_t nextVoiceCreationId{1};
 
-    // flip-flops on each note on which starts voices, feeding the voice matrix 'Alternate' source
-    bool voiceAlternate{false};
+    // steps on each note on which starts voices, feeding the voice matrix Alternate sources.
+    // 6 states so the 2 cycle and the 3 cycle alternates stay in phase across the wrap.
+    int32_t voiceAlternateCounter{0};
+    static constexpr int32_t voiceAlternateCycle{6};
 
     std::unique_ptr<voice::PreviewVoice> previewVoice;
 

--- a/src/scxt-core/engine/engine_voice_responder.cpp
+++ b/src/scxt-core/engine/engine_voice_responder.cpp
@@ -103,11 +103,13 @@ int32_t Engine::VoiceManagerResponder::initializeMultipleVoices(
     // envelope on them can wait on the gate - see Voice::createdByReleaseTrigger
     auto byReleaseTrigger = engine.inReleaseTriggerPass;
 
-    // alternate flips once per note on rather than once per voice, so zones layered on one
-    // key all sound with the same value
-    auto alternateForNote = engine.voiceAlternate * 1.f;
+    // the alternates step once per note on rather than once per voice, so zones layered on
+    // one key all sound with the same value
+    auto alternateForNote = engine.voiceAlternateCounter;
     auto assignAlternate = [&alternateForNote](voice::Voice *v) {
-        v->currentAlternate = alternateForNote;
+        v->currentAlternate = (alternateForNote % 2) * 1.f;
+        v->currentAlternateBipolar = (alternateForNote % 2) * 2.f - 1.f;
+        v->currentAlternateRotation = (alternateForNote % 3) * 1.f - 1.f;
     };
 
     for (auto idx = 0; idx < nts; ++idx)
@@ -255,7 +257,8 @@ int32_t Engine::VoiceManagerResponder::initializeMultipleVoices(
     }
 
     if (actualCreated > 0)
-        engine.voiceAlternate = !engine.voiceAlternate;
+        engine.voiceAlternateCounter =
+            (engine.voiceAlternateCounter + 1) % Engine::voiceAlternateCycle;
 
     engine.midiNoteStateCounter++;
     SCLOG_IF(voiceResponder, "Completed voice initiation " << actualCreated << " of " << nts);

--- a/src/scxt-core/modulation/voice_matrix.cpp
+++ b/src/scxt-core/modulation/voice_matrix.cpp
@@ -182,6 +182,8 @@ void MatrixEndpoints::Sources::bind(scxt::voice::modulation::Matrix &m, engine::
     m.bindSourceValue(voiceSources.isGated, v.isGatedF);
     m.bindSourceValue(voiceSources.isReleased, v.isReleasedF);
     m.bindSourceValue(voiceSources.alternate, v.currentAlternate);
+    m.bindSourceValue(voiceSources.alternateBipolar, v.currentAlternateBipolar);
+    m.bindSourceValue(voiceSources.alternateRotation, v.currentAlternateRotation);
     m.bindSourceValue(voiceSources.variantCount, v.sampleIndexF);
     m.bindSourceValue(voiceSources.loopCount, v.loopCountF);
     m.bindSourceValue(voiceSources.variantCountFraction, v.sampleIndexFraction);

--- a/src/scxt-core/modulation/voice_matrix.h
+++ b/src/scxt-core/modulation/voice_matrix.h
@@ -395,23 +395,35 @@ struct MatrixEndpoints
 
         struct VoiceSources
         {
+            // a nested category, so the three alternates get their own submenu under Voice
+            static constexpr const char *alternates{"Voice/Alternates"};
+
             VoiceSources(engine::Engine *e)
                 : isGated{'zvsr', 'gate'}, isReleased{'zvsr', 'reld'}, alternate{'zvsr', 'altr'},
+                  alternateBipolar{'zvsr', 'altb'}, alternateRotation{'zvsr', 'alt3'},
                   variantCount{'zvsr', 'vcnt', 0}, variantCountFraction{'zvsr', 'vcfr', 0},
                   loopPercentage{'zvsr', 'lppc', 0}, loopCount{'zvsr', 'lpct', 0},
                   isLooping{'zvsr', 'islp', 0}, samplePercentage{'zvsr', 'sppc', 0}
             {
                 registerVoiceModSource(e, isGated, "Voice", "Is Gated");
                 registerVoiceModSource(e, isReleased, "Voice", "Is Released");
-                registerVoiceModSource(e, alternate, "Voice", "Alternate");
                 registerVoiceModSource(e, variantCount, "Voice", "Variant Idx");
                 registerVoiceModSource(e, variantCountFraction, "Voice", "Variant %");
                 registerVoiceModSource(e, isLooping, "Voice", "Is Looping");
                 registerVoiceModSource(e, samplePercentage, "Voice", "Sample %");
                 registerVoiceModSource(e, loopPercentage, "Voice", "Loop %");
                 registerVoiceModSource(e, loopCount, "Voice", "Loop Count");
+
+                {
+                    // narrowest to widest rather than alphabetical
+                    auto orderGuard = scxt::modulation::shared::ExplicitMenuOrder(e);
+                    registerVoiceModSource(e, alternate, alternates, "0/1 Alternate");
+                    registerVoiceModSource(e, alternateBipolar, alternates, "+/-1 Alternate");
+                    registerVoiceModSource(e, alternateRotation, alternates, "-1/0/1 Rotation");
+                }
             }
-            SR isGated, isReleased, alternate;
+            SR isGated, isReleased;
+            SR alternate, alternateBipolar, alternateRotation;
             SR variantCount, variantCountFraction;
             SR isLooping, loopPercentage, samplePercentage, loopCount;
         } voiceSources;

--- a/src/scxt-core/voice/voice.h
+++ b/src/scxt-core/voice/voice.h
@@ -301,8 +301,8 @@ struct alignas(16) Voice : MoveableOnly<Voice>,
         isReleasedF = g ? 0.f : 1.f;
     };
 
-    // set from the note on which started this voice; a legato retrigger keeps that value
-    float currentAlternate{0.f};
+    // set from the note on which started this voice; a legato retrigger keeps those values
+    float currentAlternate{0.f}, currentAlternateBipolar{-1.f}, currentAlternateRotation{-1.f};
 
     std::array<bool, maxGeneratorsPerVoice> isGeneratorRunning{};
     bool isAnyGeneratorRunning{};

--- a/src/scxt-plugin/app/edit-screen/components/ModPane.cpp
+++ b/src/scxt-plugin/app/edit-screen/components/ModPane.cpp
@@ -47,6 +47,70 @@ namespace cmsg = scxt::messaging::client;
 namespace jcmp = sst::jucegui::components;
 namespace jcad = sst::jucegui::component_adapters;
 
+/*
+ * A source category can nest - "Voice/Alternates" hangs an Alternates submenu inside Voice - so
+ * the menu is built against a stack of open submenus rather than one run of a single category.
+ * Sources arrive sorted with a category contiguous, so a level is only reopened if its path
+ * actually reappears.
+ */
+struct NestedSourceMenu
+{
+    struct Level
+    {
+        std::string name;
+        juce::PopupMenu menu;
+        bool ticked{false};
+    };
+
+    juce::PopupMenu &top;
+    std::vector<Level> open;
+
+    explicit NestedSourceMenu(juce::PopupMenu &t) : top(t) {}
+    ~NestedSourceMenu() { closeTo(0); }
+
+    void addItem(const std::string &path, const std::string &name, bool ticked,
+                 std::function<void()> cb)
+    {
+        std::vector<std::string> segs;
+        size_t pos{0};
+        while (pos < path.size())
+        {
+            auto nxt = path.find('/', pos);
+            if (nxt == std::string::npos)
+                nxt = path.size();
+            if (nxt > pos)
+                segs.push_back(path.substr(pos, nxt - pos));
+            pos = nxt + 1;
+        }
+
+        size_t common{0};
+        while (common < open.size() && common < segs.size() && open[common].name == segs[common])
+            common++;
+        closeTo(common);
+
+        for (auto i = common; i < segs.size(); ++i)
+            open.push_back(Level{segs[i], juce::PopupMenu(), false});
+
+        currentMenu().addItem(name, true, ticked, cb);
+        if (ticked)
+            for (auto &l : open)
+                l.ticked = true;
+    }
+
+    juce::PopupMenu &currentMenu() { return open.empty() ? top : open.back().menu; }
+
+    void closeTo(size_t depth)
+    {
+        while (open.size() > depth)
+        {
+            auto lvl = std::move(open.back());
+            open.pop_back();
+            if (lvl.menu.getNumItems() > 0)
+                currentMenu().addSubMenu(lvl.name, lvl.menu, true, nullptr, lvl.ticked);
+        }
+    }
+};
+
 template <typename GZTrait> struct ModRow : juce::Component, HasEditor, juce::DragAndDropTarget
 {
     int index{0};
@@ -539,47 +603,29 @@ template <typename GZTrait> struct ModRow : juce::Component, HasEditor, juce::Dr
         if (hasCat)
             p.addSeparator();
 
-        auto sub = juce::PopupMenu();
         std::string sourceName{""};
-        auto subTicked{false};
-        std::string lastCat{};
-        for (const auto &[si, sn] : srcs)
         {
-            if (sn.first.empty())
-                continue;
-
-            if (lastCat != sn.first)
+            auto nested = NestedSourceMenu(p);
+            for (const auto &[si, sn] : srcs)
             {
-                if (sub.getNumItems() > 0)
+                if (sn.first.empty())
+                    continue;
+
+                const auto &row = parent->routingTable.routes[index];
+                auto selected = isVia ? (row.sourceVia == si) : (row.source == si);
+
+                auto nm = sn.second;
+                if (si.gid == 'gmac' || si.gid == 'zmac')
                 {
-                    p.addSubMenu(lastCat, sub, true, nullptr, subTicked);
+                    if (nm != scxt::engine::Macro::defaultNameFor(si.index))
+                    {
+                        nm = scxt::engine::Macro::defaultNameFor(si.index) + " (" + nm + ")";
+                    }
                 }
-                sub = juce::PopupMenu();
-                lastCat = sn.first;
-                subTicked = false;
+                nested.addItem(sn.first, nm, selected, mkCallback(si));
+                if (selected)
+                    sourceName = nm;
             }
-
-            const auto &row = parent->routingTable.routes[index];
-            auto selected = isVia ? (row.sourceVia == si) : (row.source == si);
-            if (selected)
-                subTicked = true;
-
-            auto nm = sn.second;
-            if (si.gid == 'gmac' || si.gid == 'zmac')
-            {
-                if (nm != scxt::engine::Macro::defaultNameFor(si.index))
-                {
-                    nm = scxt::engine::Macro::defaultNameFor(si.index) + " (" + nm + ")";
-                }
-            }
-            sub.addItem(nm, true, selected, mkCallback(si));
-            if (selected)
-                sourceName = nm;
-        }
-
-        if (sub.getNumItems() > 0)
-        {
-            p.addSubMenu(lastCat, sub, true, nullptr, subTicked);
         }
 
         const auto &row = parent->routingTable.routes[index];

--- a/tests/alternate_source_tests.cpp
+++ b/tests/alternate_source_tests.cpp
@@ -26,15 +26,16 @@
  */
 
 /*
- * The 'Alternate' voice modulation source - a flip flop which hands each note on 0, then 1,
- * then 0 again. It flips per note on rather than per voice, so zones layered on one key all
- * sound with the same value. The flag lives on the engine, so the alternation is global
- * rather than per zone or per key, and a legato retrigger keeps what its voice was born with.
- * GH #2647.
+ * The three Alternate voice modulation sources - a 0/1 flip flop, its bipolar twin, and a
+ * -1/0/1 rotation. All three come off one engine counter which steps on each note on that
+ * starts voices, so they are global rather than per zone or per key, they step per note on
+ * rather than per voice (zones layered on one key sound with the same value), and a legato
+ * retrigger keeps what its voice was born with. GH #2647.
  */
 
 #include "catch2/catch2.hpp"
 
+#include <algorithm>
 #include <memory>
 #include <vector>
 
@@ -53,6 +54,11 @@
 namespace
 {
 namespace vm = scxt::voice::modulation;
+
+// what each source should read on the nth note on of a fresh engine
+float expectedAlternate(int n) { return (n % 2) * 1.f; }
+float expectedBipolar(int n) { return (n % 2) * 2.f - 1.f; }
+float expectedRotation(int n) { return (n % 3) * 1.f - 1.f; }
 
 // The voice the most recent note on made in this zone. Released voices linger, so "newest"
 // has to come off the creation id rather than the first assigned slot.
@@ -77,26 +83,26 @@ scxt::engine::Zone &oneZoneOnKey(scxt::engine::Engine &eng, int key)
 }
 } // namespace
 
-TEST_CASE("Alternate flips on every note on", "[modulation]")
+TEST_CASE("Alternates step on every note on", "[modulation]")
 {
     std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
     auto &zone = oneZoneOnKey(*eng, 60);
 
-    std::vector<float> alts;
-    for (int i = 0; i < 8; ++i)
+    // twelve presses so the 6 state counter wraps twice and the 2 and 3 cycles have to come
+    // back into phase across the wrap
+    for (int i = 0; i < 12; ++i)
     {
         eng->processNoteOnEvent(0, 0, 60, -1, 1.f, 0.f);
         const auto *v = newestVoice(zone);
         REQUIRE(v);
-        alts.push_back(v->currentAlternate);
+        REQUIRE(v->currentAlternate == expectedAlternate(i));
+        REQUIRE(v->currentAlternateBipolar == expectedBipolar(i));
+        REQUIRE(v->currentAlternateRotation == expectedRotation(i));
         eng->processNoteOffEvent(0, 0, 60, -1, 0.f);
     }
-
-    for (int i = 0; i < (int)alts.size(); ++i)
-        REQUIRE(alts[i] == ((i % 2) ? 1.f : 0.f));
 }
 
-TEST_CASE("Alternate does not restart per key", "[modulation]")
+TEST_CASE("Alternates do not restart per key", "[modulation]")
 {
     std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
     auto &part = *eng->getPatch()->getPart(0);
@@ -104,20 +110,20 @@ TEST_CASE("Alternate does not restart per key", "[modulation]")
     addBlankZoneToGroup(part, 0, 48, 72);
     auto &zone = *part.getGroup(0)->getZone(0);
 
-    std::vector<float> alts;
-    for (auto key : {60, 62, 64, 60, 67})
+    int n{0};
+    for (auto key : {60, 62, 64, 60, 67, 55, 60})
     {
         eng->processNoteOnEvent(0, 0, key, -1, 1.f, 0.f);
         const auto *v = newestVoice(zone);
         REQUIRE(v);
-        alts.push_back(v->currentAlternate);
+        REQUIRE(v->currentAlternate == expectedAlternate(n));
+        REQUIRE(v->currentAlternateRotation == expectedRotation(n));
         eng->processNoteOffEvent(0, 0, key, -1, 0.f);
+        n++;
     }
-
-    REQUIRE(alts == std::vector<float>{0.f, 1.f, 0.f, 1.f, 0.f});
 }
 
-TEST_CASE("Alternate is shared by zones layered on one key", "[modulation]")
+TEST_CASE("Alternates are shared by zones layered on one key", "[modulation]")
 {
     std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
     auto &part = *eng->getPatch()->getPart(0);
@@ -128,57 +134,82 @@ TEST_CASE("Alternate is shared by zones layered on one key", "[modulation]")
     auto &upper = *part.getGroup(0)->getZone(1);
 
     // both zones on a press get the same value, and it advances press to press: 00 11 00 11
-    for (int i = 0; i < 4; ++i)
+    for (int i = 0; i < 6; ++i)
     {
         eng->processNoteOnEvent(0, 0, 60, -1, 1.f, 0.f);
         const auto *lv = newestVoice(lower);
         const auto *uv = newestVoice(upper);
         REQUIRE(lv);
         REQUIRE(uv);
-        REQUIRE(lv->currentAlternate == ((i % 2) ? 1.f : 0.f));
+        REQUIRE(lv->currentAlternate == expectedAlternate(i));
+        REQUIRE(lv->currentAlternateRotation == expectedRotation(i));
         REQUIRE(uv->currentAlternate == lv->currentAlternate);
+        REQUIRE(uv->currentAlternateRotation == lv->currentAlternateRotation);
         eng->processNoteOffEvent(0, 0, 60, -1, 0.f);
     }
 }
 
-TEST_CASE("Alternate reaches the voice matrix", "[modulation]")
+TEST_CASE("Alternates reach the voice matrix", "[modulation]")
 {
-    std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
-    auto &zone = oneZoneOnKey(*eng, 60);
-
-    // an empty zone's voice ends on its first block - no generator, no procs - so give it
-    // an oscillator to sustain through the block that runs the matrix
-    {
-        auto bypass = eng->getMessageController()->threadingChecker.bypassChecksInScope();
-        zone.setProcessorType(0, scxt::dsp::processor::proct_osc_sineplus);
-    }
-
     const auto panT = vm::MatrixConfig::TargetIdentifier{'zout', 'pan ', 0};
 
-    auto &row = zone.routingTable.routes[0];
-    row.active = true;
-    row.source = vm::sourcesForScanning().voiceSources.alternate;
-    row.target = panT;
-    row.depth = 1.f;
+    // route one source at full depth to zone pan and report the modulated pan on each of the
+    // first two presses. Pan is clamped to its own range so only the sign is asserted below.
+    auto firstTwoPans = [&panT](const vm::MatrixConfig::SourceIdentifier &src) {
+        std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
+        auto &zone = oneZoneOnKey(*eng, 60);
 
-    auto panAfterPress = [&]() {
-        eng->processNoteOnEvent(0, 0, 60, -1, 1.f, 0.f);
-        eng->processAudio();
-        const auto *v = newestVoice(zone);
-        REQUIRE(v);
-        auto p = v->modMatrix->getTargetValue(panT);
-        eng->processNoteOffEvent(0, 0, 60, -1, 0.f);
-        return p;
+        // an empty zone's voice ends on its first block - no generator, no procs - so give it
+        // an oscillator to sustain through the block that runs the matrix
+        {
+            auto bypass = eng->getMessageController()->threadingChecker.bypassChecksInScope();
+            zone.setProcessorType(0, scxt::dsp::processor::proct_osc_sineplus);
+        }
+
+        auto &row = zone.routingTable.routes[0];
+        row.active = true;
+        row.source = src;
+        row.target = panT;
+        row.depth = 1.f;
+
+        std::vector<float> pans;
+        for (int i = 0; i < 2; ++i)
+        {
+            eng->processNoteOnEvent(0, 0, 60, -1, 1.f, 0.f);
+            eng->processAudio();
+            const auto *v = newestVoice(zone);
+            REQUIRE(v);
+            pans.push_back(v->modMatrix->getTargetValue(panT));
+            eng->processNoteOffEvent(0, 0, 60, -1, 0.f);
+        }
+        return pans;
     };
 
-    auto pOff = panAfterPress();
-    auto pOn = panAfterPress();
+    const auto &srcs = vm::sourcesForScanning().voiceSources;
 
-    REQUIRE(pOff == Approx(0.f));
-    REQUIRE(pOn > 0.1f);
+    SECTION("0/1 alternate goes 0 then positive")
+    {
+        auto p = firstTwoPans(srcs.alternate);
+        REQUIRE(p[0] == Approx(0.f));
+        REQUIRE(p[1] > 0.1f);
+    }
+
+    SECTION("+/-1 alternate goes negative then positive")
+    {
+        auto p = firstTwoPans(srcs.alternateBipolar);
+        REQUIRE(p[0] < -0.1f);
+        REQUIRE(p[1] > 0.1f);
+    }
+
+    SECTION("-1/0/1 rotation goes negative then 0")
+    {
+        auto p = firstTwoPans(srcs.alternateRotation);
+        REQUIRE(p[0] < -0.1f);
+        REQUIRE(p[1] == Approx(0.f));
+    }
 }
 
-TEST_CASE("Alternate is offered as a voice source", "[modulation]")
+TEST_CASE("Alternates are offered in their own submenu", "[modulation]")
 {
     std::unique_ptr<scxt::engine::Engine> eng(makeEngine());
     auto &zone = oneZoneOnKey(*eng, 60);
@@ -186,9 +217,30 @@ TEST_CASE("Alternate is offered as a voice source", "[modulation]")
     auto md = vm::getVoiceMatrixMetadata(zone);
     const auto &sources = std::get<1>(md);
 
-    auto found = std::find_if(sources.begin(), sources.end(), [](const auto &s) {
-        return s.second.first == "Voice" && s.second.second == "Alternate";
-    });
-    REQUIRE(found != sources.end());
-    REQUIRE(found->first == vm::sourcesForScanning().voiceSources.alternate);
+    std::vector<std::string> inAlternates;
+    for (const auto &[si, sn] : sources)
+        if (sn.first == "Voice/Alternates")
+            inAlternates.push_back(sn.second);
+
+    // the menu order is pinned rather than alphabetical, narrowest range first
+    REQUIRE(inAlternates ==
+            std::vector<std::string>{"0/1 Alternate", "+/-1 Alternate", "-1/0/1 Rotation"});
+
+    auto idFor = [&sources](const std::string &name) {
+        auto it = std::find_if(sources.begin(), sources.end(), [&name](const auto &s) {
+            return s.second.first == "Voice/Alternates" && s.second.second == name;
+        });
+        REQUIRE(it != sources.end());
+        return it->first;
+    };
+
+    const auto &srcs = vm::sourcesForScanning().voiceSources;
+    REQUIRE(idFor("0/1 Alternate") == srcs.alternate);
+    REQUIRE(idFor("+/-1 Alternate") == srcs.alternateBipolar);
+    REQUIRE(idFor("-1/0/1 Rotation") == srcs.alternateRotation);
+
+    // nothing left behind at the old flat path
+    auto stale = std::find_if(sources.begin(), sources.end(),
+                              [](const auto &s) { return s.second.second == "Alternate"; });
+    REQUIRE(stale == sources.end());
 }


### PR DESCRIPTION
User feedback on #2647 asked for three alternates rather than one.

- `0/1 Alternate` — the existing one, id unchanged
- `+/-1 Alternate` — bipolar
- `-1/0/1 Rotation` — three state

All three read off a single six state counter on the engine which steps on each note on that starts voices, so they advance together and the two cycle and the three cycle come back into phase on the wrap. The per note on rather than per voice behaviour is unchanged, so zones layered on one key still sound with the same value, and a legato retrigger still keeps what its voice was born with.

In the modulation UI the three move into an `Alternates` submenu under `Voice`. Source categories can now nest on a path like `Voice/Alternates`; the source menu previously only rendered one flat level of category, so it grew a small stack based builder to open and close nested submenus and to propagate the selection tick up through them. The group pane shares that code and is unaffected, as nothing there uses a nested path.

Tests cover all three across a double wrap of the counter, that they do not restart per key, that layered zones agree, that each one reaches the matrix (routed to zone pan and read back off the target), and that all three appear under `Voice/Alternates` in the pinned order with nothing stale at the old flat path. The menu nesting itself is not covered — `scxt-test` does not link the UI — but it has been checked by hand.